### PR TITLE
Refactor of `Core::IndexMap`

### DIFF
--- a/src/Core/Algorithm/Subdivision/FullEdgeOperation.cpp
+++ b/src/Core/Algorithm/Subdivision/FullEdgeOperation.cpp
@@ -8,9 +8,17 @@
 namespace Ra {
 namespace Core {
 
+template <typename T>
+void insertInMap( IndexMap<T>& map, T& t )
+{
+    t->idx = map.insert(t);
+    CORE_ASSERT(t->idx.isValid(), "Not inserted");
+}
+
+
 void fulledgeSplit( Dcel& dcel, const Index fulledge_id ) {
-    FullEdge_ptr ptr;
-    if( dcel.m_fulledge.access( fulledge_id, ptr ) ) {
+    if( dcel.m_fulledge.contains( fulledge_id ) ) {
+        FullEdge_ptr ptr = dcel.m_fulledge.at(fulledge_id);
         // Declare the data
         Vertex_ptr   v;
         HalfEdge_ptr he[4][3];
@@ -63,18 +71,18 @@ void fulledgeSplit( Dcel& dcel, const Index fulledge_id ) {
         }
 
         // Insert new data
-        CORE_ASSERT( dcel.m_vertex.insert( v, v->idx ), "New vertex not inserted" );
-        CORE_ASSERT( dcel.m_halfedge.insert( he[0][2], he[0][2]->idx ), "New halfedge[0][2] not inserted" );
-        CORE_ASSERT( dcel.m_halfedge.insert( he[1][1], he[1][1]->idx ), "New halfedge[1][1] not inserted" );
-        CORE_ASSERT( dcel.m_halfedge.insert( he[2][1], he[2][1]->idx ), "New halfedge[2][1] not inserted" );
-        CORE_ASSERT( dcel.m_halfedge.insert( he[2][2], he[2][2]->idx ), "New halfedge[2][2] not inserted" );
-        CORE_ASSERT( dcel.m_halfedge.insert( he[3][1], he[3][1]->idx ), "New halfedge[3][1] not inserted" );
-        CORE_ASSERT( dcel.m_halfedge.insert( he[3][2], he[3][2]->idx ), "New halfedge[3][2] not inserted" );
-        CORE_ASSERT( dcel.m_fulledge.insert( fe[1], fe[1]->idx ), "New fulledge[1] not inserted" );
-        CORE_ASSERT( dcel.m_fulledge.insert( fe[2], fe[2]->idx ), "New fulledge[2] not inserted" );
-        CORE_ASSERT( dcel.m_fulledge.insert( fe[3], fe[3]->idx ), "New fulledge[3] not inserted" );
-        CORE_ASSERT( dcel.m_face.insert( f[2], f[2]->idx ), "New face[2] not inserted" );
-        CORE_ASSERT( dcel.m_face.insert( f[3], f[3]->idx ), "New face[3] not inserted" );
+        insertInMap( dcel.m_vertex,  v);
+        insertInMap( dcel.m_halfedge, he[0][2]);
+        insertInMap( dcel.m_halfedge, he[1][1]);
+        insertInMap( dcel.m_halfedge, he[2][1]);
+        insertInMap( dcel.m_halfedge, he[2][2]);
+        insertInMap( dcel.m_halfedge, he[3][1]);
+        insertInMap( dcel.m_halfedge, he[3][2]);
+        insertInMap( dcel.m_fulledge, fe[1]);
+        insertInMap( dcel.m_fulledge, fe[2]);
+        insertInMap( dcel.m_fulledge, fe[3]);
+        insertInMap( dcel.m_face, f[2]);
+        insertInMap( dcel.m_face, f[3]);
     }
 }
 

--- a/src/Core/Index/IndexMap.hpp
+++ b/src/Core/Index/IndexMap.hpp
@@ -54,25 +54,20 @@ public:
     /// REMOVE
     /// ===============================================================================
     inline bool  remove( const Index& idx );                // Remove the object with the given index. Return false if the operation failed.
-    inline bool  remove( const uint     i );                // Remove the i-th object. Return false if the operation failed.
 
     /// ===============================================================================
     /// ACCESS
     /// ===============================================================================
     inline const T&  at( const Index& idx ) const;          // Return the object with the given index. Crash if the index is not present.
-    inline const T&  at( const uint     i ) const;          // Return the i-th object. Crash if i is out of bound.
     inline bool  at( const Index& idx, T& obj ) const;      // Return the object with the given index. Return false if the index is not present, true otherwise.
-    inline bool  at( const uint     i, T& obj ) const;      // Return the i-th object. Return false if i is out of bound, true otherwise.
 
     inline T&    access( const Index& idx );                // Return a reference to the object with the given index. Crash if index is not present.
-    inline T&    access( const uint     i );                // Return a reference to the i-th object. Crash if i is out of bound.
     inline bool  access( const Index& idx, T& obj );        // Return a reference to the object with the given index. Return false if the index is not present, true otherwise.
-    inline bool  access( const uint     i, T& obj );        // Return a reference to the i-th object. Return false if i is out of bound, true otherwise.
 
     /// ===============================================================================
     /// SIZE
     /// ===============================================================================
-    inline uint  size() const;                              // Return the size of the IndexMap ( number of object contained ).
+    inline size_t size() const;                              // Return the size of the IndexMap ( number of object contained ).
     inline void  clear();                                   // Clear the IndexMap.
 
     /// ===============================================================================
@@ -80,21 +75,15 @@ public:
     /// ===============================================================================
     inline bool  empty() const;                             // Return true if the IndexMap is empty.
     inline bool  full()  const;                             // Return true if the IndexMap cannot contain more objects.
-    inline bool  contain( const Index& idx ) const;         // Return true if the IndexMap contains a object with the given index.
+    inline bool  contains( const Index& idx ) const;         // Return true if the IndexMap contains a object with the given index.
     inline bool  compact() const;                           // Return true if the indices in the map are all consecutive.
     inline Index index( const uint i ) const;               // Return the i-th index. Return an invalid index if i is out of bound.
-    inline bool  index( const uint i, Index& idx ) const;   // Return the i-th index. Return false if i is out of bound.
 
     /// ===============================================================================
     /// OPERATOR
     /// ===============================================================================
     inline T&         operator[]( const Index& idx );       // Return the reference to the object with given index. Equal to using access( idx ).
-    inline T&         operator[]( const uint     i );       // Return the reference to the i-th object. Equal to using access( i ).
     inline const T&   operator[]( const Index& idx ) const; // Return the reference to the object with given index. Equal to using access( idx ).
-    inline const T&   operator[]( const uint     i ) const; // Return the reference to the i-th object. Equal to using access( i ).
-    inline Index&     operator<<( const T&     obj );       // Insert a new object in the IndexMap. Equal to using insert( obj ).
-    inline IndexMap&  operator>>( const Index& idx );       // Remove the object with the given index and return the current IndexMap. Kind of equal to using remove( idx ).
-    inline IndexMap&  operator>>( const uint     i );       // Remove the i-th object and return the current IndexMap. Kind of equal to using remove( i ).
 
     /// ===============================================================================
     /// INDEX ITERATOR

--- a/src/Core/Index/IndexMap.hpp
+++ b/src/Core/Index/IndexMap.hpp
@@ -2,6 +2,7 @@
 #define INDEXMAP_HPP
 
 #include <Core/RaCore.hpp>
+
 #include <deque>
 #include <algorithm>
 #include <assert.h>
@@ -11,7 +12,7 @@
 namespace Ra {
 namespace Core {
 
-/*
+/*!
 * The class IndexMap define a map where a object is coupled with a index.
 * The index is unique, it is assigned to a object when it's inserted and is kept until the object is removed.
 * After a removal, the index becomes free again.
@@ -21,110 +22,112 @@ namespace Core {
 template <typename T>
 class IndexMap {
 public:
-    /// ===============================================================================
-    /// TYPEDEF
-    /// ===============================================================================
-    typedef typename std::deque<T>                  Container; // Where the objects are stored
-    typedef typename std::deque<Index>              IndexContainer; // Where the indices are stored
+    // ===============================================================================
+    // TYPEDEF
+    // ===============================================================================
+    typedef typename std::deque<T>                  Container; /// Where the objects are stored
+    typedef typename std::deque<Index>              IndexContainer; /// Where the indices are stored
 
-    typedef typename IndexContainer::const_iterator ConstIndexIterator;    // Const iterator to the list of indices of the IndexMap.
-    typedef typename Container::iterator            Iterator;              // Iterator to the list of objects of the IndexMap.
-    typedef typename Container::const_iterator      ConstIterator;         // Const iterator to the list of objects of the IndexMap.
+    typedef typename IndexContainer::const_iterator ConstIndexIterator;    /// Const iterator to the list of indices of the IndexMap.
+    typedef typename Container::iterator            Iterator;              /// Iterator to the list of objects of the IndexMap.
+    typedef typename Container::const_iterator      ConstIterator;         /// Const iterator to the list of objects of the IndexMap.
 
-    /// ===============================================================================
-    /// CONSTRUCTOR
-    /// ===============================================================================
-    inline IndexMap();                                      // Default constructor.
-    inline IndexMap( const IndexMap& id_map );              // Copy constructor.
+    // ===============================================================================
+    // CONSTRUCTOR
+    // ===============================================================================
+    inline IndexMap();                                      /// Default constructor.
+    inline IndexMap( const IndexMap& id_map );              /// Copy constructor.
 
-    /// ===============================================================================
-    /// DESTRUCTOR
-    /// ===============================================================================
-    inline ~IndexMap();                                     // Destructor.
+    // ===============================================================================
+    // DESTRUCTOR
+    // ===============================================================================
+    inline ~IndexMap();                                     /// Destructor.
 
-    /// ===============================================================================
-    /// INSERT
-    /// ===============================================================================
-    inline Index insert( const T& obj );                    // Insert a object in the IndexMap. Return an invalid index if the object is not inserted.
+    // ===============================================================================
+    // INSERT
+    // ===============================================================================
+    /// Insert a object in the IndexMap. Return an invalid index if the object is not inserted.
+    inline Index insert( const T& obj );
 
+    /// Construct an object in place in the IndexMap. Return an invalid index if the object is not inserted.
     template<typename... Args>
-    inline Index emplace( const Args&&... args );             // Construct an object in place in the IndexMap. Return an invalid index if the object is not inserted.
+    inline Index emplace( const Args&&... args );
 
-    /// ===============================================================================
-    /// REMOVE
-    /// ===============================================================================
-    inline bool  remove( const Index& idx );                // Remove the object with the given index. Return false if the operation failed.
+    // ===============================================================================
+    // REMOVE
+    // ===============================================================================
+    /// Remove the object with the given index. Return false if the operation failed.
+    inline bool  remove( const Index& idx );
 
-    /// ===============================================================================
-    /// ACCESS
-    /// ===============================================================================
-    inline const T&  at( const Index& idx ) const;          // Return the object with the given index. Crash if the index is not present.
+    // ===============================================================================
+    // ACCESS
+    // ===============================================================================
+    /// Return a read-only ref to object with the given index.  Crashes if index does not exist.
+    inline const T&  at( const Index& idx ) const;
 
-    inline T&    access( const Index& idx );                // Return a reference to the object with the given index. Crash if index is not present.
+    /// Return a reference to the object with the given index. Crash if index does not exist
+    inline T& access( const Index& idx );
 
-    /// ===============================================================================
-    /// SIZE
-    /// ===============================================================================
-    inline size_t size() const;                              // Return the size of the IndexMap ( number of object contained ).
-    inline void  clear();                                   // Clear the IndexMap.
+    // ===============================================================================
+    // SIZE
+    // ===============================================================================
+    inline size_t size() const;   /// Return the size of the IndexMap ( number of object contained ).
+    inline void  clear();         /// Clear the IndexMap.
 
-    /// ===============================================================================
-    /// QUERY
-    /// ===============================================================================
-    inline bool  empty() const;                             // Return true if the IndexMap is empty.
-    inline bool  full()  const;                             // Return true if the IndexMap cannot contain more objects.
-    inline bool  contains( const Index& idx ) const;         // Return true if the IndexMap contains a object with the given index.
-    inline Index index( const uint i ) const;               // Return the i-th index. Return an invalid index if i is out of bound.
+    // ===============================================================================
+    // QUERY
+    // ===============================================================================
+    inline bool  empty() const;                      /// Return true if the IndexMap is empty.
+    inline bool  full()  const;                      /// Return true if the IndexMap cannot contain more objects.
+    inline bool  contains( const Index& idx ) const; /// Return true if the IndexMap contains a object with the given index.
+    inline Index index( const uint i ) const;        /// Return the i-th index. Return an invalid index if i is out of bound.
 
-    /// ===============================================================================
-    /// OPERATOR
-    /// ===============================================================================
-    inline T&         operator[]( const Index& idx );       // Return the reference to the object with given index. Equal to using access( idx ).
-    inline const T&   operator[]( const Index& idx ) const; // Return the reference to the object with given index. Equal to using access( idx ).
+    // ===============================================================================
+    // OPERATOR
+    // ===============================================================================
+    inline T&         operator[]( const Index& idx );       /// Return a reference to the object with given index.
+    inline const T&   operator[]( const Index& idx ) const; /// Return a const reference to the object with given index.
 
-    /// ===============================================================================
-    /// INDEX ITERATOR
-    /// ===============================================================================
-    inline ConstIndexIterator cbegin_index() const;         // Return a const iterator to the first index in the IndexMap.
-    inline ConstIndexIterator   cend_index() const;         // Return a const iterator to the end of the indices of the IndexMap.
+    // ===============================================================================
+    // INDEX ITERATOR
+    // ===============================================================================
+    inline ConstIndexIterator cbegin_index() const; /// Return a const iterator to the first index in the IndexMap.
+    inline ConstIndexIterator   cend_index() const; /// Return a const iterator to the end of the indices of the IndexMap.
 
-    /// ===============================================================================
-    /// DATA ITERATOR
-    /// ===============================================================================
-    inline      Iterator  begin();                          // Return a iterator to the first object in the IndexMap.
-    inline      Iterator    end();                          // Return a iterator to the end of the object list in the IndexMap.
-    inline ConstIterator  begin() const;                    // Return a iterator to the first object in the IndexMap.
-    inline ConstIterator    end() const;                    // Return a iterator to the end of the object list in the IndexMap.
-    inline ConstIterator cbegin() const;                    // Return a const iterator to the first object in the IndexMap.
-    inline ConstIterator   cend() const;                    // Return a const iterator to the end of the object list in the IndexMap.
+    // ===============================================================================
+    // DATA ITERATOR
+    // ===============================================================================
+    inline      Iterator  begin();       /// Return a iterator to the first object in the IndexMap.
+    inline      Iterator    end();       /// Return a iterator to the end of the object list in the IndexMap.
+    inline ConstIterator  begin() const; /// Return a iterator to the first object in the IndexMap.
+    inline ConstIterator    end() const; /// Return a iterator to the end of the object list in the IndexMap.
+    inline ConstIterator cbegin() const; /// Return a const iterator to the first object in the IndexMap.
+    inline ConstIterator   cend() const; /// Return a const iterator to the end of the object list in the IndexMap.
 
 protected:
-    /// ===============================================================================
-    /// VARIABLE
-    /// ===============================================================================
-    Container      m_data;                             // Objects in the IndexMap
-    IndexContainer m_index;                            // Indices in the IndexMap
+    // Member variables
+    Container      m_data;  /// Objects in the IndexMap
+    IndexContainer m_index; /// Indices in the IndexMap
 
 private:
-    /// ===============================================================================
-    /// PUSH
-    /// ===============================================================================
-    inline void push_free_index( const Index& idx );        // Push a new free index in the list of the free indices.
-
-    /// ===============================================================================
-    /// POP
-    /// ===============================================================================
-    inline bool pop_free_index( Index& idx );               // Pop a free index from the list of free indices. Return false if no free indices are available.
+    // ===============================================================================
+    // FREE LIST MANAGEMENT
+    // ===============================================================================
+    inline void push_free_index( const Index& idx );  /// Push a new free index in free list
+    inline bool pop_free_index( Index& idx );         /// Pop a free index from the free list
 
 
-    inline ConstIterator citfromIndex( const ConstIndexIterator& it )const ;
-    inline Iterator itfromIndex( const ConstIndexIterator& it );
-    inline size_t idxfromIndex( const ConstIndexIterator& it )const ;
+    // ===============================================================================
+    // HELPER FUNCTIONS
+    // ===============================================================================
+    // These function return an iterator to an object from an interator in an index.
+    inline ConstIterator citfromIndex( const ConstIndexIterator& it )const ; /// Returns a const iterator on an object from its intex iterator
+    inline Iterator itfromIndex( const ConstIndexIterator& it ); /// Returns a non-const iterator on an object from its intex iterator
+    inline size_t idxfromIndex( const ConstIndexIterator& it )const ;  /// Return the index of the object in the map from its index iterator
 
-    /// ===============================================================================
-    /// VARIABLE
-    /// ===============================================================================
-    IndexContainer m_free;                             // List of available free indices.
+private:
+    // Member variables
+    IndexContainer m_free;  /// List of available free indices.
 };
 
 } // namespace Core

--- a/src/Core/Index/IndexMap.hpp
+++ b/src/Core/Index/IndexMap.hpp
@@ -24,9 +24,12 @@ public:
     /// ===============================================================================
     /// TYPEDEF
     /// ===============================================================================
-    typedef typename std::deque< Index >::const_iterator ConstIndexIterator;    // Const iterator to the list of indices of the IndexMap.
-    typedef typename std::deque< T >::iterator           Iterator;              // Iterator to the list of objects of the IndexMap.
-    typedef typename std::deque< T >::const_iterator     ConstIterator;         // Const iterator to the list of objects of the IndexMap.
+    typedef typename std::deque<T>                  Container; // Where the objects are stored
+    typedef typename std::deque<Index>              IndexContainer; // Where the indices are stored
+
+    typedef typename IndexContainer::const_iterator ConstIndexIterator;    // Const iterator to the list of indices of the IndexMap.
+    typedef typename Container::iterator            Iterator;              // Iterator to the list of objects of the IndexMap.
+    typedef typename Container::const_iterator      ConstIterator;         // Const iterator to the list of objects of the IndexMap.
 
     /// ===============================================================================
     /// CONSTRUCTOR
@@ -43,12 +46,9 @@ public:
     /// INSERT
     /// ===============================================================================
     inline Index insert( const T& obj );                    // Insert a object in the IndexMap. Return an invalid index if the object is not inserted.
-    inline bool  insert( const T& obj, Index& idx );        // Insert a object in the IndexMap. Return true if the object is inserted, and store it in idx.
 
     template<typename... Args>
     inline Index emplace( const Args&&... args );             // Construct an object in place in the IndexMap. Return an invalid index if the object is not inserted.
-    template<typename... Args>
-    inline bool  emplace(  Index& idx, const Args&&... args ); // Construct an object in place in the IndexMap. Return true if the object is inserted, and store it in idx.
 
     /// ===============================================================================
     /// REMOVE
@@ -59,10 +59,8 @@ public:
     /// ACCESS
     /// ===============================================================================
     inline const T&  at( const Index& idx ) const;          // Return the object with the given index. Crash if the index is not present.
-    inline bool  at( const Index& idx, T& obj ) const;      // Return the object with the given index. Return false if the index is not present, true otherwise.
 
     inline T&    access( const Index& idx );                // Return a reference to the object with the given index. Crash if index is not present.
-    inline bool  access( const Index& idx, T& obj );        // Return a reference to the object with the given index. Return false if the index is not present, true otherwise.
 
     /// ===============================================================================
     /// SIZE
@@ -76,7 +74,6 @@ public:
     inline bool  empty() const;                             // Return true if the IndexMap is empty.
     inline bool  full()  const;                             // Return true if the IndexMap cannot contain more objects.
     inline bool  contains( const Index& idx ) const;         // Return true if the IndexMap contains a object with the given index.
-    inline bool  compact() const;                           // Return true if the indices in the map are all consecutive.
     inline Index index( const uint i ) const;               // Return the i-th index. Return an invalid index if i is out of bound.
 
     /// ===============================================================================
@@ -105,8 +102,8 @@ protected:
     /// ===============================================================================
     /// VARIABLE
     /// ===============================================================================
-    std::deque< T >     m_data;                             // Objects in the IndexMap
-    std::deque< Index > m_index;                            // Indices in the IndexMap
+    Container      m_data;                             // Objects in the IndexMap
+    IndexContainer m_index;                            // Indices in the IndexMap
 
 private:
     /// ===============================================================================
@@ -119,10 +116,15 @@ private:
     /// ===============================================================================
     inline bool pop_free_index( Index& idx );               // Pop a free index from the list of free indices. Return false if no free indices are available.
 
+
+    inline ConstIterator citfromIndex( const ConstIndexIterator& it )const ;
+    inline Iterator itfromIndex( const ConstIndexIterator& it );
+    inline size_t idxfromIndex( const ConstIndexIterator& it )const ;
+
     /// ===============================================================================
     /// VARIABLE
     /// ===============================================================================
-    std::deque< Index > m_free;                             // List of available free indices.
+    IndexContainer m_free;                             // List of available free indices.
 };
 
 } // namespace Core

--- a/src/Core/Index/IndexMap.inl
+++ b/src/Core/Index/IndexMap.inl
@@ -4,9 +4,9 @@ namespace Ra {
 namespace Core {
 
 
-/// ===============================================================================
-/// CONSTRUCTOR
-/// ===============================================================================
+// ===============================================================================
+// CONSTRUCTOR
+// ===============================================================================
 template < typename T >
 IndexMap< T >::IndexMap() :
     m_data(),
@@ -19,23 +19,28 @@ IndexMap< T >::IndexMap( const IndexMap& id_map ) :
     m_index( id_map.m_index ),
     m_free( id_map.m_free ) { }
 
-/// ===============================================================================
-/// DESTRUCTOR
-/// ===============================================================================
+// ===============================================================================
+// DESTRUCTOR
+// ===============================================================================
 template < typename T >
 IndexMap< T >::~IndexMap() { }
 
-/// ===============================================================================
-/// INSERT
-/// ===============================================================================
+// ===============================================================================
+// INSERT
+// ===============================================================================
 template < typename T >
-inline Index IndexMap< T >::insert( const T& obj ) {
+inline Index IndexMap< T >::insert( const T& obj )
+{
     Index idx;
-    if( pop_free_index( idx ) ) {
+    if( pop_free_index( idx ) )
+    {
         typename std::deque< Index >::iterator it = std::lower_bound( m_index.begin(), m_index.end(), idx );
-        if( it == m_index.end() ) {
+        if( it == m_index.end() )
+        {
             m_data.insert( m_data.end(), obj );
-        } else {
+        }
+        else
+        {
             m_data.insert(citfromIndex(it), obj);
         }
         m_index.insert( it, idx );
@@ -48,11 +53,15 @@ template <typename... Args>
 Index IndexMap<T>::emplace(const Args&&... args)
 {
     Index idx;
-    if( pop_free_index( idx ) ) {
+    if( pop_free_index( idx ) )
+    {
         typename std::deque< Index >::iterator it = std::lower_bound( m_index.begin(), m_index.end(), idx );
-        if( it == m_index.end() ) {
+        if( it == m_index.end() )
+        {
             m_data.emplace( m_data.end(), args... );
-        } else {
+        }
+        else
+        {
             m_data.emplace(citfromIndex(it), args...);
         }
         m_index.insert( it, idx );
@@ -61,13 +70,15 @@ Index IndexMap<T>::emplace(const Args&&... args)
 }
 
 
-/// ===============================================================================
-/// REMOVE
-/// ===============================================================================
+// ===============================================================================
+// REMOVE
+// ===============================================================================
 template < typename T >
-inline bool IndexMap< T >::remove( const Index& idx ) {
+inline bool IndexMap< T >::remove( const Index& idx )
+{
     typename std::deque< Index >::iterator it = std::find( m_index.begin(), m_index.end(), idx );
-    if( it == m_index.end() ) {
+    if( it == m_index.end() )
+    {
         return false;
     }
     m_data.erase(itfromIndex(it));
@@ -77,159 +88,186 @@ inline bool IndexMap< T >::remove( const Index& idx ) {
 }
 
 
-/// ===============================================================================
-/// ACCESS
-/// ===============================================================================
+// ===============================================================================
+// ACCESS
+// ===============================================================================
 template < typename T >
-inline const T& IndexMap< T >::at( const Index& idx ) const {
+inline const T& IndexMap< T >::at( const Index& idx ) const
+{
     typename std::deque< Index >::const_iterator it = std::find( m_index.begin(), m_index.end(), idx );
     CORE_ASSERT( it != m_index.end(), "Index not found" );
     return m_data.at(idxfromIndex(it));
 }
 
 template < typename T >
-inline T& IndexMap< T >::access( const Index& idx ) {
+inline T& IndexMap< T >::access( const Index& idx )
+{
     typename std::deque< Index >::iterator it = std::find( m_index.begin(), m_index.end(), idx );
     CORE_ASSERT( ( it != m_index.end() ), "Index not found" );
     return *itfromIndex(it);
 }
 
-/// ===============================================================================
-/// SIZE
-/// ===============================================================================
+// ===============================================================================
+// SIZE
+// ===============================================================================
 template < typename T >
-inline size_t IndexMap< T >::size() const {
+inline size_t IndexMap< T >::size() const
+{
     return m_data.size();
 }
 
 template < typename T >
-inline void IndexMap< T >::clear() {
+inline void IndexMap< T >::clear()
+{
     m_index.clear();
     m_data.clear();
     m_free.clear();
     m_free.push_back( Index( 0 ) );
 }
 
-/// ===============================================================================
-/// QUERY
-/// ===============================================================================
+// ===============================================================================
+// QUERY
+// ===============================================================================
 template < typename T >
-inline bool IndexMap< T >::empty() const {
+inline bool IndexMap< T >::empty() const
+{
     return  m_data.empty();
 }
 
 template < typename T >
-inline bool IndexMap< T >::full() const {
+inline bool IndexMap< T >::full() const
+{
     return m_free.empty();
 }
 
 template < typename T >
-inline bool IndexMap< T >::contains( const Index& idx ) const {
+inline bool IndexMap< T >::contains( const Index& idx ) const
+{
     typename std::deque< Index >::const_iterator it = std::find( m_index.begin(), m_index.end(), idx );
     return !( it == m_index.end() );
 }
 
 template < typename T >
-inline Index IndexMap< T >::index( const uint i ) const {
-    if( i >= m_index.size() ) {
+inline Index IndexMap< T >::index( const uint i ) const
+{
+    if( i >= m_index.size() )
+    {
         return Index::INVALID_IDX();
     }
     return m_index.at( i );
 }
 
-/// ===============================================================================
-/// OPERATOR
-/// ===============================================================================
+// ===============================================================================
+// OPERATOR
+// ===============================================================================
 template < typename T >
-inline T& IndexMap< T >::operator[]( const Index& idx ) {
+inline T& IndexMap< T >::operator[]( const Index& idx )
+{
     return access( idx );
 }
 
 template < typename T >
-inline const T& IndexMap< T >::operator[]( const Index& idx ) const {
+inline const T& IndexMap< T >::operator[]( const Index& idx ) const
+{
     return at( idx );
 }
 
-/// ===============================================================================
-/// INDEX ITERATOR
-/// ===============================================================================
+// ===============================================================================
+// INDEX ITERATOR
+// ===============================================================================
 template <typename T>
-inline typename IndexMap< T >::ConstIndexIterator IndexMap< T >::cbegin_index() const {
+inline typename IndexMap< T >::ConstIndexIterator IndexMap< T >::cbegin_index() const
+{
     return m_index.cbegin();
 }
 
 template <typename T>
-inline typename IndexMap< T >::ConstIndexIterator IndexMap< T >::cend_index() const {
+inline typename IndexMap< T >::ConstIndexIterator IndexMap< T >::cend_index() const
+{
     return m_index.cend();
 }
 
-/// ===============================================================================
-/// DATA ITERATOR
-/// ===============================================================================
+// ===============================================================================
+// DATA ITERATOR
+// ===============================================================================
 template <typename T>
-inline typename IndexMap< T >::Iterator IndexMap< T >::begin() {
+inline typename IndexMap< T >::Iterator IndexMap< T >::begin()
+{
     return m_data.begin();
 }
 
 template <typename T>
-inline typename IndexMap< T >::Iterator IndexMap< T >::end() {
+inline typename IndexMap< T >::Iterator IndexMap< T >::end()
+{
     return m_data.end();
 }
 
 template <typename T>
-inline typename IndexMap< T >::ConstIterator IndexMap< T >::begin() const {
+inline typename IndexMap< T >::ConstIterator IndexMap< T >::begin() const
+{
     return m_data.begin();
 }
 
 template <typename T>
-inline typename IndexMap< T >::ConstIterator IndexMap< T >::end() const {
+inline typename IndexMap< T >::ConstIterator IndexMap< T >::end() const
+{
     return m_data.end();
 }
 
 template <typename T>
-inline typename IndexMap< T >::ConstIterator IndexMap< T >::cbegin() const {
+inline typename IndexMap< T >::ConstIterator IndexMap< T >::cbegin() const
+{
     return m_data.cbegin();
 }
 
 template <typename T>
-inline typename IndexMap< T >::ConstIterator IndexMap< T >::cend() const {
+inline typename IndexMap< T >::ConstIterator IndexMap< T >::cend() const
+{
     return m_data.cend();
 }
 
-/// ===============================================================================
-/// PUSH
-/// ===============================================================================
+// ===============================================================================
+// FREE LIST
+// ===============================================================================
 template < typename T >
-inline void IndexMap< T >::push_free_index( const Index& idx ) {
+inline void IndexMap< T >::push_free_index( const Index& idx )
+{
     std::deque<Index>::iterator free_it = std::lower_bound( m_free.begin(), m_free.end(), idx );
     m_free.insert( free_it, idx );
-    if( m_data.empty() ) {
+    if( m_data.empty() )
+    {
         m_free.clear();
         m_free.push_back( Index( 0 ) );
     }
 }
 
-/// ===============================================================================
-/// POP
-/// ===============================================================================
 template < typename T >
-inline bool IndexMap< T >::pop_free_index( Index& idx ) {
-    if( m_free.empty() ) {
+inline bool IndexMap< T >::pop_free_index( Index& idx )
+{
+    if( m_free.empty() )
+    {
         idx = Index::INVALID_IDX();
         return false;
     }
     idx = m_free.front();
     m_free.pop_front();
-    if( m_free.empty() ) {
+    if( m_free.empty() )
+    {
         Index next = idx + 1;
-        if( next.isValid() ) {
-            if( uint( next.getValue() ) > m_data.size() ) {
+        if( next.isValid() )
+        {
+            if( uint( next.getValue() ) > m_data.size() )
+            {
                 m_free.push_back( next );
             }
         }
     }
     return true;
 }
+
+// ===============================================================================
+// HELPER FUNCTIONS
+// ===============================================================================
 
 template<typename T>
 typename IndexMap<T>::ConstIterator IndexMap<T>::citfromIndex(const typename IndexMap<T>::ConstIndexIterator &it) const

--- a/src/Core/Index/IndexMap.inl
+++ b/src/Core/Index/IndexMap.inl
@@ -286,7 +286,7 @@ typename IndexMap<T>::Iterator IndexMap<T>::itfromIndex(const typename IndexMap<
 }
 
 template<typename T>
-size_t IndexMap<T>::idxfromIndex(const typename IndexMap::ConstIndexIterator &it) const
+size_t IndexMap<T>::idxfromIndex(const typename IndexMap<T>::ConstIndexIterator &it) const
 {
     return std::distance(m_index.cbegin(), it);
 }

--- a/src/Core/Index/IndexMap.inl
+++ b/src/Core/Index/IndexMap.inl
@@ -3,8 +3,6 @@
 namespace Ra {
 namespace Core {
 
-
-
 /// ===============================================================================
 /// CONSTRUCTOR
 /// ===============================================================================
@@ -14,29 +12,17 @@ IndexMap< T >::IndexMap() :
     m_index(),
     m_free( 1, Index( 0 ) ) { }
 
-
-
 template < typename T >
 IndexMap< T >::IndexMap( const IndexMap& id_map ) :
     m_data( id_map.m_data ),
     m_index( id_map.m_index ),
     m_free( id_map.m_free ) { }
 
-
-
-
-
-
 /// ===============================================================================
 /// DESTRUCTOR
 /// ===============================================================================
 template < typename T >
 IndexMap< T >::~IndexMap() { }
-
-
-
-
-
 
 /// ===============================================================================
 /// INSERT
@@ -55,8 +41,6 @@ inline Index IndexMap< T >::insert( const T& obj ) {
     }
     return idx;
 }
-
-
 
 template < typename T >
 inline bool IndexMap< T >::insert( const T& obj,
@@ -124,23 +108,6 @@ inline bool IndexMap< T >::remove( const Index& idx ) {
 }
 
 
-
-template < typename T >
-inline bool IndexMap< T >::remove( const uint i ) {
-    if( i >= m_data.size() ) {
-        return false;
-    }
-    push_free_index( m_index[i] );
-    m_data.erase( m_data.begin() + i );
-    m_index.erase( m_index.begin() + i );
-    return true;
-}
-
-
-
-
-
-
 /// ===============================================================================
 /// ACCESS
 /// ===============================================================================
@@ -150,16 +117,6 @@ inline const T& IndexMap< T >::at( const Index& idx ) const {
     CORE_ASSERT( it != m_index.end(), "Index not found" );
     return m_data.at( it - m_index.begin() );
 }
-
-
-
-template < typename T >
-inline const T& IndexMap< T >::at( const uint i ) const {
-    CORE_ASSERT( ( i < m_data.size() ), "Index i out of bound" );
-    return m_data.at( i );
-}
-
-
 
 template < typename T >
 inline bool IndexMap< T >::at( const Index& idx,
@@ -172,36 +129,12 @@ inline bool IndexMap< T >::at( const Index& idx,
     return true;
 }
 
-
-
-template < typename T >
-inline bool IndexMap< T >::at( const uint i,
-                               T&         obj ) const {
-    if( i >= m_data.size() ) {
-        return false;
-    }
-    obj = m_data.at( i );
-    return true;
-}
-
-
-
 template < typename T >
 inline T& IndexMap< T >::access( const Index& idx ) {
     typename std::deque< Index >::iterator it = std::find( m_index.begin(), m_index.end(), idx );
     CORE_ASSERT( ( it != m_index.end() ), "Index not found" );
     return m_data[ it - m_index.begin()  ];
 }
-
-
-
-template < typename T >
-inline T& IndexMap< T >::access( const uint i ) {
-    CORE_ASSERT( ( i < m_data.size() ) , "Index i out of bound");
-    return m_data[i];
-}
-
-
 
 template < typename T >
 inline bool IndexMap< T >::access( const Index& idx,
@@ -217,32 +150,13 @@ inline bool IndexMap< T >::access( const Index& idx,
     return true;
 }
 
-
-
-template < typename T >
-inline bool IndexMap< T >::access( const uint i,
-                                   T&         obj ) {
-    if( i >= m_data.size() ) {
-        return false;
-    }
-    obj = m_data[i];
-    return true;
-}
-
-
-
-
-
-
 /// ===============================================================================
 /// SIZE
 /// ===============================================================================
 template < typename T >
-inline uint IndexMap< T >::size() const {
+inline size_t IndexMap< T >::size() const {
     return m_data.size();
 }
-
-
 
 template < typename T >
 inline void IndexMap< T >::clear() {
@@ -252,11 +166,6 @@ inline void IndexMap< T >::clear() {
     m_free.push_back( Index( 0 ) );
 }
 
-
-
-
-
-
 /// ===============================================================================
 /// QUERY
 /// ===============================================================================
@@ -265,31 +174,23 @@ inline bool IndexMap< T >::empty() const {
     return  m_data.empty();
 }
 
-
-
 template < typename T >
 inline bool IndexMap< T >::full() const {
     return m_free.empty();
 }
 
-
-
 template < typename T >
-inline bool IndexMap< T >::contain( const Index& idx ) const {
+inline bool IndexMap< T >::contains( const Index& idx ) const {
     typename std::deque< Index >::const_iterator it = std::find( m_index.begin(), m_index.end(), idx );
     return !( it == m_index.end() );
 }
-
-
 
 template < typename T >
 inline bool IndexMap< T >::compact() const {
     size_t front = m_free.front();
     bool result = (front > m_data.size());
-    return result;;
+    return result;
 }
-
-
 
 template < typename T >
 inline Index IndexMap< T >::index( const uint i ) const {
@@ -299,22 +200,6 @@ inline Index IndexMap< T >::index( const uint i ) const {
     return m_index.at( i );
 }
 
-
-
-template < typename T >
-inline bool IndexMap< T >::index( const uint i, Index& idx ) const {
-    if( i >= m_index.size() ) {
-        return false;
-    }
-    idx = m_index.at( i );
-    return true;
-}
-
-
-
-
-
-
 /// ===============================================================================
 /// OPERATOR
 /// ===============================================================================
@@ -323,51 +208,10 @@ inline T& IndexMap< T >::operator[]( const Index& idx ) {
     return access( idx );
 }
 
-
-
-template < typename T >
-inline T& IndexMap< T >::operator[]( const uint i ) {
-    return access( i );
-}
-
 template < typename T >
 inline const T& IndexMap< T >::operator[]( const Index& idx ) const {
     return at( idx );
 }
-
-
-
-template < typename T >
-inline const T& IndexMap< T >::operator[]( const uint i ) const{
-    return at( i );
-}
-
-
-template < typename T >
-inline Index& IndexMap< T >::operator<<( const T& obj ) {
-    return insert( obj );
-}
-
-
-
-template < typename T >
-inline IndexMap< T >& IndexMap< T >::operator>>( const Index& idx ) {
-    remove( idx );
-    return *this;
-}
-
-
-
-template < typename T >
-inline IndexMap< T >& IndexMap< T >::operator>>( const uint i ) {
-    remove( i );
-    return *this;
-}
-
-
-
-
-
 
 /// ===============================================================================
 /// INDEX ITERATOR
@@ -377,17 +221,10 @@ inline typename IndexMap< T >::ConstIndexIterator IndexMap< T >::cbegin_index() 
     return m_index.cbegin();
 }
 
-
-
 template <typename T>
 inline typename IndexMap< T >::ConstIndexIterator IndexMap< T >::cend_index() const {
     return m_index.cend();
 }
-
-
-
-
-
 
 /// ===============================================================================
 /// DATA ITERATOR
@@ -397,43 +234,30 @@ inline typename IndexMap< T >::Iterator IndexMap< T >::begin() {
     return m_data.begin();
 }
 
-
-
 template <typename T>
 inline typename IndexMap< T >::Iterator IndexMap< T >::end() {
     return m_data.end();
 }
-
 
 template <typename T>
 inline typename IndexMap< T >::ConstIterator IndexMap< T >::begin() const {
     return m_data.begin();
 }
 
-
-
 template <typename T>
 inline typename IndexMap< T >::ConstIterator IndexMap< T >::end() const {
     return m_data.end();
 }
-
 
 template <typename T>
 inline typename IndexMap< T >::ConstIterator IndexMap< T >::cbegin() const {
     return m_data.cbegin();
 }
 
-
-
 template <typename T>
 inline typename IndexMap< T >::ConstIterator IndexMap< T >::cend() const {
     return m_data.cend();
 }
-
-
-
-
-
 
 /// ===============================================================================
 /// PUSH
@@ -447,11 +271,6 @@ inline void IndexMap< T >::push_free_index( const Index& idx ) {
         m_free.push_back( Index( 0 ) );
     }
 }
-
-
-
-
-
 
 /// ===============================================================================
 /// POP
@@ -474,9 +293,6 @@ inline bool IndexMap< T >::pop_free_index( Index& idx ) {
     }
     return true;
 }
-
-
-
 
 } // namespace Core
 } // namespace Ra

--- a/src/Core/Index/IndexMap.inl
+++ b/src/Core/Index/IndexMap.inl
@@ -286,7 +286,7 @@ typename IndexMap<T>::Iterator IndexMap<T>::itfromIndex(const typename IndexMap<
 }
 
 template<typename T>
-size_t IndexMap<T>::idxfromIndex(const IndexMap::ConstIndexIterator &it) const
+size_t IndexMap<T>::idxfromIndex(const typename IndexMap::ConstIndexIterator &it) const
 {
     return std::distance(m_index.cbegin(), it);
 }

--- a/src/Core/Mesh/DCEL/Dcel.cpp
+++ b/src/Core/Mesh/DCEL/Dcel.cpp
@@ -39,7 +39,7 @@ Dcel::Dcel( const Dcel& dcel ) :
     for( uint i = 0; i < dcel.m_vertex.size(); ++i ) {
         Vertex_ptr dcel_v = dcel.m_vertex.at( i );
         Vertex_ptr v      = Ra::Core::make_shared< Vertex >( dcel_v->P(), dcel_v->N() );
-        m_vertex.insert( v, v->idx );
+        v->idx = m_vertex.insert( v );
         v_table[dcel_v->idx] = v->idx;
     }
 
@@ -47,7 +47,7 @@ Dcel::Dcel( const Dcel& dcel ) :
     for( uint i = 0; i < dcel.m_halfedge.size(); ++i ) {
         HalfEdge_ptr dcel_he = dcel.m_halfedge.at( i );
         HalfEdge_ptr he      = Ra::Core::make_shared< HalfEdge >( m_vertex[v_table[dcel_he->V()->idx]] );
-        m_halfedge.insert( he, he->idx );
+        he->idx = m_halfedge.insert( he );
         he_table[dcel_he->idx] = he->idx;
     }
 
@@ -55,7 +55,7 @@ Dcel::Dcel( const Dcel& dcel ) :
     for( uint i = 0; i < dcel.m_face.size(); ++i ) {
         Face_ptr dcel_f = dcel.m_face.at( i );
         Face_ptr f      = Ra::Core::make_shared< Face >( m_halfedge[he_table[dcel_f->HE()->idx]] );
-        m_face.insert( f, f->idx );
+        f->idx = m_face.insert( f );
         f_table[dcel_f->idx] = f->idx;
     }
 
@@ -74,7 +74,7 @@ Dcel::Dcel( const Dcel& dcel ) :
     for( uint i = 0; i < dcel.m_fulledge.size(); ++i ) {
         FullEdge_ptr dcel_fe = dcel.m_fulledge.at( i );
         FullEdge_ptr fe      = Ra::Core::make_shared< FullEdge >( m_halfedge[he_table[dcel_fe->HE( 0 )->idx]] );
-        m_fulledge.insert( fe, fe->idx );
+        fe->idx = m_fulledge.insert( fe );
         fe->HE( 0 )->Twin()->setFE( fe );
     }
 }

--- a/src/Core/Mesh/DCEL/Dcel.hpp
+++ b/src/Core/Mesh/DCEL/Dcel.hpp
@@ -33,7 +33,6 @@ public:
 
     /// QUERY
     inline bool empty() const;
-    inline bool compact() const;
 
     /// VARIABLE
     IndexMap< Vertex_ptr >   m_vertex;   // Vertices  Data

--- a/src/Core/Mesh/DCEL/Dcel.inl
+++ b/src/Core/Mesh/DCEL/Dcel.inl
@@ -24,16 +24,6 @@ inline bool Dcel::empty() const {
 }
 
 
-
-inline bool Dcel::compact() const {
-    return ( m_vertex.compact()   &&
-             m_halfedge.compact() &&
-             m_fulledge.compact() &&
-             m_face.compact() );
-}
-
-
-
 } // namespace Core
 } // namespace Ra
 

--- a/src/Core/Mesh/DCEL/Operations/EdgeSplit.cpp
+++ b/src/Core/Mesh/DCEL/Operations/EdgeSplit.cpp
@@ -107,15 +107,15 @@ void splitEdge( Dcel& dcel, Index edgeIndex, Scalar fraction )
     HalfEdge_ptr BV2 = V1B->Next();
 
     // Insert new elements
-    dcel.m_vertex.insert( vm , vm->idx );
+    vm->idx = dcel.m_vertex.insert( vm );
 
-    dcel.m_halfedge.insert( he2, he2->idx );
-    dcel.m_halfedge.insert( he3, he3->idx );
+    he2->idx = dcel.m_halfedge.insert( he2 );
+    he3->idx = dcel.m_halfedge.insert( he3 );
 
-    dcel.m_fulledge.insert( fe1, fe1->idx );
+    fe1->idx = dcel.m_fulledge.insert( fe1 );
 
-    dcel.m_face.insert( f2, f2->idx );
-    dcel.m_face.insert( f3, f3->idx );
+    f2->idx = dcel.m_face.insert( f2 );
+    f3->idx = dcel.m_face.insert( f3 );
 
     // Fixup all pointers.
 

--- a/src/Core/Mesh/Wrapper/Convert.cpp
+++ b/src/Core/Mesh/Wrapper/Convert.cpp
@@ -63,7 +63,7 @@ void convert( const TriangleMesh& mesh, Dcel& dcel ) {
         // Create the connections
         for( uint i = 0; i < 3; ++i ) {
 
-            CORE_ASSERT( dcel.m_vertex.contain( t[i] ), "vertex not found" );
+            CORE_ASSERT( dcel.m_vertex.contains( t[i] ), "vertex not found" );
 
             Vertex_ptr& v = dcel.m_vertex[ t[i] ];
             v->setHE( he[i] );
@@ -83,7 +83,7 @@ void convert( const TriangleMesh& mesh, Dcel& dcel ) {
             } else {
                 // If found, set it and erase it
 
-                CORE_ASSERT( dcel.m_halfedge.contain(it->second), "Map error");
+                CORE_ASSERT( dcel.m_halfedge.contains(it->second), "Map error");
                 CORE_ASSERT(dcel.m_halfedge[it->second]->idx == it->second, "Map error");
                 he[i]->setTwin( dcel.m_halfedge[it->second] );
                 dcel.m_halfedge[it->second]->setTwin( he[i] );

--- a/src/Core/Mesh/Wrapper/Convert.cpp
+++ b/src/Core/Mesh/Wrapper/Convert.cpp
@@ -43,8 +43,9 @@ void convert( const TriangleMesh& mesh, Dcel& dcel ) {
         Vector3 n = mesh.m_normals.at( i );
         Vertex_ptr v = std::shared_ptr< Vertex >( new Vertex( p, n ) );
         CORE_ASSERT( ( v != nullptr ), "Vertex_ptr == nullptr" );
-        ON_ASSERT( bool result = ) dcel.m_vertex.insert( v, v->idx );
-        CORE_ASSERT(result , "Vertex not inserted" );
+        v->idx = dcel.m_vertex.insert(v);
+
+        CORE_ASSERT(v->idx.isValid(), "Vertex not inserted" );
     }
     /// TWIN DATA
     std::map< Twin, Index > he_table;
@@ -59,7 +60,9 @@ void convert( const TriangleMesh& mesh, Dcel& dcel ) {
         // Create the face
         Face_ptr f = Ra::Core::make_shared< Face >( he[0] );
         CORE_ASSERT( ( f != nullptr ), "Face_ptr == nullptr" );
-        CORE_ASSERT( dcel.m_face.insert( f, f->idx ), "Face not inserted" );
+        f->idx = dcel.m_face.insert( f);
+        CORE_ASSERT( f->idx.isValid(), "Face not inserted" );
+
         // Create the connections
         for( uint i = 0; i < 3; ++i ) {
 
@@ -71,8 +74,8 @@ void convert( const TriangleMesh& mesh, Dcel& dcel ) {
             he[i]->setNext( he[( i + 1 ) % 3] );
             he[i]->setPrev( he[( i + 2 ) % 3] );
             he[i]->setF( f );
-            ON_ASSERT( bool result = ) dcel.m_halfedge.insert( he[i], he[i]->idx );
-            CORE_ASSERT( result, "HalfEdge not inserted" );
+            he[i]->idx = dcel.m_halfedge.insert( he[i] );
+            CORE_ASSERT( he[i]->idx.isValid(), "HalfEdge not inserted" );
             /// TWIN SEARCH
             Twin twin( t[i], t[( i + 1 ) % 3]);
             // Search the right twin
@@ -90,8 +93,9 @@ void convert( const TriangleMesh& mesh, Dcel& dcel ) {
                 // Create the fulledge
                 FullEdge_ptr fe = std::shared_ptr< FullEdge >( new FullEdge( he[i] ) );
                 CORE_ASSERT( ( fe != nullptr ), "FullEdge_ptr == nullptr" );
-                ON_ASSERT( bool result =) dcel.m_fulledge.insert( fe, fe->idx );
-                CORE_ASSERT(result,  "FullEdge not inserted" );
+
+                fe->idx = dcel.m_fulledge.insert( fe);
+                CORE_ASSERT(fe->idx.isValid(),  "FullEdge not inserted" );
                 he[i]->setFE( fe );
                 he[i]->Twin()->setFE( fe );
                 he_table.erase( it );

--- a/src/Engine/Managers/EntityManager/EntityManager.cpp
+++ b/src/Engine/Managers/EntityManager/EntityManager.cpp
@@ -59,7 +59,7 @@ namespace Ra
 
         void EntityManager::removeEntity( Core::Index idx )
         {
-            CORE_ASSERT( idx != Core::Index::INVALID_IDX() && m_entities.contain( idx ),
+            CORE_ASSERT( idx != Core::Index::INVALID_IDX() && m_entities.contains( idx ),
                          "Trying to remove an entity that has not been added to the manager." );
 
             auto& ent = m_entities[idx];
@@ -79,7 +79,7 @@ namespace Ra
 
             Entity* ent = nullptr;
 
-            if ( m_entities.contain( idx ) )
+            if ( m_entities.contains( idx ) )
             {
                 ent = m_entities[idx].get();
             }

--- a/src/Engine/Renderer/RenderObject/RenderObjectManager.cpp
+++ b/src/Engine/Renderer/RenderObject/RenderObjectManager.cpp
@@ -26,7 +26,7 @@ namespace Ra
         bool RenderObjectManager::exists( const Core::Index& index ) const
         {
             return (index != Core::Index::INVALID_IDX()) &&
-                    m_renderObjects.contain( index );
+                    m_renderObjects.contains( index );
         }
 
         Core::Index RenderObjectManager::addRenderObject( RenderObject* renderObject )

--- a/src/Tests/CoreTests/Containers/IndexMapTest.hpp
+++ b/src/Tests/CoreTests/Containers/IndexMapTest.hpp
@@ -1,0 +1,160 @@
+#ifndef RADIUM_INDEXMAP_TEST_HPP_
+#define RADIUM_INDEXMAP_TEST_HPP_
+
+#include <Tests/CoreTests/Tests.hpp>
+#include <Core/Index/IndexMap.hpp>
+
+namespace RaTests
+{
+using Ra::Core::Index;
+using Ra::Core::IndexMap;
+
+// Just a standard test structure
+struct Foo
+{
+    Foo(int x) : value(x) {}
+    int value;
+};
+
+// A non-copyable move semantics struct
+struct NonCopy
+{
+    NonCopy(int x) : value(x) {}
+    NonCopy(NonCopy&& other)
+    {
+        value = other.value;
+        other.value = 0;
+    }
+    NonCopy& operator= ( NonCopy&& other)
+    {
+        value = other.value;
+        other.value = 0;
+        return *this;
+    }
+
+    int value;
+
+private:
+    NonCopy(const NonCopy&) = delete;
+    NonCopy& operator= ( const NonCopy&) = delete;
+};
+
+class IndexMapTest : public Test
+{
+    void run() override
+    {
+        {
+            IndexMap<Foo> map1;
+
+            // Sanity checks
+            RA_UNIT_TEST(map1.empty(), "New map should be empty");
+            RA_UNIT_TEST(map1.size() == 0, "New map should be empty (size)");
+            RA_UNIT_TEST(!map1.full(), "New map should not be full");
+
+            // Inserting
+            Index i1 =  map1.insert( Foo(12));
+            RA_UNIT_TEST(i1.isValid(), "Insert");
+
+            // We expect to have one element now.
+            RA_UNIT_TEST(!map1.empty(), "Map should be non-empty");
+            RA_UNIT_TEST(map1.size() == 1, "Size is wrong");
+
+            // Test value read and write
+            RA_UNIT_TEST(map1.at(i1).value == 12, "map read (at)" );
+            RA_UNIT_TEST(map1[i1].value == 12, "map read (operator[])" );
+
+            map1.access(i1).value = 24;
+            RA_UNIT_TEST(map1.at(i1).value == 24, "map write (access)" );
+
+            map1[i1].value = 32;
+            RA_UNIT_TEST(map1.at(i1).value == 32, "map write (operator[])" );
+
+            // Inserting a second element
+            Index i2 = map1.insert( Foo(42) );
+            RA_UNIT_TEST(map1.at(i2).value == 42, "map read " );
+            RA_UNIT_TEST(map1.size() == 2, "Size is wrong");
+
+            // Test range-based for loop (relies on iterators)
+            uint counter = 0;
+            for (const Foo& f : map1)
+            {
+                RA_UNIT_TEST(f.value == 32 || f.value == 42, "Invalid value (const loop)");
+                ++counter;
+            }
+            RA_UNIT_TEST(counter == 2, "Range-for invalid count (const loop)");
+
+            // Test non-const loop
+            counter = 0;
+            for (Foo& f : map1)
+            {
+                f.value = 2* f.value;
+                RA_UNIT_TEST(f.value == 2* 32 || f.value == 2*42, "Invalid value (non-const loop)");
+                ++counter;
+            }
+            RA_UNIT_TEST(counter == 2, "Range-for invalid count( non-const loop)");
+
+            // Test index iterators
+            counter = 0;
+            for (auto it = map1.cbegin_index();
+                 it != map1.cend_index();
+                 ++it)
+            {
+                RA_UNIT_TEST(*it == i1 || *it == i2, "Invalid index (index loop)");
+                ++counter;
+            }
+
+            // Test 'contains'
+            RA_UNIT_TEST(map1.contains(i1), "map contains");
+            RA_UNIT_TEST(map1.contains(i2), "map contains");
+            RA_UNIT_TEST(!map1.contains(Index(12000)), "Map contains");
+
+            // Remove an item once.
+            bool result = map1.remove(i1);
+            RA_UNIT_TEST(result, "Map remove (auto index)");
+            RA_UNIT_TEST(map1.size() == 1, "Map remove (size)");
+
+            // Removing it twice should not work.
+            result = map1.remove(i1);
+            RA_UNIT_TEST(!result, "Map remove (twice)");
+
+            // Remove the other item
+            result = map1.remove(Index(1000));
+            RA_UNIT_TEST(!result, "Map remove (non-exitent index)");
+
+
+            result = map1.remove(i2);
+            RA_UNIT_TEST(result, "Map remove");
+
+            RA_UNIT_TEST( map1.size() == 0, "Map should be empty (size)");
+            RA_UNIT_TEST( map1.empty(),  "Map should be empty");
+        }
+
+        // Now try to insert non-copyable elements
+        {
+            IndexMap<NonCopy> map2;
+            Index i1 = map2.emplace(std::move(12));
+            RA_UNIT_TEST( i1.isValid(), "map insert (inplace)");
+
+
+            Index i2 = map2.emplace(std::move(42));
+            RA_UNIT_TEST( i2.isValid(), "map insert (inplace)");
+
+            RA_UNIT_TEST( map2[i1].value == 12, "map access(inplace)");
+            RA_UNIT_TEST( map2[i2].value == 42, "map access(inplace)");
+
+
+            // Test the clear function
+            map2.clear();
+            RA_UNIT_TEST(map2.size() == 0, "map clear (size)");
+            RA_UNIT_TEST(map2.empty(), "map clear (empty)");
+
+        }
+    }
+};
+RA_TEST_CLASS(IndexMapTest);
+
+}
+
+
+#endif //RADIUM_INDEXMAP_TEST_HPP_
+

--- a/src/Tests/CoreTests/main.cpp
+++ b/src/Tests/CoreTests/main.cpp
@@ -4,6 +4,7 @@
 #include <Tests/CoreTests/Geometry/GeometryTests.hpp>
 #include <Tests/CoreTests/RayCasts/RayCastTest.hpp>
 #include <Tests/CoreTests/String/StringTest.hpp>
+#include <Tests/CoreTests/Containers/IndexMapTest.hpp>
 
 int main()
 {


### PR DESCRIPTION
The changelist you were all waiting for ! The refactor of `Core::IndexMap` as requested in issue #158.

This amazing changelist includes removal of dead code or duplicate functions. No need from the `bool`-returning `insert()` functions when the regular `insert()` function already signifies failure by returning an invalid index.

Also this changelist includes a ❤️  🏅 🍰  🦄 **unit test** 😄 🎉 🎈 🎂  ! 

Please review it with all your courage and love !