### PR TITLE
Add support for dynamic renderer addition and swap

### DIFF
--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -352,8 +352,11 @@ namespace Ra
 
     void Gui::MainWindow::onCurrentRenderChangedInUI()
     {
+        // always restore displaytexture to 0 before switch to keep coherent renderer state
         m_displayedTextureCombo->setCurrentIndex(0);
         m_viewer->changeRenderer(m_currentRendererCombo->currentIndex());
+        // in case the newly used renderer has not been set before and set another texture as its default,
+        // set displayTexture to 0 again ;)
         m_displayedTextureCombo->setCurrentIndex(0);
     }
 

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -1,5 +1,4 @@
 #include <Engine/Renderer/Renderers/ForwardRenderer.hpp>
-#include <Engine/Renderer/Renderers/ExperimentalRenderer.hpp>
 
 #include <Gui/MainWindow.hpp>
 
@@ -132,6 +131,7 @@ namespace Ra
                 this, &MainWindow::changeRenderer);
 
         connect(m_viewer, &Viewer::glInitialized, this, &MainWindow::onGLInitialized);
+        connect(m_viewer, SIGNAL(glInitialized()), this, SIGNAL(glInitialized()));
         connect(m_viewer, &Viewer::rendererReady, this, &MainWindow::onRendererReady);
 
         connect(m_displayedTextureCombo,
@@ -468,9 +468,9 @@ namespace Ra
     }
 
     void Gui::MainWindow::addRenderer(std::string name,
-                                      std::unique_ptr<Engine::Renderer>&& e)
+                                      Engine::Renderer* e)
     {
-        int id = m_viewer->addRenderer(std::move(e));
+        int id = m_viewer->addRenderer(e);
         CORE_UNUSED( id );
         CORE_ASSERT (id == m_currentRendererCombo->count(), "Inconsistent renderer state");
         m_currentRendererCombo->addItem(QString::fromStdString(name));
@@ -571,8 +571,7 @@ namespace Ra
     void Gui::MainWindow::onGLInitialized()
     {
         // set renderers once OpenGL is configured
-        addRenderer("Forward", std::unique_ptr<Engine::Renderer>(new Engine::ForwardRenderer()));
-        addRenderer("Experimental", std::unique_ptr<Engine::Renderer>(new Engine::ExperimentalRenderer()));
+        addRenderer("Forward Renderer", new Engine::ForwardRenderer());
     }
 
     void Gui::MainWindow::updateTrackedFeatureInfo()

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -470,7 +470,7 @@ namespace Ra
     }
 
     void Gui::MainWindow::addRenderer(std::string name,
-                                      Engine::Renderer* e)
+                                      std::shared_ptr<Engine::Renderer> e)
     {
         int id = m_viewer->addRenderer(e);
         CORE_UNUSED( id );
@@ -573,7 +573,8 @@ namespace Ra
     void Gui::MainWindow::onGLInitialized()
     {
         // set renderers once OpenGL is configured
-        addRenderer("Forward Renderer", new Engine::ForwardRenderer());
+        std::shared_ptr<Engine::Renderer> e (new Engine::ForwardRenderer());
+        addRenderer("Forward Renderer", e);
     }
 
     void Gui::MainWindow::updateTrackedFeatureInfo()

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -125,10 +125,9 @@ namespace Ra
         connect(m_fitCameraButton, &QPushButton::clicked, this, &MainWindow::fitCamera);
 
         // Renderer stuff
-
         connect(m_currentRendererCombo,
                 static_cast<void (QComboBox::*)(const QString&)>( &QComboBox::currentIndexChanged ),
-                this, &MainWindow::changeRenderer);
+                [=]( const QString& ) { this->onCurrentRenderChangedInUI(); } );
 
         connect(m_viewer, &Viewer::glInitialized, this, &MainWindow::onGLInitialized);
         connect(m_viewer, SIGNAL(glInitialized()), this, SIGNAL(glInitialized()));
@@ -351,7 +350,7 @@ namespace Ra
         }
     }
 
-    void Gui::MainWindow::changeRenderer(const QString& rendererName)
+    void Gui::MainWindow::onCurrentRenderChangedInUI()
     {
         m_displayedTextureCombo->setCurrentIndex(0);
         m_viewer->changeRenderer(m_currentRendererCombo->currentIndex());

--- a/Applications/MainApplication/Gui/MainWindow.hpp
+++ b/Applications/MainApplication/Gui/MainWindow.hpp
@@ -69,6 +69,9 @@ namespace Ra
             /// Update the UI ( most importantly gizmos ) to the modifications of the engine/
             void onFrameComplete();
 
+            // Add render in the application: UI, viewer.
+            void addRenderer(std::string name, std::unique_ptr<Engine::Renderer>&& e);
+
         public slots:
             /// Callback to rebuild the item model when the engine objects change.
             void onItemAdded( const Engine::ItemEntry& ent );
@@ -145,6 +148,9 @@ namespace Ra
             void on_m_vertexIdx_valueChanged(int arg1);
             void on_m_triangleIdx_valueChanged(int arg1);
 
+            // Slot to init renderers once gl is ready
+            void onGLInitialized();
+
             /// Slot to accept a new renderer
             void onRendererReady();
 
@@ -156,11 +162,6 @@ namespace Ra
 
             /// Clears all entities and resets the camera.
             void resetScene();
-
-            /// Change the Renderer
-            void on_actionForward_triggered();
-            void on_actionDeferred_triggered();
-            void on_actionExperimental_triggered();
 
         private:
             /// Stores the internal model of engine objects for selection.

--- a/Applications/MainApplication/Gui/MainWindow.hpp
+++ b/Applications/MainApplication/Gui/MainWindow.hpp
@@ -70,7 +70,7 @@ namespace Ra
             void onFrameComplete();
 
             // Add render in the application: UI, viewer.
-            void addRenderer(std::string name, std::unique_ptr<Engine::Renderer>&& e);
+            void addRenderer(std::string name, Engine::Renderer *e);
 
         public slots:
             /// Callback to rebuild the item model when the engine objects change.
@@ -118,6 +118,9 @@ namespace Ra
 
             /// Emitted when a new item is selected. An invalid entry is sent when no item is selected.
             void selectedItem( const Engine::ItemEntry& entry );
+
+            /// Emitted when GL is correclty initialized (forwarded from Viewer)
+            void glInitialized();
 
         private:
             /// Connect qt signals and slots. Called once by the constructor.

--- a/Applications/MainApplication/Gui/MainWindow.hpp
+++ b/Applications/MainApplication/Gui/MainWindow.hpp
@@ -142,7 +142,7 @@ namespace Ra
             void changeRenderObjectShader(const QString& shaderName);
 
             /// Slot for the user changing the current renderer
-            void changeRenderer(const QString& rendererName);
+            void onCurrentRenderChangedInUI();
 
             /// Slot for the picking results from the viewer.
             void handlePicking(int pickingResult);

--- a/Applications/MainApplication/Gui/MainWindow.hpp
+++ b/Applications/MainApplication/Gui/MainWindow.hpp
@@ -70,7 +70,7 @@ namespace Ra
             void onFrameComplete();
 
             // Add render in the application: UI, viewer.
-            void addRenderer(std::string name, Engine::Renderer *e);
+            void addRenderer(std::string name, std::shared_ptr<Engine::Renderer> e);
 
         public slots:
             /// Callback to rebuild the item model when the engine objects change.

--- a/Applications/MainApplication/Gui/ui/MainWindow.ui
+++ b/Applications/MainApplication/Gui/ui/MainWindow.ui
@@ -69,24 +69,9 @@
     <addaction name="separator"/>
     <addaction name="actionLoad_configuration_file"/>
    </widget>
-   <widget class="QMenu" name="menuRendering">
-    <property name="title">
-     <string>Rendering</string>
-    </property>
-    <widget class="QMenu" name="menuRenderers">
-     <property name="title">
-      <string>Renderers</string>
-     </property>
-     <addaction name="actionForward"/>
-     <addaction name="actionDeferred"/>
-     <addaction name="actionExperimental"/>
-    </widget>
-    <addaction name="menuRenderers"/>
-   </widget>
    <addaction name="menuFILE"/>
    <addaction name="menuMisc"/>
    <addaction name="menuKeymapping"/>
-   <addaction name="menuRendering"/>
   </widget>
   <widget class="QDockWidget" name="dockWidget">
    <attribute name="dockWidgetArea">
@@ -553,25 +538,22 @@
          </layout>
         </item>
         <item>
-         <layout class="QGridLayout" name="gridLayout_3" rowstretch="0,0,0,0" columnstretch="1,0">
-          <item row="0" column="0">
+         <layout class="QGridLayout" name="gridLayout_3" rowstretch="0,0,0,0,0" columnstretch="1,0">
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Enable Debug Drawing</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
            <widget class="QLabel" name="label_2">
             <property name="text">
              <string>Displayed Texture</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="m_displayedTextureCombo"/>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Enable Post-Process</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <widget class="QCheckBox" name="m_enablePostProcess">
             <property name="enabled">
              <bool>true</bool>
@@ -587,14 +569,23 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_6">
+          <item row="4" column="1">
+           <widget class="QCheckBox" name="m_realFrameRate">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
             <property name="text">
-             <string>Enable Debug Drawing</string>
+             <string/>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+            <property name="tristate">
+             <bool>false</bool>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QCheckBox" name="m_enableDebugDraw">
             <property name="enabled">
              <bool>true</bool>
@@ -610,28 +601,32 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Enable Post-Process</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
            <widget class="QLabel" name="label_7">
             <property name="text">
              <string>Variable Frame Rate</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
-           <widget class="QCheckBox" name="m_realFrameRate">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="m_displayedTextureCombo"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_8">
             <property name="text">
-             <string/>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-            <property name="tristate">
-             <bool>false</bool>
+             <string>Current Renderer</string>
             </property>
            </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="m_currentRendererCombo"/>
           </item>
          </layout>
         </item>
@@ -789,39 +784,6 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+O</string>
-   </property>
-  </action>
-  <action name="actionForward">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Forward</string>
-   </property>
-  </action>
-  <action name="actionDeferred">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>Deferred</string>
-   </property>
-  </action>
-  <action name="actionExperimental">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>Experimental</string>
    </property>
   </action>
  </widget>

--- a/Applications/MainApplication/MainApplication.cpp
+++ b/Applications/MainApplication/MainApplication.cpp
@@ -497,6 +497,18 @@ namespace Ra
                         ++pluginCpt;
                         loadedPlugin->registerPlugin( context );
                         m_mainWindow->updateUi( loadedPlugin );
+
+                        if(loadedPlugin->doAddRenderer())
+                        {
+                            std::vector<Engine::Renderer*> tmpR;
+                            loadedPlugin->addRenderers(&tmpR);
+                            CORE_ASSERT(! tmpR.empty(), "This plugin is expected to add a renderer");
+                            for(auto ptr : tmpR){
+                                std::string name = ptr->getRendererName()
+                                        + "(" + filename.toStdString() +  ")";
+                                m_mainWindow->addRenderer(name, ptr);
+                            }
+                        }
                     }
                     else
                     {

--- a/Applications/MainApplication/MainApplication.cpp
+++ b/Applications/MainApplication/MainApplication.cpp
@@ -500,7 +500,7 @@ namespace Ra
 
                         if(loadedPlugin->doAddRenderer())
                         {
-                            std::vector<Engine::Renderer*> tmpR;
+                            std::vector<std::shared_ptr<Engine::Renderer>> tmpR;
                             loadedPlugin->addRenderers(&tmpR);
                             CORE_ASSERT(! tmpR.empty(), "This plugin is expected to add a renderer");
                             for(auto ptr : tmpR){

--- a/Plugins/Animation/src/AnimationComponent.cpp
+++ b/Plugins/Animation/src/AnimationComponent.cpp
@@ -184,7 +184,7 @@ namespace AnimationPlugin
                 for( uint j = 0; j < handleAnim.size(); ++j ) {
                     if( m_skel.getLabel( i ) == handleAnim[j].m_name ) {
                         table[j] = i;
-                        auto set = std::move( handleAnim[j].m_anim.timeSchedule() );
+                        auto set = handleAnim[j].m_anim.timeSchedule();
                         keyTime.insert( set.begin(), set.end() );
                     }
                 }

--- a/Plugins/Animation/src/AnimationComponent.hpp
+++ b/Plugins/Animation/src/AnimationComponent.hpp
@@ -29,7 +29,7 @@ namespace AnimationPlugin
             m_dt(),
             m_speed( 1.0 ),
             m_slowMo( false ),
-            m_selectedBone(-1),
+//            m_selectedBone(-1),
             m_wasReset(false),
             m_resetDone(false)
         {}
@@ -82,7 +82,7 @@ namespace AnimationPlugin
 
         void setWeights (Ra::Core::Animation::WeightMatrix m);
 
-        
+
         // Component communication
         void setContentName (const std::string name);
         void setupIO( const std::string& id );
@@ -118,7 +118,7 @@ namespace AnimationPlugin
         Scalar m_speed;
         bool   m_slowMo;
 
-        int m_selectedBone;
+//        int m_selectedBone;
         bool m_wasReset;
         bool m_resetDone;
     };

--- a/src/Engine/Renderer/Renderer.cpp
+++ b/src/Engine/Renderer/Renderer.cpp
@@ -45,9 +45,9 @@ namespace Ra
             };
         }
 
-        Renderer::Renderer( uint width, uint height )
-            : m_width( width )
-            , m_height( height )
+        Renderer::Renderer( )
+            : m_width( 0 )
+            , m_height( 0 )
             , m_shaderMgr( nullptr )
             , m_displayedTexture( nullptr )
             , m_renderQueuesUpToDate( false )
@@ -64,8 +64,11 @@ namespace Ra
             ShaderProgramManager::destroyInstance();
         }
 
-        void Renderer::initialize()
+        void Renderer::initialize(uint width, uint height)
         {
+            m_width  = width;
+            m_height = height;
+
             // Initialize managers
             m_shaderMgr = ShaderProgramManager::getInstance();
             m_roMgr = RadiumEngine::getInstance()->getRenderObjectManager();
@@ -437,7 +440,7 @@ namespace Ra
             GL_CHECK_ERROR;
 
             resizeInternal();
-            
+
             glDrawBuffer( GL_BACK ) ;
             glReadBuffer( GL_BACK ) ;
 

--- a/src/Engine/Renderer/Renderer.hpp
+++ b/src/Engine/Renderer/Renderer.hpp
@@ -87,7 +87,7 @@ namespace Ra
             };
 
         public:
-            Renderer( uint width, uint height );
+            Renderer();
             virtual ~Renderer();
 
             // -=-=-=-=-=-=-=-=- FINAL -=-=-=-=-=-=-=-=- //
@@ -153,7 +153,7 @@ namespace Ra
             /**
              * @brief Initialize renderer
              */
-            virtual void initialize() final;
+            virtual void initialize(uint width, uint height) final;
 
             /**
              * @brief Resize the viewport and all the screen textures, fbos.

--- a/src/Engine/Renderer/Renderers/ExperimentalRenderer.cpp
+++ b/src/Engine/Renderer/Renderers/ExperimentalRenderer.cpp
@@ -45,8 +45,8 @@ namespace Ra
             };
         }
 
-        ExperimentalRenderer::ExperimentalRenderer( uint width, uint height )
-            : Renderer(width, height)
+        ExperimentalRenderer::ExperimentalRenderer( )
+            : Renderer()
         {
             LOG(logINFO) << "Building an  ExperimentalRenderer ";
         }
@@ -56,7 +56,7 @@ namespace Ra
             LOG(logINFO) << "Deleting an  ExperimentalRenderer ";
         }
 
-        void ExperimentalRenderer::initializeInternal()        
+        void ExperimentalRenderer::initializeInternal()
         {
             LOG(logINFO) << "ExperimentalRenderer::initializeInternal ";
         }

--- a/src/Engine/Renderer/Renderers/ExperimentalRenderer.cpp
+++ b/src/Engine/Renderer/Renderers/ExperimentalRenderer.cpp
@@ -32,17 +32,17 @@ namespace Ra
 
         namespace
         {
-            const GLenum buffers[] =
-            {
-                GL_COLOR_ATTACHMENT0,
-                GL_COLOR_ATTACHMENT1,
-                GL_COLOR_ATTACHMENT2,
-                GL_COLOR_ATTACHMENT3,
-                GL_COLOR_ATTACHMENT4,
-                GL_COLOR_ATTACHMENT5,
-                GL_COLOR_ATTACHMENT6,
-                GL_COLOR_ATTACHMENT7
-            };
+//            const GLenum buffers[] =
+//            {
+//                GL_COLOR_ATTACHMENT0,
+//                GL_COLOR_ATTACHMENT1,
+//                GL_COLOR_ATTACHMENT2,
+//                GL_COLOR_ATTACHMENT3,
+//                GL_COLOR_ATTACHMENT4,
+//                GL_COLOR_ATTACHMENT5,
+//                GL_COLOR_ATTACHMENT6,
+//                GL_COLOR_ATTACHMENT7
+//            };
         }
 
         ExperimentalRenderer::ExperimentalRenderer( )

--- a/src/Engine/Renderer/Renderers/ExperimentalRenderer.hpp
+++ b/src/Engine/Renderer/Renderers/ExperimentalRenderer.hpp
@@ -13,7 +13,7 @@ namespace Ra
         class RA_ENGINE_API ExperimentalRenderer : public Renderer
         {
         public:
-            ExperimentalRenderer( uint width, uint height );
+            ExperimentalRenderer( uint width = 0, uint height = 0);
             virtual ~ExperimentalRenderer();
 
             virtual std::string getRendererName() const override { return "Experimental Renderer (Mathias)"; }
@@ -53,7 +53,7 @@ namespace Ra
             std::unique_ptr<globjects::Framebuffer> m_fbo;
             std::unique_ptr<globjects::Framebuffer> m_postprocessFbo;
             std::unique_ptr<globjects::Framebuffer> m_oitFbo;
-            
+
             std::vector<RenderObjectPtr> m_transparentRenderObjects;
             uint m_fancyTransparentCount;
 

--- a/src/Engine/Renderer/Renderers/ExperimentalRenderer.hpp
+++ b/src/Engine/Renderer/Renderers/ExperimentalRenderer.hpp
@@ -13,7 +13,7 @@ namespace Ra
         class RA_ENGINE_API ExperimentalRenderer : public Renderer
         {
         public:
-            ExperimentalRenderer( uint width = 0, uint height = 0);
+            ExperimentalRenderer( );
             virtual ~ExperimentalRenderer();
 
             virtual std::string getRendererName() const override { return "Experimental Renderer (Mathias)"; }

--- a/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
+++ b/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
@@ -50,8 +50,8 @@ namespace Ra
             };
         }
 
-        ForwardRenderer::ForwardRenderer( uint width, uint height )
-            : Renderer(width, height)
+        ForwardRenderer::ForwardRenderer( )
+            : Renderer()
         {
 
         }

--- a/src/Engine/Renderer/Renderers/ForwardRenderer.hpp
+++ b/src/Engine/Renderer/Renderers/ForwardRenderer.hpp
@@ -21,7 +21,7 @@ namespace Ra
         class RA_ENGINE_API ForwardRenderer : public Renderer
         {
         public:
-            ForwardRenderer( uint width = 0, uint height = 0 );
+            ForwardRenderer();
             virtual ~ForwardRenderer();
 
             virtual std::string getRendererName() const override { return "Forward Renderer"; }

--- a/src/Engine/Renderer/Renderers/ForwardRenderer.hpp
+++ b/src/Engine/Renderer/Renderers/ForwardRenderer.hpp
@@ -21,7 +21,7 @@ namespace Ra
         class RA_ENGINE_API ForwardRenderer : public Renderer
         {
         public:
-            ForwardRenderer( uint width, uint height );
+            ForwardRenderer( uint width = 0, uint height = 0 );
             virtual ~ForwardRenderer();
 
             virtual std::string getRendererName() const override { return "Forward Renderer"; }
@@ -61,7 +61,7 @@ namespace Ra
             std::unique_ptr<globjects::Framebuffer> m_fbo;
             std::unique_ptr<globjects::Framebuffer> m_postprocessFbo;
             std::unique_ptr<globjects::Framebuffer> m_oitFbo;
-            
+
             std::vector<RenderObjectPtr> m_transparentRenderObjects;
             uint m_fancyTransparentCount;
 

--- a/src/Engine/Renderer/Texture/Texture.cpp
+++ b/src/Engine/Renderer/Texture/Texture.cpp
@@ -5,8 +5,8 @@
 namespace Ra
 {
     Engine::Texture::Texture(std::string name)
-        : m_textureId(0)
-        , m_name(name)
+        : /*m_textureId(0)
+        , */m_name(name)
         , m_texture(nullptr)
     {
     }
@@ -105,7 +105,7 @@ namespace Ra
     {
         if( unit >= 0 )
         {
-            m_texture->bindActive( unit );            
+            m_texture->bindActive( unit );
         }
         else
         {

--- a/src/Engine/Renderer/Texture/Texture.hpp
+++ b/src/Engine/Renderer/Texture/Texture.hpp
@@ -204,7 +204,7 @@ namespace Ra
             void operator= ( const Texture& ) = delete;
 
         private:
-            uint m_textureId;
+//            uint m_textureId;
             std::string m_name;
             GLenum m_format;
 

--- a/src/GuiBase/SelectionManager/SelectionManager.hpp
+++ b/src/GuiBase/SelectionManager/SelectionManager.hpp
@@ -40,7 +40,7 @@ namespace Ra
             const Engine::ItemEntry& currentItem() const;
 
             /// Select an item through an item entry. @see QItemSelectionModel::Select
-            void select( const Engine::ItemEntry& ent,  QItemSelectionModel::SelectionFlags command );
+            virtual void select( const Engine::ItemEntry& ent,  QItemSelectionModel::SelectionFlags command );
 
             /// Set an item as current through an item entry. @see QItemSelectionModel::setCurrent
             void setCurrentEntry( const Engine::ItemEntry& ent, QItemSelectionModel::SelectionFlags command);

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -30,9 +30,6 @@
 
 #include <Engine/Managers/SystemDisplay/SystemDisplay.hpp>
 #include <Engine/Managers/EntityManager/EntityManager.hpp>
-
-#include <Engine/Renderer/Renderers/ForwardRenderer.hpp>
-#include <Engine/Renderer/Renderers/ExperimentalRenderer.hpp>
 #include <Engine/Renderer/RenderTechnique/ShaderProgramManager.hpp>
 
 #include <GuiBase/Viewer/TrackballCamera.hpp>
@@ -45,9 +42,11 @@ namespace Ra
 {
     Gui::Viewer::Viewer( QWidget* parent )
         : QOpenGLWidget( parent )
-//        , m_renderers(3)
-        , m_gizmoManager(new GizmoManager(this))
+        , m_currentRenderer( nullptr )
+        , m_featurePickingManager( nullptr )
+        , m_gizmoManager( new GizmoManager(this) )
         , m_renderThread( nullptr )
+        , m_glInitStatus( false )
     {
         // Allow Viewer to receive events
         setFocusPolicy( Qt::StrongFocus );
@@ -62,13 +61,20 @@ namespace Ra
     Gui::Viewer::~Viewer(){}
 
 
-    int Gui::Viewer::addRenderer(std::unique_ptr<Engine::Renderer> e){
+    int Gui::Viewer::addRenderer(std::unique_ptr<Engine::Renderer>&& e){
+        CORE_ASSERT(m_glInitStatus.load(),
+                    "OpenGL needs to be initialized to add renderers.");
+
+        // initial state and lighting
+        intializeRenderer(e.get());
+
         m_renderers.push_back(std::move(e));
+
         return m_renderers.size()-1;
     }
 
     void Gui::Viewer::initializeGL()
-    {        
+    {
         // no need to initalize glbinding. globjects (magically) do this internally.
         globjects::init(globjects::Shader::IncludeImplementation::Fallback);
 
@@ -81,29 +87,16 @@ namespace Ra
         Engine::ShaderProgramManager::createInstance("Shaders/Default.vert.glsl",
                                                      "Shaders/Default.frag.glsl");
 
-        m_renderers.push_back(std::unique_ptr<Engine::Renderer>(new Engine::ForwardRenderer( width(), height())));
+        auto light = Ra::Core::make_shared<Engine::DirectionalLight>();
+        m_camera->attachLight( light );
 
-        for ( auto& renderer : m_renderers )
-        {
-            if (renderer)
-            {
-                renderer->initialize();
-            }
-        }
+        m_glInitStatus = true;
+        emit glInitialized();
+
+        CORE_ASSERT(! m_renderers.empty(), "At least 1 renderer is required");
 
         m_currentRenderer = m_renderers[0].get();
 
-        auto light = Ra::Core::make_shared<Engine::DirectionalLight>();
-
-        for ( auto& renderer : m_renderers )
-        {
-            if (renderer)
-            {
-                renderer->addLight( light );
-            }
-        }
-
-        m_camera->attachLight( light );
 /*
         glbinding::setCallbackMask(glbinding::CallbackMask::After | glbinding::CallbackMask::ParametersAndReturnValue);
         glbinding::setAfterCallback([](const glbinding::FunctionCall & call)
@@ -177,6 +170,13 @@ namespace Ra
     void Gui::Viewer::onResized()
     {
         m_currentRenderer->unlockRendering();
+    }
+
+    void Gui::Viewer::intializeRenderer(Engine::Renderer *renderer)
+    {
+        renderer->initialize();
+        if( m_camera->hasLightAttached() )
+            renderer->addLight( m_camera->getLight() );
     }
 
     void Gui::Viewer::resizeGL( int width, int height )
@@ -303,11 +303,8 @@ namespace Ra
     void Gui::Viewer::changeRenderer( int index )
     {
         if (m_renderers[index]) {
-            // NOTE(Charly): This is probably buggy since it has not been tested.
-            LOG( logWARNING ) << "Changing renderers might be buggy since it has not been tested.";
-            m_currentRenderer->lockRendering();
+            if(m_currentRenderer != nullptr) m_currentRenderer->lockRendering();
             m_currentRenderer = m_renderers[index].get();
-            m_currentRenderer->initialize();
             m_currentRenderer->resize( width(), height() );
             m_currentRenderer->unlockRendering();
         }

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -62,14 +62,14 @@ namespace Ra
     Gui::Viewer::~Viewer(){}
 
 
-    int Gui::Viewer::addRenderer(Engine::Renderer* e){
+    int Gui::Viewer::addRenderer(std::shared_ptr<Engine::Renderer> e){
         CORE_ASSERT(m_glInitStatus.load(),
                     "OpenGL needs to be initialized to add renderers.");
 
         // initial state and lighting
-        intializeRenderer(e);
+        intializeRenderer(e.get());
 
-        m_renderers.push_back(std::unique_ptr<Engine::Renderer>(e));
+        m_renderers.push_back(e);
 
         return m_renderers.size()-1;
     }
@@ -97,7 +97,8 @@ namespace Ra
         if(m_renderers.empty()) {
             LOG(logWARNING)
                     << "Renderers fallback: no renderer added, enabling default (Forward Renderer)";
-            addRenderer(new Ra::Engine::ForwardRenderer());
+            std::shared_ptr<Ra::Engine::Renderer> e (new Ra::Engine::ForwardRenderer());
+            addRenderer(e);
         }
 
         m_currentRenderer = m_renderers[0].get();

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -120,10 +120,10 @@ namespace Ra
             /// Write the current frame as an image. Supports either BMP or PNG file names.
             void grabFrame( const std::string& filename );
 
-            /** Add a renderer and return its index.
+            /** Add a renderer and return its index. Need to be called when catching
              * \param e : unique_ptr to your own renderer
              * \return index of the newly added renderer
-             * \code 
+             * \code
              * int rendererId = addRenderer(std::unique_ptr<Ra::Engine::Renderer>(new MyRenderer(width(), height())));
              * changeRenderer(rendererId);
              * getRenderer()->initialize();
@@ -132,10 +132,11 @@ namespace Ra
              * m_camera->attachLight( light );
              * \endcode
              */
-            
-            int addRenderer(std::unique_ptr<Engine::Renderer> e);
+
+            int addRenderer(std::unique_ptr<Engine::Renderer> &&e);
 
         signals:
+            void glInitialized();               //! Emitted when GL context is ready. We except call to addRenderer here
             void rendererReady();               //! Emitted when the rendered is correctly initialized
             void leftClickPicking ( int id );   //! Emitted when the result of a left click picking is known
             void rightClickPicking( int id );   //! Emitted when the resut of a right click picking is known
@@ -168,6 +169,8 @@ namespace Ra
             void onResized();
 
         protected:
+            /// Initialize renderer internal state + configure lights.
+            void intializeRenderer(Engine::Renderer* renderer);
 
             //
             // QOpenGlWidget primitives
@@ -216,6 +219,9 @@ namespace Ra
 
             /// Thread in which rendering is done.
             QThread* m_renderThread; // We have to use a QThread for MT rendering
+
+            /// GL initialization status
+            std::atomic_bool m_glInitStatus;
         };
 
     } // namespace Gui

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -157,7 +157,7 @@ namespace Ra
              * m_camera->attachLight( light );
              * \endcode
              */
-            int addRenderer(Engine::Renderer *e);
+            int addRenderer(std::shared_ptr<Engine::Renderer> e);
 
         private slots:
             /// These slots are connected to the base class signals to properly handle
@@ -204,7 +204,7 @@ namespace Ra
 
         protected:
             /// Owning pointer to the renderers.
-            std::vector<std::unique_ptr<Engine::Renderer>> m_renderers;
+            std::vector<std::shared_ptr<Engine::Renderer>> m_renderers;
             Engine::Renderer* m_currentRenderer;
 
             /// Owning Pointer to the feature picking manager.

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -120,21 +120,6 @@ namespace Ra
             /// Write the current frame as an image. Supports either BMP or PNG file names.
             void grabFrame( const std::string& filename );
 
-            /** Add a renderer and return its index. Need to be called when catching
-             * \param e : unique_ptr to your own renderer
-             * \return index of the newly added renderer
-             * \code
-             * int rendererId = addRenderer(std::unique_ptr<Ra::Engine::Renderer>(new MyRenderer(width(), height())));
-             * changeRenderer(rendererId);
-             * getRenderer()->initialize();
-             * auto light = Ra::Core::make_shared<Engine::DirectionalLight>();
-             * getRenderer()->addLight( light );
-             * m_camera->attachLight( light );
-             * \endcode
-             */
-
-            int addRenderer(std::unique_ptr<Engine::Renderer> &&e);
-
         signals:
             void glInitialized();               //! Emitted when GL context is ready. We except call to addRenderer here
             void rendererReady();               //! Emitted when the rendered is correctly initialized
@@ -159,6 +144,20 @@ namespace Ra
 
             /// Resets the camaera to initial values
             void resetCamera();
+
+            /** Add a renderer and return its index. Need to be called when catching
+             * \param e : unique_ptr to your own renderer
+             * \return index of the newly added renderer
+             * \code
+             * int rendererId = addRenderer(new MyRenderer(width(), height()));
+             * changeRenderer(rendererId);
+             * getRenderer()->initialize();
+             * auto light = Ra::Core::make_shared<Engine::DirectionalLight>();
+             * getRenderer()->addLight( light );
+             * m_camera->attachLight( light );
+             * \endcode
+             */
+            int addRenderer(Engine::Renderer *e);
 
         private slots:
             /// These slots are connected to the base class signals to properly handle

--- a/src/PluginBase/RadiumPluginInterface.hpp
+++ b/src/PluginBase/RadiumPluginInterface.hpp
@@ -1,6 +1,8 @@
 #ifndef RADIUM_RADIUMPLUGININTERFACE_HPP
 #define RADIUM_RADIUMPLUGININTERFACE_HPP
 
+#include <vector>
+
 class QWidget;
 class QMenu;
 class QAction;
@@ -18,6 +20,11 @@ namespace Ra
     namespace Gui
     {
         class FeaturePickingManager;
+    }
+
+    namespace Engine
+    {
+        class Renderer;
     }
 
     /// Data passed to the plugin constructor.
@@ -106,6 +113,17 @@ namespace Ra
              * @return The created and configured feature widget
              */
             virtual QWidget* getFeatureTrackingWidget() { return nullptr; }
+
+            virtual bool doAddRenderer() { return false; }
+
+            /**
+             * @brief addRenderers
+             *
+             * \param rds the TODO
+             * \warning Allocated renderers are given to the application and
+             * SHOULD not be destroyed by the plugin
+             */
+            virtual void addRenderers(std::vector<Engine::Renderer*> */*rds*/) {}
         };
     }
 }

--- a/src/PluginBase/RadiumPluginInterface.hpp
+++ b/src/PluginBase/RadiumPluginInterface.hpp
@@ -2,6 +2,7 @@
 #define RADIUM_RADIUMPLUGININTERFACE_HPP
 
 #include <vector>
+#include <memory>
 
 class QWidget;
 class QMenu;
@@ -123,7 +124,7 @@ namespace Ra
              * \warning Allocated renderers are given to the application and
              * SHOULD not be destroyed by the plugin
              */
-            virtual void addRenderers(std::vector<Engine::Renderer*> */*rds*/) {}
+            virtual void addRenderers(std::vector<std::shared_ptr<Engine::Renderer>> */*rds*/) {}
         };
     }
 }


### PR DESCRIPTION
PR is ready.
Adds: 
 * GUI to select active renderer in Gui::MainApp
 * Fallback in Gui::Viewer: when no renderer is set, use ForwardRenderer as default
 * Update PluginInterface with a new handle to create renderers from plugins.