### PR TITLE
Normalize skinning weights at load to ensure they sum to 1

### DIFF
--- a/Plugins/Animation/src/AnimationComponent.cpp
+++ b/Plugins/Animation/src/AnimationComponent.cpp
@@ -233,15 +233,8 @@ namespace AnimationPlugin
                 m_weights.coeffRef( row, col ) = w;
             }
         }
-
-        // renormalize weights just in case
-        #pragma omp parallel for
-        for (int k = 0; k < m_weights.innerSize(); ++k)
-        {
-            m_weights.row( k ) /= m_weights.row( k ).sum();
-        }
-
-        Ra::Core::Animation::checkWeightMatrix( m_weights, false );
+        Ra::Core::Animation::checkWeightMatrix( m_weights, false, true );
+        Ra::Core::Animation::normalizeWeights ( m_weights, true );
     }
 
     void AnimationComponent::setContentName (const std::string name)

--- a/Plugins/Animation/src/AnimationComponent.cpp
+++ b/Plugins/Animation/src/AnimationComponent.cpp
@@ -234,6 +234,13 @@ namespace AnimationPlugin
             }
         }
 
+        // renormalize weights just in case
+        #pragma omp parallel for
+        for (int k = 0; k < m_weights.innerSize(); ++k)
+        {
+            m_weights.row( k ) /= m_weights.row( k ).sum();
+        }
+
         Ra::Core::Animation::checkWeightMatrix( m_weights, false );
     }
 

--- a/Plugins/Animation/src/AnimationComponent.cpp
+++ b/Plugins/Animation/src/AnimationComponent.cpp
@@ -234,7 +234,11 @@ namespace AnimationPlugin
             }
         }
         Ra::Core::Animation::checkWeightMatrix( m_weights, false, true );
-        Ra::Core::Animation::normalizeWeights ( m_weights, true );
+
+        if (Ra::Core::Animation::normalizeWeights ( m_weights, true ))
+        {
+            LOG(logINFO) << "Skinning weights have been normalized";
+        }
     }
 
     void AnimationComponent::setContentName (const std::string name)

--- a/src/Core/Animation/Handle/HandleWeightOperation.cpp
+++ b/src/Core/Animation/Handle/HandleWeightOperation.cpp
@@ -175,6 +175,23 @@ bool RA_CORE_API check_NoWeightVertex( const WeightMatrix& matrix, const bool FA
     return status != 0;
 }
 
+bool normalizeWeights(WeightMatrix &matrix, const bool MT)
+{
+    bool skinningWeightOk = true;
+
+    #pragma omp parallel for if(MT)
+    for (int k = 0; k < matrix.innerSize(); ++k)
+    {
+        const Scalar sum = matrix.row( k ).sum();
+        skinningWeightOk &= Ra::Core::Math::areApproxEqual(sum, Scalar(1));
+        matrix.row( k ) /= sum;
+    }
+    if (! skinningWeightOk)
+    {
+        LOG(logINFO) << "Renormalizing skinning weights";
+    }
+}
+
 
 } // namespace Animation
 } // Namespace Core

--- a/src/Core/Animation/Handle/HandleWeightOperation.cpp
+++ b/src/Core/Animation/Handle/HandleWeightOperation.cpp
@@ -87,14 +87,15 @@ void checkWeightMatrix( Eigen::Ref<const WeightMatrix> matrix,
 
 
 
-bool RA_CORE_API check_NAN(const WeightMatrix& matrix,
+bool RA_CORE_API check_NAN(Eigen::Ref<const WeightMatrix> matrix,
                            const bool FAIL_ON_ASSERT, const bool MT ) {
+    using Iterator = Eigen::Ref<const WeightMatrix>::InnerIterator;
     int status = 1;
     LOG( logDEBUG ) << "Searching for nans in the matrix...";
     if( MT ) {
         #pragma omp parallel for
         for( int k = 0; k < matrix.outerSize(); ++k ) {
-            for( WeightMatrix::InnerIterator it( matrix, k ); it; ++it ) {
+            for( Iterator it( matrix, k ); it; ++it ) {
                 const Scalar      value = it.value();
                 const int check = std::isnan( value ) ? 0 : 1;
                 #pragma omp atomic
@@ -110,7 +111,7 @@ bool RA_CORE_API check_NAN(const WeightMatrix& matrix,
         }
     } else {
         for( int k = 0; k < matrix.outerSize(); ++k ) {
-            for( WeightMatrix::InnerIterator it( matrix, k ); it; ++it ) {
+            for( Iterator it( matrix, k ); it; ++it ) {
                 const uint        i     = it.row();
                 const uint        j     = it.col();
                 const Scalar      value = it.value();

--- a/src/Core/Animation/Handle/HandleWeightOperation.cpp
+++ b/src/Core/Animation/Handle/HandleWeightOperation.cpp
@@ -168,6 +168,8 @@ bool RA_CORE_API check_NoWeightVertex( Eigen::Ref<const WeightMatrix> matrix,
 
 bool RA_CORE_API normalizeWeights(Eigen::Ref<WeightMatrix> matrix, const bool MT)
 {
+    CORE_UNUSED(MT)
+
     bool skinningWeightOk = true;
 
     #pragma omp parallel for if(MT)
@@ -179,10 +181,7 @@ bool RA_CORE_API normalizeWeights(Eigen::Ref<WeightMatrix> matrix, const bool MT
             matrix.row( k ) /= sum;
         }
     }
-    if (! skinningWeightOk)
-    {
-        LOG(logINFO) << "Renormalizing skinning weights";
-    }
+    return ! skinningWeightOk;
 }
 
 

--- a/src/Core/Animation/Handle/HandleWeightOperation.cpp
+++ b/src/Core/Animation/Handle/HandleWeightOperation.cpp
@@ -168,7 +168,7 @@ bool RA_CORE_API check_NoWeightVertex( Eigen::Ref<const WeightMatrix> matrix,
 
 bool RA_CORE_API normalizeWeights(Eigen::Ref<WeightMatrix> matrix, const bool MT)
 {
-    CORE_UNUSED(MT)
+    CORE_UNUSED(MT);
 
     bool skinningWeightOk = true;
 
@@ -177,8 +177,10 @@ bool RA_CORE_API normalizeWeights(Eigen::Ref<WeightMatrix> matrix, const bool MT
     {
         const Scalar sum = matrix.row( k ).sum();
         if(! Ra::Core::Math::areApproxEqual(sum, Scalar(0))){
-            skinningWeightOk &= Ra::Core::Math::areApproxEqual(sum, Scalar(1));
-            matrix.row( k ) /= sum;
+            if (! Ra::Core::Math::areApproxEqual(sum, Scalar(1))){
+                skinningWeightOk = false ;
+                matrix.row( k ) /= sum;
+            }
         }
     }
     return ! skinningWeightOk;

--- a/src/Core/Animation/Handle/HandleWeightOperation.hpp
+++ b/src/Core/Animation/Handle/HandleWeightOperation.hpp
@@ -60,6 +60,10 @@ bool RA_CORE_API check_NoWeightVertex( Eigen::Ref<const WeightMatrix> matrix,
                                        const bool FAIL_ON_ASSERT = false,
                                        const bool MT = false );
 
+/**
+ * In-place normalization of the weights, such that matrix.row( k ).sum() = 1;
+ * \return true if normalization was required.
+ */
 bool RA_CORE_API normalizeWeights( Eigen::Ref<WeightMatrix> matrix,
                                    const bool MT = false );
 

--- a/src/Core/Animation/Handle/HandleWeightOperation.hpp
+++ b/src/Core/Animation/Handle/HandleWeightOperation.hpp
@@ -10,14 +10,15 @@ namespace Animation {
 /*
 * Return the WeightMatrix extracted from the MeshWeight vector, for a handle with handle_size transforms
 */
-WeightMatrix RA_CORE_API extractWeightMatrix( const MeshWeight& weight, const uint handle_size );
+WeightMatrix RA_CORE_API extractWeightMatrix( const MeshWeight& weight,
+                                              const uint handle_size );
 
 
 
 /*
 * Return the MeshWeight from the given WeightMatrix.
 */
-MeshWeight RA_CORE_API extractMeshWeight( const WeightMatrix& matrix );
+MeshWeight RA_CORE_API extractMeshWeight( Eigen::Ref<const WeightMatrix> matrix );
 
 
 
@@ -27,31 +28,40 @@ MeshWeight RA_CORE_API extractMeshWeight( const WeightMatrix& matrix );
 *       weights( i, j ) >= 0
 *       lpNorm1( weights.row( i ) ) > 0
 */
-WeightMatrix RA_CORE_API partitionOfUnity( const WeightMatrix& weights );
+WeightMatrix RA_CORE_API partitionOfUnity( Eigen::Ref<const WeightMatrix> weights );
 
 
 
 /*
 * Return the index of the weight that influence the most the position of vertex at vertexId.
 */
-uint RA_CORE_API getMaxWeightIndex( const WeightMatrix& weights, const uint vertexID );
+uint RA_CORE_API getMaxWeightIndex( Eigen::Ref<const WeightMatrix> weights,
+                                    const uint vertexID );
 
 
 
 /*
 * Return the vector containing the index of the handle influencing the most a vertex.
 */
-void RA_CORE_API getMaxWeightIndex( const WeightMatrix& weights, std::vector< uint >& handleID );
+void RA_CORE_API getMaxWeightIndex( Eigen::Ref<const WeightMatrix> weights,
+                                    std::vector< uint >& handleID );
 
 
 
-void RA_CORE_API checkWeightMatrix( const WeightMatrix& matrix, const bool FAIL_ON_ASSERT = false, const bool MT = false );
+void RA_CORE_API checkWeightMatrix( Eigen::Ref<const WeightMatrix> matrix,
+                                    const bool FAIL_ON_ASSERT = false,
+                                    const bool MT = false );
 
-bool RA_CORE_API check_NAN( const WeightMatrix& matrix, const bool FAIL_ON_ASSERT = false, const bool MT = false );
+bool RA_CORE_API check_NAN( const WeightMatrix &matrix,
+                            const bool FAIL_ON_ASSERT = false,
+                            const bool MT = false );
 
-bool RA_CORE_API check_NoWeightVertex( const WeightMatrix& matrix, const bool FAIL_ON_ASSERT = false, const bool MT = false );
+bool RA_CORE_API check_NoWeightVertex( Eigen::Ref<const WeightMatrix> matrix,
+                                       const bool FAIL_ON_ASSERT = false,
+                                       const bool MT = false );
 
-bool RA_CORE_API normalizeWeights( WeightMatrix& matrix, const bool MT = false);
+bool RA_CORE_API normalizeWeights( Eigen::Ref<WeightMatrix> matrix,
+                                   const bool MT = false );
 
 
 

--- a/src/Core/Animation/Handle/HandleWeightOperation.hpp
+++ b/src/Core/Animation/Handle/HandleWeightOperation.hpp
@@ -52,7 +52,7 @@ void RA_CORE_API checkWeightMatrix( Eigen::Ref<const WeightMatrix> matrix,
                                     const bool FAIL_ON_ASSERT = false,
                                     const bool MT = false );
 
-bool RA_CORE_API check_NAN( const WeightMatrix &matrix,
+bool RA_CORE_API check_NAN(Eigen::Ref<const WeightMatrix> matrix,
                             const bool FAIL_ON_ASSERT = false,
                             const bool MT = false );
 

--- a/src/Core/Animation/Handle/HandleWeightOperation.hpp
+++ b/src/Core/Animation/Handle/HandleWeightOperation.hpp
@@ -51,6 +51,8 @@ bool RA_CORE_API check_NAN( const WeightMatrix& matrix, const bool FAIL_ON_ASSER
 
 bool RA_CORE_API check_NoWeightVertex( const WeightMatrix& matrix, const bool FAIL_ON_ASSERT = false, const bool MT = false );
 
+bool RA_CORE_API normalizeWeights( WeightMatrix& matrix, const bool MT = false);
+
 
 
 } // namespace Animation

--- a/src/Tests/CoreTests/Animation/AnimationTest.hpp
+++ b/src/Tests/CoreTests/Animation/AnimationTest.hpp
@@ -1,0 +1,65 @@
+#ifndef RADIUM_ANIMATIONTESTS_HPP_
+#define RADIUM_ANIMATIONTESTS_HPP_
+
+#include <Tests.hpp>
+#include <Core/Animation/Handle/HandleWeightOperation.hpp>
+
+using Ra::Core::Animation::WeightMatrix;
+
+namespace RaTests
+{
+    class HandleWeightTests : public Test
+    {
+        // tests :
+        //  - normalizeWeights
+        //  - partitionOfUnity
+        //  - check_NAN
+        //
+        // \todo Add other functions
+        void run() override
+        {
+            static const constexpr int w = 50;
+            static const constexpr int h = w;
+
+            WeightMatrix matrix1 ( w, h );
+            matrix1.setIdentity();
+
+            RA_UNIT_TEST( ! Ra::Core::Animation::normalizeWeights( matrix1 ),
+                          "Matrix1 is already normalized" );
+
+            matrix1.coeffRef( w/3, h/2 ) = 0.8;
+
+            RA_UNIT_TEST( Ra::Core::Animation::normalizeWeights( matrix1 ),
+                          "Matrix1 normalization ok" );
+
+            WeightMatrix matrix2  = matrix1;
+            matrix2 *= 0.5;
+
+            WeightMatrix matrix3 = Ra::Core::Animation::partitionOfUnity( matrix2 );
+
+            RA_UNIT_TEST( Ra::Core::Animation::normalizeWeights( matrix2 ),
+                          "Matrix2 needs to be normalized" );
+
+            RA_UNIT_TEST( ! Ra::Core::Animation::normalizeWeights( matrix3 ),
+                          "Matrix3 is already normalized" );
+
+            RA_UNIT_TEST( matrix1.isApprox( matrix2),
+                          "Two matrices are equivalent after normalization" );
+
+            RA_UNIT_TEST( matrix1.isApprox( matrix3),
+                          "Two matrices are equivalent after partition of unity" );
+
+            matrix2.coeffRef(w/3, h/2) = std::nan("");
+            RA_UNIT_TEST( Ra::Core::Animation::check_NAN(matrix1),
+                          "Should not find NaN in this matrix" );
+            RA_UNIT_TEST( ! Ra::Core::Animation::check_NAN(matrix2),
+                          "Should find NaN in this matrix" );
+
+        }
+    };
+
+    RA_TEST_CLASS(HandleWeightTests)
+}
+
+
+#endif //RADIUM_GEOMETRYTESTS_HPP_

--- a/src/Tests/CoreTests/main.cpp
+++ b/src/Tests/CoreTests/main.cpp
@@ -1,6 +1,7 @@
 #include <Tests/CoreTests/Tests.hpp>
 
 #include <Tests/CoreTests/Containers/ContainersTest.hpp>
+#include <Tests/CoreTests/Animation/AnimationTest.hpp>
 #include <Tests/CoreTests/Algebra/AlgebraTests.hpp>
 #include <Tests/CoreTests/Geometry/GeometryTests.hpp>
 #include <Tests/CoreTests/RayCasts/RayCastTest.hpp>


### PR DESCRIPTION
Some models we have do not provide normalized weights.
While model files should contain normalized weights, it is safer to ensure it at load.