### PR TITLE
Clang compiling ... bugs in cmake scripts and some (very) strange problem with std::map allocators ... 

### DIFF
--- a/cmake/submoduleGlBinding.cmake
+++ b/cmake/submoduleGlBinding.cmake
@@ -1,5 +1,5 @@
 # Allow to compile with AppleCLang
-if ( APPLE AND ${CMAKE_CXX_COMPILER_ID} EQUAL Clang )
+if ( APPLE AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
     set( PLATFORM_ARGS "" )
 else()
     set( PLATFORM_ARGS "-DCMAKE_CXX_FLAGS=-D__has_feature\\\(x\\\)=false" )

--- a/cmake/submoduleGlObjects.cmake
+++ b/cmake/submoduleGlObjects.cmake
@@ -1,5 +1,5 @@
 # Allow to compile with AppleCLang
-if ( APPLE AND ${CMAKE_CXX_COMPILER_ID} EQUAL Clang )
+if ( APPLE AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
     set( PLATFORM_ARGS "" )
 else()
     set( PLATFORM_ARGS "-DCMAKE_CXX_FLAGS=-D__has_feature\\\(x\\\)=false" )

--- a/src/Core/File/KeyFrame/KeyFrame.hpp
+++ b/src/Core/File/KeyFrame/KeyFrame.hpp
@@ -162,7 +162,7 @@ protected:
 protected:
     /// VARIABLE
     AnimationTime           m_time;
-    std::map < Time, FRAME, std::less<Time>, Ra::Core::AlignedAllocator<std::pair < Time, FRAME >, RA_DEFAULT_ALIGN> > m_keyframe;
+    std::map < Time, FRAME, std::less<Time>, Ra::Core::AlignedAllocator<std::pair < const Time, FRAME >, RA_DEFAULT_ALIGN> > m_keyframe;
 };
 
 

--- a/src/Core/Geometry/Partition/Partition.cpp
+++ b/src/Core/Geometry/Partition/Partition.cpp
@@ -75,9 +75,9 @@ MeshPartition partition( const TriangleMesh& mesh, const Animation::WeightMatrix
     MeshPartition part( size );
     #pragma omp parallel for
     for( uint n = 0; n < size; ++n ) {
-        const VertexSegment   v = std::move( extractVertexSegment( weight, n, use_max ) );
-        const BitSet          b = std::move( extractBitSet( v, v_size ) );
-        const TriangleSegment t = std::move( extractTriangleSegment( b, mesh.m_triangles ) );
+        const VertexSegment   v = extractVertexSegment( weight, n, use_max );
+        const BitSet          b = extractBitSet( v, v_size );
+        const TriangleSegment t = extractTriangleSegment( b, mesh.m_triangles );
         part[n].m_vertices.resize( v.size() );
         part[n].m_normals.resize( v.size() );
         part[n].m_triangles.resize( t.size() );

--- a/src/Engine/Renderer/RenderTechnique/RenderParameters.hpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderParameters.hpp
@@ -60,7 +60,7 @@ namespace Ra
                 int m_texUnit;
             };
 
-            template <typename T> class UniformBindableVector : public std::map<std::string, T, std::less<std::string>, Core::AlignedAllocator<T, RA_DEFAULT_ALIGN> >
+            template <typename T> class UniformBindableVector : public std::map<std::string, T, std::less<std::string>, Core::AlignedAllocator<std::pair<const std::string, T>, RA_DEFAULT_ALIGN> >
             {
             public:
                 void bind(const ShaderProgram* shader ) const;


### PR DESCRIPTION
Correction of std::map bad allocator (KeyFrame and RenderParameters).
Correction of non efficient std::move (that prevent copy elision).
Correction of cmake scripts to detect compiler name.