### PR TITLE
MacosX, Retina screens,  hdpi scaling solved

### DIFF
--- a/Applications/MainApplication/main.cpp
+++ b/Applications/MainApplication/main.cpp
@@ -6,6 +6,8 @@
 
 int main( int argc, char** argv )
 {
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
     Ra::MainApplication app( argc, argv );
 
     const uint& fpsMax = app.m_targetFPS;
@@ -20,6 +22,7 @@ int main( int argc, char** argv )
         app.radiumFrame();
 
         // Wait for VSync
+        // FIXME : use a timer here instead of an active polling
         Scalar remaining = deltaTime;
         while (remaining > 0.0)
         {

--- a/src/GuiBase/Viewer/Gizmo/GizmoManager.cpp
+++ b/src/GuiBase/Viewer/Gizmo/GizmoManager.cpp
@@ -93,7 +93,7 @@ namespace Ra
             }
         }
 
-        bool GizmoManager::handleMousePressEvent(QMouseEvent* event)
+        bool GizmoManager::handleMousePressEvent(QMouseEvent* event, int hdpiScale)
         {
             if( !( Gui::KeyMappingManager::getInstance()->actionTriggered( event, Gui::KeyMappingManager::GIZMOMANAGER_MANIPULATION ) ) || !canEdit() || m_currentGizmoType == NONE)
             {
@@ -105,7 +105,7 @@ namespace Ra
             // Access the camera from the viewer. (TODO : a cleaner way to access the camera).
             // const Engine::Camera& cam = *static_cast<Viewer*>(parent())->getCameraInterface()->getCamera();
             const Engine::Camera& cam = CameraInterface::getCameraFromViewer(parent());
-            currentGizmo()->setInitialState(cam, Core::Vector2(Scalar(event->x()), Scalar(event->y())));
+            currentGizmo()->setInitialState(cam, Core::Vector2(Scalar(event->x()*hdpiScale), Scalar(event->y()*hdpiScale)));
 
             return true;
         }
@@ -119,11 +119,11 @@ namespace Ra
             return (currentGizmo() != nullptr);
         }
 
-        bool GizmoManager::handleMouseMoveEvent(QMouseEvent* event)
+        bool GizmoManager::handleMouseMoveEvent(QMouseEvent* event, int hdpiScale)
         {
             if ( event->buttons() & Gui::KeyMappingManager::getInstance()->getKeyFromAction( Gui::KeyMappingManager::GIZMOMANAGER_MANIPULATION ) && currentGizmo() )
             {
-                Core::Vector2 currentXY(event->x(), event->y());
+                Core::Vector2 currentXY(event->x()*hdpiScale, event->y()*hdpiScale);
                 // const Engine::Camera& cam = *static_cast<Viewer*>(parent())->getCameraInterface()->getCamera();
                 const Engine::Camera& cam = CameraInterface::getCameraFromViewer(parent());
                 Core::Transform newTransform = currentGizmo()->mouseMove(cam, currentXY, event->modifiers().testFlag( Qt::ControlModifier ) );

--- a/src/GuiBase/Viewer/Gizmo/GizmoManager.hpp
+++ b/src/GuiBase/Viewer/Gizmo/GizmoManager.hpp
@@ -38,9 +38,9 @@ namespace Ra
 
         public:
             /// Receive mouse events and transmit them to the gizmos.
-            virtual bool handleMousePressEvent  ( QMouseEvent* event );
+            virtual bool handleMousePressEvent  ( QMouseEvent* event, int hdpiScale );
             virtual bool handleMouseReleaseEvent( QMouseEvent* event );
-            virtual bool handleMouseMoveEvent   ( QMouseEvent* event );
+            virtual bool handleMouseMoveEvent   ( QMouseEvent* event, int hdpiScale );
 
 
         public slots:

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -237,7 +237,7 @@ namespace Ra
                 m_currentRenderer->addPickingRequest({ Core::Vector2(event->x()*m_hdpiScale, height()*m_hdpiScale - event->y()*m_hdpiScale),
                                                        Core::MouseButton::RA_MOUSE_LEFT_BUTTON,
                                                        Engine::Renderer::RO });
-                m_gizmoManager->handleMousePressEvent(event);
+                m_gizmoManager->handleMousePressEvent(event, m_hdpiScale);
             }
         }
         else if ( keyMap->actionTriggered( event, Gui::KeyMappingManager::TRACKBALLCAMERA_MANIPULATION ) )
@@ -263,7 +263,7 @@ namespace Ra
     void Gui::Viewer::mouseMoveEvent( QMouseEvent* event )
     {
         m_camera->handleMouseMoveEvent( event );
-        m_gizmoManager->handleMouseMoveEvent(event);
+        m_gizmoManager->handleMouseMoveEvent(event, m_hdpiScale);
     }
 
     void Gui::Viewer::wheelEvent( QWheelEvent* event )

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -222,6 +222,8 @@ namespace Ra
 
             /// GL initialization status
             std::atomic_bool m_glInitStatus;
+        private :
+            int m_hdpiScale;
         };
 
     } // namespace Gui


### PR DESCRIPTION
On MacosX with Retina screens, this commit solve the OpenGL hdpi scaling problem (view port only half the size on each dimension)

Note that on my test machine, this results in (very) poor performances when rendering on a retina screen (2fps instead of 600 for the default grid rendering, same for different scenes), due to the underlying QT and openGL interaction model used in the main app.
The application can be dragged from retina to non retina but, as a resize event is not always associated to this drag (I've not success in identifying why), the user as to manually generate such an event (by resizing manually the window.

To solve this performance and resizing problem, next direction will be try to remove the dependency between the application and QOpenGLWidget (in the same way the integration of glBinding with Qt is demonstrated as it not exhibit this problem).