### PR TITLE
Some improvements on Mesh and MainWindow

### DIFF
--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -355,9 +355,23 @@ namespace Ra
         // always restore displaytexture to 0 before switch to keep coherent renderer state
         m_displayedTextureCombo->setCurrentIndex(0);
         m_viewer->changeRenderer(m_currentRendererCombo->currentIndex());
+        updateDisplayedTexture();
         // in case the newly used renderer has not been set before and set another texture as its default,
         // set displayTexture to 0 again ;)
         m_displayedTextureCombo->setCurrentIndex(0);
+    }
+
+    void Gui::MainWindow::updateDisplayedTexture()
+    {
+        QSignalBlocker blockTextures(m_displayedTextureCombo);
+
+        m_displayedTextureCombo->clear();
+
+        auto texs = m_viewer->getRenderer()->getAvailableTextures();
+        for (const auto& tex : texs)
+        {
+            m_displayedTextureCombo->addItem(tex.c_str());
+        }
     }
 
     void Gui::MainWindow::changeRenderObjectShader(const QString& shaderName)
@@ -452,14 +466,7 @@ namespace Ra
     void Gui::MainWindow::onRendererReady()
     {
         m_viewer->getCameraInterface()->resetCamera();
-
-        QSignalBlocker blockTextures(m_displayedTextureCombo);
-
-        auto texs = m_viewer->getRenderer()->getAvailableTextures();
-        for (const auto& tex : texs)
-        {
-            m_displayedTextureCombo->addItem(tex.c_str());
-        }
+        updateDisplayedTexture();
     }
 
     void Gui::MainWindow::onFrameComplete()

--- a/Applications/MainApplication/Gui/MainWindow.hpp
+++ b/Applications/MainApplication/Gui/MainWindow.hpp
@@ -131,6 +131,9 @@ namespace Ra
 
             virtual void closeEvent( QCloseEvent* event ) override;
 
+            /// Update displayed texture according to the current renderer
+            void updateDisplayedTexture();
+
         private slots:
             /// Slot for the "load file" menu.
             void loadFile();

--- a/src/Engine/Renderer/Mesh/Mesh.cpp
+++ b/src/Engine/Renderer/Mesh/Mesh.cpp
@@ -18,7 +18,8 @@ namespace Ra {
             CORE_ASSERT( m_renderMode == RM_LINES
                       || m_renderMode == RM_LINES_ADJACENCY
                       || m_renderMode == RM_TRIANGLES
-                      || m_renderMode == RM_POINTS,
+                      || m_renderMode == RM_POINTS
+                      || m_renderMode == RM_LINE_STRIP_ADJACENCY,
                          "Unsupported render mode" );
         }
 

--- a/src/Engine/Renderer/Mesh/Mesh.hpp
+++ b/src/Engine/Renderer/Mesh/Mesh.hpp
@@ -125,6 +125,8 @@ namespace Ra
             /// Access the additionnal data arrays by type.
             inline const Core::Vector3Array& getData( const Vec3Data& type ) const;
             inline const Core::Vector4Array& getData( const Vec4Data& type ) const;
+            inline Core::Vector3Array& getData( const Vec3Data& type );
+            inline Core::Vector4Array& getData( const Vec4Data& type );
 
             /// Mark one of the data types as dirty, forcing an update of the openGL buffer.
             inline void setDirty( const MeshData& type );

--- a/src/Engine/Renderer/Mesh/Mesh.inl
+++ b/src/Engine/Renderer/Mesh/Mesh.inl
@@ -27,6 +27,16 @@ namespace Engine {
         return m_v4Data[static_cast<uint>(type)];
     }
 
+    Core::Vector3Array &Mesh::getData(const Mesh::Vec3Data &type)
+    {
+        return m_v3Data[static_cast<uint>(type)];
+    }
+
+    Core::Vector4Array &Mesh::getData(const Mesh::Vec4Data &type)
+    {
+        return m_v4Data[static_cast<uint>(type)];
+    }
+
     void Mesh::setDirty(const Mesh::MeshData &type) { m_dataDirty[type] = true; m_isDirty = true;}
     void Mesh::setDirty(const Mesh::Vec3Data &type) { m_dataDirty[MAX_MESH + type] = true; m_isDirty = true;}
     void Mesh::setDirty(const Mesh::Vec4Data &type) { m_dataDirty[MAX_MESH + MAX_VEC3 + type ] = true ; m_isDirty = true;}


### PR DESCRIPTION
This pr includes these few changes:
- Non-const access methods of mesh data
- RM_LINE_STRIP_ADJENCY added to the supported render modes
- Textures update when changing the current renderer (Issue #247) 
