### PR TITLE
Add Loaders in plugins

### DIFF
--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -172,7 +172,7 @@ namespace Ra
 
         QString filter;
 
-        for ( const Asset::FileLoaderInterface * loader : mainApp->m_engine->getFileLoaders() )
+        for ( const auto& loader : mainApp->m_engine->getFileLoaders() )
         {
             QString exts;
             for (const auto& e : loader->getFileExtensions())

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -180,8 +180,10 @@ namespace Ra
             filter.append( QString::fromStdString(loader->name()) +
                            tr(" (") +
                            exts +
-                           tr(");; "));
+                           tr(");;"));
         }
+        // remove the last ";;" of the string
+        filter.remove(filter.size()-2, 2);
 
         QSettings settings;
         QString path = settings.value("files/load", QDir::homePath()).toString();

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -7,8 +7,6 @@
 #include <QToolButton>
 #include <QComboBox>
 
-#include <assimp/Importer.hpp>
-
 #include <Core/File/deprecated/OBJFileManager.hpp>
 
 #include <Engine/Managers/SignalManager/SignalManager.hpp>
@@ -171,13 +169,19 @@ namespace Ra
 
     void Gui::MainWindow::loadFile()
     {
-        // Filter the files
-        aiString extList;
-        Assimp::Importer importer;
-        importer.GetExtensionList(extList);
-        std::string extListStd(extList.C_Str());
-        std::replace(extListStd.begin(), extListStd.end(), ';', ' ');
-        QString filter =""/* QString::fromStdString(extListStd)*/;
+
+        QString filter;
+
+        for ( const Asset::FileLoaderInterface * loader : mainApp->m_engine->getFileLoaders() )
+        {
+            QString exts;
+            for (const auto& e : loader->getFileExtensions())
+                exts.append(QString::fromStdString(e) + tr(" "));
+            filter.append( QString::fromStdString(loader->name()) +
+                           tr(" (") +
+                           exts +
+                           tr(");; "));
+        }
 
         QSettings settings;
         QString path = settings.value("files/load", QDir::homePath()).toString();

--- a/Applications/MainApplication/MainApplication.cpp
+++ b/Applications/MainApplication/MainApplication.cpp
@@ -171,13 +171,13 @@ namespace Ra
 #ifdef IO_USE_TINYPLY
         // Register before AssimpFileLoader, in order to ease override of such
         // custom loader (first loader able to load is taking the file)
-        m_engine->registerFileLoader( new IO::TinyPlyFileLoader() );
+        m_engine->registerFileLoader( std::shared_ptr<Asset::FileLoaderInterface>(new IO::TinyPlyFileLoader()) );
 #endif
 #ifdef IO_USE_ASSIMP
-        m_engine->registerFileLoader( new IO::AssimpFileLoader() );
+        m_engine->registerFileLoader( std::shared_ptr<Asset::FileLoaderInterface>(new IO::AssimpFileLoader()) );
 #endif
 #ifdef IO_USE_PBRT
-        m_engine->registerFileLoader( new IO::PbrtFileLoader() );
+        m_engine->registerFileLoader( std::shared_ptr<Asset::FileLoaderInterface>(new IO::PbrtFileLoader()) );
 #endif
 
         // Create main window.

--- a/Applications/MainApplication/MainApplication.cpp
+++ b/Applications/MainApplication/MainApplication.cpp
@@ -511,6 +511,16 @@ namespace Ra
                                 m_mainWindow->addRenderer(name, ptr);
                             }
                         }
+
+                        if(loadedPlugin->doAddFileLoader())
+                        {
+                            std::vector<std::shared_ptr<Asset::FileLoaderInterface>> tmpL;
+                            loadedPlugin->addFileLoaders(&tmpL);
+                            CORE_ASSERT(! tmpL.empty(), "This plugin is expected to add file loaders");
+                            for(auto ptr : tmpL){
+                                m_engine->registerFileLoader(ptr);
+                            }
+                        }
                     }
                     else
                     {

--- a/src/Core/File/FileLoaderInterface.hpp
+++ b/src/Core/File/FileLoaderInterface.hpp
@@ -29,6 +29,9 @@ namespace Ra
 
             //! Try to load file, returns nullptr in case of failure
             virtual FileData * loadFile( const std::string& filename ) = 0;
+
+            //! Unique name of the loader
+            virtual std::string name() const = 0;
         };
     }
 }

--- a/src/Engine/RadiumEngine.cpp
+++ b/src/Engine/RadiumEngine.cpp
@@ -212,6 +212,11 @@ namespace Ra
             m_fileLoaders.push_back( fileLoader );
         }
 
+        const std::vector<Asset::FileLoaderInterface *> &RadiumEngine::getFileLoaders() const
+        {
+            return m_fileLoaders;
+        }
+
         RA_SINGLETON_IMPLEMENTATION( RadiumEngine );
 
         const Asset::FileData &RadiumEngine::getFileData() const {

--- a/src/Engine/RadiumEngine.cpp
+++ b/src/Engine/RadiumEngine.cpp
@@ -207,12 +207,12 @@ namespace Ra
            return m_signalManager.get();
         }
 
-        void RadiumEngine::registerFileLoader( Asset::FileLoaderInterface * fileLoader )
+        void RadiumEngine::registerFileLoader( std::shared_ptr<Asset::FileLoaderInterface> fileLoader )
         {
             m_fileLoaders.push_back( fileLoader );
         }
 
-        const std::vector<Asset::FileLoaderInterface *> &RadiumEngine::getFileLoaders() const
+        const std::vector<std::shared_ptr<Asset::FileLoaderInterface> > &RadiumEngine::getFileLoaders() const
         {
             return m_fileLoaders;
         }

--- a/src/Engine/RadiumEngine.hpp
+++ b/src/Engine/RadiumEngine.hpp
@@ -80,6 +80,8 @@ namespace Ra
 
             void registerFileLoader( Asset::FileLoaderInterface * fileLoader );
 
+            const std::vector< Asset::FileLoaderInterface * >& getFileLoaders() const;
+
         private:
             std::map<std::string, std::shared_ptr<System>> m_systems;
 

--- a/src/Engine/RadiumEngine.hpp
+++ b/src/Engine/RadiumEngine.hpp
@@ -78,14 +78,14 @@ namespace Ra
             EntityManager*        getEntityManager()        const;
             SignalManager*        getSignalManager()        const;
 
-            void registerFileLoader( Asset::FileLoaderInterface * fileLoader );
+            void registerFileLoader( std::shared_ptr<Asset::FileLoaderInterface> fileLoader );
 
-            const std::vector< Asset::FileLoaderInterface * >& getFileLoaders() const;
+            const std::vector< std::shared_ptr<Asset::FileLoaderInterface> >& getFileLoaders() const;
 
         private:
             std::map<std::string, std::shared_ptr<System>> m_systems;
 
-            std::vector< Asset::FileLoaderInterface * > m_fileLoaders;
+            std::vector< std::shared_ptr<Asset::FileLoaderInterface> > m_fileLoaders;
 
             std::unique_ptr<RenderObjectManager> m_renderObjectManager;
             std::unique_ptr<EntityManager>       m_entityManager;

--- a/src/IO/AssimpLoader/AssimpFileLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpFileLoader.cpp
@@ -116,5 +116,10 @@ namespace Ra {
 
             return fileData;
         }
+
+        std::string AssimpFileLoader::name() const
+        {
+            return "Assimp";
+        }
     }
 }

--- a/src/IO/AssimpLoader/AssimpFileLoader.hpp
+++ b/src/IO/AssimpLoader/AssimpFileLoader.hpp
@@ -21,6 +21,7 @@ namespace Ra {
             std::vector<std::string> getFileExtensions() const override;
             bool handleFileExtension( const std::string& extension ) const override;
             Asset::FileData * loadFile( const std::string& filename ) override;
+            std::string name() const override;
 
         private:
             Assimp::Importer m_importer;

--- a/src/IO/AssimpLoader/AssimpFileLoader.hpp
+++ b/src/IO/AssimpLoader/AssimpFileLoader.hpp
@@ -18,9 +18,9 @@ namespace Ra {
 
             virtual ~AssimpFileLoader();
 
-            virtual std::vector<std::string> getFileExtensions() const override;
-            virtual bool handleFileExtension( const std::string& extension ) const override;
-            virtual Asset::FileData * loadFile( const std::string& filename ) override;
+            std::vector<std::string> getFileExtensions() const override;
+            bool handleFileExtension( const std::string& extension ) const override;
+            Asset::FileData * loadFile( const std::string& filename ) override;
 
         private:
             Assimp::Importer m_importer;

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
@@ -132,5 +132,10 @@ namespace Ra {
 
             return fileData;
         }
+
+        std::string TinyPlyFileLoader::name() const
+        {
+            return "TinyPly";
+        }
     }
 }

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.hpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.hpp
@@ -15,9 +15,9 @@ namespace Ra {
 
             virtual ~TinyPlyFileLoader();
 
-            virtual std::vector<std::string> getFileExtensions() const override;
-            virtual bool handleFileExtension( const std::string& extension ) const override;
-            virtual Asset::FileData * loadFile( const std::string& filename ) override;
+            std::vector<std::string> getFileExtensions() const override;
+            bool handleFileExtension( const std::string& extension ) const override;
+            Asset::FileData * loadFile( const std::string& filename ) override;
         };
 
     } // namespace IO

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.hpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.hpp
@@ -18,6 +18,7 @@ namespace Ra {
             std::vector<std::string> getFileExtensions() const override;
             bool handleFileExtension( const std::string& extension ) const override;
             Asset::FileData * loadFile( const std::string& filename ) override;
+            std::string name() const override;
         };
 
     } // namespace IO

--- a/src/PluginBase/RadiumPluginInterface.hpp
+++ b/src/PluginBase/RadiumPluginInterface.hpp
@@ -28,6 +28,11 @@ namespace Ra
         class Renderer;
     }
 
+    namespace Asset
+    {
+        class FileLoaderInterface;
+    }
+
     /// Data passed to the plugin constructor.
     struct PluginContext
     {
@@ -125,6 +130,10 @@ namespace Ra
              * SHOULD not be destroyed by the plugin
              */
             virtual void addRenderers(std::vector<std::shared_ptr<Engine::Renderer>> */*rds*/) {}
+
+            virtual bool doAddFileLoader() { return false; }
+
+            virtual void addFileLoaders(std::vector<std::shared_ptr<Asset::FileLoaderInterface>> */*fl*/) {}
         };
     }
 }


### PR DESCRIPTION
Small changes simplifying the addition of new loaders from plugins:
 - Expose handlers in `RadiumPluginInterface`,
 - Store FileLoaders using `shared_ptr`,
 - In MainApp, construct the list of supported file formats from the list of registered loaders

Fixes:
 - Remove unwanted explicit use of assimp in `Gui::MainWindow`, preventing to compile radium without assimp support.