### PR TITLE
[hotfix] Renderers crash

### DIFF
--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -372,11 +372,13 @@ namespace Ra
     {
         // always restore displaytexture to 0 before switch to keep coherent renderer state
         m_displayedTextureCombo->setCurrentIndex(0);
-        m_viewer->changeRenderer(m_currentRendererCombo->currentIndex());
-        updateDisplayedTexture();
-        // in case the newly used renderer has not been set before and set another texture as its default,
-        // set displayTexture to 0 again ;)
-        m_displayedTextureCombo->setCurrentIndex(0);
+        if ( m_viewer->changeRenderer(m_currentRendererCombo->currentIndex()) )
+        {
+            updateDisplayedTexture();
+            // in case the newly used renderer has not been set before and set another texture as its default,
+            // set displayTexture to 0 again ;)
+            m_displayedTextureCombo->setCurrentIndex(0);
+        }
     }
 
     void Gui::MainWindow::updateDisplayedTexture()

--- a/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
+++ b/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
@@ -66,8 +66,11 @@ namespace Ra
             initShaders();
             initBuffers();
 
-            DebugRender::createInstance();
-            DebugRender::getInstance()->initialize();
+            if (!DebugRender::getInstance())
+            {
+              DebugRender::createInstance();
+              DebugRender::getInstance()->initialize();
+            }
         }
 
         void ForwardRenderer::initShaders()

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -429,10 +429,11 @@ namespace Ra
     {
         CORE_ASSERT(m_glInitStatus.load(),
                     "OpenGL needs to be initialized to display textures.");
-
+        m_context->makeCurrent(this);
         m_currentRenderer->lockRendering();
         m_currentRenderer->displayTexture( tex.toStdString() );
         m_currentRenderer->unlockRendering();
+        m_context->doneCurrent();
     }
 
     bool Gui::Viewer::changeRenderer( int index )
@@ -453,6 +454,7 @@ namespace Ra
             LOG( logINFO ) << "[Viewer] Set active renderer: "
                            << m_currentRenderer->getRendererName();
 
+            m_context->doneCurrent();
             return true;
         }
         return false;

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -391,6 +391,7 @@ namespace Ra
     void Gui::Viewer::changeRenderer( int index )
     {
         if (m_renderers[index]) {
+            m_context->makeCurrent(this);
             if(m_currentRenderer != nullptr) m_currentRenderer->lockRendering();
             m_currentRenderer = m_renderers[index].get();
             m_currentRenderer->resize( width(), height() );

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -85,7 +85,9 @@ namespace Ra
         // initial state and lighting (deferred if GL is not ready yet)
         if ( m_glInitStatus.load() )
         {
+            m_context->makeCurrent( this );
             intializeRenderer(e.get());
+            m_context->doneCurrent( );
         }
         else
         {

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -61,21 +61,27 @@ namespace Ra
 
     Gui::Viewer::~Viewer(){
         if (m_gizmoManager != nullptr)
+        {
             delete m_gizmoManager;
+        }
     }
 
     void Gui::Viewer::createGizmoManager()
     {
         if (m_gizmoManager == nullptr)
+        {
             m_gizmoManager = new GizmoManager(this);
+        }
     }
 
     int Gui::Viewer::addRenderer(std::shared_ptr<Engine::Renderer> e){
         // initial state and lighting (deferred if GL is not ready yet)
-        if ( m_glInitStatus.load() ) {
+        if ( m_glInitStatus.load() )
+        {
             intializeRenderer(e.get());
         }
-        else {
+        else
+        {
             LOG( logINFO ) << "[Viewer] New Renderer ("
                            << e->getRendererName()
                            << ") added before GL being Ready: deferring initialization...";
@@ -97,15 +103,16 @@ namespace Ra
                                         {
                                             std::cerr << call.parameters[i]->asString();
                                             if (i < call.parameters.size() - 1)
+                                            {
                                                 std::cerr << ", ";
+                                            }
                                         }
                                         std::cerr << ")";
-
                                         if (call.returnValue)
+                                        {
                                             std::cerr << " -> " << call.returnValue->asString();
-
+                                        }
                                         std::cerr << std::endl;
-
                                     });
     }
 
@@ -126,7 +133,8 @@ namespace Ra
 
 
         // initialize renderers added before GL was ready
-        if( ! m_renderers.empty() ) {
+        if( ! m_renderers.empty() )
+        {
             for ( auto& rptr : m_renderers )
             {
                 intializeRenderer( rptr.get() );
@@ -140,7 +148,8 @@ namespace Ra
 
         emit glInitialized();
 
-        if(m_renderers.empty()) {
+        if(m_renderers.empty())
+        {
             LOG( logINFO )
                     << "Renderers fallback: no renderer added, enabling default (Forward Renderer)";
             std::shared_ptr<Ra::Engine::Renderer> e (new Ra::Engine::ForwardRenderer());
@@ -208,12 +217,15 @@ namespace Ra
     {
         renderer->initialize(width(), height());
         if( m_camera->hasLightAttached() )
+        {
             renderer->addLight( m_camera->getLight() );
+        }
     }
 
     void Gui::Viewer::resizeGL( int width_, int height_ )
     {
-        if (isExposed()) {
+        if (isExposed())
+        {
             // Renderer should have been locked by previous events.
             m_context->makeCurrent(this);
 
@@ -248,7 +260,8 @@ namespace Ra
 
     void Gui::Viewer::mousePressEvent( QMouseEvent* event )
     {
-        if(! m_glInitStatus) {
+        if(! m_glInitStatus.load())
+        {
             event->ignore();
             return;
         }
@@ -274,7 +287,9 @@ namespace Ra
                                                        Core::MouseButton::RA_MOUSE_LEFT_BUTTON,
                                                        Engine::Renderer::RO });
                 if (m_gizmoManager != nullptr)
+                {
                     m_gizmoManager->handleMousePressEvent(event);
+                }
             }
         }
         else if ( keyMap->actionTriggered( event, Gui::KeyMappingManager::TRACKBALLCAMERA_MANIPULATION ) )
@@ -295,12 +310,14 @@ namespace Ra
     {
         m_camera->handleMouseReleaseEvent( event );
         if (m_gizmoManager != nullptr)
+        {
             m_gizmoManager->handleMouseReleaseEvent(event);
+        }
     }
 
     void Gui::Viewer::mouseMoveEvent( QMouseEvent* event )
     {
-        if(m_glInitStatus)
+        if(m_glInitStatus.load())
         {
             m_camera->handleMouseMoveEvent( event );
             if (m_gizmoManager != nullptr)
@@ -312,21 +329,27 @@ namespace Ra
 
     void Gui::Viewer::wheelEvent( QWheelEvent* event )
     {
-        if(m_glInitStatus)
+        if(m_glInitStatus.load())
+        {
             m_camera->handleWheelEvent(event);
+        }
         else
+        {
             event->ignore();
+        }
     }
 
     void Gui::Viewer::keyPressEvent( QKeyEvent* event )
     {
-        if(m_glInitStatus)
+        if(m_glInitStatus.load())
         {
             keyPressed(event->key());
             m_camera->handleKeyPressEvent( event );
         }
         else
+        {
             event->ignore();
+        }
 
         // Do we need this ?
         //QWindow::keyPressEvent(event);
@@ -350,8 +373,10 @@ namespace Ra
     {
  //       LOG( logDEBUG ) << "Gui::Viewer --> Got resize event : "  << width() << 'x' << height();
 
-        if(!m_glInitStatus)
+        if(!m_glInitStatus.load())
+        {
             initializeGL();
+        }
 
         if (!m_currentRenderer || !m_camera)
             return;
@@ -362,7 +387,8 @@ namespace Ra
     void Gui::Viewer::showEvent(QShowEvent *ev)
     {
  //       LOG( logDEBUG ) << "Gui::Viewer --> Got show event : " << width() << 'x' << height();
-        if(!m_context) {
+        if(!m_context)
+        {
             m_context.reset(new QOpenGLContext());
             m_context->create();
             m_context->makeCurrent(this);
@@ -411,10 +437,14 @@ namespace Ra
 
     bool Gui::Viewer::changeRenderer( int index )
     {
-        if (m_glInitStatus.load() && m_renderers[index]) {
+        if (m_glInitStatus.load() && m_renderers[index])
+        {
             m_context->makeCurrent(this);
 
-            if(m_currentRenderer != nullptr) m_currentRenderer->lockRendering();
+            if(m_currentRenderer != nullptr)
+            {
+                m_currentRenderer->lockRendering();
+            }
 
             m_currentRenderer = m_renderers[index].get();
             m_currentRenderer->resize( width(), height() );
@@ -452,7 +482,9 @@ namespace Ra
     void Gui::Viewer::waitForRendering()
     {
         if (isExposed())
+        {
             m_context->swapBuffers(this);
+        }
 
         m_context->doneCurrent();
     }

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -388,15 +388,23 @@ namespace Ra
         m_currentRenderer->unlockRendering();
     }
 
-    void Gui::Viewer::changeRenderer( int index )
+    bool Gui::Viewer::changeRenderer( int index )
     {
-        if (m_renderers[index]) {
+        if (m_glInitStatus.load() && m_renderers[index]) {
             m_context->makeCurrent(this);
+
             if(m_currentRenderer != nullptr) m_currentRenderer->lockRendering();
+
             m_currentRenderer = m_renderers[index].get();
             m_currentRenderer->resize( width(), height() );
             m_currentRenderer->unlockRendering();
+
+            LOG( logINFO ) << "[Viewer] Set active renderer: "
+                           << m_currentRenderer->getRendererName();
+
+            return true;
         }
+        return false;
     }
 
     // Asynchronous rendering implementation

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -60,9 +60,16 @@ namespace Ra
     }
 
     Gui::Viewer::~Viewer(){
-        if (m_gizmoManager != nullptr)
+        if ( m_glInitStatus.load() )
         {
-            delete m_gizmoManager;
+            m_context->makeCurrent( this );
+            m_renderers.clear();
+
+            if (m_gizmoManager != nullptr)
+            {
+                delete m_gizmoManager;
+            }
+            m_context->doneCurrent( );
         }
     }
 

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -124,7 +124,6 @@ namespace Ra
         auto light = Ra::Core::make_shared<Engine::DirectionalLight>();
         m_camera->attachLight( light );
 
-        m_glInitStatus = true;
 
         // initialize renderers added before GL was ready
         if( ! m_renderers.empty() ) {
@@ -136,6 +135,8 @@ namespace Ra
             }
             changeRenderer(0);
         }
+
+        m_glInitStatus = true;
 
         emit glInitialized();
 

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -154,7 +154,7 @@ namespace Ra
             void displayTexture( const QString& tex );
 
             /// Set the renderer
-            void changeRenderer( int index );
+            bool changeRenderer( int index );
 
             /// Toggle the post-process effetcs
             void enablePostProcess(int enabled);

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -197,6 +197,8 @@ namespace Ra
             //
 
             /// Initialize openGL. Called on by the first "show" call to the main window.
+            /// \warning This function is NOT reentrant, and may behave incorrectly
+            /// if called at the same time than #intializeRenderer
             virtual void initializeGL();
 
             /// Resize the view port and the camera. Called by the resize event.


### PR DESCRIPTION
Fixes two problems:
* GL error when switching between to renderers at runtime (missing call to makeCurrent) 1672156
* Crash when starting main application:
  Renderers in plugins were added while GL was not initialized.
  This is fixed by allowing deferred initialization of renderers that are added before GL initialization.