### PR TITLE
[hotfix + feature] Fix Qt signaling system for OpenGL initilisation + Allow Extension of OpenGL biotope by plugins

### DIFF
--- a/Applications/HelloRadium/minimalapp.cpp
+++ b/Applications/HelloRadium/minimalapp.cpp
@@ -46,7 +46,6 @@ MinimalApp::MinimalApp(int &argc, char** argv)
     // Initialize timer for the spinning cube.
     m_frame_timer = new QTimer(this);
     m_frame_timer->setInterval(1000 / m_target_fps);
-    connect(m_frame_timer, &QTimer::timeout, this, &MinimalApp::frame);
 }
 
 MinimalApp::~MinimalApp()
@@ -58,6 +57,7 @@ void MinimalApp::openGLReady()
 {
     std::shared_ptr<Ra::Engine::Renderer> e (new Ra::Engine::ForwardRenderer());
     m_viewer->addRenderer(e);
+    connect(m_frame_timer, &QTimer::timeout, this, &MinimalApp::frame);
 }
 
 void MinimalApp::frame()

--- a/Applications/HelloRadium/minimalapp.cpp
+++ b/Applications/HelloRadium/minimalapp.cpp
@@ -41,7 +41,7 @@ MinimalApp::MinimalApp(int &argc, char** argv)
     m_viewer.reset(new Ra::Gui::Viewer);
 
     CORE_ASSERT( m_viewer != nullptr, "GUI was not initialized" );
-    connect(m_viewer.get(), &Ra::Gui::Viewer::glInitialized, this, &MinimalApp::openGLReady);
+    connect(m_viewer.get(), &Ra::Gui::Viewer::glInitialized, this, &MinimalApp::onGLInitialized);
 
     // Initialize timer for the spinning cube.
     m_frame_timer = new QTimer(this);
@@ -53,7 +53,7 @@ MinimalApp::~MinimalApp()
     m_engine->cleanup();
 }
 
-void MinimalApp::openGLReady()
+void MinimalApp::onGLInitialized()
 {
     std::shared_ptr<Ra::Engine::Renderer> e (new Ra::Engine::ForwardRenderer());
     m_viewer->addRenderer(e);

--- a/Applications/HelloRadium/minimalapp.cpp
+++ b/Applications/HelloRadium/minimalapp.cpp
@@ -1,5 +1,5 @@
 #include <minimalapp.hpp>
-
+#include <Engine/Renderer/Renderers/ForwardRenderer.hpp>
 #include <Engine/Renderer/RenderTechnique/ShaderConfigFactory.hpp>
 
 #include <GuiBase/Utils/KeyMappingManager.hpp>
@@ -41,6 +41,7 @@ MinimalApp::MinimalApp(int &argc, char** argv)
     m_viewer.reset(new Ra::Gui::Viewer);
 
     CORE_ASSERT( m_viewer != nullptr, "GUI was not initialized" );
+    connect(m_viewer.get(), &Ra::Gui::Viewer::glInitialized, this, &MinimalApp::openGLReady);
 
     // Initialize timer for the spinning cube.
     m_frame_timer = new QTimer(this);
@@ -53,7 +54,11 @@ MinimalApp::~MinimalApp()
     m_engine->cleanup();
 }
 
-
+void MinimalApp::openGLReady()
+{
+    std::shared_ptr<Ra::Engine::Renderer> e (new Ra::Engine::ForwardRenderer());
+    m_viewer->addRenderer(e);
+}
 
 void MinimalApp::frame()
 {

--- a/Applications/HelloRadium/minimalapp.hpp
+++ b/Applications/HelloRadium/minimalapp.hpp
@@ -29,6 +29,7 @@ public slots:
     /// This function is the basic "game loop" iteration of the engine.
     /// It starts the rendering then advance all systems by one frame.
     void frame();
+    void openGLReady();
 
 public:
     // Our instance of the engine

--- a/Applications/HelloRadium/minimalapp.hpp
+++ b/Applications/HelloRadium/minimalapp.hpp
@@ -29,7 +29,7 @@ public slots:
     /// This function is the basic "game loop" iteration of the engine.
     /// It starts the rendering then advance all systems by one frame.
     void frame();
-    void openGLReady();
+    void onGLInitialized();
 
 public:
     // Our instance of the engine

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -140,6 +140,7 @@ namespace Ra
                 [=]( const QString& ) { this->onCurrentRenderChangedInUI(); } );
 
         connect(m_viewer, &Viewer::glInitialized, this, &MainWindow::onGLInitialized);
+        // This seems to cause problem on MacOsX : signal is not trasnmitted ...
         connect(m_viewer, SIGNAL(glInitialized()), this, SIGNAL(glInitialized()));
         connect(m_viewer, &Viewer::rendererReady, this, &MainWindow::onRendererReady);
 
@@ -599,9 +600,12 @@ namespace Ra
 
     void Gui::MainWindow::onGLInitialized()
     {
+        LOG( logINFO ) << "****** Gui::MainWindow::onGLInitialized() ******";
         // set renderers once OpenGL is configured
         std::shared_ptr<Engine::Renderer> e (new Engine::ForwardRenderer());
         addRenderer("Forward Renderer", e);
+
+        emit glInitialized();
     }
 
     void Gui::MainWindow::updateTrackedFeatureInfo()

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -140,8 +140,8 @@ namespace Ra
                 [=]( const QString& ) { this->onCurrentRenderChangedInUI(); } );
 
         connect(m_viewer, &Viewer::glInitialized, this, &MainWindow::onGLInitialized);
-        // This seems to cause problem on MacOsX : signal is not trasnmitted ...
-        connect(m_viewer, SIGNAL(glInitialized()), this, SIGNAL(glInitialized()));
+        connect(m_viewer, &Viewer::glInitialized, mainApp, &BaseApplication::openGlIsReady);
+
         connect(m_viewer, &Viewer::rendererReady, this, &MainWindow::onRendererReady);
 
         connect(m_displayedTextureCombo,
@@ -600,12 +600,9 @@ namespace Ra
 
     void Gui::MainWindow::onGLInitialized()
     {
-        LOG( logINFO ) << "****** Gui::MainWindow::onGLInitialized() ******";
-        // set renderers once OpenGL is configured
+        // set default renderer once OpenGL is configured
         std::shared_ptr<Engine::Renderer> e (new Engine::ForwardRenderer());
         addRenderer("Forward Renderer", e);
-
-        emit glInitialized();
     }
 
     void Gui::MainWindow::updateTrackedFeatureInfo()

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -140,8 +140,6 @@ namespace Ra
                 [=]( const QString& ) { this->onCurrentRenderChangedInUI(); } );
 
         connect(m_viewer, &Viewer::glInitialized, this, &MainWindow::onGLInitialized);
-        connect(m_viewer, &Viewer::glInitialized, mainApp, &BaseApplication::openGlIsReady);
-
         connect(m_viewer, &Viewer::rendererReady, this, &MainWindow::onRendererReady);
 
         connect(m_displayedTextureCombo,

--- a/Applications/MainApplication/Gui/MainWindow.hpp
+++ b/Applications/MainApplication/Gui/MainWindow.hpp
@@ -119,9 +119,6 @@ namespace Ra
             /// Emitted when a new item is selected. An invalid entry is sent when no item is selected.
             void selectedItem( const Engine::ItemEntry& entry );
 
-            /// Emitted when GL is correclty initialized (forwarded from Viewer)
-            void glInitialized();
-
         private:
             /// Connect qt signals and slots. Called once by the constructor.
             void createConnections();

--- a/Applications/MainApplication/MainApplication.cpp
+++ b/Applications/MainApplication/MainApplication.cpp
@@ -199,8 +199,9 @@ namespace Ra
         CORE_ASSERT( m_viewer->getContext() != nullptr, "OpenGL context was not created" );
         CORE_ASSERT( m_viewer->getContext()->isValid(), "OpenGL was not initialized" );
 
-        // Allow all events to be processed (thus the viewer should have
-        // initialized the OpenGL context..)
+        // Connect the signals ans allow all pending events to be processed
+        // (thus the viewer should have initialized the OpenGL context..)
+        createConnections();
         processEvents();
 
         Ra::Engine::RadiumEngine::getInstance()->getEntityManager()->createEntity("Test");
@@ -218,7 +219,7 @@ namespace Ra
         }
         m_taskQueue.reset( new Core::TaskQueue(numThreads) );
 
-        createConnections();
+
 
         setupScene();
         emit starting();
@@ -238,6 +239,7 @@ namespace Ra
     void BaseApplication::createConnections()
     {
         connect( m_mainWindow.get(), &Gui::MainWindow::closed , this, &BaseApplication::appNeedsToQuit );
+        connect( m_viewer, &Gui::Viewer::glInitialized, this, &BaseApplication::openGlIsReady );
     }
 
     void BaseApplication::setupScene()
@@ -412,6 +414,11 @@ namespace Ra
     {
         LOG( logDEBUG ) << "About to quit.";
         m_isAboutToQuit = true;
+    }
+
+    void BaseApplication::openGlIsReady()
+    {
+        LOG( logINFO ) << "****** BaseApplication::openGlIsReady() ******";
     }
 
     void BaseApplication::setRealFrameRate(bool on)

--- a/Applications/MainApplication/MainApplication.cpp
+++ b/Applications/MainApplication/MainApplication.cpp
@@ -139,7 +139,10 @@ namespace Ra
         config << "single precision" ;
 #endif
 
-        config << "\nTexture support : ";
+        LOG( logINFO ) << config.str();
+
+        config.str( std::string() );
+        config << "Texture support : ";
 #if defined(RADIUM_WITH_TEXTURES)
         config << "enabled";
 #else

--- a/Applications/MainApplication/MainApplication.cpp
+++ b/Applications/MainApplication/MainApplication.cpp
@@ -30,6 +30,7 @@
 #include <Engine/Renderer/Mesh/Mesh.hpp>
 #include <Engine/Renderer/RenderTechnique/ShaderConfigFactory.hpp>
 
+#include <PluginBase/RadiumPluginInterface.hpp>
 
 #include <Gui/MainWindow.hpp>
 
@@ -40,9 +41,6 @@
 #endif
 #ifdef IO_USE_ASSIMP
     #include <IO/AssimpLoader/AssimpFileLoader.hpp>
-#endif
-#ifdef IO_USE_PBRT
-    #include <IO/PbrtLoader/PbrtFileLoader.hpp>
 #endif
 
 
@@ -147,7 +145,7 @@ namespace Ra
 #else
         config << "disabled" ;
 #endif
-        
+
         LOG( logINFO ) << config.str();
 
         config.str( std::string() );
@@ -185,10 +183,6 @@ namespace Ra
 #ifdef IO_USE_ASSIMP
         m_engine->registerFileLoader( std::shared_ptr<Asset::FileLoaderInterface>(new IO::AssimpFileLoader()) );
 #endif
-#ifdef IO_USE_PBRT
-        m_engine->registerFileLoader( std::shared_ptr<Asset::FileLoaderInterface>(new IO::PbrtFileLoader()) );
-#endif
-
         // Create main window.
         m_mainWindow.reset( new Gui::MainWindow );
         m_mainWindow->show();

--- a/Applications/MainApplication/MainApplication.cpp
+++ b/Applications/MainApplication/MainApplication.cpp
@@ -198,7 +198,7 @@ namespace Ra
         CORE_ASSERT( m_viewer->getContext() != nullptr, "OpenGL context was not created" );
         CORE_ASSERT( m_viewer->getContext()->isValid(), "OpenGL was not initialized" );
 
-        // Connect the signals ans allow all pending events to be processed
+        // Connect the signals and allow all pending events to be processed
         // (thus the viewer should have initialized the OpenGL context..)
         createConnections();
         processEvents();
@@ -218,8 +218,6 @@ namespace Ra
         }
         m_taskQueue.reset( new Core::TaskQueue(numThreads) );
 
-
-
         setupScene();
         emit starting();
 
@@ -238,6 +236,7 @@ namespace Ra
     void BaseApplication::createConnections()
     {
         connect( m_mainWindow.get(), &Gui::MainWindow::closed , this, &BaseApplication::appNeedsToQuit );
+        connect( m_viewer, &Gui::Viewer::glInitialized, this, &BaseApplication::initializeOpenGlPlugins );
     }
 
     void BaseApplication::setupScene()
@@ -414,7 +413,7 @@ namespace Ra
         m_isAboutToQuit = true;
     }
 
-    void BaseApplication::openGlIsReady()
+    void BaseApplication::initializeOpenGlPlugins()
     {
         // Initialize plugins that depends on Initialized OpenGL (if any)
         if (m_openGLPlugins.size() > 0) {

--- a/Applications/MainApplication/MainApplication.hpp
+++ b/Applications/MainApplication/MainApplication.hpp
@@ -7,6 +7,7 @@
 #include <Core/Time/Timer.hpp>
 #include <GuiBase/TimerData/FrameTimerData.hpp>
 #include <GuiBase/Viewer/Viewer.hpp>
+#include <PluginBase/RadiumPluginInterface.hpp>
 
 class QTimer;
 namespace Ra
@@ -119,6 +120,9 @@ namespace Ra
         uint m_targetFPS;
 
     private:
+        /// Plugins that need to be initialized once OpenGL is ready
+        std::vector<Ra::Plugins::RadiumPluginInterface*> m_openGLPlugins;
+
         /// Pointer to OpenGL Viewer for render call (belongs to MainWindow).
         Gui::Viewer* m_viewer;
 

--- a/Applications/MainApplication/MainApplication.hpp
+++ b/Applications/MainApplication/MainApplication.hpp
@@ -80,6 +80,8 @@ namespace Ra
         void loadFile( QString path );
         void framesCountForStatsChanged( uint count );
         void appNeedsToQuit();
+        void openGlIsReady();
+
         void setRealFrameRate( bool on );
         void setRecordFrames( bool on );
         void setRecordTimings( bool on );

--- a/Applications/MainApplication/MainApplication.hpp
+++ b/Applications/MainApplication/MainApplication.hpp
@@ -7,7 +7,6 @@
 #include <Core/Time/Timer.hpp>
 #include <GuiBase/TimerData/FrameTimerData.hpp>
 #include <GuiBase/Viewer/Viewer.hpp>
-#include <PluginBase/RadiumPluginInterface.hpp>
 
 class QTimer;
 namespace Ra
@@ -32,6 +31,14 @@ namespace Ra
     {
         class Viewer;
         class MainWindow;
+    }
+}
+
+namespace Ra
+{
+    namespace Plugins
+    {
+        class RadiumPluginInterface;
     }
 }
 

--- a/Applications/MainApplication/MainApplication.hpp
+++ b/Applications/MainApplication/MainApplication.hpp
@@ -81,7 +81,7 @@ namespace Ra
         void loadFile( QString path );
         void framesCountForStatsChanged( uint count );
         void appNeedsToQuit();
-        void openGlIsReady();
+        void initializeOpenGlPlugins();
 
         void setRealFrameRate( bool on );
         void setRecordFrames( bool on );

--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -12,9 +12,7 @@ if ( NOT MSVC )
     endif()
 endif()
 
-
-
-set(UNIX_DEFAULT_CXX_FLAGS                "-Wall -Wextra  -pthread -msse3 -Wno-sign-compare -Wno-unused-parameter -fno-exceptions -fPIC")
+set(UNIX_DEFAULT_CXX_FLAGS                "-Wall -Wextra  -pthread -msse3 -Wno-sign-compare -Wno-unused-parameter -fno-exceptions")
 set(UNIX_DEFAULT_CXX_FLAGS_DEBUG          "-D_DEBUG -DCORE_DEBUG -g3 -ggdb")
 set(UNIX_DEFAULT_CXX_FLAGS_RELEASE        "-DNDEBUG -O3")
 set(UNIX_DEFAULT_CXX_FLAGS_RELWITHDEBINFO "-g3")

--- a/cmake/SubModules.cmake
+++ b/cmake/SubModules.cmake
@@ -28,11 +28,6 @@ if (RADIUM_ASSIMP_SUPPORT)
     include(submoduleAssimp)
 endif()
 
-# Pbrt
-if (RADIUM_PBRT_SUPPORT)
-    include(submodulePbrt)
-endif()
-
 # OpenMesh
 include(submoduleOpenMesh)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,6 +134,7 @@ else( RADIUM_IO_IS_INTERFACE )
             ${io_target}
             ${io_libs}
     )
+    set_property( TARGET ${io_target} PROPERTY POSITION_INDEPENDENT_CODE ON )
 endif( RADIUM_IO_IS_INTERFACE )
 
 add_dependencies( ${io_target} ${core_target} ${engine_target} )
@@ -231,6 +232,10 @@ target_link_libraries(
 
 
 set(RADIUM_LIBRARIES ${RADIUM_LIBRARIES} "${core_target}" "${engine_target}" "${io_target}" "${guibase_target}" PARENT_SCOPE)
+
+set_property( TARGET ${core_target} PROPERTY POSITION_INDEPENDENT_CODE ON )
+set_property( TARGET ${engine_target} PROPERTY POSITION_INDEPENDENT_CODE ON )
+set_property( TARGET ${guibase_target} PROPERTY POSITION_INDEPENDENT_CODE ON )
 
 # Build tests
 include_directories(

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -476,6 +476,9 @@ namespace Ra
         CORE_ASSERT(m_glInitStatus.load(),
                     "OpenGL needs to be initialized before rendering.");
 
+        CORE_ASSERT(m_currentRenderer != nullptr,
+                    "No renderer found.");
+
         m_context->makeCurrent(this);
 
         // Move camera if needed. Disabled for now as it takes too long (see issue #69)
@@ -523,6 +526,12 @@ namespace Ra
 
     void Gui::Viewer::processPicking()
     {
+        CORE_ASSERT(m_glInitStatus.load(),
+                    "OpenGL needs to be initialized before rendering.");
+
+        CORE_ASSERT(m_currentRenderer != nullptr,
+                    "No renderer found.");
+
         CORE_ASSERT( m_currentRenderer->getPickingQueries().size() == m_currentRenderer->getPickingResults().size(),
                     "There should be one result per query." );
 
@@ -548,6 +557,7 @@ namespace Ra
     {
         if (!aabb.isEmpty())
         {
+            CORE_ASSERT(m_camera != nullptr, "No camera found.");
             m_camera->fitScene(aabb);
         }
         else

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -98,6 +98,10 @@ namespace Ra
 
         m_renderers.push_back(e);
 
+        if (m_currentRenderer == nullptr)
+        {
+            m_currentRenderer = e.get();
+        }
         return m_renderers.size()-1;
     }
 
@@ -157,6 +161,8 @@ namespace Ra
 
         emit glInitialized();
 
+        // This is inconsistant with event glInitialized connected to a method that do the same ...could cause the Forward renderer added twice. One here, one in the function connected to the signal glInitialized if any.
+        /*
         if(m_renderers.empty())
         {
             LOG( logINFO )
@@ -168,6 +174,7 @@ namespace Ra
         m_currentRenderer = m_renderers[0].get();
 
         emit rendererReady();
+*/
         m_context->doneCurrent();
     }
 

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -157,9 +157,8 @@ namespace Ra
             }
         }
 
-        m_context->doneCurrent();
-
         emit glInitialized();
+        m_context->doneCurrent();
 
         // this code is usefull only if glInitialized() connected slot does not add a renderer
         // On Windows, actually, the signal seems to be not fired (DLL_IMPORT/EXPORT problem ?
@@ -167,7 +166,11 @@ namespace Ra
         {
             LOG( logINFO )
                 << "Renderers fallback: no renderer added, enabling default (Forward Renderer)";
+
+            m_context->makeCurrent(this);
             std::shared_ptr<Ra::Engine::Renderer> e (new Ra::Engine::ForwardRenderer());
+            m_context->doneCurrent();
+
             addRenderer(e);
         }
 

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -159,10 +159,12 @@ namespace Ra
 
         m_glInitStatus = true;
 
-        emit glInitialized();
-
-        // This is inconsistant with event glInitialized connected to a method that do the same ...could cause the Forward renderer added twice. One here, one in the function connected to the signal glInitialized if any.
-        /*
+        // TODO : remove the following.
+        // This is inconsistant with event glInitialized connected to a method that do the same ...could cause the
+        // default (Forward) renderer added twice. One here, one in the function connected to the signal glInitialized
+        // if any.
+        // WARNING : Application must catch this signal or add a renderer when everything is OK
+/*
         if(m_renderers.empty())
         {
             LOG( logINFO )
@@ -176,6 +178,8 @@ namespace Ra
         emit rendererReady();
 */
         m_context->doneCurrent();
+        emit glInitialized();
+
     }
 
     Gui::CameraInterface* Gui::Viewer::getCameraInterface()
@@ -231,7 +235,6 @@ namespace Ra
 
     void Gui::Viewer::intializeRenderer(Engine::Renderer *renderer)
     {
-        m_context->makeCurrent(this);
         // see issue #261 Qt Event order and default viewport management (Viewer.cpp)
         // https://github.com/STORM-IRIT/Radium-Engine/issues/261
 #ifndef OS_MACOS
@@ -242,7 +245,6 @@ namespace Ra
         {
             renderer->addLight( m_camera->getLight() );
         }
-        m_context->doneCurrent();
     }
 
     void Gui::Viewer::resizeGL( int width_, int height_ )
@@ -476,6 +478,8 @@ namespace Ra
 
             LOG( logINFO ) << "[Viewer] Set active renderer: "
                            << m_currentRenderer->getRendererName();
+
+            emit rendererReady();
 
             m_context->doneCurrent();
             return true;

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -231,11 +231,18 @@ namespace Ra
 
     void Gui::Viewer::intializeRenderer(Engine::Renderer *renderer)
     {
+        m_context->makeCurrent(this);
+        // see issue #261 Qt Event order and default viewport management (Viewer.cpp)
+        // https://github.com/STORM-IRIT/Radium-Engine/issues/261
+#ifndef OS_MACOS
+        gl::glViewport(0, 0, width(), height());
+#endif
         renderer->initialize(width(), height());
         if( m_camera->hasLightAttached() )
         {
             renderer->addLight( m_camera->getLight() );
         }
+        m_context->doneCurrent();
     }
 
     void Gui::Viewer::resizeGL( int width_, int height_ )

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -159,24 +159,6 @@ namespace Ra
 
         m_glInitStatus = true;
 
-        // TODO : remove the following.
-        // This is inconsistant with event glInitialized connected to a method that do the same ...could cause the
-        // default (Forward) renderer added twice. One here, one in the function connected to the signal glInitialized
-        // if any.
-        // WARNING : Application must catch this signal or add a renderer when everything is OK
-/*
-        if(m_renderers.empty())
-        {
-            LOG( logINFO )
-                    << "Renderers fallback: no renderer added, enabling default (Forward Renderer)";
-            std::shared_ptr<Ra::Engine::Renderer> e (new Ra::Engine::ForwardRenderer());
-            addRenderer(e);
-        }
-
-        m_currentRenderer = m_renderers[0].get();
-
-        emit rendererReady();
-*/
         m_context->doneCurrent();
         emit glInitialized();
 

--- a/src/PluginBase/RadiumPluginInterface.hpp
+++ b/src/PluginBase/RadiumPluginInterface.hpp
@@ -7,6 +7,7 @@
 class QWidget;
 class QMenu;
 class QAction;
+class QOpenGLContext;
 
 namespace Ra
 {

--- a/src/PluginBase/RadiumPluginInterface.hpp
+++ b/src/PluginBase/RadiumPluginInterface.hpp
@@ -134,6 +134,20 @@ namespace Ra
             virtual bool doAddFileLoader() { return false; }
 
             virtual void addFileLoaders(std::vector<std::shared_ptr<Asset::FileLoaderInterface>> */*fl*/) {}
+
+            /**
+             * @brief openGlInitialize
+             *
+             * \param context (const PluginContext& context) the Plugin context
+             * \param openGLContext (const QOpenGLContext *openGLContext) the existing OpenGLcontext use by the viewer
+             * @see https://herbsutter.com/2013/06/05/gotw-91-solution-smart-pointer-parameters/ for the reason a
+             * const QOpenGLContext * is given
+             * \warning Allocated renderers are given to the application and
+             * SHOULD not be destroyed by the plugin
+             */
+            virtual void openGlInitialize(const PluginContext& context, const QOpenGLContext *openGLContext) {}
+
+            virtual bool doAddROpenGLInitializer() { return false; }
         };
     }
 }


### PR DESCRIPTION
- [hotfix] HelloRadium works fine now on Linux and MacOs : fix problem due to wrong order of initialisation and confusion of Qt event. Small rewrinting of the MainApplication to follow this fix. These modifications were also usefull for the introduced feature.
- [Feature] Extend the Plugin Interface to notify the plugins once OpenGL is initialised. This allow plugins to interact with the Radium OpenGl system (adding shaders, configuring the context, ...)