### PR TITLE
Window factory

### DIFF
--- a/Applications/MainApplication/MainApplication.cpp
+++ b/Applications/MainApplication/MainApplication.cpp
@@ -45,7 +45,7 @@
 
 namespace Ra
 {
-    BaseApplication::BaseApplication( int argc, char** argv, QString applicationName, QString organizationName)
+    BaseApplication::BaseApplication( int argc, char** argv, const Gui::WindowFactory &factory, QString applicationName, QString organizationName)
         : QApplication( argc, argv )
         , m_mainWindow( nullptr )
         , m_engine( nullptr )
@@ -181,7 +181,7 @@ namespace Ra
         m_engine->registerFileLoader( std::shared_ptr<Asset::FileLoaderInterface>(new IO::AssimpFileLoader()) );
 #endif
         // Create main window.
-        m_mainWindow.reset( new Gui::MainWindow );
+        m_mainWindow.reset( factory.createMainWindow() );
         m_mainWindow->show();
 
         m_viewer = m_mainWindow->getViewer();

--- a/Applications/MainApplication/MainApplication.cpp
+++ b/Applications/MainApplication/MainApplication.cpp
@@ -54,6 +54,7 @@ namespace Ra
         , m_frameTimer( new QTimer( this ) )
         , m_frameCounter( 0 )
         , m_numFrames( 0 )
+        , m_maxThreads( 7 )
         , m_realFrameRate( false )
         , m_recordFrames( false )
         , m_recordTimings( false )

--- a/Applications/MainApplication/MainApplication.hpp
+++ b/Applications/MainApplication/MainApplication.hpp
@@ -22,7 +22,7 @@ namespace Ra
     namespace Engine
     {
         class RadiumEngine;
-        class ItemEntry;
+        struct ItemEntry;
     }
 }
 
@@ -51,13 +51,24 @@ namespace Ra
 
 namespace Ra
 {
+namespace Gui
+{
+
+class WindowFactory{
+public:
+    WindowFactory(){};
+    virtual  Gui::MainWindow *createMainWindow() const =0;
+};
+}
+
+
     /// This class contains the main application logic. It owns the engine and the GUI.
     class BaseApplication : public QApplication
     {
         Q_OBJECT
 
     public:
-        BaseApplication( int argc, char** argv, QString applicationName = "RadiumEngine", QString organizationName = "STORM-IRIT" );
+        BaseApplication( int argc, char** argv, const Gui::WindowFactory &f, QString applicationName = "RadiumEngine", QString organizationName = "STORM-IRIT");
         ~BaseApplication();
 
         /// Advance the engine for one frame.

--- a/Applications/MainApplication/main.cpp
+++ b/Applications/MainApplication/main.cpp
@@ -4,9 +4,21 @@
 
 #include <GuiBase/Utils/KeyMappingManager.hpp>
 
+#include <Gui/MainWindow.hpp>
+
+
+class MainWindowFactory:public Ra::Gui::WindowFactory{
+public:
+    using Ra::Gui::WindowFactory::WindowFactory;
+    Ra::Gui::MainWindow *createMainWindow() const
+    {
+        return new Ra::Gui::MainWindow();
+    }
+};
+
 int main( int argc, char** argv )
 {
-    Ra::MainApplication app( argc, argv );
+    Ra::MainApplication app( argc, argv, MainWindowFactory() );
 
     const uint& fpsMax = app.m_targetFPS;
     const Scalar deltaTime( fpsMax == 0 ? 0.f : 1.f / Scalar( fpsMax ) );


### PR DESCRIPTION

Add MainWindowFactory class to extend MainApplication.

MainApplication constructor take a factory to delegate the creation of MainWindow. This allows the creation of MainWindow derivate class without duplicating the MainApplication.
Next step is to provide a MainWindowInterface and move MainApplication in GuiBase.

(this PR also incorporate #277 )