### PR TITLE
Fix Mac and laptop mouse controls

### DIFF
--- a/Configs/alternative.xml
+++ b/Configs/alternative.xml
@@ -10,11 +10,11 @@
 		<information id="action" value="TRACKBALLCAMERA_ROTATE_AROUND"></information>
 	</keymap>
         <keymap>
-                <information id="type" modifier="NoModifier" type="mouse" value="RightButton"></information>
+                <information id="type" modifier="ControlModifier" type="mouse" value="RightButton"></information>
                 <information id="action" value="GIZMOMANAGER_MANIPULATION"></information>
         </keymap>
 	<keymap>
-		<information id="type" modifier="NoModifier" type="mouse" value="MiddleClick"></information>
+                <information id="type" modifier="NoModifier" type="mouse" value="RightButton"></information>
                 <information id="action" value="VIEWER_BUTTON_PICKING_QUERY"></information>
 	</keymap>
         <keymap>

--- a/Plugins/MeshFeatureTracking/src/MeshFeatureTrackingComponent.cpp
+++ b/Plugins/MeshFeatureTracking/src/MeshFeatureTrackingComponent.cpp
@@ -3,6 +3,7 @@
 #include <Core/Mesh/TriangleMesh.hpp>
 #include <Core/Mesh/MeshPrimitives.hpp>
 
+#include <Engine/Entity/Entity.hpp>
 #include <Engine/Managers/ComponentMessenger/ComponentMessenger.hpp>
 #include <Engine/RadiumEngine.hpp>
 #include <Engine/Renderer/Material/Material.hpp>
@@ -510,7 +511,8 @@ namespace MeshFeatureTrackingPlugin
             break;
         }
 
-        return P;
+        // deal with transformations
+        return ro->getTransform() * P;
     }
 
     Ra::Core::Vector3 MeshFeatureTrackingComponent::getFeatureVector() const
@@ -556,7 +558,8 @@ namespace MeshFeatureTrackingPlugin
             break;
         }
 
-        return V;
+        // deal with transformations
+        return (ro->getTransformAsMatrix().inverse().transpose() * Ra::Core::Vector4(V(0), V(1), V(2), 0)).head<3>();
     }
 
 }

--- a/Plugins/MeshFeatureTracking/src/MeshFeatureTrackingComponent.cpp
+++ b/Plugins/MeshFeatureTracking/src/MeshFeatureTrackingComponent.cpp
@@ -12,6 +12,8 @@
 #include <Engine/Renderer/RenderObject/RenderObject.hpp>
 
 using Ra::Engine::ComponentMessenger;
+using MeshRenderMode = Ra::Engine::Mesh::MeshRenderMode;
+using PickingMode = Ra::Engine::Renderer::PickingMode;
 
 namespace MeshFeatureTrackingPlugin
 {
@@ -53,23 +55,12 @@ namespace MeshFeatureTrackingPlugin
         m_RO->setLocalTransform( T.scale( scale ) );
     }
 
-    void MeshFeatureTrackingComponent::setData( const Ra::Engine::Renderer::PickingResult &data )
-    {
-        m_data = data;
-    }
-
-    const Ra::Engine::Renderer::PickingResult& MeshFeatureTrackingComponent::getData() const
-    {
-        return m_data;
-    }
-
     int MeshFeatureTrackingComponent::getMaxV() const
     {
-        if ( m_data.m_mode != Ra::Engine::Renderer::RO &&
-             m_data.m_mode < Ra::Engine::Renderer::C_VERTEX &&
-             getRoMgr()->exists( m_data.m_roIdx ) )
+        if ( m_data.m_mode != PickingMode::RO && getRoMgr()->exists(m_pickedRoIdx) )
         {
-            return Ra::Engine::RadiumEngine::getInstance()->getRenderObjectManager()->getRenderObject( m_data.m_roIdx )
+            return Ra::Engine::RadiumEngine::getInstance()
+                    ->getRenderObjectManager()->getRenderObject( m_pickedRoIdx )
                     ->getMesh()->getGeometry().m_vertices.size();
         }
         return 0;
@@ -77,12 +68,11 @@ namespace MeshFeatureTrackingPlugin
 
     int MeshFeatureTrackingComponent::getMaxT() const
     {
-        if ( m_data.m_mode != Ra::Engine::Renderer::RO &&
-             m_data.m_mode < Ra::Engine::Renderer::C_VERTEX &&
-             getRoMgr()->exists( m_data.m_roIdx ) )
+        if ( m_data.m_mode != PickingMode::RO && getRoMgr()->exists(m_pickedRoIdx) )
         {
-            auto ro = Ra::Engine::RadiumEngine::getInstance()->getRenderObjectManager()->getRenderObject( m_data.m_roIdx );
-            if (ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_TRIANGLES)
+            auto ro = Ra::Engine::RadiumEngine::getInstance()
+                    ->getRenderObjectManager()->getRenderObject( m_pickedRoIdx );
+            if (ro->getMesh()->getRenderMode() == MeshRenderMode::RM_TRIANGLES)
             {
                 return ro->getMesh()->getGeometry().m_triangles.size();
             }
@@ -90,62 +80,339 @@ namespace MeshFeatureTrackingPlugin
         return 0;
     }
 
+    namespace { // anonymous namespace for line mesh indices retrieval from triangles -- according to the render mode
+        // returns the triangles where the vertices can be found, along with the corresponding vertex indices within them.
+        void getPos_L2T( int l, int &v0, int &v1, int &t0, int &t1 )
+        {
+            v0 = 0;
+            v1 = 1;
+            t0 = l/3*2;
+            t1 = t0;
+            if ( l % 3 == 1 )
+            {
+                v0 = 2;
+                v1 = 0;
+                ++t1;
+            }
+            else if ( l % 3 == 2 )
+            {
+                v0 = 1;
+                v1 = 2;
+                ++t0;
+                ++t1;
+            }
+        }
+        void getPos_L2T_strip( int l, int &v0, int &v1, int &t0, int&t1 )
+        {
+            v0 = 0;
+            v1 = 1;
+            t0 = l/3;
+            t1 = t0;
+            if ( l % 3 == 1 )
+            {
+                ++v0;
+                ++v1;
+            }
+            else if ( l % 3 == 2 )
+            {
+                v0 = 2;
+                v1 = 0;
+                ++t1;
+            }
+        }
+        void getPos_L2T_adjacency( int l, int &v0, int &v1, int &t0, int &t1 )
+        {
+            v0 = 1;
+            v1 = 2;
+            t0 = (l*4)/3;
+            t1 = t0;
+            if ( l % 3 == 1 )
+            {
+                v0 = 2;
+                v1 = 0;
+                ++t1;
+            }
+            else if ( l % 3 == 2 )
+            {
+                v0 = 0;
+                v1 = 1;
+                ++t0;
+                ++t1;
+            }
+        }
+        void getPos_L2T_strip_adjacency( int l, int &v0, int &v1, int &t0, int&t1 )
+        {
+            v0 = 0;
+            v1 = 1;
+            t0 = (l+1)/3;
+            t1 = t0;
+            if ( l % 3 == 0 )
+            {
+                ++v0;
+                ++v1;
+            }
+            else if ( l % 3 == 1 )
+            {
+                v0 = 2;
+                v1 = 0;
+                ++t1;
+            }
+        }
+
+        void getPos_TS2T( int ts, int &v0, int &v1, int &v2, int &t0, int &t1, int &t2 )
+        {
+            v0 = 0;
+            v1 = 1;
+            v2 = 2;
+            t0 = ts/3;
+            t1 = t0;
+            t2 = t0;
+            if (ts%3 == 1)
+            {
+                v0 = 1;
+                v1 = 2;
+                v2 = 0;
+                ++t2;
+            }
+            else if (ts%3 == 2)
+            {
+                v0 = 2;
+                v1 = 0;
+                v2 = 1;
+                ++t1;
+                ++t2;
+            }
+        }
+
+        // for fans, first triangle vertex is always triangle[0](0)
+        void getPos_TF2T( int tf, int &v1, int &v2, int &t1, int &t2)
+        {
+            v1 = 0;
+            v2 = 1;
+            t1 = (tf+1) / 3;
+            t2 = t1;
+            if (tf % 3 == 0)
+            {
+                v1 = 1;
+                v2 = 2;
+            }
+            else if (tf%3 == 1)
+            {
+                v1 = 2;
+                v2 = 0;
+                ++t2;
+            }
+        }
+    }
+
+    void MeshFeatureTrackingComponent::setData( const Ra::Engine::Renderer::PickingResult &data )
+    {
+        m_pickedRoIdx = data.m_roIdx;
+        m_data.m_mode = data.m_mode;
+        m_data.m_data = {-1, -1, -1, -1};
+        // check picking mode / render config OK
+        if ( m_data.m_mode == PickingMode::RO || m_data.m_mode > PickingMode::TRIANGLE)
+        {
+            return;
+        }
+        if ( !getRoMgr()->exists(m_pickedRoIdx) )
+        {
+            m_data.m_mode = PickingMode::RO;
+            return;
+        }
+        auto ro = Ra::Engine::RadiumEngine::getInstance()->getRenderObjectManager()->getRenderObject( m_pickedRoIdx );
+        auto rm = ro->getMesh()->getRenderMode();
+        if ( rm == MeshRenderMode::RM_POINTS && m_data.m_mode != PickingMode::VERTEX )
+        {
+            m_data.m_mode = PickingMode::RO;
+            return;
+        }
+        if ( (rm == MeshRenderMode::RM_LINES      || rm == MeshRenderMode::RM_LINE_LOOP ||
+              rm == MeshRenderMode::RM_LINE_STRIP || rm == MeshRenderMode::RM_LINES_ADJACENCY ||
+              rm == MeshRenderMode::RM_LINE_STRIP_ADJACENCY) &&
+             m_data.m_mode == PickingMode::TRIANGLE )
+        {
+            m_data.m_mode = PickingMode::RO;
+            return;
+        }
+        // fill data accordingly
+        if ( rm == MeshRenderMode::RM_POINTS )
+        {
+            m_data.m_data[0] = data.m_elementIdx[0];
+            return;
+        }
+        // if lines, retrieve triangle-based indices
+        if ( rm == MeshRenderMode::RM_LINES )
+        {
+            int v0, v1, t0, t1;
+            getPos_L2T( data.m_elementIdx[0], v0, v1, t0, t1 );
+            const auto &t = ro->getMesh()->getGeometry().m_triangles;
+            if ( m_data.m_mode == PickingMode::VERTEX )
+            {
+                m_data.m_data[0] = data.m_vertexIdx[0] == 0 ? t[t0](v0) : t[t1](v1) ;
+                m_data.m_data[1] = data.m_vertexIdx[0] == 0 ? t[t1](v1) : t[t0](v0) ;
+            }
+            else
+            {
+                m_data.m_data[0] = t[t0](v0);
+                m_data.m_data[1] = t[t1](v1);
+            }
+            return;
+        }
+        if ( rm == MeshRenderMode::RM_LINE_LOOP || rm == MeshRenderMode::RM_LINE_STRIP )
+        {
+            int v0, v1, t0, t1;
+            getPos_L2T_strip( data.m_elementIdx[0], v0, v1, t0, t1 );
+            const auto &t = ro->getMesh()->getGeometry().m_triangles;
+            if ( m_data.m_mode == PickingMode::VERTEX )
+            {
+                m_data.m_data[0] = data.m_vertexIdx[0] == 0 ? t[t0](v0) : t[t1](v1) ;
+                m_data.m_data[1] = data.m_vertexIdx[0] == 0 ? t[t1](v1) : t[t0](v0) ;
+            }
+            else
+            {
+                m_data.m_data[0] = t[t0](v0);
+                m_data.m_data[1] = t[t1](v1);
+            }
+            return;
+        }
+        if ( rm == MeshRenderMode::RM_LINES_ADJACENCY )
+        {
+            int v0, v1, t0, t1;
+            getPos_L2T_adjacency( data.m_elementIdx[0], v0, v1, t0, t1 );
+            const auto &t = ro->getMesh()->getGeometry().m_triangles;
+            if ( m_data.m_mode == PickingMode::VERTEX )
+            {
+                m_data.m_data[0] = data.m_vertexIdx[0] == 0 ? t[t0](v0) : t[t1](v1) ;
+                m_data.m_data[1] = data.m_vertexIdx[0] == 0 ? t[t1](v1) : t[t0](v0) ;
+            }
+            else
+            {
+                m_data.m_data[0] = t[t0](v0);
+                m_data.m_data[1] = t[t1](v1);
+            }
+            return;
+        }
+        if ( rm == MeshRenderMode::RM_LINE_STRIP_ADJACENCY )
+        {
+            int v0, v1, t0, t1;
+            getPos_L2T_strip_adjacency( data.m_elementIdx[0], v0, v1, t0, t1 );
+            const auto &t = ro->getMesh()->getGeometry().m_triangles;
+            if ( m_data.m_mode == PickingMode::VERTEX )
+            {
+                m_data.m_data[0] = data.m_vertexIdx[0] == 0 ? t[t0](v0) : t[t1](v1) ;
+                m_data.m_data[1] = data.m_vertexIdx[0] == 0 ? t[t1](v1) : t[t0](v0) ;
+            }
+            else
+            {
+                m_data.m_data[0] = t[t0](v0);
+                m_data.m_data[1] = t[t1](v1);
+            }
+            return;
+        }
+        if ( rm == MeshRenderMode::RM_TRIANGLES && m_data.m_mode == PickingMode::VERTEX )
+        {
+            const auto &T = ro->getMesh()->getGeometry().m_triangles[ data.m_elementIdx[0] ];
+            m_data.m_data[0] = T( data.m_vertexIdx[0] );
+            m_data.m_data[1] = T( (data.m_vertexIdx[0]+1)%3 );
+            return;
+        }
+        if ( rm == MeshRenderMode::RM_TRIANGLES && m_data.m_mode == PickingMode::EDGE )
+        {
+            const auto &T = ro->getMesh()->getGeometry().m_triangles[ data.m_elementIdx[0] ];
+            m_data.m_data[0] = T( (data.m_edgeIdx[0]+1)%3 );
+            m_data.m_data[1] = T( (data.m_edgeIdx[0]+2)%3 );
+            return;
+        }
+        if ( rm == MeshRenderMode::RM_TRIANGLES )
+        {
+            const auto &T = ro->getMesh()->getGeometry().m_triangles[ data.m_elementIdx[0] ];
+            m_data.m_data[0] = T( 0 );
+            m_data.m_data[1] = T( 1 );
+            m_data.m_data[2] = T( 2 );
+            m_data.m_data[3] = data.m_elementIdx[0];
+            return;
+        }
+        if ( rm == MeshRenderMode::RM_TRIANGLE_STRIP && m_data.m_mode == PickingMode::VERTEX )
+        {
+            int v0, v1, v2, t0, t1, t2;
+            getPos_TS2T( data.m_elementIdx[0], v0, v1, v2, t0, t1, t2 );
+            const auto &t = ro->getMesh()->getGeometry().m_triangles;
+            m_data.m_data[0] = data.m_vertexIdx[0] == 0 ? t[t0](v0) :
+                              (data.m_vertexIdx[0] == 1 ? t[t1](v1) : t[t2](v2));
+            m_data.m_data[1] = data.m_vertexIdx[0] == 0 ? t[t1](v1) : t[t0](v0);
+            return;
+        }
+        if ( rm == MeshRenderMode::RM_TRIANGLE_STRIP && m_data.m_mode == PickingMode::EDGE )
+        {
+            int v0, v1, v2, t0, t1, t2;
+            getPos_TS2T( data.m_elementIdx[0], v0, v1, v2, t0, t1, t2 );
+            const auto &t = ro->getMesh()->getGeometry().m_triangles;
+            m_data.m_data[0] = data.m_edgeIdx[0] == 0 ? t[t1](v1) : t[t0](v0);
+            m_data.m_data[1] = data.m_edgeIdx[0] == 2 ? t[t1](v1) : t[t2](v2);
+            return;
+        }
+        if ( rm == MeshRenderMode::RM_TRIANGLE_STRIP )
+        {
+            int v0, v1, v2, t0, t1, t2;
+            getPos_TS2T( data.m_elementIdx[0], v0, v1, v2, t0, t1, t2 );
+            const auto &t = ro->getMesh()->getGeometry().m_triangles;
+            m_data.m_data[0] = t[t0](v0);
+            m_data.m_data[1] = t[t1](v1);
+            m_data.m_data[2] = t[t2](v2);
+            m_data.m_data[3] = data.m_elementIdx[0];
+            return;
+        }
+        if ( rm == MeshRenderMode::RM_TRIANGLE_FAN && m_data.m_mode == PickingMode::VERTEX )
+        {
+            int v1, v2, t1, t2;
+            getPos_TF2T( data.m_elementIdx[0], v1, v2, t1, t2 );
+            const auto &t = ro->getMesh()->getGeometry().m_triangles;
+            m_data.m_data[0] = data.m_vertexIdx[0] == 0 ? t[ 0]( 0) :
+                              (data.m_vertexIdx[0] == 1 ? t[t1](v1) : t[t2](v2));
+            m_data.m_data[1] = data.m_vertexIdx[0] == 0 ? t[t1](v1) : t[ 0]( 0);
+            return;
+        }
+        if ( rm == MeshRenderMode::RM_TRIANGLE_FAN && m_data.m_mode == PickingMode::EDGE )
+        {
+            int v1, v2, t1, t2;
+            getPos_TF2T( data.m_elementIdx[0], v1, v2, t1, t2 );
+            const auto &t = ro->getMesh()->getGeometry().m_triangles;
+            m_data.m_data[0] = data.m_edgeIdx[0] == 0 ? t[t1](v1) : t[ 0]( 0);
+            m_data.m_data[1] = data.m_edgeIdx[0] == 2 ? t[t1](v1) : t[t2](v2);
+            return;
+        }
+        if ( rm == MeshRenderMode::RM_TRIANGLE_FAN )
+        {
+            int v1, v2, t1, t2;
+            getPos_TF2T( data.m_elementIdx[0], v1, v2, t1, t2 );
+            const auto &t = ro->getMesh()->getGeometry().m_triangles;
+            m_data.m_data[0] = t[ 0]( 0);
+            m_data.m_data[1] = t[t1](v1);
+            m_data.m_data[2] = t[t2](v2);
+            m_data.m_data[3] = data.m_elementIdx[0];
+            return;
+        }
+    }
+
     void MeshFeatureTrackingComponent::setVertexIdx( int idx )
     {
-        if ( getRoMgr()->exists( m_data.m_roIdx ) )
-        {
-            auto ro = Ra::Engine::RadiumEngine::getInstance()->getRenderObjectManager()->getRenderObject( m_data.m_roIdx );
-            if (ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_POINTS)
-            {
-                m_data.m_elementIdx[0] = idx;
-                return;
-            }
-            if (ro->getMesh()->getRenderMode() != Ra::Engine::Mesh::RM_TRIANGLES)
-            {
-                return;
-            }
-            const auto& T = ro->getMesh()->getGeometry().m_triangles;
-            for ( int t = 0; t < T.size(); ++t )
-            {
-                if (T[t](0) == idx)
-                {
-                    m_data.m_elementIdx[0] = t;
-                    m_data.m_vertexIdx[0] = 0;
-                    return;
-                }
-                if (T[t](1) == idx)
-                {
-                    m_data.m_elementIdx[0] = t;
-                    m_data.m_vertexIdx[0] = 1;
-                    return;
-                }
-                if (T[t](2) == idx)
-                {
-                    m_data.m_elementIdx[0] = t;
-                    m_data.m_vertexIdx[0] = 2;
-                    return;
-                }
-            }
-        };
+        m_data.m_data[0] = idx;
     }
 
     void MeshFeatureTrackingComponent::setTriangleIdx( int idx )
     {
-        m_data.m_elementIdx[0] = idx;
+        m_data.m_data[3] = idx;
     }
 
     void MeshFeatureTrackingComponent::update()
     {
         // check supported picking mode
-        if ( m_data.m_mode != Ra::Engine::Renderer::RO &&
-             m_data.m_mode < Ra::Engine::Renderer::C_VERTEX &&
-             getRoMgr()->exists( m_data.m_roIdx ) )
+        if ( m_data.m_mode != PickingMode::RO && getRoMgr()->exists( m_pickedRoIdx ) )
         {
         	setPosition( getFeaturePosition() );
-        	setScale( getFeatureScale() );
-            auto ro = Ra::Engine::RadiumEngine::getInstance()->getRenderObjectManager()->getRenderObject( m_data.m_roIdx );
-            m_RO->setVisible( ro->getMesh()->getRenderMode() != Ra::Engine::Mesh::RM_POINTS ||
-                              m_data.m_mode == Ra::Engine::Renderer::VERTEX );
+            setScale( getFeatureScale() );
+            m_RO->setVisible( true );
         }
         else
         {
@@ -155,113 +422,47 @@ namespace MeshFeatureTrackingPlugin
 
     FeatureData MeshFeatureTrackingComponent::getFeatureData() const
     {
-        FeatureData data;
-        data.m_mode = Ra::Engine::Renderer::RO;
-        // check supported picking mode
-        if ( m_data.m_mode == Ra::Engine::Renderer::RO ||
-             m_data.m_mode >= Ra::Engine::Renderer::C_VERTEX ||
-             !getRoMgr()->exists( m_data.m_roIdx ) )
-        {
-            return data;
-        }
-
-        // check supported RO type
-        auto ro = Ra::Engine::RadiumEngine::getInstance()->getRenderObjectManager()->getRenderObject( m_data.m_roIdx );
-        if ( ro->getMesh()->getRenderMode() != Ra::Engine::Mesh::RM_POINTS &&
-             ro->getMesh()->getRenderMode() != Ra::Engine::Mesh::RM_TRIANGLES )
-        {
-            return data;
-        }
-
-        // manage picking mode
-        if ( m_data.m_mode == Ra::Engine::Renderer::VERTEX)
-        {
-            data.m_mode = m_data.m_mode;
-            if (ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_POINTS)
-            {
-                data.m_data[0] = m_data.m_elementIdx[0];
-            }
-            else
-            {
-                data.m_data[0] = ro->getMesh()->getGeometry().m_triangles[ m_data.m_elementIdx[0] ]( m_data.m_vertexIdx[0] );
-            }
-        }
-        if (ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_POINTS)
-        {
-            return data;
-        }
-        if ( m_data.m_mode == Ra::Engine::Renderer::EDGE )
-        {
-            data.m_mode = m_data.m_mode;
-            data.m_data[0] = ro->getMesh()->getGeometry().m_triangles[ m_data.m_elementIdx[0] ]( (m_data.m_edgeIdx[0]+1)%3 );
-            data.m_data[1] = ro->getMesh()->getGeometry().m_triangles[ m_data.m_elementIdx[0] ]( (m_data.m_edgeIdx[0]+2)%3 );
-        }
-        if ( m_data.m_mode == Ra::Engine::Renderer::TRIANGLE )
-        {
-            data.m_mode = m_data.m_mode;
-            data.m_data[0] = ro->getMesh()->getGeometry().m_triangles[ m_data.m_elementIdx[0] ]( 0 );
-            data.m_data[1] = ro->getMesh()->getGeometry().m_triangles[ m_data.m_elementIdx[0] ]( 1 );
-            data.m_data[2] = ro->getMesh()->getGeometry().m_triangles[ m_data.m_elementIdx[0] ]( 2 );
-            data.m_data[3] = m_data.m_elementIdx[0];
-        }
-        return data;
+        return m_data;
     }
 
     Scalar MeshFeatureTrackingComponent::getFeatureScale() const
     {
         // check supported picking mode
-        if ( m_data.m_mode == Ra::Engine::Renderer::RO ||
-             m_data.m_mode >= Ra::Engine::Renderer::C_VERTEX ||
-             !getRoMgr()->exists( m_data.m_roIdx ) )
+        if ( m_data.m_mode == PickingMode::RO || !getRoMgr()->exists( m_pickedRoIdx ) )
         {
             return 1.0;
-        }
-
-        // check supported RO type
-        auto ro = Ra::Engine::RadiumEngine::getInstance()->getRenderObjectManager()->getRenderObject(m_data.m_roIdx);
-        if ( ro->getMesh()->getRenderMode() != Ra::Engine::Mesh::RM_POINTS &&
-             ro->getMesh()->getRenderMode() != Ra::Engine::Mesh::RM_TRIANGLES )
-        {
-            return 1.0;
-        }
-        if (ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_POINTS)
-        {
-            return ro->getAabb().sizes().norm() / 500;
         }
 
         // manage picking mode
+        auto ro = Ra::Engine::RadiumEngine::getInstance()
+                ->getRenderObjectManager()->getRenderObject( m_pickedRoIdx );
+        if (ro->getMesh()->getRenderMode() == MeshRenderMode::RM_POINTS)
+        {
+            return ro->getAabb().sizes().norm() / 500;
+        }
         const auto& v = ro->getMesh()->getGeometry().m_vertices;
-        const auto& T = ro->getMesh()->getGeometry().m_triangles[ m_data.m_elementIdx[0] ];
         switch (m_data.m_mode)
         {
-        case Ra::Engine::Renderer::VERTEX:
+        case PickingMode::VERTEX:
         {
             // return 1 fourth of the edge length of the first edge we can find with the vertex
-            const auto& V = T( m_data.m_vertexIdx[0] );
-            for (const auto& t : ro->getMesh()->getGeometry().m_triangles)
-            {
-                if (t(0) == V || t(1) == V || t(2) == V)
-                {
-                    const Ra::Core::Vector3& v0 = v[ V ];
-                    const Ra::Core::Vector3& v1 = v[ t(0)==V? t(1) : t(0) ];
-                    return (v1-v0).norm() / 4.0;
-                }
-            }
-            return ro->getAabb().diagonal().norm() / 100; // default for point clouds
-        }
-        case Ra::Engine::Renderer::EDGE:
-        {
-            // return 1 fourth of the edge length
-            const Ra::Core::Vector3& v0 = v[ T( (m_data.m_edgeIdx[0]+1)%3 ) ];
-            const Ra::Core::Vector3& v1 = v[ T( (m_data.m_edgeIdx[0]+2)%3 ) ];
+            const Ra::Core::Vector3& v0 = v[ m_data.m_data[0] ];
+            const Ra::Core::Vector3& v1 = v[ m_data.m_data[1] ];
             return (v1-v0).norm() / 4.0;
         }
-        case Ra::Engine::Renderer::TRIANGLE:
+        case PickingMode::EDGE:
+        {
+            // return 1 fourth of the edge length
+            const Ra::Core::Vector3& v0 = v[ m_data.m_data[0] ];
+            const Ra::Core::Vector3& v1 = v[ m_data.m_data[1] ];
+            return (v1-v0).norm() / 4.0;
+        }
+        case PickingMode::TRIANGLE:
         {
             // return half the smallest distance from C to an edge
-            const Ra::Core::Vector3& v0 = v[ T(0) ];
-            const Ra::Core::Vector3& v1 = v[ T(1) ];
-            const Ra::Core::Vector3& v2 = v[ T(2) ];
+            const Ra::Core::Vector3& v0 = v[ m_data.m_data[0] ];
+            const Ra::Core::Vector3& v1 = v[ m_data.m_data[1] ];
+            const Ra::Core::Vector3& v2 = v[ m_data.m_data[2] ];
             const Ra::Core::Vector3 C = ( v0 + v1 + v2 ) / 3.0;
             const Ra::Core::Vector3 C0 = C-v0;
             const Ra::Core::Vector3 C1 = C-v1;
@@ -278,44 +479,31 @@ namespace MeshFeatureTrackingPlugin
     Ra::Core::Vector3 MeshFeatureTrackingComponent::getFeaturePosition() const
     {
         // check supported picking mode
-        if ( m_data.m_mode == Ra::Engine::Renderer::RO ||
-             m_data.m_mode >= Ra::Engine::Renderer::C_VERTEX ||
-             !getRoMgr()->exists( m_data.m_roIdx ) )
+        if ( m_data.m_mode == PickingMode::RO || !getRoMgr()->exists(m_pickedRoIdx) )
         {
             return Ra::Core::Vector3();
-        }
-
-        // check supported RO type
-        auto ro = Ra::Engine::RadiumEngine::getInstance()->getRenderObjectManager()->getRenderObject( m_data.m_roIdx );
-        if ( ro->getMesh()->getRenderMode() != Ra::Engine::Mesh::RM_POINTS &&
-             ro->getMesh()->getRenderMode() != Ra::Engine::Mesh::RM_TRIANGLES )
-        {
-            return Ra::Core::Vector3();
-        }
-        const auto& v = ro->getMesh()->getGeometry().m_vertices;
-        if (ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_POINTS)
-        {
-            return v[ m_data.m_elementIdx[0] ];
         }
 
         // manage picking mode
-        const auto& T = ro->getMesh()->getGeometry().m_triangles[ m_data.m_elementIdx[0] ];
+        auto ro = Ra::Engine::RadiumEngine::getInstance()
+                ->getRenderObjectManager()->getRenderObject( m_pickedRoIdx );
+        const auto& v = ro->getMesh()->getGeometry().m_vertices;
         Ra::Core::Vector3 P(0,0,0);
         switch (m_data.m_mode)
         {
-        case Ra::Engine::Renderer::VERTEX:
+        case PickingMode::VERTEX:
         {
-            P = v[ T( m_data.m_vertexIdx[0] ) ];
+            P = v[ m_data.m_data[0] ];
             break;
         }
-        case Ra::Engine::Renderer::EDGE:
+        case PickingMode::EDGE:
         {
-            P = ( v[ T( (m_data.m_edgeIdx[0]+1)%3 ) ] + v[ T( (m_data.m_edgeIdx[0]+2)%3 ) ] ) / 2.0;
+            P = ( v[ m_data.m_data[0] ] + v[ m_data.m_data[1] ] ) / 2.0;
             break;
         }
-        case Ra::Engine::Renderer::TRIANGLE:
+        case PickingMode::TRIANGLE:
         {
-            P = ( v[ T(0) ] + v[ T(1) ] + v[ T(2) ] ) / 3.0;
+            P = ( v[ m_data.m_data[0] ] + v[ m_data.m_data[1] ] + v[ m_data.m_data[2] ] ) / 3.0;
             break;
         }
         default:
@@ -328,49 +516,39 @@ namespace MeshFeatureTrackingPlugin
     Ra::Core::Vector3 MeshFeatureTrackingComponent::getFeatureVector() const
     {
         // check supported picking mode
-        if ( m_data.m_mode == Ra::Engine::Renderer::RO ||
-             m_data.m_mode >= Ra::Engine::Renderer::C_VERTEX ||
-             !getRoMgr()->exists( m_data.m_roIdx ) )
+        if ( m_data.m_mode == PickingMode::RO || !getRoMgr()->exists(m_pickedRoIdx) )
         {
-            return Ra::Core::Vector3();
-        }
-
-        // check supported RO type
-        auto ro = Ra::Engine::RadiumEngine::getInstance()->getRenderObjectManager()->getRenderObject( m_data.m_roIdx );
-        const auto& n = ro->getMesh()->getGeometry().m_normals;
-        if (ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_POINTS)
-        {
-            if ( !n.empty() )
-            {
-                return n[ m_data.m_elementIdx[0] ];
-            }
             return Ra::Core::Vector3();
         }
 
         // manage picking mode
+        auto ro = Ra::Engine::RadiumEngine::getInstance()
+                ->getRenderObjectManager()->getRenderObject( m_pickedRoIdx );
+        const auto& n = ro->getMesh()->getGeometry().m_normals;
+        if (m_data.m_mode == PickingMode::VERTEX)
+        {
+            if ( !n.empty() )
+            {
+                return n[ m_data.m_data[0] ];
+            }
+            return Ra::Core::Vector3();
+        }
         const auto& v = ro->getMesh()->getGeometry().m_vertices;
-        const auto& T = ro->getMesh()->getGeometry().m_triangles[ m_data.m_elementIdx[0] ];
         Ra::Core::Vector3 V(0,0,0);
         switch (m_data.m_mode)
         {
-        case Ra::Engine::Renderer::VERTEX:
-        {
-            // for vertices, the normal
-            V = n[ T( m_data.m_vertexIdx[0] ) ];
-            break;
-        }
-        case Ra::Engine::Renderer::EDGE:
+        case PickingMode::EDGE:
         {
             // for edges, the edge vector
-            V = v[ T( (m_data.m_edgeIdx[0]+1)%3 ) ] - v[ T( (m_data.m_edgeIdx[0]+2)%3 ) ];
+            V = v[ m_data.m_data[0] ] - v[ m_data.m_data[1] ];
             break;
         }
-        case Ra::Engine::Renderer::TRIANGLE:
+        case PickingMode::TRIANGLE:
         {
             // for triangles, the normal
-            const Ra::Core::Vector3& p0 = v[ T(0) ];
-            const Ra::Core::Vector3& p1 = v[ T(1) ];
-            const Ra::Core::Vector3& p2 = v[ T(2) ];
+            const Ra::Core::Vector3& p0 = v[ m_data.m_data[0] ];
+            const Ra::Core::Vector3& p1 = v[ m_data.m_data[1] ];
+            const Ra::Core::Vector3& p2 = v[ m_data.m_data[2] ];
             V = (p1-p0).cross(p2-p0).normalized();
             break;
         }

--- a/Plugins/MeshFeatureTracking/src/MeshFeatureTrackingComponent.hpp
+++ b/Plugins/MeshFeatureTracking/src/MeshFeatureTrackingComponent.hpp
@@ -20,7 +20,6 @@ namespace MeshFeatureTrackingPlugin
         virtual void initialize() override;
 
         void setData( const Ra::Engine::Renderer::PickingResult& data );
-        const Ra::Engine::Renderer::PickingResult& getData() const;
 
         void setVertexIdx( int idx );
         void setTriangleIdx( int idx );
@@ -40,7 +39,8 @@ namespace MeshFeatureTrackingPlugin
         /// Registers the new scale for the sphere.
         void setScale( Scalar scale );
 
-        Ra::Engine::Renderer::PickingResult m_data;
+        FeatureData m_data;
+        int m_pickedRoIdx;
         Ra::Engine::RenderObject *m_RO;
     };
 }

--- a/Plugins/MeshFeatureTracking/src/UI/MeshFeatureTrackingUI.cpp
+++ b/Plugins/MeshFeatureTracking/src/UI/MeshFeatureTrackingUI.cpp
@@ -18,12 +18,12 @@ MeshFeatureTrackingUI::~MeshFeatureTrackingUI()
 
 void MeshFeatureTrackingUI::setMaxV( int max )
 {
-    ui->m_vertexIdx->setMaximum( max );
+    ui->m_vertexIdx->setMaximum( std::max( max-1, 0) );
 }
 
 void MeshFeatureTrackingUI::setMaxT( int max )
 {
-    ui->m_triangleIdx->setMaximum( max );
+    ui->m_triangleIdx->setMaximum( std::max( max-1, 0) );
 }
 
 void MeshFeatureTrackingUI::updateTracking( const FeatureData &data,

--- a/Plugins/MeshPaint/src/MeshPaintComponent.cpp
+++ b/Plugins/MeshPaint/src/MeshPaintComponent.cpp
@@ -84,10 +84,15 @@ void MeshPaintComponent::paintMesh( const Ra::Engine::Renderer::PickingResult& p
     }
 
     if ( (ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_LINES ||
+          ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_LINE_LOOP ||
+          ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_LINE_STRIP ||
           ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_LINES_ADJACENCY ||
-          ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_LINE_STRIP_ADJACENCY ) )
+          ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_LINE_STRIP_ADJACENCY ||
+          ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_TRIANGLES ||
+          ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_TRIANGLE_STRIP ||
+          ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_TRIANGLE_FAN ) )
     {
-        // line meshes not supported yet -- because picking not tested
+        // not supported yet -> might use same util functions as MeshFeatureTrackingComponent
         return;
     }
 

--- a/Plugins/MeshPaint/src/MeshPaintComponent.cpp
+++ b/Plugins/MeshPaint/src/MeshPaintComponent.cpp
@@ -88,7 +88,6 @@ void MeshPaintComponent::paintMesh( const Ra::Engine::Renderer::PickingResult& p
           ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_LINE_STRIP ||
           ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_LINES_ADJACENCY ||
           ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_LINE_STRIP_ADJACENCY ||
-          ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_TRIANGLES ||
           ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_TRIANGLE_STRIP ||
           ro->getMesh()->getRenderMode() == Ra::Engine::Mesh::RM_TRIANGLE_FAN ) )
     {

--- a/Shaders/LinesAdjacency.geom.glsl
+++ b/Shaders/LinesAdjacency.geom.glsl
@@ -1,20 +1,8 @@
-layout (lines) in;
+layout (lines_adjacency) in;
 layout (triangle_strip, max_vertices = 4) out;
 
-in gl_PerVertex {
-    vec4  gl_Position;
-    float gl_PointSize;
-    float gl_ClipDistance[];
-} gl_in[];
-
-out gl_PerVertex {
-    vec4  gl_Position;
-    float gl_PointSize;
-    float gl_ClipDistance[];
-};
-
-in vec3 vPosition[2];
-in vec4 vColor[2];
+in vec3 vPosition[4];
+in vec4 vColor[4];
 
 out vec4 gColor;
 
@@ -22,8 +10,8 @@ uniform float lineWidth;
 
 void main()
 {
-    vec3 p0 = vPosition[0];
-    vec3 p1 = vPosition[1];
+    vec3 p0 = vPosition[1];
+    vec3 p1 = vPosition[2];
 
     vec3 line = p1 - p0;
     vec3 n = normalize(vec3(-line.y, line.x, 0));
@@ -35,29 +23,29 @@ void main()
 
     gl_Position.w = 1.0;
 
-    gColor = vColor[0];
+    gColor = vColor[1];
     gl_Position.xyz = a;
     EmitVertex();
 
-    gColor = vColor[0];
+    gColor = vColor[1];
     gl_Position.xyz = b;
     EmitVertex();
 
-    gColor = vColor[1];
+    gColor = vColor[2];
     gl_Position.xyz = c;
     EmitVertex();
 
     EndPrimitive();
 
-    gColor = vColor[0];
+    gColor = vColor[1];
     gl_Position.xyz = b;
     EmitVertex();
 
-    gColor = vColor[1];
+    gColor = vColor[2];
     gl_Position.xyz = c;
     EmitVertex();
 
-    gColor = vColor[1];
+    gColor = vColor[2];
     gl_Position.xyz = d;
     EmitVertex();
 

--- a/Shaders/Picking.frag.glsl
+++ b/Shaders/Picking.frag.glsl
@@ -9,7 +9,6 @@ layout (location = 4)      in vec3 in_eltCoords;
 out ivec4 fragId;
 
 uniform int objectId;
-uniform int eltType; // FIXME (Florian): this one is not set by setUniform("eltType", ...)
 
 void main()
 {
@@ -33,12 +32,7 @@ void main()
         fragId.g = 2;
     // set Element ID
     fragId.b = in_eltID;
-    // set Edge opposite vertex if triangle element
-//    if (eltType != 2)
-//    {
-//        fragId.a = -1;
-//        return;
-//    }
+    // set Edge opposite vertex, valid only if triangle element
     if( in_eltCoords.x < in_eltCoords.y && in_eltCoords.x < in_eltCoords.z)
         fragId.a = 0;
     if( in_eltCoords.y < in_eltCoords.x && in_eltCoords.y < in_eltCoords.z)

--- a/Shaders/PickingLines.geom.glsl
+++ b/Shaders/PickingLines.geom.glsl
@@ -2,8 +2,8 @@
 
 // FIXME (florian): TO BE TESTED
 
-layout(lines_adjacency) in;
-layout(triangle_strip, max_vertices = 4) out;
+layout(lines) in;
+layout(line_strip, max_vertices = 2) out;
 
 in gl_PerVertex {
     vec4  gl_Position;
@@ -17,76 +17,33 @@ out gl_PerVertex {
     float gl_ClipDistance[];
 };
 
-layout (location = 0) in vec3 in_position[4];
-layout (location = 1) in vec3 in_normal[4];
-layout (location = 2) in vec3 in_eye[4];
+layout (location = 0) in vec3 in_position[2];
+layout (location = 1) in vec3 in_normal[2];
+layout (location = 2) in vec3 in_eye[2];
 
 uniform Transform transform;
-uniform float lineWidth;
 
-layout (location = 0) out vec3  out_position;
-layout (location = 1) out vec3  out_normal;
-layout (location = 2) out vec3  out_eye;
-layout (location = 3) out int   out_eltID;
-layout (location = 4) out vec3  out_eltCoords;
+layout (location = 0)      out vec3  out_position;
+layout (location = 1)      out vec3  out_normal;
+layout (location = 2)      out vec3  out_eye;
+layout (location = 3) flat out int   out_eltID;
+layout (location = 4)      out vec3  out_eltCoords;
 
 void main()
 {
     vec3 p0 = in_position[0];
     vec3 p1 = in_position[1];
 
-    vec3 line = p1 - p0;
-    vec3 n = normalize(vec3(-line.y, line.x, 0));
-
-    vec3 a = p0 + n;
-    vec3 b = p0 - n;
-    vec3 c = p1 + n;
-    vec3 d = p1 - n;
-
-    gl_Position   = transform.proj * transform.view * vec4(a,1);
-    out_position  = a;
+    gl_Position   = transform.proj * transform.view * vec4(p0,1);
+    out_position  = p0;
     out_normal    = in_normal[0];
     out_eye       = in_eye[0];
     out_eltID     = gl_PrimitiveIDIn;
     out_eltCoords = vec3(1,0,0);
     EmitVertex();
 
-    gl_Position   = transform.proj * transform.view * vec4(b,1);
-    out_position  = b;
-    out_normal    = in_normal[0];
-    out_eye       = in_eye[0];
-    out_eltID     = gl_PrimitiveIDIn;
-    out_eltCoords = vec3(1,0,0);
-    EmitVertex();
-
-    gl_Position   = transform.proj * transform.view * vec4(c,1);
-    out_position  = c;
-    out_normal    = in_normal[1];
-    out_eye       = in_eye[1];
-    out_eltID     = gl_PrimitiveIDIn;
-    out_eltCoords = vec3(0,1,0);
-    EmitVertex();
-
-    EndPrimitive();
-
-    gl_Position   = transform.proj * transform.view * vec4(b,1);
-    out_position  = b;
-    out_normal    = in_normal[0];
-    out_eye       = in_eye[0];
-    out_eltID     = gl_PrimitiveIDIn;
-    out_eltCoords = vec3(1,0,0);
-    EmitVertex();
-
-    gl_Position   = transform.proj * transform.view * vec4(c,1);
-    out_position  = c;
-    out_normal    = in_normal[1];
-    out_eye       = in_eye[1];
-    out_eltID     = gl_PrimitiveIDIn;
-    out_eltCoords = vec3(0,1,0);
-    EmitVertex();
-
-    gl_Position   = transform.proj * transform.view * vec4(d,1);
-    out_position  = d;
+    gl_Position   = transform.proj * transform.view * vec4(p1,1);
+    out_position  = p1;
     out_normal    = in_normal[1];
     out_eye       = in_eye[1];
     out_eltID     = gl_PrimitiveIDIn;

--- a/Shaders/PickingLines.geom.glsl
+++ b/Shaders/PickingLines.geom.glsl
@@ -1,7 +1,5 @@
 #include "Structs.glsl"
 
-// FIXME (florian): TO BE TESTED
-
 layout(lines) in;
 layout(line_strip, max_vertices = 2) out;
 

--- a/Shaders/PickingLinesAdjacency.geom.glsl
+++ b/Shaders/PickingLinesAdjacency.geom.glsl
@@ -1,5 +1,9 @@
-layout(triangles) in;
-layout(triangle_strip, max_vertices = 3) out;
+#include "Structs.glsl"
+
+// FIXME (florian): TO BE TESTED
+
+layout(lines_adjacency) in;
+layout(line_strip, max_vertices = 2) out;
 
 in gl_PerVertex {
     vec4  gl_Position;
@@ -13,9 +17,11 @@ out gl_PerVertex {
     float gl_ClipDistance[];
 };
 
-layout (location = 0) in vec3 in_position[3];
-layout (location = 1) in vec3 in_normal[3];
-layout (location = 2) in vec3 in_eye[3];
+layout (location = 0) in vec3 in_position[4];
+layout (location = 1) in vec3 in_normal[4];
+layout (location = 2) in vec3 in_eye[4];
+
+uniform Transform transform;
 
 layout (location = 0)      out vec3  out_position;
 layout (location = 1)      out vec3  out_normal;
@@ -25,30 +31,24 @@ layout (location = 4)      out vec3  out_eltCoords;
 
 void main()
 {
-    // a
-    gl_Position   = gl_in[0].gl_Position;
-    out_position  = in_position[0];
-    out_normal    = in_normal[0];
-    out_eye       = in_eye[0];
+    vec3 p1 = in_position[1];
+    vec3 p2 = in_position[2];
+
+    gl_Position   = transform.proj * transform.view * vec4(p1,1);
+    out_position  = p1;
+    out_normal    = in_normal[1];
+    out_eye       = in_eye[1];
     out_eltID     = gl_PrimitiveIDIn;
     out_eltCoords = vec3(1,0,0);
     EmitVertex();
 
-    // b
-    gl_Position   = gl_in[1].gl_Position;
-    out_position  = in_position[1];
-    out_normal    = in_normal[1];
-    out_eye       = in_eye[1];
+    gl_Position   = transform.proj * transform.view * vec4(p2,1);
+    out_position  = p2;
+    out_normal    = in_normal[2];
+    out_eye       = in_eye[2];
     out_eltID     = gl_PrimitiveIDIn;
     out_eltCoords = vec3(0,1,0);
     EmitVertex();
 
-    // c
-    gl_Position   = gl_in[2].gl_Position;
-    out_position  = in_position[2];
-    out_normal    = in_normal[2];
-    out_eye       = in_eye[2];
-    out_eltID     = gl_PrimitiveIDIn;
-    out_eltCoords = vec3(0,0,1);
-    EmitVertex();
+    EndPrimitive();
 }

--- a/Shaders/PickingLinesAdjacency.geom.glsl
+++ b/Shaders/PickingLinesAdjacency.geom.glsl
@@ -1,7 +1,5 @@
 #include "Structs.glsl"
 
-// FIXME (florian): TO BE TESTED
-
 layout(lines_adjacency) in;
 layout(line_strip, max_vertices = 2) out;
 

--- a/Shaders/PickingPoints.geom.glsl
+++ b/Shaders/PickingPoints.geom.glsl
@@ -21,11 +21,11 @@ layout (location = 2) in vec3 in_eye[];
 
 uniform Transform transform;
 
-layout (location = 0) out vec3  out_position;
-layout (location = 1) out vec3  out_normal;
-layout (location = 2) out vec3  out_eye;
-layout (location = 3) out int   out_eltID;
-layout (location = 4) out vec3  out_eltCoords;
+layout (location = 0)      out vec3  out_position;
+layout (location = 1)      out vec3  out_normal;
+layout (location = 2)      out vec3  out_eye;
+layout (location = 3) flat out int   out_eltID;
+layout (location = 4)      out vec3  out_eltCoords;
 
 void main()
 {

--- a/src/Engine/Entity/Entity.inl
+++ b/src/Engine/Entity/Entity.inl
@@ -1,3 +1,4 @@
+#include <Engine/Entity/Entity.hpp>
 
 namespace Ra
 {

--- a/src/Engine/Renderer/Mesh/Mesh.cpp
+++ b/src/Engine/Renderer/Mesh/Mesh.cpp
@@ -17,10 +17,14 @@ namespace Ra {
             , m_numElements (0)
             , m_isDirty( false )
         {
-            CORE_ASSERT( m_renderMode == RM_LINES
-                      || m_renderMode == RM_LINES_ADJACENCY
+            CORE_ASSERT( m_renderMode == RM_POINTS
+                      || m_renderMode == RM_LINES
+                      || m_renderMode == RM_LINE_LOOP
+                      || m_renderMode == RM_LINE_STRIP
                       || m_renderMode == RM_TRIANGLES
-                      || m_renderMode == RM_POINTS
+                      || m_renderMode == RM_TRIANGLE_STRIP
+                      || m_renderMode == RM_TRIANGLE_FAN
+                      || m_renderMode == RM_LINES_ADJACENCY
                       || m_renderMode == RM_LINE_STRIP_ADJACENCY,
                          "Unsupported render mode" );
         }
@@ -92,9 +96,10 @@ namespace Ra {
                 m_numElements = nIdx;
             m_mesh.m_vertices = vertices;
 
-            // Check that when loading a triangle mesh we actually have triangles.
-            CORE_ASSERT( m_renderMode != GL_TRIANGLES || nIdx % 3 == 0, "There should be 3 indices per triangle " );
-            CORE_ASSERT( m_renderMode != GL_LINES     || nIdx % 2 == 0, "There should be 2 indices per lines" );
+            // Check that when loading a triangle mesh we actually have triangles or lines.
+            CORE_ASSERT( m_renderMode != GL_TRIANGLES       || nIdx % 3 == 0, "There should be 3 indices per triangle " );
+            CORE_ASSERT( m_renderMode != GL_LINES           || nIdx % 2 == 0, "There should be 2 indices per line" );
+            CORE_ASSERT( m_renderMode != GL_LINES_ADJACENCY || nIdx % 4 == 0, "There should be 4 indices per line adjacency" );
 
             for ( uint i = 0; i < indices.size(); i = i + 3 )
             {

--- a/src/Engine/Renderer/RenderObject/Primitives/DrawPrimitives.cpp
+++ b/src/Engine/Renderer/RenderObject/Primitives/DrawPrimitives.cpp
@@ -166,7 +166,7 @@ namespace Ra {
                             "Cannot draw a circle with less than 3 points");
 
                 Core::Vector3Array vertices(segments);
-                std::vector<uint> indices(2 * segments);
+                std::vector<uint> indices(segments);
 
                 Core::Vector3 xPlane, yPlane;
                 Core::Vector::getOrthogonalVectors(normal, xPlane, yPlane);
@@ -177,21 +177,16 @@ namespace Ra {
                 Scalar theta(0.0);
                 for (uint i = 0; i < segments; ++i)
                 {
-                    vertices[i] = center + radius *
-                        (std::cos(theta) * xPlane +
-                         std::sin(theta) * yPlane);
-
-                    indices.push_back((segments - 1 + i) % segments);
-                    indices.push_back(i);
-                    indices.push_back((i + 1) % segments);
-                    indices.push_back((i + 2) % segments);
+                    vertices[i] = center + radius * (std::cos(theta) * xPlane +
+                                                     std::sin(theta) * yPlane);
+                    indices[i] = i;
 
                     theta += thetaInc;
                 }
 
                 Core::Vector4Array colors(vertices.size(), color);
 
-                MeshPtr mesh(new Mesh("Circle Primitive", Mesh::RM_LINES_ADJACENCY));
+                MeshPtr mesh(new Mesh("Circle Primitive", Mesh::RM_LINE_LOOP));
                 mesh->loadGeometry(vertices, indices);
                 mesh->addData(Mesh::VERTEX_COLOR, colors);
 
@@ -260,7 +255,7 @@ namespace Ra {
 
                 uint seg = segments + 1;
                 Core::Vector3Array vertices(seg);
-                std::vector<uint> indices;
+                std::vector<uint> indices(seg+1);
 
                 Core::Vector3 xPlane, yPlane;
                 Core::Vector::getOrthogonalVectors(normal, xPlane, yPlane);
@@ -271,21 +266,20 @@ namespace Ra {
                 Scalar theta(0.0);
 
                 vertices[0] = center;
-                indices.push_back(0);
+                indices[0] = 0;
                 for (uint i = 1; i < seg; ++i)
                 {
                     vertices[i] = center + radius * (std::cos(theta) * xPlane +
                                                      std::sin(theta) * yPlane);
-                    indices.push_back(i);
+                    indices[i] = i;
 
                     theta += thetaInc;
                 }
-                indices.push_back(1);
+                indices[seg] = 1;
 
                 Core::Vector4Array colors(vertices.size(), color);
 
-                // FIXME(Charly): This will assert in mesh
-                MeshPtr mesh(new Mesh("Circle Primitive", Mesh::RM_TRIANGLE_FAN));
+                MeshPtr mesh(new Mesh("Disk Primitive", Mesh::RM_TRIANGLE_FAN));
                 mesh->loadGeometry(vertices, indices);
                 mesh->addData(Mesh::VERTEX_COLOR, colors);
 

--- a/src/Engine/Renderer/RenderObject/Primitives/DrawPrimitives.cpp
+++ b/src/Engine/Renderer/RenderObject/Primitives/DrawPrimitives.cpp
@@ -159,6 +159,35 @@ namespace Ra {
                 return mesh;
             }
 
+            MeshPtr QuadStrip(const Core::Vector3& a, const Core::Vector3& x,
+                              const Core::Vector3& y, uint quads, const Core::Color& color)
+            {
+                Core::Vector3Array vertices(quads*2+2);
+                std::vector<uint> indices(quads*2+2);
+
+                Core::Vector3 B = a;
+                vertices[0] = B;
+                vertices[1] = B + x;
+                indices[0] = 0;
+                indices[1] = 1;
+                for (uint i=0; i<quads; ++i)
+                {
+                    B += y;
+                    vertices[2*i+2] = B;
+                    vertices[2*i+3] = B+x;
+                    indices[2*i+2] = 2*i+2;
+                    indices[2*i+3] = 2*i+3;
+                }
+
+                Core::Vector4Array colors(vertices.size(), color);
+
+                MeshPtr mesh(new Mesh("Quad Strip Primitive", Mesh::RM_TRIANGLE_STRIP));
+                mesh->loadGeometry(vertices, indices);
+                mesh->addData(Mesh::VERTEX_COLOR, colors);
+
+                return mesh;
+            }
+
             MeshPtr Circle(const Core::Vector3& center, const Core::Vector3& normal,
                            Scalar radius, uint segments, const Core::Color& color)
             {
@@ -187,6 +216,38 @@ namespace Ra {
                 Core::Vector4Array colors(vertices.size(), color);
 
                 MeshPtr mesh(new Mesh("Circle Primitive", Mesh::RM_LINE_LOOP));
+                mesh->loadGeometry(vertices, indices);
+                mesh->addData(Mesh::VERTEX_COLOR, colors);
+
+                return mesh;
+            }
+
+            MeshPtr CircleArc(const Core::Vector3& center, const Core::Vector3& normal,
+                              Scalar radius, Scalar angle, uint segments,
+                              const Core::Color& color)
+            {
+                Core::Vector3Array vertices(segments);
+                std::vector<uint> indices(segments);
+
+                Core::Vector3 xPlane, yPlane;
+                Core::Vector::getOrthogonalVectors(normal, xPlane, yPlane);
+                xPlane.normalize();
+                yPlane.normalize();
+
+                Scalar thetaInc(2*angle / Scalar(segments));
+                Scalar theta(0.0);
+                for (uint i = 0; i < segments; ++i)
+                {
+                    vertices[i] = center + radius * (std::cos(theta) * xPlane +
+                                                     std::sin(theta) * yPlane);
+                    indices[i] = i;
+
+                    theta += thetaInc;
+                }
+
+                Core::Vector4Array colors(vertices.size(), color);
+
+                MeshPtr mesh(new Mesh("Arc Circle Primitive", Mesh::RM_LINE_STRIP));
                 mesh->loadGeometry(vertices, indices);
                 mesh->addData(Mesh::VERTEX_COLOR, colors);
 

--- a/src/Engine/Renderer/RenderObject/Primitives/DrawPrimitives.hpp
+++ b/src/Engine/Renderer/RenderObject/Primitives/DrawPrimitives.hpp
@@ -54,6 +54,13 @@ namespace Ra
                                            const Core::Color& color,
                                            bool fill = false);
 
+            /// Displays a strip of n quads, starting at A and with directions X and Y.
+            RA_ENGINE_API MeshPtr QuadStrip(const Core::Vector3& a,
+                                            const Core::Vector3& x,
+                                            const Core::Vector3& y,
+                                            uint quads,
+                                            const Core::Color& color);
+
             /// Displays circle computed with given center and radius,
             /// in plane normal to given vector in wireframe
             RA_ENGINE_API MeshPtr Circle(const Core::Vector3& center,
@@ -61,6 +68,15 @@ namespace Ra
                                          Scalar radius,
                                          uint segments,
                                          const Core::Color& color);
+
+            /// Displays arc of a circle computed with given center, radius and angle
+            /// in plane normal to given vector in wireframe
+            RA_ENGINE_API MeshPtr CircleArc(const Core::Vector3& center,
+                                            const Core::Vector3& normal,
+                                            Scalar radius,
+                                            Scalar angle,
+                                            uint segments,
+                                            const Core::Color& color);
 
             /// Displays sphere computed with given center and radius
             RA_ENGINE_API MeshPtr Sphere(const Core::Vector3& center,

--- a/src/Engine/Renderer/Renderer.hpp
+++ b/src/Engine/Renderer/Renderer.hpp
@@ -309,10 +309,10 @@ namespace Ra
             // 3.
             void splitRenderQueuesForPicking( const RenderData &renderData );
             void splitRQ( const std::vector<RenderObjectPtr>& renderQueue,
-                                  std::array<std::vector<RenderObjectPtr>,3>& renderQueuePicking );
+                                  std::array<std::vector<RenderObjectPtr>,4>& renderQueuePicking );
             void renderForPicking( const RenderData& renderData,
-                                   const std::array<const ShaderProgram*,3>& pickingShaders,
-                                   const std::array<std::vector<RenderObjectPtr>,3>& renderQueuePicking );
+                                   const std::array<const ShaderProgram*,4>& pickingShaders,
+                                   const std::array<std::vector<RenderObjectPtr>,4>& renderQueuePicking );
 
             void doPicking( const RenderData& renderData );
 
@@ -352,12 +352,6 @@ namespace Ra
             std::vector<RenderObjectPtr> m_xrayRenderObjects;
             std::vector<RenderObjectPtr> m_uiRenderObjects;
 
-            std::array<std::vector<RenderObjectPtr>,3> m_fancyRenderObjectsPicking;
-            std::array<std::vector<RenderObjectPtr>,3> m_debugRenderObjectsPicking;
-            std::array<std::vector<RenderObjectPtr>,3> m_xrayRenderObjectsPicking;
-            std::array<std::vector<RenderObjectPtr>,3> m_uiRenderObjectsPicking;
-            std::array<const ShaderProgram*,3>               m_pickingShaders;
-
             // Simple quad mesh, used to render the final image
             std::unique_ptr<Mesh> m_quadMesh;
 
@@ -383,11 +377,17 @@ namespace Ra
             std::unique_ptr<globjects::Framebuffer> m_pickingFbo;
             std::unique_ptr<Texture>                m_pickingTexture;
 
-            std::unique_ptr<Texture>   m_depthTexture;
+            std::array<std::vector<RenderObjectPtr>,4> m_fancyRenderObjectsPicking;
+            std::array<std::vector<RenderObjectPtr>,4> m_debugRenderObjectsPicking;
+            std::array<std::vector<RenderObjectPtr>,4> m_xrayRenderObjectsPicking;
+            std::array<std::vector<RenderObjectPtr>,4> m_uiRenderObjectsPicking;
+            std::array<const ShaderProgram*,4>         m_pickingShaders;
 
             std::vector<PickingQuery>  m_pickingQueries;
             std::vector<PickingQuery>  m_lastFramePickingQueries;
             std::vector<PickingResult> m_pickingResults;
+
+            std::unique_ptr<Texture> m_depthTexture;
         };
 
     } // namespace Engine

--- a/src/GuiBase/BaseApplication.cpp
+++ b/src/GuiBase/BaseApplication.cpp
@@ -305,6 +305,12 @@ namespace GuiBase
         lgConfig.addShader(ShaderType_GEOMETRY, "Shaders/Lines.geom.glsl");
         ShaderConfigurationFactory::addConfiguration(lgConfig);
 
+        ShaderConfiguration lagConfig("LinesAdjacencyGeom");
+        lagConfig.addShader(ShaderType_VERTEX, "Shaders/Lines.vert.glsl");
+        lagConfig.addShader(ShaderType_FRAGMENT, "Shaders/LinesAdjacency.frag.glsl");
+        lagConfig.addShader(ShaderType_GEOMETRY, "Shaders/Lines.geom.glsl");
+        ShaderConfigurationFactory::addConfiguration(lagConfig);
+
         ShaderConfiguration lConfig("Lines");
         lConfig.addShader(ShaderType_VERTEX, "Shaders/Lines.vert.glsl");
         lConfig.addShader(ShaderType_FRAGMENT, "Shaders/Lines.frag.glsl");

--- a/src/GuiBase/Utils/KeyMappingManager.cpp
+++ b/src/GuiBase/Utils/KeyMappingManager.cpp
@@ -33,7 +33,7 @@ namespace Ra
 
         bool KeyMappingManager::actionTriggered( QMouseEvent * event, KeyMappingAction action )
         {
-            return event->button() == getKeyFromAction( action );
+            return (int(event->button()) | event->modifiers()) == getKeyFromAction( action );
         }
 
         bool KeyMappingManager::actionTriggered( QKeyEvent * event, KeyMappingAction action )
@@ -126,6 +126,7 @@ namespace Ra
             }
             else
             {
+                std::cout << "WTF" << std::endl;
                 LOG(logERROR) << "Unrecognized XML keymapping configuration file tag \"" << qPrintable(node.tagName()) << "\" !";
                 LOG(logERROR) << "Trying to load default configuration...";
 
@@ -160,7 +161,7 @@ namespace Ra
             else if( typeString == "mouse" )
             {
                 int buttonValue = getQtMouseButtonValue( keyString );
-                bindKeyToAction( buttonValue, actionValue );
+                bindKeyToAction( buttonValue | modifierValue, actionValue );
             }
         }
 

--- a/src/GuiBase/Utils/KeyMappingManager.cpp
+++ b/src/GuiBase/Utils/KeyMappingManager.cpp
@@ -23,6 +23,16 @@ namespace Ra
 
         void KeyMappingManager::bindKeyToAction( int keyCode, KeyMappingAction action )
         {
+            auto f = std::find_if( m_mapping.begin(), m_mapping.end(),
+                                   [&keyCode](const auto &a)
+                                   {
+                                       return a.second == keyCode;
+                                   } );
+            if (f != m_mapping.end())
+            {
+                LOG(logWARNING) << "Binding action " << action << " to code " << keyCode <<
+                                   ", which is already used for action " << f->first << ".";
+            }
             m_mapping[action] = keyCode;
         }
 
@@ -91,6 +101,8 @@ namespace Ra
 
         void KeyMappingManager::loadConfigurationInternal()
         {
+            m_mapping.clear();
+
             QDomElement domElement = m_domDocument.documentElement();
             QDomNode node = domElement.firstChild();
 
@@ -126,7 +138,6 @@ namespace Ra
             }
             else
             {
-                std::cout << "WTF" << std::endl;
                 LOG(logERROR) << "Unrecognized XML keymapping configuration file tag \"" << qPrintable(node.tagName()) << "\" !";
                 LOG(logERROR) << "Trying to load default configuration...";
 

--- a/src/GuiBase/Viewer/TrackballCamera.cpp
+++ b/src/GuiBase/Viewer/TrackballCamera.cpp
@@ -65,13 +65,6 @@ namespace Ra
 
     bool Gui::TrackballCamera::handleMousePressEvent( QMouseEvent* event )
     {
-        // Whole manipulation is done with middle button and modifiers
-        /*if ( event->button() != Qt::MiddleButton )*/
-        if ( !( Gui::KeyMappingManager::getInstance()->actionTriggered( event, Gui::KeyMappingManager::TRACKBALLCAMERA_MANIPULATION) ) )
-        {
-            return false;
-        }
-
         bool handled = false;
         m_lastMouseX = event->pos().x();
         m_lastMouseY = event->pos().y();

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -301,7 +301,7 @@ namespace Ra
                 e->rayCastQuery(r);
             }
         }
-        else if ( keyMap->actionTriggered( event, Gui::KeyMappingManager::TRACKBALLCAMERA_MANIPULATION ) )
+        else if ( keyMap->getKeyFromAction(Gui::KeyMappingManager::TRACKBALLCAMERA_MANIPULATION) == event->button() )
         {
             m_camera->handleMousePressEvent(event);
         }

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -307,7 +307,6 @@ namespace Ra
         }
         else if ( keyMap->actionTriggered( event, Gui::KeyMappingManager::GIZMOMANAGER_MANIPULATION ) )
         {
-            std::cout << "gizmo" << std::endl;
             m_currentRenderer->addPickingRequest({ Core::Vector2(event->x(), height() - event->y()),
                                                    Core::MouseButton::RA_MOUSE_LEFT_BUTTON,
                                                    Engine::Renderer::RO });
@@ -318,7 +317,6 @@ namespace Ra
         }
         else if ( keyMap->actionTriggered( event, Gui::KeyMappingManager::VIEWER_BUTTON_PICKING_QUERY ) )
         {
-            std::cout << "picking" << std::endl;
             // Check picking
             Engine::Renderer::PickingQuery query  = { Core::Vector2(event->x(), height() - event->y()),
                                                       Core::MouseButton::RA_MOUSE_RIGHT_BUTTON,

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -301,8 +301,13 @@ namespace Ra
                 e->rayCastQuery(r);
             }
         }
+        else if ( keyMap->actionTriggered( event, Gui::KeyMappingManager::TRACKBALLCAMERA_MANIPULATION ) )
+        {
+            m_camera->handleMousePressEvent(event);
+        }
         else if ( keyMap->actionTriggered( event, Gui::KeyMappingManager::GIZMOMANAGER_MANIPULATION ) )
         {
+            std::cout << "gizmo" << std::endl;
             m_currentRenderer->addPickingRequest({ Core::Vector2(event->x(), height() - event->y()),
                                                    Core::MouseButton::RA_MOUSE_LEFT_BUTTON,
                                                    Engine::Renderer::RO });
@@ -311,12 +316,9 @@ namespace Ra
                 m_gizmoManager->handleMousePressEvent(event);
             }
         }
-        else if ( keyMap->actionTriggered( event, Gui::KeyMappingManager::TRACKBALLCAMERA_MANIPULATION ) )
-        {
-            m_camera->handleMousePressEvent(event);
-        }
         else if ( keyMap->actionTriggered( event, Gui::KeyMappingManager::VIEWER_BUTTON_PICKING_QUERY ) )
         {
+            std::cout << "picking" << std::endl;
             // Check picking
             Engine::Renderer::PickingQuery query  = { Core::Vector2(event->x(), height() - event->y()),
                                                       Core::MouseButton::RA_MOUSE_RIGHT_BUTTON,
@@ -344,7 +346,7 @@ namespace Ra
                 m_gizmoManager->handleMouseMoveEvent(event);
             }
             m_currentRenderer->setMousePosition(Ra::Core::Vector2(event->x(), event->y()));
-            if ( event->buttons() & Gui::KeyMappingManager::getInstance()->getKeyFromAction( Gui::KeyMappingManager::VIEWER_BUTTON_PICKING_QUERY ) )
+            if ( (int(event->buttons()) | event->modifiers()) == Gui::KeyMappingManager::getInstance()->getKeyFromAction( Gui::KeyMappingManager::VIEWER_BUTTON_PICKING_QUERY ) )
             {
                 // Check picking
                 Engine::Renderer::PickingQuery query  = { Core::Vector2(event->x(), (height() - event->y())),


### PR DESCRIPTION
Add possibility to have modifiers on mouse buttons ;
Adapt Viewer's mousePressEvent and mouseMoveEvent accordingly ;
Fix alternative keymapping config to work on computers with pad only (e.g. mac and laptop) ;
Add a warning if an action key is bound to multiple actions ;

Add transforms management to MeshFeatureTracking ;
Add picking support for some OpenGL primitive types (see Mesh.cpp for supported types ) ;

Fixes #285

**Note**: the default configuration uses the same key for `GIZMOMANAGER_MANIPULATION`, `VIEWER_BUTTON_CAST_RAY_QUERY` and `COLORWIDGET_PRESSBUTTON` ; while the alternative configuration uses the same key for `VIEWER_BUTTON_PICKING_QUERY` and `VIEWER_BUTTON_CAST_RAY_QUERY`, and the same key for `TRACKBALLCAMERA_MANIPULATION` and `COLORWIDGET_PRESSBUTTON`.
This is currently not a big problem since the `VIEWER_BUTTON_CAST_RAY_QUERY` action is activated only if `VIEWER_RAYCAST_QUERY` is active, which overrides the other actions, and the `COLORWIDGET_PRESSBUTTON` is currently not in use.