### PR TITLE
Do not add RM_LINES meshes to renderQueuePicking.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
     # mac clang Release
     - env:
         - BUILD_TYPE=Release
-        - PREFIX_PATH="/usr/local/Cellar/qt/5.10.0_1"
+        - PREFIX_PATH="/usr/local/opt/qt/lib/cmake"
       os: osx
       compiler: clang
 

--- a/src/Engine/Renderer/Renderer.cpp
+++ b/src/Engine/Renderer/Renderer.cpp
@@ -286,13 +286,14 @@ namespace Ra {
                     renderQueuePicking[0].push_back( *it );
                     break;
                 }
-                case Mesh::RM_LINES:
-                case Mesh::RM_LINES_ADJACENCY:
-                case Mesh::RM_LINE_STRIP_ADJACENCY: // fall through
-                {
-                    renderQueuePicking[1].push_back( *it );
-                    break;
-                }
+///\todo Fix picking for line meshes
+//               case Mesh::RM_LINES:
+//                case Mesh::RM_LINES_ADJACENCY:
+//                case Mesh::RM_LINE_STRIP_ADJACENCY: // fall through
+//                {
+//                    renderQueuePicking[1].push_back( *it );
+//                    break;
+//                }
                 case Mesh::RM_TRIANGLES:
                 {
                     renderQueuePicking[2].push_back( *it );


### PR DESCRIPTION
Just remove RM_LINES from type of geomerty that can be picked (and so remove the assert exception). 
To be fixed later.