### PR TITLE
Multiple file loading

### DIFF
--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -192,11 +192,11 @@ namespace Gui
         if(!pathList.empty())
         {
             settings.setValue("files/load", pathList.front());
-        }
 
-        for(auto file : pathList)
-        {
-            emit fileLoading(file);
+            for(const auto& file : pathList)
+            {
+                emit fileLoading(file);
+            }
         }
     }
 

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -185,14 +185,18 @@ namespace Gui
         // remove the last ";;" of the string
         filter.remove(filter.size()-2, 2);
 
-
         QSettings settings;
         QString path = settings.value("files/load", QDir::homePath()).toString();
-        path = QFileDialog::getOpenFileName(this, "Open File", path, filter);
-        if (path.size() > 0)
+        QStringList pathList = QFileDialog::getOpenFileNames(this, "Open Files", path, filter);
+
+        if(!pathList.empty())
         {
-            settings.setValue("files/load", path);
-            emit fileLoading(path);
+            settings.setValue("files/load", pathList.front());
+        }
+
+        for(auto file : pathList)
+        {
+            emit fileLoading(file);
         }
     }
 


### PR DESCRIPTION
This PR enables the loading of multiple files at once.

Currently, only one single file can be selected when opening new models.

With this change, several files can be selected and loaded at once, as if we have loaded them separately.


