### PR TITLE
Fix fileloader precedence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+sudo: true
 
 script:
   - make -j 4
@@ -10,7 +11,6 @@ script:
 
 cache:
   directories:
-    - ${TRAVIS_BUILD_DIR}/cmake3.3
 
 env:
   global:
@@ -30,15 +30,15 @@ before_install:
   ############################################################################
   # Install a recent CMake
   ############################################################################
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      # remove existing cmake install
-      sudo apt-get remove -qq cmake cmake-data
-
-      CMAKE_URL="https://www.cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.tar.gz"
-      mkdir cmake3.3 && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake3.3
-      export PATH=${PWD}/cmake3.3/bin:${PATH}
-    fi
+  #- |
+  #  if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+  #    # remove existing cmake install
+  #    sudo apt-get remove -qq cmake cmake-data
+  #
+  #    CMAKE_URL="https://www.cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.tar.gz"
+  #    mkdir cmake3.3 && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake3.3
+  #    export PATH=${PWD}/cmake3.3/bin:${PATH}
+  #  fi
   - cmake --version
 
   ############################################################################
@@ -46,12 +46,18 @@ before_install:
   ############################################################################
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      if [ ! -d "~/Qt/5.10.0/gcc_64" ]; then
-        wget http://download.qt.io/official_releases/online_installers/qt-unified-linux-x64-online.run ;
-        chmod a+x ./qt-unified-linux-x64-online.run ;
-        export QT_QPA_PLATFORM=minimal ;
-        travis_wait 60 ./qt-unified-linux-x64-online.run --script .ci/qt-installer-noninteractive.qs --no-force-installations --verbose ;
-      fi;
+      sudo add-apt-repository --yes ppa:beineri/opt-qt-5.10.1-trusty
+      sudo apt-get --yes update
+      sudo apt-get --yes install qt510-meta-minimal qt510svg
+      source /opt/qt510/bin/qt510-env.sh # see https://launchpad.net/~beineri/+archive/ubuntu/opt-qt-5.10.1-trusty
+
+
+      #if [ ! -d "~/Qt/5.10.1/gcc_64" ]; then
+      #  # wget http://download.qt.io/official_releases/online_installers/qt-unified-linux-x64-online.run ;
+      #  TRAVIS_URL="https://download.qt.io/official_releases/qt/5.10/5.10.1/qt-opensource-linux-x64-5.10.1.run"
+      #  export QT_QPA_PLATFORM=minimal ;
+      #  travis_retry wget ${TRAVIS_URL} &&  chmod a+x ./qt-opensource-linux-x64-5.10.1.run && ./qt-opensource-linux-x64-5.10.1.run --script .ci/qt-installer-noninteractive.qs --no-force-installations --verbose ;
+      #fi;
     fi;
 
 
@@ -76,6 +82,7 @@ matrix:
             - util-linux
             - clang-5.0
             - g++-7
+            - cmake3
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-5.0
@@ -90,6 +97,7 @@ matrix:
         apt:
           packages:
             - g++-7
+            - cmake3
           sources:
             - ubuntu-toolchain-r-test
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,8 +46,9 @@ branches:
     - gh-pages
 
 # scripts that run after cloning repository
+# https://www.appveyor.com/docs/build-environment/#qt
 install:
-  - set QTDIR=C:\Qt\5.10.0\msvc2017_64
+  - set QTDIR=C:\Qt\5.10.1\msvc2017_64
   - cmd: git submodule update --init --recursive
 
 # scripts to run before build

--- a/src/GuiBase/BaseApplication.cpp
+++ b/src/GuiBase/BaseApplication.cpp
@@ -178,14 +178,6 @@ namespace GuiBase
         m_engine.reset(Engine::RadiumEngine::createInstance());
         m_engine->initialize();
         addBasicShaders();
-#ifdef IO_USE_TINYPLY
-        // Register before AssimpFileLoader, in order to ease override of such
-        // custom loader (first loader able to load is taking the file)
-        m_engine->registerFileLoader( std::shared_ptr<Asset::FileLoaderInterface>(new IO::TinyPlyFileLoader()) );
-#endif
-#ifdef IO_USE_ASSIMP
-        m_engine->registerFileLoader( std::shared_ptr<Asset::FileLoaderInterface>(new IO::AssimpFileLoader()) );
-#endif
         // Create main window.
         m_mainWindow.reset( factory.createMainWindow() );
         m_mainWindow->show();
@@ -206,6 +198,15 @@ namespace GuiBase
         {
             LOG( logERROR ) << "An error occurred while trying to load plugins.";
         }
+        // Make builtin loaders the fallback if no plugins can load some file format
+#ifdef IO_USE_TINYPLY
+        // Register before AssimpFileLoader, in order to ease override of such
+        // custom loader (first loader able to load is taking the file)
+        m_engine->registerFileLoader( std::shared_ptr<Asset::FileLoaderInterface>(new IO::TinyPlyFileLoader()) );
+#endif
+#ifdef IO_USE_ASSIMP
+        m_engine->registerFileLoader( std::shared_ptr<Asset::FileLoaderInterface>(new IO::AssimpFileLoader()) );
+#endif
 
         // Create task queue with N-1 threads (we keep one for rendering),
         // unless monothread CPU


### PR DESCRIPTION
For plugins being able to take precedence over builtin loaders, when both can read the same file format, add builtin loaders after the plugins are loaded.

* **Please check if the PR fulfills these requirements**
- [X] Is the Pull-Request done against the right branch:
  - `master`: for hotfixes not impacting the API
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.
when plugins can load the same file format than builtins laoders (eg assimp), plugins must have precedence over builtins.

* **What is the current behavior?** (You can also link to an open issue here)
assimp load all its recognize file format, even if a plugin can load the file in a better way.


* **What is the new behavior (if this is a feature change)?**
if a plugin can load a file format, it have the precedence over assimp


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
