### PR TITLE
Change the selection manager clear when clearing the scene ;

### DIFF
--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -563,7 +563,7 @@ namespace Gui
     void MainWindow::resetScene()
     {
         // To see why this call is important, please see deleteCurrentItem().
-        m_selectionManager->clearSelection();
+        m_selectionManager->clear();
         Engine::RadiumEngine::getInstance()->getEntityManager()->deleteEntities();
         m_viewer->resetCamera();
     }


### PR DESCRIPTION
When clearing the scene with a selected component, while having one of our private plugins enabled, makes the app crash.
Actually, the selection manager is told to clear its selection, then entities are destroyed. While destroying the entities', and thus their components', treeItems in the treeItemView, it somehow happens that the "currentChanged" signal of the selection manager is triggered.
This causes one of our plugins, which is connected on this signal, to crash since the "currentItem" of the selection manager isn't invalid.

Clearing the selection manager with "clear" prevents this crash (currentItem is an invalid one).
Also, it's coherent with the way we clear the selection manager when handling picking while not RO has been picked.
