### PR TITLE
Fix c2877

### DIFF
--- a/src/Core/Containers/AlignedStdVector.hpp
+++ b/src/Core/Containers/AlignedStdVector.hpp
@@ -12,7 +12,7 @@ namespace Core {
 /// Uses Eigen's aligned allocator, as stated in
 /// http://eigen.tuxfamily.org/dox/group__TopicStlContainers.html
 template <typename T>
-class AlignedStdVector : public std::vector<T, Eigen::aligned_allocator<T>> {
+struct AlignedStdVector : public std::vector<T, Eigen::aligned_allocator<T>> {
     using std::vector<T, Eigen::aligned_allocator<T>>::vector;
 };
 } // namespace Core


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master`: for hotfixes not impacting the API
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix compilation error on windows compiler 15.7.


* **What is the current behavior?** (You can also link to an open issue here)
The default constructor of `AlignedStdVector` was `private`,  while being inherited in `VectorArray`.

* `AlignedStdVector.hpp`:
```c++
template <typename T>
class AlignedStdVector : public std::vector<T, Eigen::aligned_allocator<T>> {
    using std::vector<T, Eigen::aligned_allocator<T>>::vector;
};
```
* `VectorArray.hpp`:
```c++
template <typename V>
class VectorArray : public AlignedStdVector<V> {
  // ...
  public:
    /// Inheriting constructors from std::vector
    using AlignedStdVector<V>::AlignedStdVector;
```


* **What is the new behavior (if this is a feature change)?**
Switch to struct to get public visibility.
* `AlignedStdVector.hpp`:
```c++
template <typename T>
struct AlignedStdVector : public std::vector<T, Eigen::aligned_allocator<T>> {
    using std::vector<T, Eigen::aligned_allocator<T>>::vector;
};
```


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
