### PR TITLE
Fix issue #325

### DIFF
--- a/src/Engine/Managers/LightManager/DefaultLightManager.cpp
+++ b/src/Engine/Managers/LightManager/DefaultLightManager.cpp
@@ -16,7 +16,7 @@ const Light* DefaultLightManager::getLight( size_t li ) const {
 }
 
 void DefaultLightManager::addLight( Light* li ) {
-    m_data->push( li );
+    m_data->add(li);
 }
 //
 // Pre/Post render operations.
@@ -48,8 +48,18 @@ DefaultLightStorage::DefaultLightStorage() {}
 
 void DefaultLightStorage::upload() const {}
 
-void DefaultLightStorage::push( Light* li ) {
+void DefaultLightStorage::add(Light *li) {
     m_lights.emplace( li->getType(), li );
+}
+
+void DefaultLightStorage::remove(Light* li) {
+    auto range = m_lights.equal_range(li->getType());
+    for (auto i = range.first; i != range.second; ++i) {
+        if (i->second == li) {
+            m_lights.erase(i);
+            break;
+        }
+    }
 }
 
 size_t DefaultLightStorage::size() const {

--- a/src/Engine/Managers/LightManager/DefaultLightManager.hpp
+++ b/src/Engine/Managers/LightManager/DefaultLightManager.hpp
@@ -17,7 +17,8 @@ namespace Engine {
 class RA_ENGINE_API DefaultLightStorage : public LightStorage {
   public:
     DefaultLightStorage();
-    void push( Light* i ) override;
+    void add(Light *i) override;
+    void remove(Light* li) override;
     void upload() const override;
     size_t size() const override;
     void clear() override;

--- a/src/Engine/Managers/LightManager/LightManager.cpp
+++ b/src/Engine/Managers/LightManager/LightManager.cpp
@@ -78,8 +78,8 @@ void LightManager::generateTasks( Core::TaskQueue* taskQueue, const Engine::Fram
     */
 }
 
-void LightManager::handleAssetLoading( Entity* entity, const Asset::FileData* data ) {
-    std::vector<Asset::LightData*> lightData = data->getLightData();
+void LightManager::handleAssetLoading( Entity* entity, const Asset::FileData* filedata ) {
+    std::vector<Asset::LightData*> lightData = filedata->getLightData();
     uint id = 0;
     m_data->clear();
     for ( const auto& data : lightData )
@@ -138,9 +138,29 @@ void LightManager::handleAssetLoading( Entity* entity, const Asset::FileData* da
             continue;
 
         registerComponent( entity, comp );
-        m_data->push( comp );
     }
     LOG( logINFO ) << "LightManager : loaded " << count() << " lights.";
 }
-} // namespace Engine
+
+/// Inhereted method is make final so that only the LightStorage could differ from a LightManager to the other.
+void LightManager::registerComponent( const Entity* entity, Component* component ) {
+    System::registerComponent(entity, component);
+        m_data->add(reinterpret_cast<Light *>(component));
+}
+
+/// Inhereted method is make final so that only the LightStorage could differ from a LightManager to the other.
+void LightManager::unregisterComponent( const Entity* entity, Component* component ) {
+    m_data->remove( reinterpret_cast<Light *>(component) );
+    System::unregisterComponent(entity, component);
+
+}
+
+/// Inhereted method is make final so that only the LightStorage could differ from a LightManager to the other.
+void LightManager::unregisterAllComponents( const Entity* entity ) {
+    m_data->clear();
+    System::unregisterAllComponents(entity);
+}
+
+
+  } // namespace Engine
 } // namespace Ra

--- a/src/Engine/Managers/LightManager/LightManager.hpp
+++ b/src/Engine/Managers/LightManager/LightManager.hpp
@@ -86,10 +86,17 @@ class RA_ENGINE_API LightManager : public System {
     // System methods
     //
 
-    /// Method generating the correct tasks for a LightManager.
+    /// Inhereted method is make final so that only the LightStorage could differ from a LightManager to the other.
+    void registerComponent( const Entity* entity, Component* component ) override final;
+
+    /// Inhereted method is make final so that only the LightStorage could differ from a LightManager to the other.
+    void unregisterComponent( const Entity* entity, Component* component ) override final;
+
+    /// Inhereted method is make final so that only the LightStorage could differ from a LightManager to the other.
+    void unregisterAllComponents( const Entity* entity ) override final;
+
     void generateTasks( Core::TaskQueue* taskQueue, const Engine::FrameInfo& frameInfo ) override;
 
-    /// Handle Lights loading.
     void handleAssetLoading( Entity* entity, const Asset::FileData* data ) override;
 
   protected:

--- a/src/Engine/Managers/LightManager/LightStorage.hpp
+++ b/src/Engine/Managers/LightManager/LightStorage.hpp
@@ -36,11 +36,11 @@ class RA_ENGINE_API LightStorage {
     /// Returns the container size.
     virtual size_t size() const = 0;
 
-    /// Push a Light to the container.
-    virtual void push( Light* li ) = 0;
+    /// Add a Light to the container.
+    virtual void add(Light *li) = 0;
 
-    /// Pop a Light from the container.
-    // virtual Light& pop() = 0;
+    /// Remove a Light from the container.
+    virtual void remove(Light* li) = 0;
 
     /// Clear the container.
     virtual void clear() = 0;

--- a/src/Engine/RadiumEngine.cpp
+++ b/src/Engine/RadiumEngine.cpp
@@ -39,6 +39,7 @@ void RadiumEngine::initialize() {
     ComponentMessenger::createInstance();
     // Engine support some built-in materials. Register here
     BlinnPhongMaterial::registerMaterial();
+    m_loadingState = false;
 }
 
 void RadiumEngine::cleanup() {
@@ -56,6 +57,7 @@ void RadiumEngine::cleanup() {
 
     ComponentMessenger::destroyInstance();
     ShaderProgramManager::destroyInstance();
+    m_loadingState = false;
 }
 
 void RadiumEngine::endFrameSync() {
@@ -172,12 +174,13 @@ bool RadiumEngine::loadFile( const std::string& filename ) {
         LOG( logWARNING ) << "File \"" << filename << "\" has no usable data. Deleting entity...";
         m_entityManager->removeEntity( entity );
     }
-
+    m_loadingState = true;
     return true;
 }
 
 void RadiumEngine::releaseFile() {
     m_loadedFile.reset( nullptr );
+    m_loadingState = false;
 }
 
 RenderObjectManager* RadiumEngine::getRenderObjectManager() const {
@@ -204,6 +207,7 @@ RadiumEngine::getFileLoaders() const {
 RA_SINGLETON_IMPLEMENTATION( RadiumEngine );
 
 const Asset::FileData& RadiumEngine::getFileData() const {
+    CORE_ASSERT(m_loadingState, "Access to file content is only available at loading time.");
     return *( m_loadedFile.get() );
 }
 

--- a/src/Engine/RadiumEngine.hpp
+++ b/src/Engine/RadiumEngine.hpp
@@ -57,10 +57,32 @@ class RA_ENGINE_API RadiumEngine {
     Mesh* getMesh( const std::string& entityName, const std::string& componentName,
                    const std::string& roName = std::string() ) const;
 
+    /**
+     * Try to loads the given file.
+     * If no loader able to manage the fileformat of the file (determined based on its extension), return false.
+     * If a loader is found, creates the root entity of the loaded scene and gives the content of the file to all
+     * systems to add components and
+     * to this root entity.
+     * @note Calling this method set the engine in the "loading state".
+     * @param file
+     * @return true if file is loaded, false else.
+     */
     bool loadFile( const std::string& file );
 
+    /**
+     * Access to the content of the loaded file.
+     * Acces to the content is only available at loading time. As soon as the loaded file is released, its content is
+     * no more available outside the Entity/Component architecture.
+     * @pre The Engine must be in "loading state".
+     * @return
+     */
     const Asset::FileData& getFileData() const;
 
+    /**
+     * Release the content of the loaded file.
+     * After calling this, the getFileData method is
+      * @note Calling this method set the engine out of the "loading state".
+    */
     void releaseFile();
 
     /// Is called at the end of the frame to synchronize any data
@@ -85,6 +107,8 @@ class RA_ENGINE_API RadiumEngine {
     std::unique_ptr<EntityManager> m_entityManager;
     std::unique_ptr<SignalManager> m_signalManager;
     std::unique_ptr<Asset::FileData> m_loadedFile;
+
+    bool m_loadingState = false;
 };
 
 } // namespace Engine

--- a/src/Engine/System/System.hpp
+++ b/src/Engine/System/System.hpp
@@ -47,22 +47,39 @@ class RA_ENGINE_API System {
     virtual void generateTasks( Core::TaskQueue* taskQueue,
                                 const Engine::FrameInfo& frameInfo ) = 0;
 
-    /// Registers a component belonging to an entity, making it active within the system.
-    void registerComponent( const Entity* entity, Component* component );
+    /**
+     * Registers a component belonging to an entity, making it active within the system.
+     * @note If a system overrides this function, it must call the inherited method first to any specific stuff.
+     * @param entity
+     * @param component
+     */
+    virtual void registerComponent( const Entity* entity, Component* component );
 
-    /// Unregisters a component. The system will not update it.
-    void unregisterComponent( const Entity* entity, Component* component );
+    /**
+     * Unregisters a component. The system will not update it.
+     * @note If a system overrides this function, it must call the inherited method first to any specific stuff.
+     * @param entity
+     * @param component
+     */
+    virtual void unregisterComponent( const Entity* entity, Component* component );
 
-    /// Removes all components belonging to a given entity.
-    void unregisterAllComponents( const Entity* entity );
+    /**
+     * Removes all components belonging to a given entity.
+     * @note If a system overrides this function, it must call the inherited method first to any specific stuff.
+     * @param entity
+     */
+    virtual void unregisterAllComponents( const Entity* entity );
 
     /// Returns the components stored for the given entity.
     std::vector<Component*> getEntityComponents( const Entity* entity );
 
     /**
      * Factory method for component creation from file data.
-     * Given a given file and the corresponding entity, the system will create the
-     * corresponding components,add them to the entity.
+     * From a given file and the corresponding entity, the system will create the
+     * corresponding components, add them to the entity, and register the component.
+     * @note : Issue #325 - As this method register components and might also manage each component outside the
+     * m_components vectors (e.g in a buffer on the GPU) the methods, the registerComponent and unregister*Component
+     * must be virtual method that could be overriden.
      */
     virtual void handleAssetLoading( Entity* entity, const Asset::FileData* data ) {}
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Is the Pull-Request done against the right branch:
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR is a bugfix for issue #325 _Can't clear scene that contains light_

* **What is the current behavior?** (You can also link to an open issue here)
When clearing the scene, and then deleting all components of the scene, Engine segfault while trying to access the lights through the Light Manager. (see issue #325).

This is due to the way Lights component are organized and stored for GPU efficiency (needed for many light rendering but also for renderers that use batch of light per rendering passes).

* **What is the new behavior (if this is a feature change)?**
When a component is deleted, it could now signal the system that handle it so that not only the component is deleted but also all the references the system could store for this component.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Not really a braking change. The ``System``interface change just add the virtual keyword and some documentation on how to override these methods.

* **Other information**:
Closes issue #325 