### PR TITLE
Camera fit

### DIFF
--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -465,7 +465,6 @@ void Gui::MainWindow::updateUi( Plugins::RadiumPluginInterface* plugin ) {
 }
 
 void MainWindow::onRendererReady() {
-    m_viewer->getCameraInterface()->resetCamera();
     updateDisplayedTexture();
 }
 

--- a/src/GuiBase/Viewer/TrackballCamera.cpp
+++ b/src/GuiBase/Viewer/TrackballCamera.cpp
@@ -202,7 +202,7 @@ void Gui::TrackballCamera::fitScene( const Core::Aabb& aabb ) {
     const Scalar y = r / std::sin( f * a / 2.0 );
     Scalar d = std::max( std::max( x, y ), Scalar( 0.001 ) );
 
-    m_camera->setPosition( Core::Vector3( aabb.center().x(), aabb.center().y(), d ) );
+    m_camera->setPosition( Core::Vector3( aabb.center().x(), aabb.center().y(), aabb.center().z()+d ) );
     m_camera->setDirection( Core::Vector3( 0, 0, -1 ) );
     m_trackballCenter = aabb.center();
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes these two issues : 
#327 Camera fit scene
#328 Camera reset when changing renderer

* **What is the current behavior?** (You can also link to an open issue here)
The updated position of the fitted camera does not take into account the Z-coordinate of the scene's bounding box. The camera is reset when the current renderer is changed.

* **What is the new behavior (if this is a feature change)?**
The updated position of the fitted camera takes into account the Z-coordinate of the scene's bounding box. The camera is not reset when the current renderer is changed.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No it does not introduce a breaking change.


* **Other information**:
