### PR TITLE
Change the Eigen ref to a working one

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/g-truc/glm.git
 [submodule "3rdPartyLibraries/Eigen"]
 	path = 3rdPartyLibraries/Eigen
-	url = https://github.com/RLovelett/eigen.git
+	url = https://github.com/eigenteam/eigen-git-mirror.git
 [submodule "3rdPartyLibraries/tinyply"]
 	path = 3rdPartyLibraries/tinyply
 	url = https://github.com/nmellado/tinyply.git


### PR DESCRIPTION
When trying to clone the submodules it appeared that the current repo for Eigen (https://github.com/RLovelett/eigen.git) was dead, so this PR replaces the reference with one to https://github.com/eigenteam/eigen-git-mirror.