### PR TITLE
Fix skinning

### DIFF
--- a/Applications/SimpleSubdivideExample/main.cpp
+++ b/Applications/SimpleSubdivideExample/main.cpp
@@ -4,8 +4,7 @@
 #include <OpenMesh/Tools/Subdivider/Uniform/CatmullClarkT.hh>
 #include <OpenMesh/Tools/Subdivider/Uniform/LoopT.hh>
 #include <memory>
-struct args
-{
+struct args {
     bool valid;
     int iteration;
     std::string outputFilename;
@@ -14,8 +13,7 @@ struct args
         subdivider;
 };
 
-void printHelp( char* argv[] )
-{
+void printHelp( char* argv[] ) {
     std::cout << "Usage :\n"
               << argv[0] << " -i input.obj -o output -s type -n iteration  \n\n"
               << " .obj extension is added automatically to output filename\n"
@@ -26,8 +24,7 @@ void printHelp( char* argv[] )
                  "iteration of subdivision\n";
 }
 
-args processArgs( int argc, char* argv[] )
-{
+args processArgs( int argc, char* argv[] ) {
     args ret;
     bool outputFilenameSet{false};
     bool subdividerSet{false};
@@ -35,23 +32,22 @@ args processArgs( int argc, char* argv[] )
 
     for ( int i = 1; i < argc; i += 2 )
     {
-        if ( i >= argc ) break;
+        if ( i >= argc )
+            break;
         if ( std::string( argv[i] ) == std::string( "-i" ) )
         {
             if ( i + 1 < argc )
             {
                 ret.inputFilename = argv[i + 1];
             }
-        }
-        else if ( std::string( argv[i] ) == std::string( "-o" ) )
+        } else if ( std::string( argv[i] ) == std::string( "-o" ) )
         {
             if ( i + 1 < argc )
             {
                 ret.outputFilename = argv[i + 1];
-                outputFilenameSet  = true;
+                outputFilenameSet = true;
             }
-        }
-        else if ( std::string( argv[i] ) == std::string( "-s" ) )
+        } else if ( std::string( argv[i] ) == std::string( "-s" ) )
         {
             if ( i + 1 < argc )
             {
@@ -61,19 +57,14 @@ args processArgs( int argc, char* argv[] )
                 {
                     ret.subdivider = std::make_unique<
                         OpenMesh::Subdivider::Uniform::CatmullClarkT<Ra::Core::TopologicalMesh>>();
-                }
-                else if ( a == std::string( "loop" ) )
+                } else if ( a == std::string( "loop" ) )
                 {
                     ret.subdivider = std::make_unique<
                         OpenMesh::Subdivider::Uniform::LoopT<Ra::Core::TopologicalMesh>>();
-                }
-                else
-                {
-                    subdividerSet = false;
-                }
+                } else
+                { subdividerSet = false; }
             }
-        }
-        else if ( std::string( argv[i] ) == std::string( "-n" ) )
+        } else if ( std::string( argv[i] ) == std::string( "-n" ) )
         {
             if ( i + 1 < argc )
             {
@@ -85,25 +76,20 @@ args processArgs( int argc, char* argv[] )
     return ret;
 }
 
-int main( int argc, char* argv[] )
-{
+int main( int argc, char* argv[] ) {
     args a = processArgs( argc, argv );
     if ( !a.valid )
     {
         printHelp( argv );
-    }
-    else
+    } else
     {
         Ra::Core::TriangleMesh mesh;
         Ra::Core::OBJFileManager obj;
         if ( a.inputFilename.empty() )
         {
             mesh = Ra::Core::MeshUtils::makeBox();
-        }
-        else
-        {
-            obj.load( a.inputFilename, mesh );
-        }
+        } else
+        { obj.load( a.inputFilename, mesh ); }
 
         LOG( logINFO ) << "in Mesh";
         for ( auto v : mesh.vertices() )
@@ -116,19 +102,19 @@ int main( int argc, char* argv[] )
             LOG( logINFO ) << v.transpose();
         }
 
-        float i           = 0;
-        auto test_handle2 = mesh.attribManager().addAttrib<Ra::Core::Vector4>( "test vec4" );
-        mesh.attribManager().getAttrib( test_handle2 ).resize( mesh.vertices().size() );
-        for ( auto& v : mesh.attribManager().getAttrib( test_handle2 ).data() )
+        float i = 0;
+        auto test_handle2 = mesh.addAttrib<Ra::Core::Vector4>( "test vec4" );
+        mesh.getAttrib( test_handle2 ).resize( mesh.vertices().size() );
+        for ( auto& v : mesh.getAttrib( test_handle2 ).data() )
         {
             v = Ra::Core::Vector4( i, i, i, i );
             i += 1.f;
         }
 
-        auto test_handle = mesh.attribManager().addAttrib<Ra::Core::Vector3>( "test vec3" );
-        mesh.attribManager().getAttrib( test_handle ).resize( mesh.vertices().size() );
+        auto test_handle = mesh.addAttrib<Ra::Core::Vector3>( "test vec3" );
+        mesh.getAttrib( test_handle ).resize( mesh.vertices().size() );
 
-        for ( auto& v : mesh.attribManager().getAttrib( test_handle ).data() )
+        for ( auto& v : mesh.getAttrib( test_handle ).data() )
         {
             v = Ra::Core::Vector3( i, i, i );
             LOG( logINFO ) << v.transpose();
@@ -166,14 +152,14 @@ int main( int argc, char* argv[] )
 
         LOG( logINFO ) << "out Vec3";
 
-        auto out_handle = mesh.attribManager().getAttribHandle<Ra::Core::Vector3>( "test vec3" );
-        for ( auto v : mesh.attribManager().getAttrib( out_handle ).data() )
+        auto out_handle = mesh.getAttribHandle<Ra::Core::Vector3>( "test vec3" );
+        for ( auto v : mesh.getAttrib( out_handle ).data() )
         {
             LOG( logINFO ) << v.transpose();
         }
 
-        auto out_handle2 = mesh.attribManager().getAttribHandle<Ra::Core::Vector4>( "test vec4" );
-        for ( auto v : mesh.attribManager().getAttrib( out_handle2 ).data() )
+        auto out_handle2 = mesh.getAttribHandle<Ra::Core::Vector4>( "test vec4" );
+        for ( auto v : mesh.getAttrib( out_handle2 ).data() )
         {
             LOG( logINFO ) << v.transpose();
         }

--- a/Docs/mesh.md
+++ b/Docs/mesh.md
@@ -45,10 +45,11 @@ For instance
         m.m_triangles.push_back( {0, 1, 2} );
 
         auto handle1 = m.addAttrib<Vector3>( "vector3_attrib" );
-        m.getAttrib( handle1 ).data().reserve( 3 );
-        m.getAttrib( handle1 ).data().push_back( {1, 1, 1} );
-        m.getAttrib( handle1 ).data().push_back( {2, 2, 2} );
-        m.getAttrib( handle1 ).data().push_back( {3, 3, 3} );
+        auto& buf = m.getAttrib( handle1 ).data();
+        buf.reserve( 3 );
+        buf.push_back( {1, 1, 1} );
+        buf.push_back( {2, 2, 2} );
+        buf.push_back( {3, 3, 3} );
 
         VertexAttribHandle<float> handle2 =
         m.addAttrib<float>( "float_attrib" );

--- a/Docs/mesh.md
+++ b/Docs/mesh.md
@@ -17,17 +17,20 @@ This class handles data only, in a way suitable for rendering.
 ## Mesh creation
 `FancyMesh` is in charge of loading a `GeometryData` and create the corresponding `Mesh`.
 
-The user can add on the fly new attributes to vertex via `VertexAttribManager` (accessible with `Mesh::attribManager()`).
-An attrib is defined by an unique name (`std::string`) and then represented as a `VertexAttribHandle<T>`.
+The user can add on the fly new vertex attributes via the `VertexAttribManager` (accessible with `Mesh::attribManager()`).
+An attrib is defined by a unique name (`std::string`) and then represented as a `VertexAttribHandle<T>`.
 The type of the attrib is defined by the caller using the template parameter of the method `addAttrib`.
 To ensure consistency, it is strongly recommended to store the handle returned by the `addAttrib` method:
 ```
         auto handle1 = m.attribManager().addAttrib<Vector3>( "vector3_attrib" );
 ```
 Note that handles of existing attributes can be retrieved by name (see `getAttrib(const std::string& name)`), however the caller have to provide the type of the associate attribute. 
-There is no type check on this access, and we recommend not to use this. We keep this merthod for convenience in some specific cases, however note that it might be marked as deprecated at any time.
+There is no type check on this access, and we recommend not to use this. We keep this method for convenience in some specific cases such as copy of attributes, however note that it might be marked as deprecated at any time.
 
 There is no (in the current version) data checking, and attribs are simple `std::vector` added to the attrib manager. It's meant to be used as vector of data as vertices and normals, with the same size and accessed with the faces indices. But please be aware no check nor allocation are done, so the allocation has to be performed on client side.
+
+When copying a `TriangleMesh`, only a shallow copy of its attributes is performed to fasten functions return.
+In order to perform a deep copy of some/all of the attributes, the dedicated methods must be used (directly using the `AttribManager` is highly discouraged).
 
 For instance
 ```
@@ -50,5 +53,8 @@ For instance
         m.attribManager().addAttrib<float>( "float_attrib" );
         auto attrib2 = m.attribManager().getAttrib( handle2 );
         attrib2.data().assign( { 1.f, 2.f, 3.f } );
+        
+        TriangleMesh m2;
+        m2.partialCopy( m, handle1 );
 ```
 

--- a/Docs/mesh.md
+++ b/Docs/mesh.md
@@ -17,20 +17,21 @@ This class handles data only, in a way suitable for rendering.
 ## Mesh creation
 `FancyMesh` is in charge of loading a `GeometryData` and create the corresponding `Mesh`.
 
-The user can add on the fly new vertex attributes via the `VertexAttribManager` (accessible with `Mesh::attribManager()`).
+The user can add on the fly new vertex attributes to a `TriangleMesh`.
 An attrib is defined by a unique name (`std::string`) and then represented as a `VertexAttribHandle<T>`.
 The type of the attrib is defined by the caller using the template parameter of the method `addAttrib`.
 To ensure consistency, it is strongly recommended to store the handle returned by the `addAttrib` method:
 ```
-        auto handle1 = m.attribManager().addAttrib<Vector3>( "vector3_attrib" );
+        auto handle1 = m.addAttrib<Vector3>( "vector3_attrib" );
 ```
+Attribute names `in_position` and `in_normals` are reserved.
 Note that handles of existing attributes can be retrieved by name (see `getAttrib(const std::string& name)`), however the caller have to provide the type of the associate attribute. 
 There is no type check on this access, and we recommend not to use this. We keep this method for convenience in some specific cases such as copy of attributes, however note that it might be marked as deprecated at any time.
 
-There is no (in the current version) data checking, and attribs are simple `std::vector` added to the attrib manager. It's meant to be used as vector of data as vertices and normals, with the same size and accessed with the faces indices. But please be aware no check nor allocation are done, so the allocation has to be performed on client side.
+There is no (in the current version) data checking, and attribs are simple `std::vector`s added to the attrib manager. It's meant to be used as vector of data as vertices and normals, with the same size and accessed with the vertices indices. But please be aware no check nor allocation are done, so the allocation has to be performed on client side.
 
-When copying a `TriangleMesh`, only a shallow copy of its attributes is performed to fasten functions return.
-In order to perform a deep copy of some/all of the attributes, the dedicated methods must be used (directly using the `AttribManager` is highly discouraged).
+When copying a `TriangleMesh`, no copy of its attributes is performed.
+In order to copy some/all of the attributes, the dedicated methods must be used.
 
 For instance
 ```
@@ -43,18 +44,18 @@ For instance
         m.normals().push_back( {0, 0, 1} );
         m.m_triangles.push_back( {0, 1, 2} );
 
-        auto handle1 = m.attribManager().addAttrib<Vector3>( "vector3_attrib" );
-        m.attribManager().getAttrib( handle1 ).data().reserve( 3 );
-        m.attribManager().getAttrib( handle1 ).data().push_back( {1, 1, 1} );
-        m.attribManager().getAttrib( handle1 ).data().push_back( {2, 2, 2} );
-        m.attribManager().getAttrib( handle1 ).data().push_back( {3, 3, 3} );
+        auto handle1 = m.addAttrib<Vector3>( "vector3_attrib" );
+        m.getAttrib( handle1 ).data().reserve( 3 );
+        m.getAttrib( handle1 ).data().push_back( {1, 1, 1} );
+        m.getAttrib( handle1 ).data().push_back( {2, 2, 2} );
+        m.getAttrib( handle1 ).data().push_back( {3, 3, 3} );
 
         VertexAttribHandle<float> handle2 =
-        m.attribManager().addAttrib<float>( "float_attrib" );
-        auto attrib2 = m.attribManager().getAttrib( handle2 );
+        m.addAttrib<float>( "float_attrib" );
+        auto attrib2 = m.getAttrib( handle2 );
         attrib2.data().assign( { 1.f, 2.f, 3.f } );
         
-        TriangleMesh m2;
-        m2.partialCopy( m, handle1 );
+        TriangleMesh m2 = m;
+        m2.copyAttributes( m, handle1 );
 ```
 

--- a/Plugins/MeshFeatureTracking/src/MeshFeatureTrackingComponent.cpp
+++ b/Plugins/MeshFeatureTracking/src/MeshFeatureTrackingComponent.cpp
@@ -19,7 +19,9 @@ using PickingMode = Ra::Engine::Renderer::PickingMode;
 
 namespace MeshFeatureTrackingPlugin {
 MeshFeatureTrackingComponent::MeshFeatureTrackingComponent(const std::string& name) :
-    Component( name, Ra::Engine::SystemEntity::getInstance() ) {}
+    Component( name, Ra::Engine::SystemEntity::getInstance() ) {
+    m_data.m_mode = Ra::Engine::Renderer::PickingMode::RO;
+}
 
 MeshFeatureTrackingComponent::~MeshFeatureTrackingComponent() {}
 

--- a/Plugins/Skinning/src/SkinningComponent.cpp
+++ b/Plugins/Skinning/src/SkinningComponent.cpp
@@ -52,7 +52,7 @@ void SkinningComponent::setupSkinning() {
         const auto norAttr =
             mesh.attribManager().getAttribHandle<TriangleMesh::NormalAttribHandle::value_type>(
                 "in_normal" );
-        m_refData.m_referenceMesh.copyAttribs( mesh, posAttr, norAttr );
+        m_refData.m_referenceMesh.partialCopy( mesh, posAttr, norAttr );
 
         // get other data
         m_refData.m_skeleton = compMsg->get<Skeleton>( getEntity(), m_contentsName );

--- a/Plugins/Skinning/src/SkinningComponent.cpp
+++ b/Plugins/Skinning/src/SkinningComponent.cpp
@@ -4,8 +4,8 @@
 #include <Core/Geometry/Normal/Normal.hpp>
 
 #include <Core/Animation/Skinning/DualQuaternionSkinning.hpp>
-#include <Core/Animation/Skinning/RotationCenterSkinning.hpp>
 #include <Core/Animation/Skinning/LinearBlendSkinning.hpp>
+#include <Core/Animation/Skinning/RotationCenterSkinning.hpp>
 
 using Ra::Core::DualQuaternion;
 using Ra::Core::Quaternion;
@@ -42,8 +42,20 @@ void SkinningComponent::setupSkinning() {
         m_duplicateTableGetter =
             compMsg->getterCallback<std::vector<Ra::Core::Index>>( getEntity(), m_contentsName );
 
+        // copy mesh triangles
+        const TriangleMesh& mesh = compMsg->get<TriangleMesh>( getEntity(), m_contentsName );
+        m_refData.m_referenceMesh = mesh;
+        // copy mesh positions and normals
+        const auto posAttr =
+            mesh.attribManager().getAttribHandle<TriangleMesh::PointAttribHandle::value_type>(
+                "in_position" );
+        const auto norAttr =
+            mesh.attribManager().getAttribHandle<TriangleMesh::NormalAttribHandle::value_type>(
+                "in_normal" );
+        m_refData.m_referenceMesh.copyAttribs( mesh, posAttr, norAttr );
+
+        // get other data
         m_refData.m_skeleton = compMsg->get<Skeleton>( getEntity(), m_contentsName );
-        m_refData.m_referenceMesh = compMsg->get<TriangleMesh>( getEntity(), m_contentsName );
         m_refData.m_refPose = compMsg->get<RefPose>( getEntity(), m_contentsName );
         m_refData.m_weights = compMsg->get<WeightMatrix>( getEntity(), m_contentsName );
 

--- a/Plugins/Skinning/src/SkinningComponent.cpp
+++ b/Plugins/Skinning/src/SkinningComponent.cpp
@@ -45,14 +45,6 @@ void SkinningComponent::setupSkinning() {
         // copy mesh triangles
         const TriangleMesh& mesh = compMsg->get<TriangleMesh>( getEntity(), m_contentsName );
         m_refData.m_referenceMesh = mesh;
-        // copy mesh positions and normals
-        const auto posAttr =
-            mesh.attribManager().getAttribHandle<TriangleMesh::PointAttribHandle::value_type>(
-                "in_position" );
-        const auto norAttr =
-            mesh.attribManager().getAttribHandle<TriangleMesh::NormalAttribHandle::value_type>(
-                "in_normal" );
-        m_refData.m_referenceMesh.partialCopy( mesh, posAttr, norAttr );
 
         // get other data
         m_refData.m_skeleton = compMsg->get<Skeleton>( getEntity(), m_contentsName );

--- a/Plugins/Skinning/src/SkinningComponent.cpp
+++ b/Plugins/Skinning/src/SkinningComponent.cpp
@@ -110,7 +110,6 @@ void SkinningComponent::skin() {
             case DQS:
             {
                 Ra::Core::AlignedStdVector<DualQuaternion> DQ;
-                // computeDQ( m_frameData.m_prevToCurrentRelPose, m_refData.m_weights, DQ );
                 Ra::Core::Animation::computeDQ( m_frameData.m_refToCurrentRelPose,
                                                 m_refData.m_weights, DQ );
                 Ra::Core::Animation::dualQuaternionSkinning( m_refData.m_referenceMesh.vertices(),
@@ -146,7 +145,6 @@ void SkinningComponent::endSkinning() {
         std::swap( m_frameData.m_previousPos, m_frameData.m_currentPos );
 
         m_frameData.m_doSkinning = false;
-
     } else if ( m_frameData.m_doReset )
     {
         // Reset mesh to its initial state.

--- a/Plugins/Skinning/src/SkinningComponent.cpp
+++ b/Plugins/Skinning/src/SkinningComponent.cpp
@@ -232,12 +232,6 @@ void SkinningComponent::setupSkinningType( SkinningType type ) {
         if ( m_refData.m_CoR.empty() )
         {
             Ra::Core::Animation::computeCoR( m_refData );
-            /*
-                       for ( const auto& v :m_refData.m_CoR )
-                       {
-                           RA_DISPLAY_POINT( v, Ra::Core::Colors::Red(), 0.1f );
-                       }
-            */
         }
     }
     } // end of switch.

--- a/src/Core/File/deprecated/OBJFileManager.cpp
+++ b/src/Core/File/deprecated/OBJFileManager.cpp
@@ -21,7 +21,7 @@ std::string OBJFileManager::fileExtension() const {
 }
 
 bool OBJFileManager::importData( std::istream& file, TriangleMesh& data ) {
-    data = TriangleMesh();
+    data.clear();
     std::string line;
     while ( std::getline( file, line ) )
     {

--- a/src/Core/File/deprecated/OFFFileManager.cpp
+++ b/src/Core/File/deprecated/OFFFileManager.cpp
@@ -39,7 +39,7 @@ bool OFFFileManager::importData( std::istream& file, TriangleMesh& data ) {
     uint f_size;
     uint e_size;
     file >> v_size >> f_size >> e_size;
-    data = TriangleMesh();
+    data.clear();
     data.vertices().resize( v_size );
     data.m_triangles.resize( f_size );
 

--- a/src/Core/Geometry/Approximation/VariationalShapeApproximation.inl
+++ b/src/Core/Geometry/Approximation/VariationalShapeApproximation.inl
@@ -134,7 +134,7 @@ inline void VariationalShapeApproximationBase<K_Region>::shuffle_regions() {
     {
         id[i] = i;
     }
-    std::random_shuffle( id.begin(), id.end() );
+    std::shuffle( id.begin(), id.end(), std::mt19937( std::random_device()() ) );
     for ( uint i = 0; i < K; ++i )
     {
         tmp_region[i] = this->m_region[id[i]];

--- a/src/Core/Math/ColorPresets.hpp
+++ b/src/Core/Math/ColorPresets.hpp
@@ -2,6 +2,7 @@
 #define RADIUMENGINE_COLOR_PRESET_HPP_
 
 #include <Core/Math/LinearAlgebra.hpp>
+#include <random>
 
 namespace Ra {
 namespace Core {
@@ -177,7 +178,7 @@ inline std::vector<C> scatter( const uint size, const Scalar gamma ) {
         }
     else
     { color[0] = Red(); }
-    std::random_shuffle( color.begin(), color.end() );
+    std::shuffle( color.begin(), color.end(), std::mt19937( std::random_device()() ) );
     return color;
 }
 } // namespace Colors

--- a/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.cpp
+++ b/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.cpp
@@ -9,10 +9,8 @@
 #include <utility>
 #include <vector>
 
-namespace Ra
-{
-namespace Core
-{
+namespace Ra {
+namespace Core {
 
 template <typename T>
 using PropPair = std::pair<AttribHandle<T>, OpenMesh::HPropHandleT<T>>;
@@ -20,9 +18,8 @@ using PropPair = std::pair<AttribHandle<T>, OpenMesh::HPropHandleT<T>>;
 template <typename T>
 void addAttribPairToTopo( const TriangleMesh& triMesh, TopologicalMesh* topoMesh,
                           AttribManager::value_type attr, std::vector<PropPair<T>>& vprop,
-                          std::vector<OpenMesh::HPropHandleT<T>>& pph )
-{
-    AttribHandle<T> h = triMesh.attribManager().getAttribHandle<T>( attr->getName() );
+                          std::vector<OpenMesh::HPropHandleT<T>>& pph ) {
+    AttribHandle<T> h = triMesh.getAttribHandle<T>( attr->getName() );
     OpenMesh::HPropHandleT<T> oh;
     topoMesh->add_property( oh, attr->getName() );
     vprop.push_back( std::make_pair( h, oh ) );
@@ -31,21 +28,18 @@ void addAttribPairToTopo( const TriangleMesh& triMesh, TopologicalMesh* topoMesh
 
 template <typename T>
 void addAttribPairToCore( TriangleMesh& triMesh, TopologicalMesh* topoMesh,
-                          OpenMesh::HPropHandleT<T> oh, std::vector<PropPair<T>>& vprop )
-{
-    AttribHandle<T> h{triMesh.attribManager().addAttrib<T>( topoMesh->property( oh ).name() )};
+                          OpenMesh::HPropHandleT<T> oh, std::vector<PropPair<T>>& vprop ) {
+    AttribHandle<T> h{triMesh.addAttrib<T>( topoMesh->property( oh ).name() )};
     vprop.push_back( std::make_pair( h, oh ) );
 }
 
 template <typename T>
 void copyAttribToTopo( const TriangleMesh& triMesh, TopologicalMesh* topoMesh,
                        std::vector<PropPair<T>>& vprop, TopologicalMesh::HalfedgeHandle heh,
-                       unsigned int vindex )
-{
+                       unsigned int vindex ) {
     for ( auto pp : vprop )
     {
-        topoMesh->property( pp.second, heh ) =
-            triMesh.attribManager().getAttrib( pp.first ).data()[vindex];
+        topoMesh->property( pp.second, heh ) = triMesh.getAttrib( pp.first ).data()[vindex];
     }
 }
 
@@ -55,8 +49,8 @@ using HandleAndValueVector = std::vector<std::pair<AttribHandle<T>, T>,
 
 template <typename T>
 void copyAttribToCoreVertex( HandleAndValueVector<T>& data, TopologicalMesh* topoMesh,
-                             std::vector<PropPair<T>>& vprop, TopologicalMesh::HalfedgeHandle heh )
-{
+                             std::vector<PropPair<T>>& vprop,
+                             TopologicalMesh::HalfedgeHandle heh ) {
     for ( auto pp : vprop )
     {
         data.push_back( std::make_pair( pp.first, topoMesh->property( pp.second, heh ) ) );
@@ -64,20 +58,16 @@ void copyAttribToCoreVertex( HandleAndValueVector<T>& data, TopologicalMesh* top
 }
 
 template <typename T>
-void copyAttribToCore( TriangleMesh& triMesh, HandleAndValueVector<T>& data )
-{
+void copyAttribToCore( TriangleMesh& triMesh, HandleAndValueVector<T>& data ) {
     for ( auto pp : data )
     {
-        triMesh.attribManager().getAttrib( pp.first ).data().push_back( pp.second );
+        triMesh.getAttrib( pp.first ).data().push_back( pp.second );
     }
 }
 
-TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh )
-{
-    struct hash_vec
-    {
-        size_t operator()( const Vector3& lvalue ) const
-        {
+TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh ) {
+    struct hash_vec {
+        size_t operator()( const Vector3& lvalue ) const {
             return lvalue[0] + lvalue[1] + lvalue[2] + floor( lvalue[0] ) * 1000.f +
                    floor( lvalue[1] ) * 1000.f + floor( lvalue[2] ) * 1000.f;
         }
@@ -135,11 +125,8 @@ TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh )
                 vh = this->add_vertex( p );
                 vertexHandles.insert( vtr, VertexMap::value_type( p, vh ) );
                 this->set_normal( vh, TopologicalMesh::Normal( n[0], n[1], n[2] ) );
-            }
-            else
-            {
-                vh = vtr->second;
-            }
+            } else
+            { vh = vtr->second; }
 
             face_vhandles.push_back( vh );
             face_normals.push_back( n );
@@ -167,10 +154,8 @@ TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh )
     }
 }
 
-TriangleMesh TopologicalMesh::toTriangleMesh()
-{
-    struct VertexData
-    {
+TriangleMesh TopologicalMesh::toTriangleMesh() {
+    struct VertexData {
         Vector3 _vertex;
         Vector3 _normal;
 
@@ -181,17 +166,14 @@ TriangleMesh TopologicalMesh::toTriangleMesh()
 
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-        bool operator==( const VertexData& lhs ) const
-        {
+        bool operator==( const VertexData& lhs ) const {
             return _vertex == lhs._vertex && _normal == lhs._normal && _float == lhs._float &&
                    _vec2 == lhs._vec2 && _vec3 == lhs._vec3 && _vec4 == lhs._vec4;
         }
     };
 
-    struct hash_vec
-    {
-        size_t operator()( const VertexData& lvalue ) const
-        {
+    struct hash_vec {
+        size_t operator()( const VertexData& lvalue ) const {
             return lvalue._vertex[0] + lvalue._vertex[1] + lvalue._vertex[2] +
                    floor( lvalue._vertex[0] ) * 1000.f + floor( lvalue._vertex[1] ) * 1000.f +
                    floor( lvalue._vertex[2] ) * 1000.f;
@@ -264,11 +246,8 @@ TriangleMesh TopologicalMesh::toTriangleMesh()
                 copyAttribToCore( out, v._vec2 );
                 copyAttribToCore( out, v._vec3 );
                 copyAttribToCore( out, v._vec4 );
-            }
-            else
-            {
-                vi = vtr->second;
-            }
+            } else
+            { vi = vtr->second; }
             indices[i] = vi;
             i++;
         }

--- a/src/Core/Mesh/TriangleMesh.hpp
+++ b/src/Core/Mesh/TriangleMesh.hpp
@@ -38,7 +38,6 @@ class TriangleMesh {
     /// Copy constructor, copy only the mesh topology,
     /// the list of vertices and vertices normals.
     /// For attributes copy, use the copyAttributes() or copyAllAttributes() methods.
-    /// \note Directly using the AttribManager is highly discouraged.
     inline TriangleMesh( const TriangleMesh& other );
 
     /// Move constructor, copy all the mesh data (topology, geometry, attributes).
@@ -47,18 +46,16 @@ class TriangleMesh {
     /// Assignment operator copy only the mesh topology,
     /// the list of vertices and vertices normals.
     /// For attributes copy, use the copyAttributes() or copyAllAttributes() methods.
-    /// \note Directly using the AttribManager is highly discouraged.
     inline TriangleMesh& operator=( const TriangleMesh& other );
 
     /// Move assignment, copy all the mesh data (topology, geometry, attributes).
     inline TriangleMesh& operator=( TriangleMesh&& other );
 
     /// Erases all data, making the mesh empty.
-    /// Note: invalidates shallow copies.
     inline void clear();
 
     /// Appends another mesh to this one.
-    /// \todo handle attrib here as well !
+    /// \todo handle attribs here as well !
     inline void append( const TriangleMesh& other );
 
     /// Access the vertices positions.

--- a/src/Core/Mesh/TriangleMesh.hpp
+++ b/src/Core/Mesh/TriangleMesh.hpp
@@ -38,7 +38,6 @@ class TriangleMesh
     /// Create an empty mesh.
     inline TriangleMesh() { initDefaultAttribs(); }
     /// Copy constructor and assignment operator
-    /// \warning No deep copy of attributes !
     TriangleMesh( const TriangleMesh& ) = default;
     TriangleMesh& operator=( const TriangleMesh& ) = default;
 

--- a/src/Core/Mesh/TriangleMesh.hpp
+++ b/src/Core/Mesh/TriangleMesh.hpp
@@ -36,21 +36,31 @@ class TriangleMesh {
     /// Create an empty mesh.
     inline TriangleMesh() { initDefaultAttribs(); }
 
-    /// Copy constructor and assignment operator are pure shallow copy of attributes.
-    /// For deep copy of attributes, use the partialCopy or fullCopy methods.
-    /// Note: Directly using the AttribManager is highly discouraged.
-    TriangleMesh( const TriangleMesh& ) = default;
-    TriangleMesh& operator=( const TriangleMesh& ) = default;
+    /// Copy constructor copy only the mesh topology,
+    /// the list of vertices and vertices normals.
+    /// For attributes copy, use the copyAttributes() or copyAllAttributes() methods.
+    /// \note Directly using the AttribManager is highly discouraged.
+    inline TriangleMesh( const TriangleMesh& other );
+
+    inline TriangleMesh( TriangleMesh&& other );
+
+    /// Assignment operator copy only the mesh topology,
+    /// the list of vertices and vertices normals.
+    /// For attributes copy, use the copyAttributes() or copyAllAttributes() methods.
+    /// \note Directly using the AttribManager is highly discouraged.
+    inline TriangleMesh& operator=( const TriangleMesh& other );
+
+    inline TriangleMesh& operator=( TriangleMesh&& other );
 
     /// Copy only the required attributes (deep copy).
     /// The position and normal attributes are always copied, no need to provide their handles.
-    /// Note: The original handles are not valid for the mesh copy.
+    /// \warning The original handles are not valid for the mesh copy.
     template <typename... Handles>
-    void partialCopy( const TriangleMesh& input, Handles... attribs );
+    void copyAttributes( const TriangleMesh& input, Handles... attribs );
 
     /// Copy all the attributes (deep copy).
-    /// Note: The original handles are also valid for the mesh copy.
-    inline void fullCopy( const TriangleMesh& input );
+    /// \warning The original handles are also valid for the mesh copy.
+    inline void copyAllAttributes( const TriangleMesh& input );
 
     /// Erases all data, making the mesh empty.
     /// Note: invalidates shallow copies.

--- a/src/Core/Mesh/TriangleMesh.hpp
+++ b/src/Core/Mesh/TriangleMesh.hpp
@@ -82,12 +82,14 @@ class TriangleMesh {
     }
 
     /// Get attribute by handle.
+    /// \see AttribManager::getAttrib() for more info.
     template <typename T>
     inline Attrib<T>& getAttrib( AttribHandle<T> h ) {
         return m_vertexAttribs.getAttrib( h );
     }
 
     /// Get attribute by handle (const).
+    /// \see AttribManager::getAttrib() for more info.
     template <typename T>
     inline const Attrib<T>& getAttrib( AttribHandle<T> h ) const {
         return m_vertexAttribs.getAttrib( h );
@@ -114,11 +116,13 @@ class TriangleMesh {
     /// Copy only the required attributes (deep copy).
     /// The position and normal attributes are always copied, no need to provide their handles.
     /// \warning The original handles are not valid for the mesh copy.
+    /// \see AttribManager::copyAttributes() for more info.
     template <typename... Handles>
     void copyAttributes( const TriangleMesh& input, Handles... attribs );
 
     /// Copy all the attributes (deep copy).
     /// \warning The original handles are also valid for the mesh copy.
+    /// \see AttribManager::copyAllAttributes() for more info.
     inline void copyAllAttributes( const TriangleMesh& input );
 
   public:

--- a/src/Core/Mesh/TriangleMesh.hpp
+++ b/src/Core/Mesh/TriangleMesh.hpp
@@ -36,15 +36,21 @@ class TriangleMesh {
     /// Create an empty mesh.
     inline TriangleMesh() { initDefaultAttribs(); }
 
-    /// Copy constructor and assignment operator.
-    /// Note: shallow copy of attributes.
+    /// Copy constructor and assignment operator are pure shallow copy of attributes.
+    /// For deep copy of attributes, use the partialCopy or fullCopy methods.
+    /// Note: Directly using the AttribManager is highly discouraged.
     TriangleMesh( const TriangleMesh& ) = default;
     TriangleMesh& operator=( const TriangleMesh& ) = default;
 
     /// Copy only the required attributes (deep copy).
-    /// Note: Passing directly through the AttribManager is highly discouraged.
+    /// The position and normal attributes are always copied, no need to provide their handles.
+    /// Note: The original handles are not valid for the mesh copy.
     template <typename... Handles>
-    void copyAttribs( const TriangleMesh& input, Handles... attribs );
+    void partialCopy( const TriangleMesh& input, Handles... attribs );
+
+    /// Copy all the attributes (deep copy).
+    /// Note: The original handles are also valid for the mesh copy.
+    inline void fullCopy( const TriangleMesh& input );
 
     /// Erases all data, making the mesh empty.
     /// Note: invalidates shallow copies.

--- a/src/Core/Mesh/TriangleMesh.hpp
+++ b/src/Core/Mesh/TriangleMesh.hpp
@@ -36,12 +36,13 @@ class TriangleMesh {
     /// Create an empty mesh.
     inline TriangleMesh() { initDefaultAttribs(); }
 
-    /// Copy constructor copy only the mesh topology,
+    /// Copy constructor, copy only the mesh topology,
     /// the list of vertices and vertices normals.
     /// For attributes copy, use the copyAttributes() or copyAllAttributes() methods.
     /// \note Directly using the AttribManager is highly discouraged.
     inline TriangleMesh( const TriangleMesh& other );
 
+    /// Move constructor, copy all the mesh data (topology, geometry, attributes).
     inline TriangleMesh( TriangleMesh&& other );
 
     /// Assignment operator copy only the mesh topology,
@@ -50,6 +51,7 @@ class TriangleMesh {
     /// \note Directly using the AttribManager is highly discouraged.
     inline TriangleMesh& operator=( const TriangleMesh& other );
 
+    /// Move assignment, copy all the mesh data (topology, geometry, attributes).
     inline TriangleMesh& operator=( TriangleMesh&& other );
 
     /// Copy only the required attributes (deep copy).

--- a/src/Core/Mesh/TriangleMesh.inl
+++ b/src/Core/Mesh/TriangleMesh.inl
@@ -29,5 +29,17 @@ inline void TriangleMesh::append( const TriangleMesh& other ) {
         }
     }
 }
+
+template <typename... Handles>
+void TriangleMesh::copyAttribs( const TriangleMesh& input, Handles... attribs ) {
+    // copy attribs
+    m_vertexAttribs.copyAttribs( input.m_vertexAttribs, attribs... );
+    // update custom handles
+    m_verticesHandle =
+        m_vertexAttribs.getAttribHandle<PointAttribHandle::value_type>( "in_position" );
+    m_normalsHandle =
+        m_vertexAttribs.getAttribHandle<NormalAttribHandle::value_type>( "in_normal" );
+}
+
 } // namespace Core
 } // namespace Ra

--- a/src/Core/Mesh/TriangleMesh.inl
+++ b/src/Core/Mesh/TriangleMesh.inl
@@ -31,9 +31,20 @@ inline void TriangleMesh::append( const TriangleMesh& other ) {
 }
 
 template <typename... Handles>
-void TriangleMesh::copyAttribs( const TriangleMesh& input, Handles... attribs ) {
+void TriangleMesh::partialCopy( const TriangleMesh& input, Handles... attribs ) {
     // copy attribs
-    m_vertexAttribs.copyAttribs( input.m_vertexAttribs, attribs... );
+    m_vertexAttribs.partialCopy( input.m_vertexAttribs, input.m_verticesHandle,
+                                 input.m_normalsHandle, attribs... );
+    // update custom handles
+    m_verticesHandle =
+        m_vertexAttribs.getAttribHandle<PointAttribHandle::value_type>( "in_position" );
+    m_normalsHandle =
+        m_vertexAttribs.getAttribHandle<NormalAttribHandle::value_type>( "in_normal" );
+}
+
+inline void TriangleMesh::fullCopy( const TriangleMesh& input ) {
+    // copy attribs
+    m_vertexAttribs.fullCopy( input.m_vertexAttribs );
     // update custom handles
     m_verticesHandle =
         m_vertexAttribs.getAttribHandle<PointAttribHandle::value_type>( "in_position" );

--- a/src/Core/Mesh/TriangleMesh.inl
+++ b/src/Core/Mesh/TriangleMesh.inl
@@ -2,6 +2,42 @@
 
 namespace Ra {
 namespace Core {
+
+inline TriangleMesh::TriangleMesh( const TriangleMesh& other ) :
+    m_triangles( other.m_triangles ),
+    m_faces( other.m_faces ) {
+    copyAttributes( other, other.m_verticesHandle, other.m_normalsHandle );
+    m_verticesHandle =
+        m_vertexAttribs.getAttribHandle<PointAttribHandle::value_type>( "in_position" );
+    m_normalsHandle =
+        m_vertexAttribs.getAttribHandle<NormalAttribHandle::value_type>( "in_normal" );
+}
+
+inline TriangleMesh::TriangleMesh( TriangleMesh&& other ) :
+    m_triangles( std::move( other.m_triangles ) ),
+    m_faces( std::move( other.m_faces ) ),
+    m_vertexAttribs( std::move( other.m_vertexAttribs ) ),
+    m_verticesHandle( std::move( other.m_verticesHandle ) ),
+    m_normalsHandle( std::move( other.m_normalsHandle ) ) {}
+
+inline TriangleMesh& TriangleMesh::operator=( const TriangleMesh& other ) {
+    m_triangles = other.m_triangles;
+    m_faces = other.m_faces;
+    copyAttributes( other, other.m_verticesHandle, other.m_normalsHandle );
+    m_verticesHandle =
+        m_vertexAttribs.getAttribHandle<PointAttribHandle::value_type>( "in_position" );
+    m_normalsHandle =
+        m_vertexAttribs.getAttribHandle<NormalAttribHandle::value_type>( "in_normal" );
+}
+
+inline TriangleMesh& TriangleMesh::operator=( TriangleMesh&& other ) {
+    m_triangles = std::move( other.m_triangles );
+    m_faces = std::move( other.m_faces );
+    m_vertexAttribs = std::move( other.m_vertexAttribs );
+    m_verticesHandle = std::move( other.m_verticesHandle );
+    m_normalsHandle = std::move( other.m_normalsHandle );
+}
+
 inline void TriangleMesh::clear() {
     m_vertexAttribs.clear();
     vertices().clear();
@@ -31,10 +67,9 @@ inline void TriangleMesh::append( const TriangleMesh& other ) {
 }
 
 template <typename... Handles>
-void TriangleMesh::partialCopy( const TriangleMesh& input, Handles... attribs ) {
+void TriangleMesh::copyAttributes( const TriangleMesh& input, Handles... attribs ) {
     // copy attribs
-    m_vertexAttribs.partialCopy( input.m_vertexAttribs, input.m_verticesHandle,
-                                 input.m_normalsHandle, attribs... );
+    m_vertexAttribs.copyAttributes( input.m_vertexAttribs, attribs... );
     // update custom handles
     m_verticesHandle =
         m_vertexAttribs.getAttribHandle<PointAttribHandle::value_type>( "in_position" );
@@ -42,9 +77,9 @@ void TriangleMesh::partialCopy( const TriangleMesh& input, Handles... attribs ) 
         m_vertexAttribs.getAttribHandle<NormalAttribHandle::value_type>( "in_normal" );
 }
 
-inline void TriangleMesh::fullCopy( const TriangleMesh& input ) {
+inline void TriangleMesh::copyAllAttributes( const TriangleMesh& input ) {
     // copy attribs
-    m_vertexAttribs.fullCopy( input.m_vertexAttribs );
+    m_vertexAttribs.copyAllAttributes( input.m_vertexAttribs );
     // update custom handles
     m_verticesHandle =
         m_vertexAttribs.getAttribHandle<PointAttribHandle::value_type>( "in_position" );

--- a/src/Core/Utils/Attribs.hpp
+++ b/src/Core/Utils/Attribs.hpp
@@ -140,6 +140,18 @@ class AttribManager
     using value_type = AttribBase*;
     using Container = std::vector<value_type>;
 
+    AttribManager(){}
+    AttribManager(const AttribManager& m)
+    {
+        copyFrom( m );
+    }
+
+    AttribManager& operator=(const AttribManager& m)
+    {
+        copyFrom( m );
+        return *this;
+    }
+
     /// const acces to attrib vector
     const Container& attribs() const { return m_attribs; }
 
@@ -256,6 +268,40 @@ class AttribManager
     }
 
   private:
+    /// Implements deep copy of attributes
+    void copyFrom(const AttribManager& m)
+    {
+        clear();
+        for (const AttribBase* attr : m.attribs())
+        {
+            const auto n = attr->getName();
+            if ( attr->isFloat() )
+            {
+                auto a = addAttrib<float>( n );
+                getAttrib( a ).data() = m.getAttrib( m.getAttribHandle<float>( n ) ).data();
+            }
+            else if ( attr->isVec2() )
+            {
+                auto a = addAttrib<Ra::Core::Vector2>( n );
+                getAttrib( a ).data() = m.getAttrib( m.getAttribHandle<Ra::Core::Vector2>( n ) ).data();
+            }
+            else if ( attr->isVec3() )
+            {
+                auto a = addAttrib<Ra::Core::Vector3>( n );
+                getAttrib( a ).data() = m.getAttrib( m.getAttribHandle<Ra::Core::Vector3>( n ) ).data();
+            }
+            else if ( attr->isVec4() )
+            {
+                auto a = addAttrib<Ra::Core::Vector4>( n );
+                getAttrib( a ).data() = m.getAttrib( m.getAttribHandle<Ra::Core::Vector4>( n ) ).data();
+            }
+            else
+                LOG( logWARNING )
+                    << "Warning, mesh attribute " << attr->getName()
+                    << " type is not supported (only float, vec2, vec3 nor vec4 are supported)";
+        }
+    }
+
     std::map<std::string, int> m_attribsIndex;
     Container m_attribs;
 };

--- a/src/Core/Utils/Attribs.hpp
+++ b/src/Core/Utils/Attribs.hpp
@@ -134,25 +134,53 @@ class AttribManager {
 
     AttribManager() {}
 
-    /// Shallow copy of attributes
+    /// Copy constructor and assignment operator are pure shallow copy of attributes.
+    /// For copy, use the partialCopy or fullCopy methods.
     AttribManager( const AttribManager& m ) = default;
     AttribManager& operator=( const AttribManager& m ) = default;
 
     // Deep copy of attributes
     /// Base copy, does nothing.
-    void copyAttribs( const AttribManager& m ) {}
+    void partialCopy( const AttribManager& m ) {}
 
-    /// Deep copy of attrib.
+    /// Deep copy of some attributes.
     /// Note: if some attrib already exist, it will be replaced but not de-allocated.
     template <class T, class... Handle>
-    void copyAttribs( const AttribManager& m, const AttribHandle<T>& attr, Handle... attribs ) {
+    void partialCopy( const AttribManager& m, const AttribHandle<T>& attr, Handle... attribs ) {
         // get attrib to copy
         auto a = m.getAttrib( attr );
         // add new attrib
         auto h = addAttrib<T>( a.getName() );
         getAttrib( h ).data() = a.data();
         // deal with other attribs
-        copyAttribs( m, attribs... );
+        partialCopy( m, attribs... );
+    }
+
+    /// Deep copy of all attributes.
+    void fullCopy( const AttribManager& m ) {
+        for ( const auto& attr : m.m_attribs )
+        {
+            if ( attr->isFloat() )
+            {
+                auto h = addAttrib<float>( attr->getName() );
+                getAttrib( h ).data() = static_cast<Attrib<float>*>( attr )->data();
+            } else if ( attr->isVec2() )
+            {
+                auto h = addAttrib<Vector2>( attr->getName() );
+                getAttrib( h ).data() = static_cast<Attrib<Vector2>*>( attr )->data();
+            } else if ( attr->isVec3() )
+            {
+                auto h = addAttrib<Vector3>( attr->getName() );
+                getAttrib( h ).data() = static_cast<Attrib<Vector3>*>( attr )->data();
+            } else if ( attr->isVec4() )
+            {
+                auto h = addAttrib<Vector4>( attr->getName() );
+                getAttrib( h ).data() = static_cast<Attrib<Vector4>*>( attr )->data();
+            } else
+                LOG( logWARNING )
+                    << "Warning, mesh attribute " << attr->getName()
+                    << " type is not supported (only float, vec2, vec3 nor vec4 are supported)";
+        }
     }
 
     /// clear all attribs, invalidate handles and shallow copies.

--- a/src/Core/Utils/Attribs.hpp
+++ b/src/Core/Utils/Attribs.hpp
@@ -96,7 +96,7 @@ class AttribHandle {
     Ra::Core::Index idx() { return m_idx; }
 
   private:
-    Ra::Core::Index m_idx = -1;
+    Ra::Core::Index m_idx = Ra::Core::Index::Invalid();
 
     friend class AttribManager;
 };

--- a/src/Engine/Renderer/Mesh/Mesh.cpp
+++ b/src/Engine/Renderer/Mesh/Mesh.cpp
@@ -7,16 +7,13 @@
 #include <Engine/Renderer/OpenGL/OpenGL.hpp>
 
 #include <Core/Log/Log.hpp>
-namespace Ra
-{
-namespace Engine
-{
+namespace Ra {
+namespace Engine {
 
 // Template parameter must be a Core::VectorNArray
 template <typename ContainedType>
 inline void sendGLData( Ra::Engine::Mesh* mesh, const Ra::Core::VectorArray<ContainedType>& arr,
-                        const uint vboIdx )
-{
+                        const uint vboIdx ) {
     using VecArray = Ra::Core::VectorArray<ContainedType>;
 #ifdef CORE_USE_DOUBLE
     GLenum type = GL_DOUBLE;
@@ -52,11 +49,8 @@ inline void sendGLData( Ra::Engine::Mesh* mesh, const Ra::Core::VectorArray<Cont
         if ( arr.size() > 0 )
         {
             GL_ASSERT( glEnableVertexAttribArray( vboIdx - 1 ) );
-        }
-        else
-        {
-            GL_ASSERT( glDisableVertexAttribArray( vboIdx - 1 ) );
-        }
+        } else
+        { GL_ASSERT( glDisableVertexAttribArray( vboIdx - 1 ) ); }
     }
 } // sendGLData
 
@@ -67,8 +61,7 @@ Mesh::Mesh( const std::string& name, MeshRenderMode renderMode ) :
     m_vao( 0 ),
     m_renderMode( renderMode ),
     m_numElements( 0 ),
-    m_isDirty( false )
-{
+    m_isDirty( false ) {
     CORE_ASSERT( m_renderMode == RM_POINTS || m_renderMode == RM_LINES ||
                      m_renderMode == RM_LINE_LOOP || m_renderMode == RM_LINE_STRIP ||
                      m_renderMode == RM_TRIANGLES || m_renderMode == RM_TRIANGLE_STRIP ||
@@ -77,8 +70,7 @@ Mesh::Mesh( const std::string& name, MeshRenderMode renderMode ) :
                  "Unsupported render mode" );
 }
 
-Mesh::~Mesh()
-{
+Mesh::~Mesh() {
     if ( m_vao != 0 )
     {
         GL_ASSERT( glDeleteVertexArrays( 1, &m_vao ) );
@@ -93,8 +85,7 @@ Mesh::~Mesh()
     }
 }
 
-void Mesh::render()
-{
+void Mesh::render() {
     if ( m_vao != 0 )
     {
         GL_ASSERT( glBindVertexArray( m_vao ) );
@@ -103,16 +94,14 @@ void Mesh::render()
     }
 }
 
-void Mesh::loadGeometry( const Core::TriangleMesh& mesh )
-{
+void Mesh::loadGeometry( const Core::TriangleMesh& mesh ) {
     m_mesh = mesh;
 
     if ( m_mesh.m_triangles.empty() )
     {
         m_numElements = mesh.vertices().size();
         m_renderMode = RM_POINTS;
-    }
-    else
+    } else
         m_numElements = mesh.m_triangles.size() * 3;
 
     for ( uint i = 0; i < MAX_MESH; ++i )
@@ -122,16 +111,16 @@ void Mesh::loadGeometry( const Core::TriangleMesh& mesh )
     m_isDirty = true;
 }
 
-void Mesh::updateMeshGeometry( MeshData type, const Core::Vector3Array& data )
-{
-    if ( type == VERTEX_POSITION ) m_mesh.vertices() = data;
-    if ( type == VERTEX_NORMAL ) m_mesh.normals() = data;
+void Mesh::updateMeshGeometry( MeshData type, const Core::Vector3Array& data ) {
+    if ( type == VERTEX_POSITION )
+        m_mesh.vertices() = data;
+    if ( type == VERTEX_NORMAL )
+        m_mesh.normals() = data;
     m_dataDirty[static_cast<uint>( type )] = true;
     m_isDirty = true;
 }
 
-void Mesh::loadGeometry( const Core::Vector3Array& vertices, const std::vector<uint>& indices )
-{
+void Mesh::loadGeometry( const Core::Vector3Array& vertices, const std::vector<uint>& indices ) {
     // Do not remove this function to force everyone to use triangle mesh.
     //  ... because we have some line meshes as well...
     const uint nIdx = indices.size();
@@ -140,8 +129,7 @@ void Mesh::loadGeometry( const Core::Vector3Array& vertices, const std::vector<u
     {
         m_numElements = vertices.size();
         m_renderMode = RM_POINTS;
-    }
-    else
+    } else
         m_numElements = nIdx;
     m_mesh.vertices() = vertices;
 
@@ -168,30 +156,28 @@ void Mesh::loadGeometry( const Core::Vector3Array& vertices, const std::vector<u
     m_isDirty = true;
 }
 
-void Mesh::addData( const Vec3Data& type, const Core::Vector3Array& data )
-{
+void Mesh::addData( const Vec3Data& type, const Core::Vector3Array& data ) {
     const int index = static_cast<uint>( type );
     auto& handle = m_v3DataHandle[index];
 
     // if it's the first time this handle is used, add it to m_mesh.
     if ( data.size() != 0 && !handle.isValid() )
     {
-        handle = m_mesh.attribManager().addAttrib<Core::Vector3>( std::string( "Vec3_attr_" ) +
-                                                                  std::to_string( type ) );
+        handle =
+            m_mesh.addAttrib<Core::Vector3>( std::string( "Vec3_attr_" ) + std::to_string( type ) );
     }
 
     //    if ( data.size() != 0 && handle.isValid() )
     if ( handle.isValid() )
     {
-        m_mesh.attribManager().getAttrib( handle ).data() = data;
+        m_mesh.getAttrib( handle ).data() = data;
 
         m_dataDirty[MAX_MESH + index] = true;
         m_isDirty = true;
     }
 }
 
-void Mesh::addData( const Vec4Data& type, const Core::Vector4Array& data )
-{
+void Mesh::addData( const Vec4Data& type, const Core::Vector4Array& data ) {
 
     const int index = static_cast<uint>( type );
     auto& handle = m_v4DataHandle[index];
@@ -199,21 +185,20 @@ void Mesh::addData( const Vec4Data& type, const Core::Vector4Array& data )
     // if it's the first time this handle is used, add it to m_mesh.
     if ( data.size() != 0 && !handle.isValid() )
     {
-        handle = m_mesh.attribManager().addAttrib<Core::Vector4>( std::string( "Vec4_attr_" ) +
-                                                                  std::to_string( type ) );
+        handle =
+            m_mesh.addAttrib<Core::Vector4>( std::string( "Vec4_attr_" ) + std::to_string( type ) );
     }
 
     //    if ( data.size() != 0 && handle.isValid() )
     if ( handle.isValid() )
     {
-        m_mesh.attribManager().getAttrib( handle ).data() = data;
+        m_mesh.getAttrib( handle ).data() = data;
         m_dataDirty[MAX_MESH + MAX_VEC3 + index] = true;
         m_isDirty = true;
     }
 }
 
-void Mesh::updateGL()
-{
+void Mesh::updateGL() {
     if ( m_isDirty )
     {
         // Check that our dirty bits are consistent.
@@ -245,8 +230,7 @@ void Mesh::updateGL()
                 std::iota( indices.begin(), indices.end(), 0 );
                 GL_ASSERT( glBufferData( GL_ELEMENT_ARRAY_BUFFER, m_numElements * sizeof( int ),
                                          indices.data(), GL_DYNAMIC_DRAW ) );
-            }
-            else
+            } else
             {
                 GL_ASSERT( glBufferData( GL_ELEMENT_ARRAY_BUFFER,
                                          m_mesh.m_triangles.size() * sizeof( Ra::Core::Triangle ),
@@ -263,8 +247,7 @@ void Mesh::updateGL()
         {
             if ( m_v3DataHandle[i].isValid() )
             {
-                sendGLData( this, m_mesh.attribManager().getAttrib( m_v3DataHandle[i] ).data(),
-                            MAX_MESH + i );
+                sendGLData( this, m_mesh.getAttrib( m_v3DataHandle[i] ).data(), MAX_MESH + i );
             }
         }
 
@@ -272,7 +255,7 @@ void Mesh::updateGL()
         {
             if ( m_v4DataHandle[i].isValid() )
             {
-                sendGLData( this, m_mesh.attribManager().getAttrib( m_v4DataHandle[i] ).data(),
+                sendGLData( this, m_mesh.getAttrib( m_v4DataHandle[i] ).data(),
                             MAX_MESH + MAX_VEC3 + i );
             }
         }

--- a/src/Engine/Renderer/Mesh/Mesh.hpp
+++ b/src/Engine/Renderer/Mesh/Mesh.hpp
@@ -28,6 +28,7 @@ namespace Engine
 /// It stores the vertex attributes, indices, and can be rendered
 /// with a specific render mode (e.g. GL_TRIANGLES or GL_LINES).
 /// It maintains the attributes and keeps them in sync with the GPU.
+/// \note Attribute names are used to automatic location binding when using shaders.
 class RA_ENGINE_API Mesh
 {
   public:

--- a/src/Engine/Renderer/Mesh/Mesh.inl
+++ b/src/Engine/Renderer/Mesh/Mesh.inl
@@ -21,27 +21,27 @@ Core::TriangleMesh& Mesh::getGeometry() {
 const Core::Vector3Array& Mesh::getData( const Mesh::Vec3Data& type ) const {
     const int index = static_cast<uint>( type );
     CORE_ASSERT( m_v3DataHandle[index].isValid(), "Attrib must be initialized" );
-    return m_mesh.attribManager().getAttrib( m_v3DataHandle[index] ).data();
+    return m_mesh.getAttrib( m_v3DataHandle[index] ).data();
 }
 
 const Core::Vector4Array& Mesh::getData( const Mesh::Vec4Data& type ) const {
     const int index = static_cast<uint>( type );
     if ( !m_v4DataHandle[index].isValid() )
         return m_dummy;
-    return m_mesh.attribManager().getAttrib( m_v4DataHandle[index] ).data();
+    return m_mesh.getAttrib( m_v4DataHandle[index] ).data();
 }
 
 Core::Vector3Array& Mesh::getData( const Mesh::Vec3Data& type ) {
     const int index = static_cast<uint>( type );
     CORE_ASSERT( m_v3DataHandle[index].isValid(), "Attrib must be initialized" );
-    return m_mesh.attribManager().getAttrib( m_v3DataHandle[index] ).data();
+    return m_mesh.getAttrib( m_v3DataHandle[index] ).data();
 }
 
 Core::Vector4Array& Mesh::getData( const Mesh::Vec4Data& type ) {
     const int index = static_cast<uint>( type );
     if ( !m_v4DataHandle[index].isValid() )
         return m_dummy;
-    return m_mesh.attribManager().getAttrib( m_v4DataHandle[index] ).data();
+    return m_mesh.getAttrib( m_v4DataHandle[index] ).data();
 }
 
 void Mesh::setDirty( const Mesh::MeshData& type ) {

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -138,15 +138,9 @@ void Gui::Viewer::initializeGL() {
     m_glInitStatus = true;
     m_context->makeCurrent( this );
 
-    m_camera.reset( new Gui::TrackballCamera( width(), height() ) );
-
     LOG( logINFO ) << "*** Radium Engine Viewer ***";
     Engine::ShaderProgramManager::createInstance( "Shaders/Default.vert.glsl",
                                                   "Shaders/Default.frag.glsl" );
-
-    // Lights are components. So they must be attached to an entity. Attache headlight to system Entity
-    auto light = new Engine::DirectionalLight( Ra::Engine::SystemEntity::getInstance(), "headlight" );
-    m_camera->attachLight( light );
 
     // initialize renderers added before GL was ready
     if ( !m_renderers.empty() )
@@ -433,6 +427,18 @@ void Gui::Viewer::showEvent( QShowEvent* ev ) {
                        << gl::glGetString( gl::GLenum( GL_SHADING_LANGUAGE_VERSION ) );
 
         m_context->doneCurrent();
+    }
+
+    if ( !m_camera )
+    {
+        // quick fix meanwhile camera management refactoring
+        // see issue #339 Crash when using -f option
+        // https://github.com/STORM-IRIT/Radium-Engine/issues/339
+        m_camera.reset( new Gui::TrackballCamera( width(), height() ) );
+
+        // Lights are components. So they must be attached to an entity. Attache headlight to system Entity
+        auto light = new Engine::DirectionalLight( Ra::Engine::SystemEntity::getInstance(), "headlight" );
+        m_camera->attachLight( light );
     }
 }
 

--- a/src/Tests/CoreTests/src/Mesh.hpp
+++ b/src/Tests/CoreTests/src/Mesh.hpp
@@ -24,7 +24,8 @@ class MeshTests : public Test {
         auto handlerEmpty = mesh.attribManager().addAttrib<Vec3AttribHandle::value_type>( "empty" );
         RA_UNIT_TEST( handlerEmpty.isValid(), "Should get a valid handle here !" );
         mesh.attribManager().removeAttrib( handlerEmpty );
-        handlerEmpty = mesh.attribManager().getAttribHandle<Vec3AttribHandle::value_type>( "empty" );
+        handlerEmpty =
+            mesh.attribManager().getAttribHandle<Vec3AttribHandle::value_type>( "empty" );
         RA_UNIT_TEST( !handlerEmpty.isValid(), "Should be an invalid handle." );
 
         // Test access to the attribute container
@@ -55,11 +56,17 @@ class MeshTests : public Test {
         auto invalid = mesh.attribManager().getAttribHandle<float>( "toto" );
         RA_UNIT_TEST( !invalid.isValid(), "Invalid Attrib Handle cannot be recognized" );
 
-        // Test deep copy
+        // Test shallow copy
         const auto v0 = mesh.vertices()[0];
         TriangleMesh meshCopy = mesh;
         meshCopy.vertices()[0] += Ra::Core::Vector3( 0.5, 0.5, 0.5 );
-        RA_UNIT_TEST( mesh.vertices()[0].isApprox( v0 ), "Cannot deep-copy TriangleMesh" );
+        RA_UNIT_TEST( !mesh.vertices()[0].isApprox( v0 ), "Cannot shallow-copy TriangleMesh" );
+
+        // Test deep copy
+        auto attr = mesh.attribManager().getAttribHandle<Ra::Core::Vector3>( "in_position" );
+        meshCopy.copyAttribs( mesh, attr );
+        meshCopy.vertices()[0] -= Ra::Core::Vector3( 0.5, 0.5, 0.5 );
+        RA_UNIT_TEST( !mesh.vertices()[0].isApprox( v0 ), "Cannot deep-copy TriangleMesh" );
     }
 
     void run() override { testAttributeManagement(); }

--- a/src/Tests/CoreTests/src/Mesh.hpp
+++ b/src/Tests/CoreTests/src/Mesh.hpp
@@ -56,22 +56,14 @@ class MeshTests : public Test {
         auto invalid = mesh.attribManager().getAttribHandle<float>( "toto" );
         RA_UNIT_TEST( !invalid.isValid(), "Invalid Attrib Handle cannot be recognized" );
 
-        // Test shallow copy
+        // Test attribute copy
         const auto v0 = mesh.vertices()[0];
         TriangleMesh meshCopy = mesh;
+        meshCopy.copyAllAttributes( mesh );
+        RA_UNIT_TEST( mesh.vertices()[0].isApprox( v0 ), "Cannot copy TriangleMesh" );
         meshCopy.vertices()[0] += Ra::Core::Vector3( 0.5, 0.5, 0.5 );
-        RA_UNIT_TEST( !mesh.vertices()[0].isApprox( v0 ), "Cannot shallow-copy TriangleMesh" );
-
-        // Test deep copy
-        auto attr = mesh.attribManager().getAttribHandle<Ra::Core::Vector3>( "in_position" );
-        meshCopy.partialCopy( mesh, attr );
-        meshCopy.vertices()[0] -= Ra::Core::Vector3( 0.5, 0.5, 0.5 );
-        RA_UNIT_TEST( !mesh.vertices()[0].isApprox( v0 ), "Cannot deep-copy TriangleMesh" );
-
-        // Test full copy
-        meshCopy.fullCopy( mesh );
-        meshCopy.vertices()[0] += Ra::Core::Vector3( 0.5, 0.5, 0.5 );
-        RA_UNIT_TEST( !mesh.vertices()[0].isApprox( v0 ), "Cannot full-copy TriangleMesh" );
+        RA_UNIT_TEST( !meshCopy.vertices()[0].isApprox( v0 ),
+                      "Cannot copy TriangleMesh attributes" );
     }
 
     void run() override { testAttributeManagement(); }

--- a/src/Tests/CoreTests/src/Mesh.hpp
+++ b/src/Tests/CoreTests/src/Mesh.hpp
@@ -19,41 +19,37 @@ class MeshTests : public Test {
 
         // Add/Remove attributes without filling it
         mesh = Ra::Core::MeshUtils::makeBox();
-        mesh.attribManager().addAttrib<Vec3AttribHandle::value_type>( "empty" );
-        mesh.attribManager().removeAttrib( "empty" );
-        auto handlerEmpty = mesh.attribManager().addAttrib<Vec3AttribHandle::value_type>( "empty" );
+        auto handlerEmpty = mesh.addAttrib<Vec3AttribHandle::value_type>( "empty" );
+        mesh.removeAttrib( handlerEmpty );
+        handlerEmpty = mesh.addAttrib<Vec3AttribHandle::value_type>( "empty" );
         RA_UNIT_TEST( handlerEmpty.isValid(), "Should get a valid handle here !" );
-        mesh.attribManager().removeAttrib( handlerEmpty );
-        handlerEmpty =
-            mesh.attribManager().getAttribHandle<Vec3AttribHandle::value_type>( "empty" );
+        mesh.removeAttrib( handlerEmpty );
+        handlerEmpty = mesh.getAttribHandle<Vec3AttribHandle::value_type>( "empty" );
         RA_UNIT_TEST( !handlerEmpty.isValid(), "Should be an invalid handle." );
 
         // Test access to the attribute container
-        auto handlerFilled =
-            mesh.attribManager().addAttrib<Vec3AttribHandle::value_type>( "filled" );
-        auto& container = mesh.attribManager().getAttrib( handlerFilled ).data();
-        auto containerHandler =
-            mesh.attribManager().getAttribHandle<Vec3AttribHandle::value_type>( "filled" );
-        auto& container2 = mesh.attribManager().getAttrib( containerHandler ).data();
+        auto handlerFilled = mesh.addAttrib<Vec3AttribHandle::value_type>( "filled" );
+        auto& container = mesh.getAttrib( handlerFilled ).data();
+        auto containerHandler = mesh.getAttribHandle<Vec3AttribHandle::value_type>( "filled" );
+        auto& container2 = mesh.getAttrib( containerHandler ).data();
         RA_UNIT_TEST( container == container2, "getAttrib variants are not consistents" );
 
         // Test filling and removing vec3 attributes
         for ( int i = 0; i != mesh.vertices().size(); ++i )
             container.push_back( Vec3AttribHandle::value_type::Random() );
-        mesh.attribManager().removeAttrib( "filled" );
+        mesh.removeAttrib( handlerFilled );
 
         // Test attribute creation by type, filling and removal
-        auto handler =
-            mesh.attribManager().addAttrib<Eigen::Matrix<unsigned int, 1, 1>>( "filled2" );
-        auto& container3 = mesh.attribManager().getAttrib( handler ).data();
+        auto handler = mesh.addAttrib<Eigen::Matrix<unsigned int, 1, 1>>( "filled2" );
+        auto& container3 = mesh.getAttrib( handler ).data();
         using HandlerType = decltype( handler );
 
         for ( int i = 0; i != mesh.vertices().size(); ++i )
             container3.push_back( typename HandlerType::value_type( i ) );
-        mesh.attribManager().removeAttrib( "filled2" );
+        mesh.removeAttrib( handler );
 
         // Test dummy handler
-        auto invalid = mesh.attribManager().getAttribHandle<float>( "toto" );
+        auto invalid = mesh.getAttribHandle<float>( "toto" );
         RA_UNIT_TEST( !invalid.isValid(), "Invalid Attrib Handle cannot be recognized" );
 
         // Test attribute copy

--- a/src/Tests/CoreTests/src/Mesh.hpp
+++ b/src/Tests/CoreTests/src/Mesh.hpp
@@ -22,8 +22,10 @@ class MeshTests : public Test {
         mesh.attribManager().addAttrib<Vec3AttribHandle::value_type>( "empty" );
         mesh.attribManager().removeAttrib( "empty" );
         auto handlerEmpty = mesh.attribManager().addAttrib<Vec3AttribHandle::value_type>( "empty" );
-        RA_UNIT_TEST( handlerEmpty.isValid(), "Should get a valid handler here !" );
+        RA_UNIT_TEST( handlerEmpty.isValid(), "Should get a valid handle here !" );
         mesh.attribManager().removeAttrib( handlerEmpty );
+        handlerEmpty = mesh.attribManager().getAttribHandle<Vec3AttribHandle::value_type>( "empty" );
+        RA_UNIT_TEST( !handlerEmpty.isValid(), "Should be an invalid handle." );
 
         // Test access to the attribute container
         auto handlerFilled =
@@ -51,12 +53,18 @@ class MeshTests : public Test {
 
         // Test dummy handler
         auto invalid = mesh.attribManager().getAttribHandle<float>( "toto" );
-        RA_UNIT_TEST( !invalid.isValid(), "Invalid Attrib Handler cannot be recognized" );
+        RA_UNIT_TEST( !invalid.isValid(), "Invalid Attrib Handle cannot be recognized" );
+
+        // Test deep copy
+        const auto v0 = mesh.vertices()[0];
+        TriangleMesh meshCopy = mesh;
+        meshCopy.vertices()[0] += Ra::Core::Vector3( 0.5, 0.5, 0.5 );
+        RA_UNIT_TEST( mesh.vertices()[0].isApprox( v0 ), "Cannot deep-copy TriangleMesh" );
     }
 
     void run() override { testAttributeManagement(); }
 };
-RA_TEST_CLASS( MeshTests );
+RA_TEST_CLASS( MeshTests )
 } // namespace RaTests
 
 #endif // RADIUM_CONVERT_TESTS_HPP_

--- a/src/Tests/CoreTests/src/Mesh.hpp
+++ b/src/Tests/CoreTests/src/Mesh.hpp
@@ -64,9 +64,14 @@ class MeshTests : public Test {
 
         // Test deep copy
         auto attr = mesh.attribManager().getAttribHandle<Ra::Core::Vector3>( "in_position" );
-        meshCopy.copyAttribs( mesh, attr );
+        meshCopy.partialCopy( mesh, attr );
         meshCopy.vertices()[0] -= Ra::Core::Vector3( 0.5, 0.5, 0.5 );
         RA_UNIT_TEST( !mesh.vertices()[0].isApprox( v0 ), "Cannot deep-copy TriangleMesh" );
+
+        // Test full copy
+        meshCopy.fullCopy( mesh );
+        meshCopy.vertices()[0] += Ra::Core::Vector3( 0.5, 0.5, 0.5 );
+        RA_UNIT_TEST( !mesh.vertices()[0].isApprox( v0 ), "Cannot full-copy TriangleMesh" );
     }
 
     void run() override { testAttributeManagement(); }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes #343 , which was due to non deep copy of attributes in `TriangleMesh`.
Also fixes compilation error with AppleClang due to the c++17 standard modification regarding std::random_shuffle.


* **What is the current behavior?** (You can also link to an open issue here)
No deep copy of attributes when copying a `TriangleMesh`.


* **What is the new behavior (if this is a feature change)?**
No copy of attributes when copying a TriangleMesh.
Copy of needed/all attributes from the corresponding methods, plus improved management of attributes addition/deletion in AttribManager.
Thus, there is no shallow copies anymore.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
The `TriangleMesh` doesn't give access to its `AttribManager` anymore, it only exposes a reduced interface for it.



* **Other information**:
