### PR TITLE
Add attributes-aware subdivision

### DIFF
--- a/Applications/SimpleSubdivideExample/main.cpp
+++ b/Applications/SimpleSubdivideExample/main.cpp
@@ -5,6 +5,11 @@
 #include <Core/Mesh/TopologicalTriMesh/TopologicalMesh.hpp>
 #include <memory>
 
+/// Macro used for testing only, to add attibutes to the TopologicalMesh
+/// before subdivisition
+/// \FIXME Must be removed once using Radium::IO with attribute loading.
+//#define TEST_ATTRIBUTES_SUBDIV
+
 struct args {
     bool valid;
     int iteration;
@@ -22,7 +27,14 @@ void printHelp( char* argv[] ) {
                  "given, a simple cube is used\n"
               << "type \t\t is a string for the subdivider type name : catmull, loop\n"
               << "iteration \t (default is 1) is a positive integer to specify the number of "
-                 "iteration of subdivision\n";
+                 "iteration of subdivision\n\n";
+    /// \FIXME Use Radium::IO to load and save meshes.
+    std::cout
+        << "Warning: The Subdivide application does not use Radium::IO for loading/saving "
+        << "files. Input *.obj files must list only vertex position (v) and vertex normal (vn), "
+        << "and the face list.\n"
+        << "Other features of the OBJ file format are not supported and might lead to "
+        << "unexpected behaviors." << std::endl;
 }
 
 args processArgs( int argc, char* argv[] ) {
@@ -103,6 +115,7 @@ int main( int argc, char* argv[] ) {
             LOG( logINFO ) << v.transpose();
         }
 
+#ifdef TEST_ATTRIBUTES_SUBDIV
         float i = 0;
         auto test_handle2 = mesh.addAttrib<Ra::Core::Vector4>( "test vec4" );
         mesh.getAttrib( test_handle2 ).resize( mesh.vertices().size() );
@@ -121,6 +134,7 @@ int main( int argc, char* argv[] ) {
             LOG( logINFO ) << v.transpose();
             i += 1.f;
         }
+#endif
 
         Ra::Core::TopologicalMesh topologicalMesh( mesh );
 
@@ -142,6 +156,7 @@ int main( int argc, char* argv[] ) {
             LOG( logINFO ) << v.transpose();
         }
 
+#ifdef TEST_ATTRIBUTES_SUBDIV
         LOG( logINFO ) << "out Vec3";
         auto out_handle = mesh.getAttribHandle<Ra::Core::Vector3>( "test vec3" );
         for ( auto v : mesh.getAttrib( out_handle ).data() )
@@ -155,6 +170,7 @@ int main( int argc, char* argv[] ) {
         {
             LOG( logINFO ) << v.transpose();
         }
+#endif
 
         obj.save( a.outputFilename, mesh );
     }

--- a/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.cpp
+++ b/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.cpp
@@ -112,7 +112,7 @@ bool CatmullClarkSubdivider::subdivide( TopologicalMesh& mesh, size_t n,
 
 #if defined( _DEBUG ) || defined( DEBUG )
         // Now we have an consistent mesh!
-        assert( OpenMesh::Utils::MeshCheckerT<TopologicalMesh>( _m ).check() );
+        assert( OpenMesh::Utils::MeshCheckerT<TopologicalMesh>( mesh ).check() );
 #endif
     }
 

--- a/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.cpp
+++ b/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.cpp
@@ -1,0 +1,393 @@
+#include <Core/Algorithm/Subdivision/CatmullClarkSubdivider.hpp>
+#include <Core/Algorithm/Subdivision/SubdividerUtils.hpp>
+
+namespace Ra {
+namespace Core {
+
+bool CatmullClarkSubdivider::prepare( TopologicalMesh& mesh ) {
+    mesh.add_property( m_vpPos );
+    mesh.add_property( m_epPos );
+    mesh.add_property( m_fpPos );
+    mesh.add_property( m_creaseWeights );
+    addPropsCopy( mesh.m_floatPph, mesh, m_floatProps );
+    addPropsCopy( mesh.m_vec2Pph, mesh, m_vec2Props );
+    addPropsCopy( mesh.m_vec3Pph, mesh, m_vec3Props );
+    addPropsCopy( mesh.m_vec4Pph, mesh, m_vec4Props );
+    addPropsCopyF( mesh.m_floatPph, mesh, m_floatPropsF );
+    addPropsCopyF( mesh.m_vec2Pph, mesh, m_vec2PropsF );
+    addPropsCopyF( mesh.m_vec3Pph, mesh, m_vec3PropsF );
+    addPropsCopyF( mesh.m_vec4Pph, mesh, m_vec4PropsF );
+
+    // initialize all weights to 0 (= smooth edge)
+    for ( auto e_it = mesh.edges_begin(); e_it != mesh.edges_end(); ++e_it )
+        mesh.property( m_creaseWeights, *e_it ) = 0.0;
+
+    return true;
+}
+
+bool CatmullClarkSubdivider::cleanup( TopologicalMesh& mesh ) {
+    mesh.remove_property( m_vpPos );
+    mesh.remove_property( m_epPos );
+    mesh.remove_property( m_fpPos );
+    mesh.remove_property( m_creaseWeights );
+    clearProps( m_floatProps, mesh );
+    clearProps( m_vec2Props, mesh );
+    clearProps( m_vec3Props, mesh );
+    clearProps( m_vec4Props, mesh );
+    clearProps( m_floatPropsF, mesh );
+    clearProps( m_vec2PropsF, mesh );
+    clearProps( m_vec3PropsF, mesh );
+    clearProps( m_vec4PropsF, mesh );
+    return true;
+}
+
+bool CatmullClarkSubdivider::subdivide( TopologicalMesh& mesh, size_t n,
+                                        const bool update_points ) {
+    // Do n subdivisions
+    for ( size_t i = 0; i < n; ++i )
+    {
+        // Compute face centroid
+#pragma omp parallel for
+        for ( uint i = 0; i < mesh.n_faces(); ++i )
+        {
+            const auto& fh = mesh.face_handle( i );
+            TopologicalMesh::Point centroid;
+            mesh.calc_face_centroid( fh, centroid );
+            mesh.property( m_fpPos, fh ) = centroid;
+            interpolateProps( mesh.m_floatPph, m_floatPropsF, fh, mesh );
+            interpolateProps( mesh.m_vec2Pph, m_vec2PropsF, fh, mesh );
+            interpolateProps( mesh.m_vec3Pph, m_vec3PropsF, fh, mesh );
+            interpolateProps( mesh.m_vec4Pph, m_vec4PropsF, fh, mesh );
+        }
+
+        // Compute position for new (edge-) vertices and store them in the edge property
+#pragma omp parallel for
+        for ( uint i = 0; i < mesh.n_edges(); ++i )
+        {
+            const auto& eh = mesh.edge_handle( i );
+            compute_midpoint( mesh, eh, update_points );
+        }
+
+        // position updates activated?
+        if ( update_points )
+        {
+            // compute new positions for old vertices
+#pragma omp parallel for
+            for ( uint i = 0; i < mesh.n_vertices(); ++i )
+            {
+                const auto& vh = mesh.vertex_handle( i );
+                update_vertex( mesh, vh );
+            }
+
+            // Commit changes in geometry
+#pragma omp parallel for
+            for ( uint i = 0; i < mesh.n_vertices(); ++i )
+            {
+                const auto& vh = mesh.vertex_handle( i );
+                mesh.set_point( vh, mesh.property( m_vpPos, vh ) );
+            }
+        }
+
+        // Split each edge at midpoint stored in edge property m_epPos;
+        // Attention! Creating new edges, hence make sure the loop ends correctly.
+        auto e_end = mesh.edges_end();
+        for ( auto e_itr = mesh.edges_begin(); e_itr != e_end; ++e_itr )
+        {
+            split_edge( mesh, *e_itr );
+        }
+
+        // Commit changes in topology and reconsitute consistency
+        // Attention! Creating new faces, hence make sure the loop ends correctly.
+        auto f_end = mesh.faces_end();
+        for ( auto f_itr = mesh.faces_begin(); f_itr != f_end; ++f_itr )
+        {
+            split_face( mesh, *f_itr );
+        }
+
+        // Commit properties
+        commitProps( m_floatProps, mesh, mesh.m_floatPph );
+        commitProps( m_vec2Props, mesh, mesh.m_vec2Pph );
+        commitProps( m_vec3Props, mesh, mesh.m_vec3Pph );
+        commitProps( m_vec4Props, mesh, mesh.m_vec4Pph );
+
+#if defined( _DEBUG ) || defined( DEBUG )
+        // Now we have an consistent mesh!
+        assert( OpenMesh::Utils::MeshCheckerT<TopologicalMesh>( _m ).check() );
+#endif
+    }
+
+    // ###########################################################################
+    // FIXME: THIS IS ONLY THERE BECAUSE CORE ONLY MANAGES TRIANGLE MESHES FOR NOW
+
+    // triangulate resulting quads
+    auto f_end = mesh.faces_end();
+    for ( auto f_itr = mesh.faces_begin(); f_itr != f_end; ++f_itr )
+    {
+        // get all needed halfedges
+        auto heh1 = mesh.halfedge_handle( *f_itr );
+        auto heh2 = mesh.next_halfedge_handle( heh1 );
+        auto heh3 = mesh.next_halfedge_handle( heh2 );
+        auto heh4 = mesh.next_halfedge_handle( heh3 );
+        auto heh5 = mesh.new_edge( mesh.to_vertex_handle( heh1 ), mesh.to_vertex_handle( heh3 ) );
+        auto heh6 = mesh.opposite_halfedge_handle( heh5 );
+
+        // triangulate
+        auto fnew = mesh.new_face();
+        mesh.set_halfedge_handle( fnew, heh2 );
+        mesh.set_face_handle( heh5, *f_itr );
+        mesh.set_face_handle( heh2, fnew );
+        mesh.set_face_handle( heh3, fnew );
+        mesh.set_face_handle( heh6, fnew );
+        mesh.set_next_halfedge_handle( heh1, heh5 );
+        mesh.set_next_halfedge_handle( heh5, heh4 );
+        mesh.set_next_halfedge_handle( heh3, heh6 );
+        mesh.set_next_halfedge_handle( heh6, heh2 );
+
+        // deal with properties
+        copyProps( m_floatProps, heh3, heh5, mesh );
+        copyProps( m_vec2Props, heh3, heh5, mesh );
+        copyProps( m_vec3Props, heh3, heh5, mesh );
+        copyProps( m_vec4Props, heh3, heh5, mesh );
+        copyProps( m_floatProps, heh1, heh6, mesh );
+        copyProps( m_vec2Props, heh1, heh6, mesh );
+        copyProps( m_vec3Props, heh1, heh6, mesh );
+        copyProps( m_vec4Props, heh1, heh6, mesh );
+    }
+
+    // Commit properties (again since can still subdivide after all this)
+    commitProps( m_floatProps, mesh, mesh.m_floatPph );
+    commitProps( m_vec2Props, mesh, mesh.m_vec2Pph );
+    commitProps( m_vec3Props, mesh, mesh.m_vec3Pph );
+    commitProps( m_vec4Props, mesh, mesh.m_vec4Pph );
+
+    // ###########################################################################
+
+    // compute normals
+    mesh.request_face_normals();
+    mesh.request_vertex_normals();
+    mesh.update_normals();
+
+    return true;
+}
+
+void CatmullClarkSubdivider::split_face( TopologicalMesh& mesh,
+                                         const TopologicalMesh::FaceHandle& fh ) {
+    /*
+        Split an n-gon into n quads by connecting
+        each vertex of fh to vh.
+
+        - fh will remain valid (it will become one of the quads)
+        - the halfedge handles of the new quads will point to the old halfedges
+    */
+
+    // Since edges are already refined (valence*2)
+    size_t valence = mesh.valence( fh ) / 2;
+
+    // Add new mesh vertex from face centroid
+    auto vh = mesh.add_vertex( mesh.property( m_fpPos, fh ) );
+
+    // init new topology with first face
+    auto hend = mesh.halfedge_handle( fh );
+    auto hh = mesh.next_halfedge_handle( hend );
+    auto hold = mesh.new_edge( mesh.to_vertex_handle( hend ), vh );
+    mesh.set_next_halfedge_handle( hend, hold );
+    mesh.set_face_handle( hold, fh );
+
+    // deal with properties for vh
+    copyProps( m_floatPropsF, m_floatProps, fh, hold, mesh );
+    copyProps( m_vec2PropsF, m_vec2Props, fh, hold, mesh );
+    copyProps( m_vec3PropsF, m_vec3Props, fh, hold, mesh );
+    copyProps( m_vec4PropsF, m_vec4Props, fh, hold, mesh );
+
+    // go around new vertex to build topology
+    hold = mesh.opposite_halfedge_handle( hold );
+
+    // deal with properties for hold
+    copyProps( m_floatProps, hend, hold, mesh );
+    copyProps( m_vec2Props, hend, hold, mesh );
+    copyProps( m_vec3Props, hend, hold, mesh );
+    copyProps( m_vec4Props, hend, hold, mesh );
+
+    for ( size_t i = 1; i < valence; i++ )
+    {
+        // go to next mid-edge vertex
+        auto hnext = mesh.next_halfedge_handle( hh );
+        auto hnew = mesh.new_edge( mesh.to_vertex_handle( hnext ), vh );
+
+        // create new face
+        auto fnew = mesh.new_face();
+        mesh.set_halfedge_handle( fnew, hh );
+        mesh.set_face_handle( hnew, fnew );
+        mesh.set_face_handle( hold, fnew );
+        mesh.set_face_handle( hh, fnew );
+        mesh.set_face_handle( hnext, fnew );
+        mesh.set_next_halfedge_handle( hnew, hold );
+        mesh.set_next_halfedge_handle( hold, hh );
+
+        // deal with properties for hnew
+        copyProps( m_floatPropsF, m_floatProps, fh, hnew, mesh );
+        copyProps( m_vec2PropsF, m_vec2Props, fh, hnew, mesh );
+        copyProps( m_vec3PropsF, m_vec3Props, fh, hnew, mesh );
+        copyProps( m_vec4PropsF, m_vec4Props, fh, hnew, mesh );
+
+        // prepare for next face
+        hh = mesh.next_halfedge_handle( hnext );
+        hold = mesh.opposite_halfedge_handle( hnew );
+        mesh.set_next_halfedge_handle( hnext, hnew ); // this has to be done after hh !
+
+        // deal with properties for hold
+        copyProps( m_floatProps, hnext, hold, mesh );
+        copyProps( m_vec2Props, hnext, hold, mesh );
+        copyProps( m_vec3Props, hnext, hold, mesh );
+        copyProps( m_vec4Props, hnext, hold, mesh );
+    }
+
+    // finish topology
+    mesh.set_next_halfedge_handle( hold, hh );
+    mesh.set_next_halfedge_handle( hh, hend );
+    hh = mesh.next_halfedge_handle( hend );
+    mesh.set_next_halfedge_handle( hh, hold );
+    mesh.set_face_handle( hold, fh );
+    mesh.set_halfedge_handle( vh, hold );
+}
+
+void CatmullClarkSubdivider::split_edge( TopologicalMesh& mesh,
+                                         const TopologicalMesh::EdgeHandle& eh ) {
+    using HeHandle = TopologicalMesh::HalfedgeHandle;
+    using VHandle = TopologicalMesh::VertexHandle;
+    using FHandle = TopologicalMesh::FaceHandle;
+
+    // prepare data
+    HeHandle heh = mesh.halfedge_handle( eh, 0 );
+    HeHandle opp_heh = mesh.halfedge_handle( eh, 1 );
+    HeHandle new_heh;
+    HeHandle opp_new_heh;
+    HeHandle t_heh;
+    VHandle vh;
+    VHandle vh1( mesh.to_vertex_handle( heh ) );
+
+    // new vertex
+    vh = mesh.new_vertex( mesh.property( m_epPos, eh ) );
+
+    // Re-link mesh entities
+    if ( mesh.is_boundary( eh ) )
+    {
+        for ( t_heh = heh; mesh.next_halfedge_handle( t_heh ) != opp_heh;
+              t_heh = mesh.opposite_halfedge_handle( mesh.next_halfedge_handle( t_heh ) ) )
+            ;
+    } else
+    {
+        for ( t_heh = mesh.next_halfedge_handle( opp_heh );
+              mesh.next_halfedge_handle( t_heh ) != opp_heh;
+              t_heh = mesh.next_halfedge_handle( t_heh ) )
+            ;
+    }
+
+    new_heh = mesh.new_edge( vh, vh1 );
+    opp_new_heh = mesh.opposite_halfedge_handle( new_heh );
+    mesh.set_vertex_handle( heh, vh );
+
+    mesh.set_next_halfedge_handle( t_heh, opp_new_heh );
+    mesh.set_next_halfedge_handle( new_heh, mesh.next_halfedge_handle( heh ) );
+    mesh.set_next_halfedge_handle( heh, new_heh );
+    mesh.set_next_halfedge_handle( opp_new_heh, opp_heh );
+
+    if ( mesh.face_handle( opp_heh ).is_valid() )
+    {
+        mesh.set_face_handle( opp_new_heh, mesh.face_handle( opp_heh ) );
+        mesh.set_halfedge_handle( mesh.face_handle( opp_new_heh ), opp_new_heh );
+    }
+
+    if ( mesh.face_handle( heh ).is_valid() )
+    {
+        mesh.set_face_handle( new_heh, mesh.face_handle( heh ) );
+        mesh.set_halfedge_handle( mesh.face_handle( heh ), heh );
+    }
+
+    mesh.set_halfedge_handle( vh, new_heh );
+    mesh.set_halfedge_handle( vh1, opp_new_heh );
+
+    // Never forget this, when playing with the topology
+    mesh.adjust_outgoing_halfedge( vh );
+    mesh.adjust_outgoing_halfedge( vh1 );
+
+    // deal with custom properties
+    interpolateProps( m_floatProps, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
+    interpolateProps( m_vec2Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
+    interpolateProps( m_vec3Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
+    interpolateProps( m_vec4Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
+}
+
+void CatmullClarkSubdivider::compute_midpoint( TopologicalMesh& mesh,
+                                               const TopologicalMesh::EdgeHandle& eh,
+                                               const bool update_points ) {
+    TopologicalMesh::HalfedgeHandle heh = mesh.halfedge_handle( eh, 0 );
+    TopologicalMesh::HalfedgeHandle opp_heh = mesh.halfedge_handle( eh, 1 );
+
+    TopologicalMesh::Point pos = mesh.point( mesh.to_vertex_handle( heh ) );
+    pos += mesh.point( mesh.to_vertex_handle( opp_heh ) );
+
+    // boundary edge: just average vertex positions
+    // this yields the [1/2 1/2] mask
+    if ( mesh.is_boundary( eh ) || !update_points )
+    {
+        pos *= 0.5;
+    } else // inner edge: add neighbouring Vertices to sum
+           // this yields the [1/16 1/16; 3/8 3/8; 1/16 1/16] mask
+    {
+        pos += mesh.property( m_fpPos, mesh.face_handle( heh ) );
+        pos += mesh.property( m_fpPos, mesh.face_handle( opp_heh ) );
+        pos *= 0.25;
+    }
+    mesh.property( m_epPos, eh ) = pos;
+}
+
+void CatmullClarkSubdivider::update_vertex( TopologicalMesh& mesh,
+                                            const TopologicalMesh::VertexHandle& vh ) {
+    TopologicalMesh::Point pos( 0.0, 0.0, 0.0 );
+
+    // TODO boundary, Extraordinary Vertex and  Creased Surfaces
+    // see "A Factored Approach to Subdivision Surfaces"
+    // http://faculty.cs.tamu.edu/schaefer/research/tutorial.pdf
+    // and http://www.cs.utah.edu/~lacewell/subdeval
+    if ( mesh.is_boundary( vh ) )
+    {
+        pos = mesh.point( vh );
+        for ( auto ve_itr = mesh.ve_iter( vh ); ve_itr.is_valid(); ++ve_itr )
+            if ( mesh.is_boundary( *ve_itr ) )
+                pos += mesh.property( m_epPos, *ve_itr );
+        pos /= 3.0;
+    } else // inner vertex
+    {
+        /* For each (non boundary) vertex V, introduce a new vertex whose
+           position is F/n + 2E/n + (n-3)V/n where F is the average of
+           the new face vertices of all faces adjacent to the old vertex
+           V, E is the average of the midpoints of all edges incident
+           on the old vertex V, and n is the number of edges incident on
+           the vertex.
+       */
+        Scalar valence = 0.0;
+        for ( auto voh_it = mesh.voh_iter( vh ); voh_it.is_valid(); ++voh_it )
+        {
+            pos += mesh.point( mesh.to_vertex_handle( *voh_it ) );
+            valence += 1.0;
+        }
+        pos /= valence * valence;
+
+        TopologicalMesh::Point Q( 0, 0, 0 );
+
+        for ( auto vf_itr = mesh.vf_iter( vh ); vf_itr.is_valid(); ++vf_itr )
+        {
+            Q += mesh.property( m_fpPos, *vf_itr );
+        }
+
+        Q /= valence * valence;
+
+        pos += mesh.point( vh ) * ( valence - 2.0 ) / valence + Q;
+    }
+
+    mesh.property( m_vpPos, vh ) = pos;
+}
+
+} // namespace Core
+} // namespace Ra

--- a/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.cpp
+++ b/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.cpp
@@ -111,7 +111,7 @@ bool CatmullClarkSubdivider::subdivide( TopologicalMesh& mesh, size_t n,
         commitProps( m_vec4Props, mesh, mesh.getVector4PropsHandles() );
 
         CORE_ASSERT( OpenMesh::Utils::MeshCheckerT<TopologicalMesh>( mesh ).check(),
-                     "CatmullClarkSubdivision ended with a bad topology." )
+                     "CatmullClarkSubdivision ended with a bad topology." );
     }
 
     // ###########################################################################

--- a/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.cpp
+++ b/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.cpp
@@ -270,11 +270,13 @@ void CatmullClarkSubdivider::split_edge( TopologicalMesh& mesh,
     // Re-link mesh entities
     if ( mesh.is_boundary( eh ) )
     {
+        // spin around vh1
         for ( t_heh = heh; mesh.next_halfedge_handle( t_heh ) != opp_heh;
               t_heh = mesh.opposite_halfedge_handle( mesh.next_halfedge_handle( t_heh ) ) )
             ;
     } else
     {
+        // spin inside opp_heh's face
         for ( t_heh = mesh.next_halfedge_handle( opp_heh );
               mesh.next_halfedge_handle( t_heh ) != opp_heh;
               t_heh = mesh.next_halfedge_handle( t_heh ) )
@@ -294,12 +296,29 @@ void CatmullClarkSubdivider::split_edge( TopologicalMesh& mesh,
     {
         mesh.set_face_handle( opp_new_heh, mesh.face_handle( opp_heh ) );
         mesh.set_halfedge_handle( mesh.face_handle( opp_new_heh ), opp_new_heh );
+
+        // deal with custom properties
+        interpolateProps( m_floatProps, t_heh, opp_heh, opp_new_heh, 0.5, mesh );
+        interpolateProps( m_vec2Props, t_heh, opp_heh, opp_new_heh, 0.5, mesh );
+        interpolateProps( m_vec3Props, t_heh, opp_heh, opp_new_heh, 0.5, mesh );
+        interpolateProps( m_vec4Props, t_heh, opp_heh, opp_new_heh, 0.5, mesh );
     }
 
     if ( mesh.face_handle( heh ).is_valid() )
     {
         mesh.set_face_handle( new_heh, mesh.face_handle( heh ) );
         mesh.set_halfedge_handle( mesh.face_handle( heh ), heh );
+
+        // deal with custom properties
+        copyProps( m_floatProps, heh, new_heh, mesh );
+        copyProps( m_vec2Props, heh, new_heh, mesh );
+        copyProps( m_vec3Props, heh, new_heh, mesh );
+        copyProps( m_vec4Props, heh, new_heh, mesh );
+        HeHandle heh_prev = mesh.prev_halfedge_handle( heh );
+        interpolateProps( m_floatProps, heh_prev, new_heh, heh, 0.5, mesh );
+        interpolateProps( m_vec2Props, heh_prev, new_heh, heh, 0.5, mesh );
+        interpolateProps( m_vec3Props, heh_prev, new_heh, heh, 0.5, mesh );
+        interpolateProps( m_vec4Props, heh_prev, new_heh, heh, 0.5, mesh );
     }
 
     mesh.set_halfedge_handle( vh, new_heh );
@@ -308,12 +327,6 @@ void CatmullClarkSubdivider::split_edge( TopologicalMesh& mesh,
     // Never forget this, when playing with the topology
     mesh.adjust_outgoing_halfedge( vh );
     mesh.adjust_outgoing_halfedge( vh1 );
-
-    // deal with custom properties
-    interpolateProps( m_floatProps, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
-    interpolateProps( m_vec2Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
-    interpolateProps( m_vec3Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
-    interpolateProps( m_vec4Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
 }
 
 void CatmullClarkSubdivider::compute_midpoint( TopologicalMesh& mesh,

--- a/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.cpp
+++ b/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.cpp
@@ -110,10 +110,8 @@ bool CatmullClarkSubdivider::subdivide( TopologicalMesh& mesh, size_t n,
         commitProps( m_vec3Props, mesh, mesh.m_vec3Pph );
         commitProps( m_vec4Props, mesh, mesh.m_vec4Pph );
 
-#if defined( _DEBUG ) || defined( DEBUG )
-        // Now we have an consistent mesh!
-        assert( OpenMesh::Utils::MeshCheckerT<TopologicalMesh>( mesh ).check() );
-#endif
+        CORE_ASSERT( OpenMesh::Utils::MeshCheckerT<TopologicalMesh>( mesh ).check(),
+                     "CatmullClarkSubdivision ended with a bad topology." )
     }
 
     // ###########################################################################

--- a/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.cpp
+++ b/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.cpp
@@ -9,14 +9,14 @@ bool CatmullClarkSubdivider::prepare( TopologicalMesh& mesh ) {
     mesh.add_property( m_epPos );
     mesh.add_property( m_fpPos );
     mesh.add_property( m_creaseWeights );
-    addPropsCopy( mesh.m_floatPph, mesh, m_floatProps );
-    addPropsCopy( mesh.m_vec2Pph, mesh, m_vec2Props );
-    addPropsCopy( mesh.m_vec3Pph, mesh, m_vec3Props );
-    addPropsCopy( mesh.m_vec4Pph, mesh, m_vec4Props );
-    addPropsCopyF( mesh.m_floatPph, mesh, m_floatPropsF );
-    addPropsCopyF( mesh.m_vec2Pph, mesh, m_vec2PropsF );
-    addPropsCopyF( mesh.m_vec3Pph, mesh, m_vec3PropsF );
-    addPropsCopyF( mesh.m_vec4Pph, mesh, m_vec4PropsF );
+    addPropsCopy( mesh.getFloatPropsHandles(), mesh, m_floatProps );
+    addPropsCopy( mesh.getVector2PropsHandles(), mesh, m_vec2Props );
+    addPropsCopy( mesh.getVector3PropsHandles(), mesh, m_vec3Props );
+    addPropsCopy( mesh.getVector4PropsHandles(), mesh, m_vec4Props );
+    addPropsCopyF( mesh.getFloatPropsHandles(), mesh, m_floatPropsF );
+    addPropsCopyF( mesh.getVector2PropsHandles(), mesh, m_vec2PropsF );
+    addPropsCopyF( mesh.getVector3PropsHandles(), mesh, m_vec3PropsF );
+    addPropsCopyF( mesh.getVector4PropsHandles(), mesh, m_vec4PropsF );
 
     // initialize all weights to 0 (= smooth edge)
     for ( auto e_it = mesh.edges_begin(); e_it != mesh.edges_end(); ++e_it )
@@ -54,10 +54,10 @@ bool CatmullClarkSubdivider::subdivide( TopologicalMesh& mesh, size_t n,
             TopologicalMesh::Point centroid;
             mesh.calc_face_centroid( fh, centroid );
             mesh.property( m_fpPos, fh ) = centroid;
-            interpolateProps( mesh.m_floatPph, m_floatPropsF, fh, mesh );
-            interpolateProps( mesh.m_vec2Pph, m_vec2PropsF, fh, mesh );
-            interpolateProps( mesh.m_vec3Pph, m_vec3PropsF, fh, mesh );
-            interpolateProps( mesh.m_vec4Pph, m_vec4PropsF, fh, mesh );
+            interpolateProps( mesh.getFloatPropsHandles(), m_floatPropsF, fh, mesh );
+            interpolateProps( mesh.getVector2PropsHandles(), m_vec2PropsF, fh, mesh );
+            interpolateProps( mesh.getVector3PropsHandles(), m_vec3PropsF, fh, mesh );
+            interpolateProps( mesh.getVector4PropsHandles(), m_vec4PropsF, fh, mesh );
         }
 
         // Compute position for new (edge-) vertices and store them in the edge property
@@ -105,10 +105,10 @@ bool CatmullClarkSubdivider::subdivide( TopologicalMesh& mesh, size_t n,
         }
 
         // Commit properties
-        commitProps( m_floatProps, mesh, mesh.m_floatPph );
-        commitProps( m_vec2Props, mesh, mesh.m_vec2Pph );
-        commitProps( m_vec3Props, mesh, mesh.m_vec3Pph );
-        commitProps( m_vec4Props, mesh, mesh.m_vec4Pph );
+        commitProps( m_floatProps, mesh, mesh.getFloatPropsHandles() );
+        commitProps( m_vec2Props, mesh, mesh.getVector2PropsHandles() );
+        commitProps( m_vec3Props, mesh, mesh.getVector3PropsHandles() );
+        commitProps( m_vec4Props, mesh, mesh.getVector4PropsHandles() );
 
         CORE_ASSERT( OpenMesh::Utils::MeshCheckerT<TopologicalMesh>( mesh ).check(),
                      "CatmullClarkSubdivision ended with a bad topology." )
@@ -153,10 +153,10 @@ bool CatmullClarkSubdivider::subdivide( TopologicalMesh& mesh, size_t n,
     }
 
     // Commit properties (again since can still subdivide after all this)
-    commitProps( m_floatProps, mesh, mesh.m_floatPph );
-    commitProps( m_vec2Props, mesh, mesh.m_vec2Pph );
-    commitProps( m_vec3Props, mesh, mesh.m_vec3Pph );
-    commitProps( m_vec4Props, mesh, mesh.m_vec4Pph );
+    commitProps( m_floatProps, mesh, mesh.getFloatPropsHandles() );
+    commitProps( m_vec2Props, mesh, mesh.getVector2PropsHandles() );
+    commitProps( m_vec3Props, mesh, mesh.getVector3PropsHandles() );
+    commitProps( m_vec4Props, mesh, mesh.getVector4PropsHandles() );
 
     // ###########################################################################
 

--- a/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.hpp
+++ b/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.hpp
@@ -1,0 +1,77 @@
+#ifndef RADIUMENGINE_CATMULLCLARKSUBDIVIDER_H
+#define RADIUMENGINE_CATMULLCLARKSUBDIVIDER_H
+
+#include <Core/Mesh/TopologicalTriMesh/TopologicalMesh.hpp>
+
+#include <OpenMesh/Tools/Subdivider/Uniform/SubdividerT.hh>
+
+namespace Ra {
+namespace Core {
+
+/// This class implements the Loop subdivision algorithm
+///
+/// This class extends OpenMesh's LoopT subdivider to handle attributes.
+class RA_CORE_API CatmullClarkSubdivider
+    : public OpenMesh::Subdivider::Uniform::SubdividerT<TopologicalMesh, Scalar> {
+  public:
+    using base = OpenMesh::Subdivider::Uniform::SubdividerT<TopologicalMesh, Scalar>;
+
+  public:
+    CatmullClarkSubdivider() : base() {}
+
+    CatmullClarkSubdivider( TopologicalMesh& mesh ) : base( mesh ) {}
+
+    ~CatmullClarkSubdivider() {}
+
+  public:
+    /// must implement
+    const char* name( void ) const override { return "CatmullClarkSubdivider"; }
+
+  protected:
+    virtual bool prepare( TopologicalMesh& _m ) override;
+
+    virtual bool cleanup( TopologicalMesh& _m ) override;
+
+    virtual bool subdivide( TopologicalMesh& _m, size_t _n,
+                            const bool _update_points = true ) override;
+
+  private:
+    // topology helpers
+
+    void split_edge( TopologicalMesh& mesh, const TopologicalMesh::EdgeHandle& eh );
+
+    void split_face( TopologicalMesh& mesh, const TopologicalMesh::FaceHandle& fh );
+
+    void compute_midpoint( TopologicalMesh& mesh, const TopologicalMesh::EdgeHandle& eh,
+                           const bool update_points );
+
+    void update_vertex( TopologicalMesh& mesh, const TopologicalMesh::VertexHandle& vh );
+
+  private:
+    /// old vertex new position
+    OpenMesh::VPropHandleT<TopologicalMesh::Point> m_vpPos;
+
+    /// new edge midpoint position
+    OpenMesh::EPropHandleT<TopologicalMesh::Point> m_epPos;
+
+    /// new face pts
+    OpenMesh::FPropHandleT<TopologicalMesh::Point> m_fpPos;
+
+    /// crease weights
+    OpenMesh::EPropHandleT<Scalar> m_creaseWeights;
+
+    /// deal with properties
+    std::vector<OpenMesh::HPropHandleT<float>> m_floatProps;
+    std::vector<OpenMesh::HPropHandleT<Vector2>> m_vec2Props;
+    std::vector<OpenMesh::HPropHandleT<Vector3>> m_vec3Props;
+    std::vector<OpenMesh::HPropHandleT<Vector4>> m_vec4Props;
+    std::vector<OpenMesh::FPropHandleT<float>> m_floatPropsF;
+    std::vector<OpenMesh::FPropHandleT<Vector2>> m_vec2PropsF;
+    std::vector<OpenMesh::FPropHandleT<Vector3>> m_vec3PropsF;
+    std::vector<OpenMesh::FPropHandleT<Vector4>> m_vec4PropsF;
+};
+
+} // namespace Core
+} // namespace Ra
+
+#endif // RADIUMENGINE_LOOPSUBDIVIDER_H

--- a/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.hpp
+++ b/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.hpp
@@ -10,7 +10,7 @@ namespace Core {
 
 /// This class implements the Loop subdivision algorithm
 ///
-/// This class extends OpenMesh's LoopT subdivider to handle attributes.
+/// This class extends OpenMesh's CatmullClarkT subdivider to handle attributes.
 class RA_CORE_API CatmullClarkSubdivider
     : public OpenMesh::Subdivider::Uniform::SubdividerT<TopologicalMesh, Scalar> {
   public:

--- a/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.hpp
+++ b/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.hpp
@@ -8,7 +8,7 @@
 namespace Ra {
 namespace Core {
 
-/// This class implements the Loop subdivision algorithm
+/// This class implements the Catmull-Clark subdivision algorithm
 ///
 /// This class extends OpenMesh's CatmullClarkT subdivider to handle attributes.
 /// \note We here consider that boundary halfedges do not store attributes.
@@ -25,7 +25,6 @@ class RA_CORE_API CatmullClarkSubdivider
     ~CatmullClarkSubdivider() {}
 
   public:
-    /// must implement
     const char* name( void ) const override { return "CatmullClarkSubdivider"; }
 
   protected:
@@ -38,13 +37,19 @@ class RA_CORE_API CatmullClarkSubdivider
   private:
     // topology helpers
 
+    /// Edge recomposition
     void split_edge( TopologicalMesh& mesh, const TopologicalMesh::EdgeHandle& eh );
 
+    /// Face recomposition
     void split_face( TopologicalMesh& mesh, const TopologicalMesh::FaceHandle& fh );
 
+    // geometry helpers
+
+    /// compute edge midpoint
     void compute_midpoint( TopologicalMesh& mesh, const TopologicalMesh::EdgeHandle& eh,
                            const bool update_points );
 
+    /// smooth input vertices
     void update_vertex( TopologicalMesh& mesh, const TopologicalMesh::VertexHandle& vh );
 
   private:
@@ -74,4 +79,4 @@ class RA_CORE_API CatmullClarkSubdivider
 } // namespace Core
 } // namespace Ra
 
-#endif // RADIUMENGINE_LOOPSUBDIVIDER_H
+#endif // RADIUMENGINE_CATMULLCLARKSUBDIVIDER_H

--- a/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.hpp
+++ b/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.hpp
@@ -28,12 +28,11 @@ class RA_CORE_API CatmullClarkSubdivider
     const char* name( void ) const override { return "CatmullClarkSubdivider"; }
 
   protected:
-    virtual bool prepare( TopologicalMesh& _m ) override;
+    bool prepare( TopologicalMesh& _m ) override;
 
-    virtual bool cleanup( TopologicalMesh& _m ) override;
+    bool cleanup( TopologicalMesh& _m ) override;
 
-    virtual bool subdivide( TopologicalMesh& _m, size_t _n,
-                            const bool _update_points = true ) override;
+    bool subdivide( TopologicalMesh& _m, size_t _n, const bool _update_points = true ) override;
 
   private:
     // topology helpers

--- a/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.hpp
+++ b/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.hpp
@@ -11,6 +11,7 @@ namespace Core {
 /// This class implements the Loop subdivision algorithm
 ///
 /// This class extends OpenMesh's CatmullClarkT subdivider to handle attributes.
+/// \note We here consider that boundary halfedges do not store attributes.
 class RA_CORE_API CatmullClarkSubdivider
     : public OpenMesh::Subdivider::Uniform::SubdividerT<TopologicalMesh, Scalar> {
   public:

--- a/src/Core/Algorithm/Subdivision/LoopSubdivider.cpp
+++ b/src/Core/Algorithm/Subdivision/LoopSubdivider.cpp
@@ -1,0 +1,323 @@
+#include <Core/Algorithm/Subdivision/LoopSubdivider.hpp>
+#include <Core/Algorithm/Subdivision/SubdividerUtils.hpp>
+
+namespace Ra {
+namespace Core {
+
+bool LoopSubdivider::prepare( TopologicalMesh& mesh ) {
+    mesh.add_property( m_vpPos );
+    mesh.add_property( m_epPos );
+    addPropsCopy( mesh.m_floatPph, mesh, m_floatProps );
+    addPropsCopy( mesh.m_vec2Pph, mesh, m_vec2Props );
+    addPropsCopy( mesh.m_vec3Pph, mesh, m_vec3Props );
+    addPropsCopy( mesh.m_vec4Pph, mesh, m_vec4Props );
+    return true;
+}
+
+bool LoopSubdivider::cleanup( TopologicalMesh& mesh ) {
+    mesh.remove_property( m_vpPos );
+    mesh.remove_property( m_epPos );
+    clearProps( m_floatProps, mesh );
+    clearProps( m_vec2Props, mesh );
+    clearProps( m_vec3Props, mesh );
+    clearProps( m_vec4Props, mesh );
+    return true;
+}
+
+bool LoopSubdivider::subdivide( TopologicalMesh& mesh, size_t n, const bool updatePoints ) {
+    TopologicalMesh::FaceIter fit, f_end;
+    TopologicalMesh::EdgeIter eit, e_end;
+    TopologicalMesh::VertexIter vit;
+
+    // Do _n subdivisions
+    for ( size_t i = 0; i < n; ++i )
+    {
+        if ( updatePoints )
+        {
+            // compute new positions for old vertices
+#pragma omp parallel for
+            for ( uint i = 0; i < mesh.n_vertices(); ++i )
+            {
+                const auto& vh = mesh.vertex_handle( i );
+                smooth( mesh, vh );
+            }
+        }
+
+        // Compute position for new vertices and store them in the edge property
+#pragma omp parallel for
+        for ( uint i = 0; i < mesh.n_edges(); ++i )
+        {
+            const auto& eh = mesh.edge_handle( i );
+            compute_midpoint( mesh, eh );
+        }
+
+        // Split each edge at midpoint and store precomputed positions (stored in
+        // edge property ep_pos_) in the vertex property vp_pos_;
+        // Attention! Creating new edges, hence make sure the loop ends correctly.
+        e_end = mesh.edges_end();
+        for ( eit = mesh.edges_begin(); eit != e_end; ++eit )
+        {
+            split_edge( mesh, *eit );
+        }
+
+        // Commit changes in topology and reconsitute consistency
+        // Attention! Creating new faces, hence make sure the loop ends correctly.
+        f_end = mesh.faces_end();
+        for ( fit = mesh.faces_begin(); fit != f_end; ++fit )
+        {
+            split_face( mesh, *fit );
+        }
+
+        // Commit properties
+        commitProps( m_floatProps, mesh, mesh.m_floatPph );
+        commitProps( m_vec2Props, mesh, mesh.m_vec2Pph );
+        commitProps( m_vec3Props, mesh, mesh.m_vec3Pph );
+        commitProps( m_vec4Props, mesh, mesh.m_vec4Pph );
+
+        if ( updatePoints )
+        {
+            // Commit changes in geometry
+#pragma omp parallel for
+            for ( uint i = 0; i < mesh.n_vertices(); ++i )
+            {
+                const auto& vh = mesh.vertex_handle( i );
+                mesh.set_point( vh, mesh.property( m_vpPos, vh ) );
+            }
+        }
+
+#if defined( _DEBUG ) || defined( DEBUG )
+        // Now we have an consistent mesh!
+        assert( OpenMesh::Utils::MeshCheckerT<TopologicalMesh>( mesh ).check() );
+#endif
+    }
+
+    // compute normals
+    mesh.request_face_normals();
+    mesh.request_vertex_normals();
+    mesh.update_normals();
+
+    return true;
+}
+
+void LoopSubdivider::split_face( TopologicalMesh& mesh, const TopologicalMesh::FaceHandle& fh ) {
+    using HeHandle = TopologicalMesh::HalfedgeHandle;
+    // get where to cut
+    HeHandle heh1( mesh.halfedge_handle( fh ) );
+    HeHandle heh2( mesh.next_halfedge_handle( mesh.next_halfedge_handle( heh1 ) ) );
+    HeHandle heh3( mesh.next_halfedge_handle( mesh.next_halfedge_handle( heh2 ) ) );
+
+    // Cutting off every corner of the 6_gon
+    corner_cutting( mesh, heh1 );
+    corner_cutting( mesh, heh2 );
+    corner_cutting( mesh, heh3 );
+}
+
+void LoopSubdivider::corner_cutting( TopologicalMesh& mesh,
+                                     const TopologicalMesh::HalfedgeHandle& he ) {
+    using HeHandle = TopologicalMesh::HalfedgeHandle;
+    using VHandle = TopologicalMesh::VertexHandle;
+    using FHandle = TopologicalMesh::FaceHandle;
+
+    // Define Halfedge Handles
+    HeHandle heh1( he );
+    HeHandle heh5( heh1 );
+    HeHandle heh6( mesh.next_halfedge_handle( heh1 ) );
+
+    // Cycle around the polygon to find correct Halfedge
+    for ( ; mesh.next_halfedge_handle( mesh.next_halfedge_handle( heh5 ) ) != heh1;
+          heh5 = mesh.next_halfedge_handle( heh5 ) )
+        ;
+
+    VHandle vh1 = mesh.to_vertex_handle( heh1 );
+    VHandle vh2 = mesh.to_vertex_handle( heh5 );
+
+    HeHandle heh2( mesh.next_halfedge_handle( heh5 ) );
+    HeHandle heh3( mesh.new_edge( vh1, vh2 ) );
+    HeHandle heh4( mesh.opposite_halfedge_handle( heh3 ) );
+
+    /* Intermediate result
+     *
+     *            *
+     *         5 /|\
+     *          /_  \
+     *    vh2> *     *
+     *        /|\3   |\
+     *       /_  \|4   \
+     *      *----\*----\*
+     *          1 ^   6
+     *            vh1 (adjust_outgoing halfedge!)
+     */
+
+    // Old and new Face
+    FHandle fh_old( mesh.face_handle( heh6 ) );
+    FHandle fh_new( mesh.new_face() );
+
+    // Re-Set Handles around old Face
+    mesh.set_next_halfedge_handle( heh4, heh6 );
+    mesh.set_next_halfedge_handle( heh5, heh4 );
+
+    mesh.set_face_handle( heh4, fh_old );
+    mesh.set_face_handle( heh5, fh_old );
+    mesh.set_face_handle( heh6, fh_old );
+    mesh.set_halfedge_handle( fh_old, heh4 );
+
+    // Re-Set Handles around new Face
+    mesh.set_next_halfedge_handle( heh1, heh3 );
+    mesh.set_next_halfedge_handle( heh3, heh2 );
+
+    mesh.set_face_handle( heh1, fh_new );
+    mesh.set_face_handle( heh2, fh_new );
+    mesh.set_face_handle( heh3, fh_new );
+
+    mesh.set_halfedge_handle( fh_new, heh1 );
+
+    // deal with custom properties
+    copyProps( m_floatProps, heh1, heh4, mesh );
+    copyProps( m_floatProps, heh5, heh3, mesh );
+    copyProps( m_vec2Props, heh1, heh4, mesh );
+    copyProps( m_vec2Props, heh5, heh3, mesh );
+    copyProps( m_vec3Props, heh1, heh4, mesh );
+    copyProps( m_vec3Props, heh5, heh3, mesh );
+    copyProps( m_vec4Props, heh1, heh4, mesh );
+    copyProps( m_vec4Props, heh5, heh3, mesh );
+}
+
+void LoopSubdivider::split_edge( TopologicalMesh& mesh, const TopologicalMesh::EdgeHandle& eh ) {
+    using HeHandle = TopologicalMesh::HalfedgeHandle;
+    using VHandle = TopologicalMesh::VertexHandle;
+    using FHandle = TopologicalMesh::FaceHandle;
+
+    // prepare data
+    HeHandle heh = mesh.halfedge_handle( eh, 0 );
+    HeHandle opp_heh = mesh.halfedge_handle( eh, 1 );
+    HeHandle new_heh;
+    HeHandle opp_new_heh;
+    HeHandle t_heh;
+    VHandle vh;
+    VHandle vh1( mesh.to_vertex_handle( heh ) );
+
+    // new vertex
+    vh = mesh.new_vertex( mesh.property( m_epPos, eh ) );
+
+    // memorize position, since it will be set later
+    mesh.property( m_vpPos, vh ) = mesh.property( m_epPos, eh );
+
+    // Re-link mesh entities
+    if ( mesh.is_boundary( eh ) )
+    {
+        for ( t_heh = heh; mesh.next_halfedge_handle( t_heh ) != opp_heh;
+              t_heh = mesh.opposite_halfedge_handle( mesh.next_halfedge_handle( t_heh ) ) )
+            ;
+    } else
+    {
+        for ( t_heh = mesh.next_halfedge_handle( opp_heh );
+              mesh.next_halfedge_handle( t_heh ) != opp_heh;
+              t_heh = mesh.next_halfedge_handle( t_heh ) )
+            ;
+    }
+
+    new_heh = mesh.new_edge( vh, vh1 );
+    opp_new_heh = mesh.opposite_halfedge_handle( new_heh );
+    mesh.set_vertex_handle( heh, vh );
+
+    mesh.set_next_halfedge_handle( t_heh, opp_new_heh );
+    mesh.set_next_halfedge_handle( new_heh, mesh.next_halfedge_handle( heh ) );
+    mesh.set_next_halfedge_handle( heh, new_heh );
+    mesh.set_next_halfedge_handle( opp_new_heh, opp_heh );
+
+    if ( mesh.face_handle( opp_heh ).is_valid() )
+    {
+        mesh.set_face_handle( opp_new_heh, mesh.face_handle( opp_heh ) );
+        mesh.set_halfedge_handle( mesh.face_handle( opp_new_heh ), opp_new_heh );
+    }
+
+    if ( mesh.face_handle( heh ).is_valid() )
+    {
+        mesh.set_face_handle( new_heh, mesh.face_handle( heh ) );
+        mesh.set_halfedge_handle( mesh.face_handle( heh ), heh );
+    }
+
+    mesh.set_halfedge_handle( vh, new_heh );
+    mesh.set_halfedge_handle( vh1, opp_new_heh );
+
+    // Never forget this, when playing with the topology
+    mesh.adjust_outgoing_halfedge( vh );
+    mesh.adjust_outgoing_halfedge( vh1 );
+
+    // deal with custom properties
+    interpolateProps( m_floatProps, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
+    interpolateProps( m_vec2Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
+    interpolateProps( m_vec3Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
+    interpolateProps( m_vec4Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
+}
+
+void LoopSubdivider::compute_midpoint( TopologicalMesh& mesh,
+                                       const TopologicalMesh::EdgeHandle& eh ) {
+    TopologicalMesh::HalfedgeHandle heh = mesh.halfedge_handle( eh, 0 );
+    TopologicalMesh::HalfedgeHandle opp_heh = mesh.halfedge_handle( eh, 1 );
+
+    TopologicalMesh::Point pos = mesh.point( mesh.to_vertex_handle( heh ) );
+    pos += mesh.point( mesh.to_vertex_handle( opp_heh ) );
+
+    // boundary edge: just average vertex positions
+    if ( mesh.is_boundary( eh ) )
+    {
+        pos *= 0.5;
+    } else // inner edge: add neighbouring Vertices to sum
+    {
+        pos *= 3.0;
+        pos += mesh.point( mesh.to_vertex_handle( mesh.next_halfedge_handle( heh ) ) );
+        pos += mesh.point( mesh.to_vertex_handle( mesh.next_halfedge_handle( opp_heh ) ) );
+        pos *= 1.0 / 8.0;
+    }
+    mesh.property( m_epPos, eh ) = pos;
+}
+
+void LoopSubdivider::smooth( TopologicalMesh& mesh, const TopologicalMesh::VertexHandle& vh ) {
+    using VHandle = TopologicalMesh::VertexHandle;
+
+    TopologicalMesh::Point pos( 0.0, 0.0, 0.0 );
+
+    if ( mesh.is_boundary( vh ) ) // if boundary: Point 1-6-1
+    {
+        TopologicalMesh::HalfedgeHandle heh;
+        TopologicalMesh::HalfedgeHandle prev_heh;
+        heh = mesh.halfedge_handle( vh );
+
+        if ( heh.is_valid() )
+        {
+            assert( mesh.is_boundary( mesh.edge_handle( heh ) ) );
+
+            prev_heh = mesh.prev_halfedge_handle( heh );
+
+            VHandle to_vh = mesh.to_vertex_handle( heh );
+            VHandle from_vh = mesh.from_vertex_handle( prev_heh );
+
+            // ( v_l + 6 v + v_r ) / 8
+            pos = mesh.point( vh );
+            pos *= 6.0;
+            pos += mesh.point( to_vh );
+            pos += mesh.point( from_vh );
+            pos *= 1.0 / 8.0;
+        } else
+            return;
+    } else // inner vertex: (1-a) * p + a/n * Sum q, q in one-ring of p
+    {
+        TopologicalMesh::VertexVertexIter vvit;
+        size_t valence( 0 );
+
+        // Calculate Valence and sum up neighbour points
+        for ( vvit = mesh.vv_iter( vh ); vvit.is_valid(); ++vvit )
+        {
+            ++valence;
+            pos += mesh.point( *vvit );
+        }
+        pos *= m_weights[valence].second; // alpha(n)/n * Sum q, q in one-ring of p
+        pos += m_weights[valence].first * mesh.point( vh ); // + (1-a)*p
+    }
+
+    mesh.property( m_vpPos, vh ) = pos;
+}
+
+} // namespace Core
+} // namespace Ra

--- a/src/Core/Algorithm/Subdivision/LoopSubdivider.cpp
+++ b/src/Core/Algorithm/Subdivision/LoopSubdivider.cpp
@@ -228,12 +228,29 @@ void LoopSubdivider::split_edge( TopologicalMesh& mesh, const TopologicalMesh::E
     {
         mesh.set_face_handle( opp_new_heh, mesh.face_handle( opp_heh ) );
         mesh.set_halfedge_handle( mesh.face_handle( opp_new_heh ), opp_new_heh );
+
+        // deal with custom properties
+        interpolateProps( m_floatProps, t_heh, opp_heh, opp_new_heh, 0.5, mesh );
+        interpolateProps( m_vec2Props, t_heh, opp_heh, opp_new_heh, 0.5, mesh );
+        interpolateProps( m_vec3Props, t_heh, opp_heh, opp_new_heh, 0.5, mesh );
+        interpolateProps( m_vec4Props, t_heh, opp_heh, opp_new_heh, 0.5, mesh );
     }
 
     if ( mesh.face_handle( heh ).is_valid() )
     {
         mesh.set_face_handle( new_heh, mesh.face_handle( heh ) );
         mesh.set_halfedge_handle( mesh.face_handle( heh ), heh );
+
+        // deal with custom properties
+        copyProps( m_floatProps, heh, new_heh, mesh );
+        copyProps( m_vec2Props, heh, new_heh, mesh );
+        copyProps( m_vec3Props, heh, new_heh, mesh );
+        copyProps( m_vec4Props, heh, new_heh, mesh );
+        HeHandle heh_prev = mesh.prev_halfedge_handle( heh );
+        interpolateProps( m_floatProps, heh_prev, new_heh, heh, 0.5, mesh );
+        interpolateProps( m_vec2Props, heh_prev, new_heh, heh, 0.5, mesh );
+        interpolateProps( m_vec3Props, heh_prev, new_heh, heh, 0.5, mesh );
+        interpolateProps( m_vec4Props, heh_prev, new_heh, heh, 0.5, mesh );
     }
 
     mesh.set_halfedge_handle( vh, new_heh );
@@ -242,12 +259,6 @@ void LoopSubdivider::split_edge( TopologicalMesh& mesh, const TopologicalMesh::E
     // Never forget this, when playing with the topology
     mesh.adjust_outgoing_halfedge( vh );
     mesh.adjust_outgoing_halfedge( vh1 );
-
-    // deal with custom properties
-    interpolateProps( m_floatProps, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
-    interpolateProps( m_vec2Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
-    interpolateProps( m_vec3Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
-    interpolateProps( m_vec4Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
 }
 
 void LoopSubdivider::compute_midpoint( TopologicalMesh& mesh,

--- a/src/Core/Algorithm/Subdivision/LoopSubdivider.cpp
+++ b/src/Core/Algorithm/Subdivision/LoopSubdivider.cpp
@@ -85,10 +85,9 @@ bool LoopSubdivider::subdivide( TopologicalMesh& mesh, size_t n, const bool upda
             }
         }
 
-#if defined( _DEBUG ) || defined( DEBUG )
         // Now we have an consistent mesh!
-        assert( OpenMesh::Utils::MeshCheckerT<TopologicalMesh>( mesh ).check() );
-#endif
+        CORE_ASSERT( OpenMesh::Utils::MeshCheckerT<TopologicalMesh>( mesh ).check(),
+                     "LoopSubdivision ended with a bad topology." )
     }
 
     // compute normals

--- a/src/Core/Algorithm/Subdivision/LoopSubdivider.cpp
+++ b/src/Core/Algorithm/Subdivision/LoopSubdivider.cpp
@@ -87,7 +87,7 @@ bool LoopSubdivider::subdivide( TopologicalMesh& mesh, size_t n, const bool upda
 
         // Now we have an consistent mesh!
         CORE_ASSERT( OpenMesh::Utils::MeshCheckerT<TopologicalMesh>( mesh ).check(),
-                     "LoopSubdivision ended with a bad topology." )
+                     "LoopSubdivision ended with a bad topology." );
     }
 
     // compute normals

--- a/src/Core/Algorithm/Subdivision/LoopSubdivider.cpp
+++ b/src/Core/Algorithm/Subdivision/LoopSubdivider.cpp
@@ -7,10 +7,10 @@ namespace Core {
 bool LoopSubdivider::prepare( TopologicalMesh& mesh ) {
     mesh.add_property( m_vpPos );
     mesh.add_property( m_epPos );
-    addPropsCopy( mesh.m_floatPph, mesh, m_floatProps );
-    addPropsCopy( mesh.m_vec2Pph, mesh, m_vec2Props );
-    addPropsCopy( mesh.m_vec3Pph, mesh, m_vec3Props );
-    addPropsCopy( mesh.m_vec4Pph, mesh, m_vec4Props );
+    addPropsCopy( mesh.getFloatPropsHandles(), mesh, m_floatProps );
+    addPropsCopy( mesh.getVector2PropsHandles(), mesh, m_vec2Props );
+    addPropsCopy( mesh.getVector3PropsHandles(), mesh, m_vec3Props );
+    addPropsCopy( mesh.getVector4PropsHandles(), mesh, m_vec4Props );
     return true;
 }
 
@@ -69,10 +69,10 @@ bool LoopSubdivider::subdivide( TopologicalMesh& mesh, size_t n, const bool upda
         }
 
         // Commit properties
-        commitProps( m_floatProps, mesh, mesh.m_floatPph );
-        commitProps( m_vec2Props, mesh, mesh.m_vec2Pph );
-        commitProps( m_vec3Props, mesh, mesh.m_vec3Pph );
-        commitProps( m_vec4Props, mesh, mesh.m_vec4Pph );
+        commitProps( m_floatProps, mesh, mesh.getFloatPropsHandles() );
+        commitProps( m_vec2Props, mesh, mesh.getVector2PropsHandles() );
+        commitProps( m_vec3Props, mesh, mesh.getVector3PropsHandles() );
+        commitProps( m_vec4Props, mesh, mesh.getVector4PropsHandles() );
 
         if ( updatePoints )
         {

--- a/src/Core/Algorithm/Subdivision/LoopSubdivider.hpp
+++ b/src/Core/Algorithm/Subdivision/LoopSubdivider.hpp
@@ -1,9 +1,9 @@
 #ifndef RADIUMENGINE_LOOPSUBDIVIDER_H
 #define RADIUMENGINE_LOOPSUBDIVIDER_H
 
-#include <OpenMesh/Tools/Subdivider/Uniform/SubdividerT.hh>
-
 #include <Core/Mesh/TopologicalTriMesh/TopologicalMesh.hpp>
+
+#include <OpenMesh/Tools/Subdivider/Uniform/SubdividerT.hh>
 
 namespace Ra {
 namespace Core {
@@ -11,7 +11,8 @@ namespace Core {
 /// This class implements the Loop subdivision algorithm
 ///
 /// This class extends OpenMesh's LoopT subdivider to handle attributes.
-class LoopSubdivider : public OpenMesh::Subdivider::Uniform::SubdividerT<TopologicalMesh, Scalar> {
+class RA_CORE_API LoopSubdivider
+    : public OpenMesh::Subdivider::Uniform::SubdividerT<TopologicalMesh, Scalar> {
   public:
     using base = OpenMesh::Subdivider::Uniform::SubdividerT<TopologicalMesh, Scalar>;
     using Weight = std::pair<Scalar, Scalar>;
@@ -28,152 +29,18 @@ class LoopSubdivider : public OpenMesh::Subdivider::Uniform::SubdividerT<Topolog
     /// must implement
     const char* name( void ) const override { return "LoopSubdivider"; }
 
+  protected:
     /// Pre-compute weights
     void init_weights( size_t max_valence = 50 ) {
         m_weights.resize( max_valence );
         std::generate( m_weights.begin(), m_weights.end(), compute_weight() );
     }
 
-  protected:
-    template <typename T>
-    void addPropsCopy( const std::vector<OpenMesh::HPropHandleT<T>>& input, TopologicalMesh& mesh,
-                       std::vector<OpenMesh::HPropHandleT<T>>& copy ) {
-        copy.resize( input.size() );
-        for ( const auto& oh : input )
-        {
-            // make new property
-            OpenMesh::HPropHandleT<T> oh_;
-            mesh.add_property( oh_, mesh.property( oh ).name() + "_loop_copy" );
-            copy.push_back( oh_ );
-            // copy values
-#pragma omp parallel for
-            for ( int i = 0; i < mesh.n_halfedges(); ++i )
-            {
-                auto heh = mesh.halfedge_handle( i );
-                mesh.property( oh, heh ) = mesh.property( oh, heh );
-            }
-        }
-    }
+    bool prepare( TopologicalMesh& mesh ) override;
 
-    template <typename T>
-    void commitProps( const std::vector<OpenMesh::HPropHandleT<T>>& input, TopologicalMesh& mesh,
-                      std::vector<OpenMesh::HPropHandleT<T>>& copy ) {
-        for ( uint i = 0; i < input.size(); ++i )
-        {
-            auto oh = input[i];
-            auto oh_ = copy[i];
-            // copy values
-#pragma omp parallel for
-            for ( int i = 0; i < mesh.n_halfedges(); ++i )
-            {
-                auto heh = mesh.halfedge_handle( i );
-                mesh.property( oh_, heh ) = mesh.property( oh, heh );
-            }
-        }
-    }
+    bool cleanup( TopologicalMesh& mesh ) override;
 
-    template <typename T>
-    void clearProps( std::vector<OpenMesh::HPropHandleT<T>>& props, TopologicalMesh& mesh ) {
-        for ( auto& oh : props )
-        {
-            mesh.remove_property( oh );
-        }
-        props.clear();
-    }
-
-    bool prepare( TopologicalMesh& mesh ) override {
-        mesh.add_property( m_vpPos );
-        mesh.add_property( m_epPos );
-        addPropsCopy( mesh.m_floatPph, mesh, m_floatProps );
-        addPropsCopy( mesh.m_vec2Pph, mesh, m_vec2Props );
-        addPropsCopy( mesh.m_vec3Pph, mesh, m_vec3Props );
-        addPropsCopy( mesh.m_vec4Pph, mesh, m_vec4Props );
-        return true;
-    }
-
-    bool cleanup( TopologicalMesh& mesh ) override {
-        mesh.remove_property( m_vpPos );
-        mesh.remove_property( m_epPos );
-        clearProps( m_floatProps, mesh );
-        clearProps( m_vec2Props, mesh );
-        clearProps( m_vec3Props, mesh );
-        clearProps( m_vec4Props, mesh );
-        return true;
-    }
-
-    bool subdivide( TopologicalMesh& mesh, size_t n, const bool updatePoints = true ) override {
-        typename TopologicalMesh::FaceIter fit, f_end;
-        typename TopologicalMesh::EdgeIter eit, e_end;
-        typename TopologicalMesh::VertexIter vit;
-
-        // Do _n subdivisions
-        for ( size_t i = 0; i < n; ++i )
-        {
-            if ( updatePoints )
-            {
-                // compute new positions for old vertices
-#pragma omp parallel for
-                for ( uint i = 0; i < mesh.n_vertices(); ++i )
-                {
-                    const auto& vh = mesh.vertex_handle( i );
-                    smooth( mesh, vh );
-                }
-            }
-
-            // Compute position for new vertices and store them in the edge property
-#pragma omp parallel for
-            for ( uint i = 0; i < mesh.n_edges(); ++i )
-            {
-                const auto& eh = mesh.edge_handle( i );
-                compute_midpoint( mesh, eh );
-            }
-
-            // Split each edge at midpoint and store precomputed positions (stored in
-            // edge property ep_pos_) in the vertex property vp_pos_;
-            // Attention! Creating new edges, hence make sure the loop ends correctly.
-            e_end = mesh.edges_end();
-            for ( eit = mesh.edges_begin(); eit != e_end; ++eit )
-            {
-                split_edge( mesh, *eit );
-            }
-
-            // Commit changes in topology and reconsitute consistency
-            // Attention! Creating new faces, hence make sure the loop ends correctly.
-            f_end = mesh.faces_end();
-            for ( fit = mesh.faces_begin(); fit != f_end; ++fit )
-            {
-                split_face( mesh, *fit );
-            }
-
-            // Commit properties
-            commitProps( m_floatProps, mesh, mesh.m_floatPph );
-            commitProps( m_vec2Props, mesh, mesh.m_vec2Pph );
-            commitProps( m_vec3Props, mesh, mesh.m_vec3Pph );
-            commitProps( m_vec4Props, mesh, mesh.m_vec4Pph );
-
-            if ( updatePoints )
-            {
-                // Commit changes in geometry
-                for ( vit = mesh.vertices_begin(); vit != mesh.vertices_end(); ++vit )
-                {
-                    mesh.set_point( *vit, mesh.property( m_vpPos, *vit ) );
-                }
-            }
-
-#if defined( _DEBUG ) || defined( DEBUG )
-            // Now we have an consistent mesh!
-            assert( OpenMesh::Utils::MeshCheckerT<TopologicalMesh>( mesh ).check() );
-#endif
-        }
-
-        // compute normals
-        mesh.request_face_normals();
-        mesh.update_face_normals();
-        mesh.request_vertex_normals();
-        mesh.update_vertex_normals();
-
-        return true;
-    }
+    bool subdivide( TopologicalMesh& mesh, size_t n, const bool updatePoints = true ) override;
 
   private:
     /// Helper functor to compute weights for Loop-subdivision
@@ -197,274 +64,31 @@ class LoopSubdivider : public OpenMesh::Subdivider::Uniform::SubdividerT<Topolog
     };
 
   private:
-    template <typename T>
-    void interpolateProps( const std::vector<OpenMesh::HPropHandleT<T>>& props,
-                           const TopologicalMesh::HalfedgeHandle& old_heh,
-                           const TopologicalMesh::HalfedgeHandle& opp_old_heh,
-                           const TopologicalMesh::HalfedgeHandle& t_heh,
-                           const TopologicalMesh::HalfedgeHandle& new_heh,
-                           const TopologicalMesh::HalfedgeHandle& opp_new_heh,
-                           TopologicalMesh& mesh ) {
-        // get handle to first edge vertex
-        TopologicalMesh::HalfedgeHandle old_heh_prev;
-        for ( old_heh_prev = mesh.next_halfedge_handle( old_heh );
-              mesh.next_halfedge_handle( old_heh_prev ) != old_heh;
-              old_heh_prev = mesh.next_halfedge_handle( old_heh_prev ) )
-            ;
-        // interpolate properties
-        for ( const auto& oh : props )
-        {
-            mesh.property( oh, new_heh ) = mesh.property( oh, old_heh );
-            mesh.property( oh, old_heh ) =
-                0.5 * ( mesh.property( oh, old_heh ) + mesh.property( oh, old_heh_prev ) );
-            mesh.property( oh, opp_new_heh ) =
-                0.5 * ( mesh.property( oh, opp_old_heh ) + mesh.property( oh, t_heh ) );
-        }
-    }
-
-    template <typename T>
-    void copyProps( const std::vector<OpenMesh::HPropHandleT<T>>& props,
-                    const TopologicalMesh::HalfedgeHandle& heh1,
-                    const TopologicalMesh::HalfedgeHandle& heh5,
-                    const TopologicalMesh::HalfedgeHandle& heh3,
-                    const TopologicalMesh::HalfedgeHandle& heh4, TopologicalMesh& mesh ) {
-        for ( const auto& oh : props )
-        {
-            mesh.property( oh, heh3 ) = mesh.property( oh, heh5 );
-            mesh.property( oh, heh4 ) = mesh.property( oh, heh1 );
-        }
-    }
-
     // topological modifiers
 
     /// Face recomposition
-    void split_face( TopologicalMesh& mesh, const typename TopologicalMesh::FaceHandle& fh ) {
-        using HeHandle = typename TopologicalMesh::HalfedgeHandle;
-        // get where to cut
-        HeHandle heh1( mesh.halfedge_handle( fh ) );
-        HeHandle heh2( mesh.next_halfedge_handle( mesh.next_halfedge_handle( heh1 ) ) );
-        HeHandle heh3( mesh.next_halfedge_handle( mesh.next_halfedge_handle( heh2 ) ) );
-
-        // Cutting off every corner of the 6_gon
-        corner_cutting( mesh, heh1 );
-        corner_cutting( mesh, heh2 );
-        corner_cutting( mesh, heh3 );
-    }
+    void split_face( TopologicalMesh& mesh, const TopologicalMesh::FaceHandle& fh );
 
     /// Face corner recomposition
-    void corner_cutting( TopologicalMesh& mesh,
-                         const typename TopologicalMesh::HalfedgeHandle& he ) {
-        using HeHandle = typename TopologicalMesh::HalfedgeHandle;
-        using VHandle = typename TopologicalMesh::VertexHandle;
-        using FHandle = typename TopologicalMesh::FaceHandle;
-
-        // Define Halfedge Handles
-        HeHandle heh1( he );
-        HeHandle heh5( heh1 );
-        HeHandle heh6( mesh.next_halfedge_handle( heh1 ) );
-
-        // Cycle around the polygon to find correct Halfedge
-        for ( ; mesh.next_halfedge_handle( mesh.next_halfedge_handle( heh5 ) ) != heh1;
-              heh5 = mesh.next_halfedge_handle( heh5 ) )
-            ;
-
-        VHandle vh1 = mesh.to_vertex_handle( heh1 );
-        VHandle vh2 = mesh.to_vertex_handle( heh5 );
-
-        HeHandle heh2( mesh.next_halfedge_handle( heh5 ) );
-        HeHandle heh3( mesh.new_edge( vh1, vh2 ) );
-        HeHandle heh4( mesh.opposite_halfedge_handle( heh3 ) );
-
-        /* Intermediate result
-         *
-         *            *
-         *         5 /|\
-         *          /_  \
-         *    vh2> *     *
-         *        /|\3   |\
-         *       /_  \|4   \
-         *      *----\*----\*
-         *          1 ^   6
-         *            vh1 (adjust_outgoing halfedge!)
-         */
-
-        // Old and new Face
-        FHandle fh_old( mesh.face_handle( heh6 ) );
-        FHandle fh_new( mesh.new_face() );
-
-        // Re-Set Handles around old Face
-        mesh.set_next_halfedge_handle( heh4, heh6 );
-        mesh.set_next_halfedge_handle( heh5, heh4 );
-
-        mesh.set_face_handle( heh4, fh_old );
-        mesh.set_face_handle( heh5, fh_old );
-        mesh.set_face_handle( heh6, fh_old );
-        mesh.set_halfedge_handle( fh_old, heh4 );
-
-        // Re-Set Handles around new Face
-        mesh.set_next_halfedge_handle( heh1, heh3 );
-        mesh.set_next_halfedge_handle( heh3, heh2 );
-
-        mesh.set_face_handle( heh1, fh_new );
-        mesh.set_face_handle( heh2, fh_new );
-        mesh.set_face_handle( heh3, fh_new );
-
-        mesh.set_halfedge_handle( fh_new, heh1 );
-
-        // deal with custom properties
-        copyProps( m_floatProps, heh1, heh5, heh3, heh4, mesh );
-        copyProps( m_vec2Props, heh1, heh5, heh3, heh4, mesh );
-        copyProps( m_vec3Props, heh1, heh5, heh3, heh4, mesh );
-        copyProps( m_vec4Props, heh1, heh5, heh3, heh4, mesh );
-    }
+    void corner_cutting( TopologicalMesh& mesh, const TopologicalMesh::HalfedgeHandle& he );
 
     /// Edge recomposition
-    void split_edge( TopologicalMesh& mesh, const typename TopologicalMesh::EdgeHandle& eh ) {
-        using HeHandle = typename TopologicalMesh::HalfedgeHandle;
-        using VHandle = typename TopologicalMesh::VertexHandle;
-        using FHandle = typename TopologicalMesh::FaceHandle;
+    void split_edge( TopologicalMesh& mesh, const TopologicalMesh::EdgeHandle& eh );
 
-        // prepare data
-        HeHandle heh = mesh.halfedge_handle( eh, 0 );
-        HeHandle opp_heh = mesh.halfedge_handle( eh, 1 );
-        HeHandle new_heh;
-        HeHandle opp_new_heh;
-        HeHandle t_heh;
-        VHandle vh;
-        VHandle vh1( mesh.to_vertex_handle( heh ) );
-        TopologicalMesh::Point midP( mesh.point( mesh.to_vertex_handle( heh ) ) );
-        midP += mesh.point( mesh.to_vertex_handle( opp_heh ) );
-        midP *= 0.5;
+    // geometry helpers
 
-        // new vertex
-        vh = mesh.new_vertex( midP );
+    /// compute edge midpoint
+    void compute_midpoint( TopologicalMesh& mesh, const TopologicalMesh::EdgeHandle& eh );
 
-        // memorize position, will be set later
-        mesh.property( m_vpPos, vh ) = mesh.property( m_epPos, eh );
-
-        // Re-link mesh entities
-        if ( mesh.is_boundary( eh ) )
-        {
-            for ( t_heh = heh; mesh.next_halfedge_handle( t_heh ) != opp_heh;
-                  t_heh = mesh.opposite_halfedge_handle( mesh.next_halfedge_handle( t_heh ) ) )
-                ;
-        } else
-        {
-            for ( t_heh = mesh.next_halfedge_handle( opp_heh );
-                  mesh.next_halfedge_handle( t_heh ) != opp_heh;
-                  t_heh = mesh.next_halfedge_handle( t_heh ) )
-                ;
-        }
-
-        new_heh = mesh.new_edge( vh, vh1 );
-        opp_new_heh = mesh.opposite_halfedge_handle( new_heh );
-        mesh.set_vertex_handle( heh, vh );
-
-        mesh.set_next_halfedge_handle( t_heh, opp_new_heh );
-        mesh.set_next_halfedge_handle( new_heh, mesh.next_halfedge_handle( heh ) );
-        mesh.set_next_halfedge_handle( heh, new_heh );
-        mesh.set_next_halfedge_handle( opp_new_heh, opp_heh );
-
-        if ( mesh.face_handle( opp_heh ).is_valid() )
-        {
-            mesh.set_face_handle( opp_new_heh, mesh.face_handle( opp_heh ) );
-            mesh.set_halfedge_handle( mesh.face_handle( opp_new_heh ), opp_new_heh );
-        }
-
-        mesh.set_face_handle( new_heh, mesh.face_handle( heh ) );
-        mesh.set_halfedge_handle( vh, new_heh );
-        mesh.set_halfedge_handle( mesh.face_handle( heh ), heh );
-        mesh.set_halfedge_handle( vh1, opp_new_heh );
-
-        // Never forget this, when playing with the topology
-        mesh.adjust_outgoing_halfedge( vh );
-        mesh.adjust_outgoing_halfedge( vh1 );
-
-        // deal with custom properties
-        interpolateProps( m_floatProps, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
-        interpolateProps( m_vec2Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
-        interpolateProps( m_vec3Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
-        interpolateProps( m_vec4Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
-    }
-
-  private: // geometry helper
-    void compute_midpoint( TopologicalMesh& mesh, const typename TopologicalMesh::EdgeHandle& eh ) {
-        typename TopologicalMesh::HalfedgeHandle heh;
-        typename TopologicalMesh::HalfedgeHandle opp_heh;
-
-        heh = mesh.halfedge_handle( eh, 0 );
-        opp_heh = mesh.halfedge_handle( eh, 1 );
-
-        typename TopologicalMesh::Point pos( mesh.point( mesh.to_vertex_handle( heh ) ) );
-
-        pos += mesh.point( mesh.to_vertex_handle( opp_heh ) );
-
-        // boundary edge: just average vertex positions
-        if ( mesh.is_boundary( eh ) )
-        {
-            pos *= 0.5;
-        } else // inner edge: add neighbouring Vertices to sum
-        {
-            pos *= 3.0;
-            pos += mesh.point( mesh.to_vertex_handle( mesh.next_halfedge_handle( heh ) ) );
-            pos += mesh.point( mesh.to_vertex_handle( mesh.next_halfedge_handle( opp_heh ) ) );
-            pos *= 1.0 / 8.0;
-        }
-        mesh.property( m_epPos, eh ) = pos;
-    }
-
-    void smooth( TopologicalMesh& mesh, const typename TopologicalMesh::VertexHandle& vh ) {
-        using VHandle = typename TopologicalMesh::VertexHandle;
-
-        typename TopologicalMesh::Point pos( 0.0, 0.0, 0.0 );
-
-        if ( mesh.is_boundary( vh ) ) // if boundary: Point 1-6-1
-        {
-            typename TopologicalMesh::HalfedgeHandle heh;
-            typename TopologicalMesh::HalfedgeHandle prev_heh;
-            heh = mesh.halfedge_handle( vh );
-
-            if ( heh.is_valid() )
-            {
-                assert( mesh.is_boundary( mesh.edge_handle( heh ) ) );
-
-                prev_heh = mesh.prev_halfedge_handle( heh );
-
-                VHandle to_vh = mesh.to_vertex_handle( heh );
-                VHandle from_vh = mesh.from_vertex_handle( prev_heh );
-
-                // ( v_l + 6 v + v_r ) / 8
-                pos = mesh.point( vh );
-                pos *= 6.0;
-                pos += mesh.point( to_vh );
-                pos += mesh.point( from_vh );
-                pos *= 1.0 / 8.0;
-            } else
-                return;
-        } else // inner vertex: (1-a) * p + a/n * Sum q, q in one-ring of p
-        {
-            typename TopologicalMesh::VertexVertexIter vvit;
-            size_t valence( 0 );
-
-            // Calculate Valence and sum up neighbour points
-            for ( vvit = mesh.vv_iter( vh ); vvit.is_valid(); ++vvit )
-            {
-                ++valence;
-                pos += mesh.point( *vvit );
-            }
-            pos *= m_weights[valence].second; // alpha(n)/n * Sum q, q in one-ring of p
-            pos += m_weights[valence].first * mesh.point( vh ); // + (1-a)*p
-        }
-
-        mesh.property( m_vpPos, vh ) = pos;
-    }
+    /// smooth input vertices
+    void smooth( TopologicalMesh& mesh, const TopologicalMesh::VertexHandle& vh );
 
   private:
     /// old vertex new position
-    OpenMesh::VPropHandleT<typename TopologicalMesh::Point> m_vpPos;
+    OpenMesh::VPropHandleT<TopologicalMesh::Point> m_vpPos;
 
     /// new edge midpoint position
-    OpenMesh::EPropHandleT<typename TopologicalMesh::Point> m_epPos;
+    OpenMesh::EPropHandleT<TopologicalMesh::Point> m_epPos;
 
     /// deal with properties
     std::vector<OpenMesh::HPropHandleT<float>> m_floatProps;

--- a/src/Core/Algorithm/Subdivision/LoopSubdivider.hpp
+++ b/src/Core/Algorithm/Subdivision/LoopSubdivider.hpp
@@ -1,0 +1,482 @@
+#ifndef RADIUMENGINE_LOOPSUBDIVIDER_H
+#define RADIUMENGINE_LOOPSUBDIVIDER_H
+
+#include <OpenMesh/Tools/Subdivider/Uniform/SubdividerT.hh>
+
+#include <Core/Mesh/TopologicalTriMesh/TopologicalMesh.hpp>
+
+namespace Ra {
+namespace Core {
+
+/// This class implements the Loop subdivision algorithm
+///
+/// This class extends OpenMesh's LoopT subdivider to handle attributes.
+class LoopSubdivider : public OpenMesh::Subdivider::Uniform::SubdividerT<TopologicalMesh, Scalar> {
+  public:
+    using base = OpenMesh::Subdivider::Uniform::SubdividerT<TopologicalMesh, Scalar>;
+    using Weight = std::pair<Scalar, Scalar>;
+    using Weights = std::vector<Weight>;
+
+  public:
+    LoopSubdivider() : base() { init_weights(); }
+
+    LoopSubdivider( TopologicalMesh& mesh ) : base( mesh ) { init_weights(); }
+
+    ~LoopSubdivider() {}
+
+  public:
+    /// must implement
+    const char* name( void ) const override { return "LoopSubdivider"; }
+
+    /// Pre-compute weights
+    void init_weights( size_t max_valence = 50 ) {
+        m_weights.resize( max_valence );
+        std::generate( m_weights.begin(), m_weights.end(), compute_weight() );
+    }
+
+  protected:
+    template <typename T>
+    void addPropsCopy( const std::vector<OpenMesh::HPropHandleT<T>>& input, TopologicalMesh& mesh,
+                       std::vector<OpenMesh::HPropHandleT<T>>& copy ) {
+        copy.resize( input.size() );
+        for ( const auto& oh : input )
+        {
+            // make new property
+            OpenMesh::HPropHandleT<T> oh_;
+            mesh.add_property( oh_, mesh.property( oh ).name() + "_loop_copy" );
+            copy.push_back( oh_ );
+            // copy values
+#pragma omp parallel for
+            for ( int i = 0; i < mesh.n_halfedges(); ++i )
+            {
+                auto heh = mesh.halfedge_handle( i );
+                mesh.property( oh, heh ) = mesh.property( oh, heh );
+            }
+        }
+    }
+
+    template <typename T>
+    void commitProps( const std::vector<OpenMesh::HPropHandleT<T>>& input, TopologicalMesh& mesh,
+                      std::vector<OpenMesh::HPropHandleT<T>>& copy ) {
+        for ( uint i = 0; i < input.size(); ++i )
+        {
+            auto oh = input[i];
+            auto oh_ = copy[i];
+            // copy values
+#pragma omp parallel for
+            for ( int i = 0; i < mesh.n_halfedges(); ++i )
+            {
+                auto heh = mesh.halfedge_handle( i );
+                mesh.property( oh_, heh ) = mesh.property( oh, heh );
+            }
+        }
+    }
+
+    template <typename T>
+    void clearProps( std::vector<OpenMesh::HPropHandleT<T>>& props, TopologicalMesh& mesh ) {
+        for ( auto& oh : props )
+        {
+            mesh.remove_property( oh );
+        }
+        props.clear();
+    }
+
+    bool prepare( TopologicalMesh& mesh ) override {
+        mesh.add_property( m_vpPos );
+        mesh.add_property( m_epPos );
+        addPropsCopy( mesh.m_floatPph, mesh, m_floatProps );
+        addPropsCopy( mesh.m_vec2Pph, mesh, m_vec2Props );
+        addPropsCopy( mesh.m_vec3Pph, mesh, m_vec3Props );
+        addPropsCopy( mesh.m_vec4Pph, mesh, m_vec4Props );
+        return true;
+    }
+
+    bool cleanup( TopologicalMesh& mesh ) override {
+        mesh.remove_property( m_vpPos );
+        mesh.remove_property( m_epPos );
+        clearProps( m_floatProps, mesh );
+        clearProps( m_vec2Props, mesh );
+        clearProps( m_vec3Props, mesh );
+        clearProps( m_vec4Props, mesh );
+        return true;
+    }
+
+    bool subdivide( TopologicalMesh& mesh, size_t n, const bool updatePoints = true ) override {
+        typename TopologicalMesh::FaceIter fit, f_end;
+        typename TopologicalMesh::EdgeIter eit, e_end;
+        typename TopologicalMesh::VertexIter vit;
+
+        // Do _n subdivisions
+        for ( size_t i = 0; i < n; ++i )
+        {
+            if ( updatePoints )
+            {
+                // compute new positions for old vertices
+#pragma omp parallel for
+                for ( uint i = 0; i < mesh.n_vertices(); ++i )
+                {
+                    const auto& vh = mesh.vertex_handle( i );
+                    smooth( mesh, vh );
+                }
+            }
+
+            // Compute position for new vertices and store them in the edge property
+#pragma omp parallel for
+            for ( uint i = 0; i < mesh.n_edges(); ++i )
+            {
+                const auto& eh = mesh.edge_handle( i );
+                compute_midpoint( mesh, eh );
+            }
+
+            // Split each edge at midpoint and store precomputed positions (stored in
+            // edge property ep_pos_) in the vertex property vp_pos_;
+            // Attention! Creating new edges, hence make sure the loop ends correctly.
+            e_end = mesh.edges_end();
+            for ( eit = mesh.edges_begin(); eit != e_end; ++eit )
+            {
+                split_edge( mesh, *eit );
+            }
+
+            // Commit changes in topology and reconsitute consistency
+            // Attention! Creating new faces, hence make sure the loop ends correctly.
+            f_end = mesh.faces_end();
+            for ( fit = mesh.faces_begin(); fit != f_end; ++fit )
+            {
+                split_face( mesh, *fit );
+            }
+
+            // Commit properties
+            commitProps( m_floatProps, mesh, mesh.m_floatPph );
+            commitProps( m_vec2Props, mesh, mesh.m_vec2Pph );
+            commitProps( m_vec3Props, mesh, mesh.m_vec3Pph );
+            commitProps( m_vec4Props, mesh, mesh.m_vec4Pph );
+
+            if ( updatePoints )
+            {
+                // Commit changes in geometry
+                for ( vit = mesh.vertices_begin(); vit != mesh.vertices_end(); ++vit )
+                {
+                    mesh.set_point( *vit, mesh.property( m_vpPos, *vit ) );
+                }
+            }
+
+#if defined( _DEBUG ) || defined( DEBUG )
+            // Now we have an consistent mesh!
+            assert( OpenMesh::Utils::MeshCheckerT<TopologicalMesh>( mesh ).check() );
+#endif
+        }
+
+        // compute normals
+        mesh.request_face_normals();
+        mesh.update_face_normals();
+        mesh.request_vertex_normals();
+        mesh.update_vertex_normals();
+
+        return true;
+    }
+
+  private:
+    /// Helper functor to compute weights for Loop-subdivision
+    /// \internal
+    struct compute_weight {
+        compute_weight() : m_valence( -1 ) {}
+        Weight operator()( void ) {
+            //              1
+            // alpha(n) = ---- * (40 - ( 3 + 2 cos( 2 Pi / n ) )^2 )
+            //             64
+            if ( ++m_valence )
+            {
+                double inv_v = 1.0 / double( m_valence );
+                double t = ( 3.0 + 2.0 * std::cos( 2.0 * Math::Pi * inv_v ) );
+                double alpha = ( 40.0 - t * t ) / 64.0;
+                return Weight( 1.0 - alpha, inv_v * alpha );
+            }
+            return Weight( 0, 0 );
+        }
+        int m_valence;
+    };
+
+  private:
+    template <typename T>
+    void interpolateProps( const std::vector<OpenMesh::HPropHandleT<T>>& props,
+                           const TopologicalMesh::HalfedgeHandle& old_heh,
+                           const TopologicalMesh::HalfedgeHandle& opp_old_heh,
+                           const TopologicalMesh::HalfedgeHandle& t_heh,
+                           const TopologicalMesh::HalfedgeHandle& new_heh,
+                           const TopologicalMesh::HalfedgeHandle& opp_new_heh,
+                           TopologicalMesh& mesh ) {
+        // get handle to first edge vertex
+        TopologicalMesh::HalfedgeHandle old_heh_prev;
+        for ( old_heh_prev = mesh.next_halfedge_handle( old_heh );
+              mesh.next_halfedge_handle( old_heh_prev ) != old_heh;
+              old_heh_prev = mesh.next_halfedge_handle( old_heh_prev ) )
+            ;
+        // interpolate properties
+        for ( const auto& oh : props )
+        {
+            mesh.property( oh, new_heh ) = mesh.property( oh, old_heh );
+            mesh.property( oh, old_heh ) =
+                0.5 * ( mesh.property( oh, old_heh ) + mesh.property( oh, old_heh_prev ) );
+            mesh.property( oh, opp_new_heh ) =
+                0.5 * ( mesh.property( oh, opp_old_heh ) + mesh.property( oh, t_heh ) );
+        }
+    }
+
+    template <typename T>
+    void copyProps( const std::vector<OpenMesh::HPropHandleT<T>>& props,
+                    const TopologicalMesh::HalfedgeHandle& heh1,
+                    const TopologicalMesh::HalfedgeHandle& heh5,
+                    const TopologicalMesh::HalfedgeHandle& heh3,
+                    const TopologicalMesh::HalfedgeHandle& heh4, TopologicalMesh& mesh ) {
+        for ( const auto& oh : props )
+        {
+            mesh.property( oh, heh3 ) = mesh.property( oh, heh5 );
+            mesh.property( oh, heh4 ) = mesh.property( oh, heh1 );
+        }
+    }
+
+    // topological modifiers
+
+    /// Face recomposition
+    void split_face( TopologicalMesh& mesh, const typename TopologicalMesh::FaceHandle& fh ) {
+        using HeHandle = typename TopologicalMesh::HalfedgeHandle;
+        // get where to cut
+        HeHandle heh1( mesh.halfedge_handle( fh ) );
+        HeHandle heh2( mesh.next_halfedge_handle( mesh.next_halfedge_handle( heh1 ) ) );
+        HeHandle heh3( mesh.next_halfedge_handle( mesh.next_halfedge_handle( heh2 ) ) );
+
+        // Cutting off every corner of the 6_gon
+        corner_cutting( mesh, heh1 );
+        corner_cutting( mesh, heh2 );
+        corner_cutting( mesh, heh3 );
+    }
+
+    /// Face corner recomposition
+    void corner_cutting( TopologicalMesh& mesh,
+                         const typename TopologicalMesh::HalfedgeHandle& he ) {
+        using HeHandle = typename TopologicalMesh::HalfedgeHandle;
+        using VHandle = typename TopologicalMesh::VertexHandle;
+        using FHandle = typename TopologicalMesh::FaceHandle;
+
+        // Define Halfedge Handles
+        HeHandle heh1( he );
+        HeHandle heh5( heh1 );
+        HeHandle heh6( mesh.next_halfedge_handle( heh1 ) );
+
+        // Cycle around the polygon to find correct Halfedge
+        for ( ; mesh.next_halfedge_handle( mesh.next_halfedge_handle( heh5 ) ) != heh1;
+              heh5 = mesh.next_halfedge_handle( heh5 ) )
+            ;
+
+        VHandle vh1 = mesh.to_vertex_handle( heh1 );
+        VHandle vh2 = mesh.to_vertex_handle( heh5 );
+
+        HeHandle heh2( mesh.next_halfedge_handle( heh5 ) );
+        HeHandle heh3( mesh.new_edge( vh1, vh2 ) );
+        HeHandle heh4( mesh.opposite_halfedge_handle( heh3 ) );
+
+        /* Intermediate result
+         *
+         *            *
+         *         5 /|\
+         *          /_  \
+         *    vh2> *     *
+         *        /|\3   |\
+         *       /_  \|4   \
+         *      *----\*----\*
+         *          1 ^   6
+         *            vh1 (adjust_outgoing halfedge!)
+         */
+
+        // Old and new Face
+        FHandle fh_old( mesh.face_handle( heh6 ) );
+        FHandle fh_new( mesh.new_face() );
+
+        // Re-Set Handles around old Face
+        mesh.set_next_halfedge_handle( heh4, heh6 );
+        mesh.set_next_halfedge_handle( heh5, heh4 );
+
+        mesh.set_face_handle( heh4, fh_old );
+        mesh.set_face_handle( heh5, fh_old );
+        mesh.set_face_handle( heh6, fh_old );
+        mesh.set_halfedge_handle( fh_old, heh4 );
+
+        // Re-Set Handles around new Face
+        mesh.set_next_halfedge_handle( heh1, heh3 );
+        mesh.set_next_halfedge_handle( heh3, heh2 );
+
+        mesh.set_face_handle( heh1, fh_new );
+        mesh.set_face_handle( heh2, fh_new );
+        mesh.set_face_handle( heh3, fh_new );
+
+        mesh.set_halfedge_handle( fh_new, heh1 );
+
+        // deal with custom properties
+        copyProps( m_floatProps, heh1, heh5, heh3, heh4, mesh );
+        copyProps( m_vec2Props, heh1, heh5, heh3, heh4, mesh );
+        copyProps( m_vec3Props, heh1, heh5, heh3, heh4, mesh );
+        copyProps( m_vec4Props, heh1, heh5, heh3, heh4, mesh );
+    }
+
+    /// Edge recomposition
+    void split_edge( TopologicalMesh& mesh, const typename TopologicalMesh::EdgeHandle& eh ) {
+        using HeHandle = typename TopologicalMesh::HalfedgeHandle;
+        using VHandle = typename TopologicalMesh::VertexHandle;
+        using FHandle = typename TopologicalMesh::FaceHandle;
+
+        // prepare data
+        HeHandle heh = mesh.halfedge_handle( eh, 0 );
+        HeHandle opp_heh = mesh.halfedge_handle( eh, 1 );
+        HeHandle new_heh;
+        HeHandle opp_new_heh;
+        HeHandle t_heh;
+        VHandle vh;
+        VHandle vh1( mesh.to_vertex_handle( heh ) );
+        TopologicalMesh::Point midP( mesh.point( mesh.to_vertex_handle( heh ) ) );
+        midP += mesh.point( mesh.to_vertex_handle( opp_heh ) );
+        midP *= 0.5;
+
+        // new vertex
+        vh = mesh.new_vertex( midP );
+
+        // memorize position, will be set later
+        mesh.property( m_vpPos, vh ) = mesh.property( m_epPos, eh );
+
+        // Re-link mesh entities
+        if ( mesh.is_boundary( eh ) )
+        {
+            for ( t_heh = heh; mesh.next_halfedge_handle( t_heh ) != opp_heh;
+                  t_heh = mesh.opposite_halfedge_handle( mesh.next_halfedge_handle( t_heh ) ) )
+                ;
+        } else
+        {
+            for ( t_heh = mesh.next_halfedge_handle( opp_heh );
+                  mesh.next_halfedge_handle( t_heh ) != opp_heh;
+                  t_heh = mesh.next_halfedge_handle( t_heh ) )
+                ;
+        }
+
+        new_heh = mesh.new_edge( vh, vh1 );
+        opp_new_heh = mesh.opposite_halfedge_handle( new_heh );
+        mesh.set_vertex_handle( heh, vh );
+
+        mesh.set_next_halfedge_handle( t_heh, opp_new_heh );
+        mesh.set_next_halfedge_handle( new_heh, mesh.next_halfedge_handle( heh ) );
+        mesh.set_next_halfedge_handle( heh, new_heh );
+        mesh.set_next_halfedge_handle( opp_new_heh, opp_heh );
+
+        if ( mesh.face_handle( opp_heh ).is_valid() )
+        {
+            mesh.set_face_handle( opp_new_heh, mesh.face_handle( opp_heh ) );
+            mesh.set_halfedge_handle( mesh.face_handle( opp_new_heh ), opp_new_heh );
+        }
+
+        mesh.set_face_handle( new_heh, mesh.face_handle( heh ) );
+        mesh.set_halfedge_handle( vh, new_heh );
+        mesh.set_halfedge_handle( mesh.face_handle( heh ), heh );
+        mesh.set_halfedge_handle( vh1, opp_new_heh );
+
+        // Never forget this, when playing with the topology
+        mesh.adjust_outgoing_halfedge( vh );
+        mesh.adjust_outgoing_halfedge( vh1 );
+
+        // deal with custom properties
+        interpolateProps( m_floatProps, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
+        interpolateProps( m_vec2Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
+        interpolateProps( m_vec3Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
+        interpolateProps( m_vec4Props, heh, opp_heh, t_heh, new_heh, opp_new_heh, mesh );
+    }
+
+  private: // geometry helper
+    void compute_midpoint( TopologicalMesh& mesh, const typename TopologicalMesh::EdgeHandle& eh ) {
+        typename TopologicalMesh::HalfedgeHandle heh;
+        typename TopologicalMesh::HalfedgeHandle opp_heh;
+
+        heh = mesh.halfedge_handle( eh, 0 );
+        opp_heh = mesh.halfedge_handle( eh, 1 );
+
+        typename TopologicalMesh::Point pos( mesh.point( mesh.to_vertex_handle( heh ) ) );
+
+        pos += mesh.point( mesh.to_vertex_handle( opp_heh ) );
+
+        // boundary edge: just average vertex positions
+        if ( mesh.is_boundary( eh ) )
+        {
+            pos *= 0.5;
+        } else // inner edge: add neighbouring Vertices to sum
+        {
+            pos *= 3.0;
+            pos += mesh.point( mesh.to_vertex_handle( mesh.next_halfedge_handle( heh ) ) );
+            pos += mesh.point( mesh.to_vertex_handle( mesh.next_halfedge_handle( opp_heh ) ) );
+            pos *= 1.0 / 8.0;
+        }
+        mesh.property( m_epPos, eh ) = pos;
+    }
+
+    void smooth( TopologicalMesh& mesh, const typename TopologicalMesh::VertexHandle& vh ) {
+        using VHandle = typename TopologicalMesh::VertexHandle;
+
+        typename TopologicalMesh::Point pos( 0.0, 0.0, 0.0 );
+
+        if ( mesh.is_boundary( vh ) ) // if boundary: Point 1-6-1
+        {
+            typename TopologicalMesh::HalfedgeHandle heh;
+            typename TopologicalMesh::HalfedgeHandle prev_heh;
+            heh = mesh.halfedge_handle( vh );
+
+            if ( heh.is_valid() )
+            {
+                assert( mesh.is_boundary( mesh.edge_handle( heh ) ) );
+
+                prev_heh = mesh.prev_halfedge_handle( heh );
+
+                VHandle to_vh = mesh.to_vertex_handle( heh );
+                VHandle from_vh = mesh.from_vertex_handle( prev_heh );
+
+                // ( v_l + 6 v + v_r ) / 8
+                pos = mesh.point( vh );
+                pos *= 6.0;
+                pos += mesh.point( to_vh );
+                pos += mesh.point( from_vh );
+                pos *= 1.0 / 8.0;
+            } else
+                return;
+        } else // inner vertex: (1-a) * p + a/n * Sum q, q in one-ring of p
+        {
+            typename TopologicalMesh::VertexVertexIter vvit;
+            size_t valence( 0 );
+
+            // Calculate Valence and sum up neighbour points
+            for ( vvit = mesh.vv_iter( vh ); vvit.is_valid(); ++vvit )
+            {
+                ++valence;
+                pos += mesh.point( *vvit );
+            }
+            pos *= m_weights[valence].second; // alpha(n)/n * Sum q, q in one-ring of p
+            pos += m_weights[valence].first * mesh.point( vh ); // + (1-a)*p
+        }
+
+        mesh.property( m_vpPos, vh ) = pos;
+    }
+
+  private:
+    /// old vertex new position
+    OpenMesh::VPropHandleT<typename TopologicalMesh::Point> m_vpPos;
+
+    /// new edge midpoint position
+    OpenMesh::EPropHandleT<typename TopologicalMesh::Point> m_epPos;
+
+    /// deal with properties
+    std::vector<OpenMesh::HPropHandleT<float>> m_floatProps;
+    std::vector<OpenMesh::HPropHandleT<Vector2>> m_vec2Props;
+    std::vector<OpenMesh::HPropHandleT<Vector3>> m_vec3Props;
+    std::vector<OpenMesh::HPropHandleT<Vector4>> m_vec4Props;
+
+    /// precomputed weights
+    Weights m_weights;
+};
+
+} // namespace Core
+} // namespace Ra
+
+#endif // RADIUMENGINE_LOOPSUBDIVIDER_H

--- a/src/Core/Algorithm/Subdivision/LoopSubdivider.hpp
+++ b/src/Core/Algorithm/Subdivision/LoopSubdivider.hpp
@@ -27,11 +27,10 @@ class RA_CORE_API LoopSubdivider
     ~LoopSubdivider() {}
 
   public:
-    /// must implement
     const char* name( void ) const override { return "LoopSubdivider"; }
 
   protected:
-    /// Pre-compute weights
+    /// Pre-compute weights.
     void init_weights( size_t max_valence = 50 ) {
         m_weights.resize( max_valence );
         std::generate( m_weights.begin(), m_weights.end(), compute_weight() );

--- a/src/Core/Algorithm/Subdivision/LoopSubdivider.hpp
+++ b/src/Core/Algorithm/Subdivision/LoopSubdivider.hpp
@@ -11,6 +11,7 @@ namespace Core {
 /// This class implements the Loop subdivision algorithm
 ///
 /// This class extends OpenMesh's LoopT subdivider to handle attributes.
+/// \note We here consider that boundary halfedges do not store attributes.
 class RA_CORE_API LoopSubdivider
     : public OpenMesh::Subdivider::Uniform::SubdividerT<TopologicalMesh, Scalar> {
   public:

--- a/src/Core/Algorithm/Subdivision/SubdividerUtils.hpp
+++ b/src/Core/Algorithm/Subdivision/SubdividerUtils.hpp
@@ -1,0 +1,156 @@
+
+#include <Core/Mesh/TopologicalTriMesh/TopologicalMesh.hpp>
+
+namespace Ra {
+namespace Core {
+
+/// Create copy \p input properties of \p mesh.
+template <typename T>
+void addPropsCopy( const std::vector<OpenMesh::HPropHandleT<T>>& input, TopologicalMesh& mesh,
+                   std::vector<OpenMesh::HPropHandleT<T>>& copy ) {
+    copy.reserve( input.size() );
+    for ( const auto& oh : input )
+    {
+        // make new property
+        OpenMesh::HPropHandleT<T> oh_;
+        mesh.add_property( oh_, mesh.property( oh ).name() + "_subdiv_copy" );
+        copy.push_back( oh_ );
+        // copy values
+#pragma omp parallel for
+        for ( int i = 0; i < mesh.n_halfedges(); ++i )
+        {
+            auto heh = mesh.halfedge_handle( i );
+            mesh.property( oh_, heh ) = mesh.property( oh, heh );
+        }
+    }
+}
+
+/// Add a copy of \p input properties of \p mesh on faces.
+template <typename T>
+void addPropsCopyF( const std::vector<OpenMesh::HPropHandleT<T>>& input, TopologicalMesh& mesh,
+                    std::vector<OpenMesh::FPropHandleT<T>>& copy ) {
+    copy.reserve( input.size() );
+    for ( const auto& oh : input )
+    {
+        OpenMesh::FPropHandleT<T> oh_;
+        mesh.add_property( oh_, mesh.property( oh ).name() + "_subdiv_copy_F" );
+        copy.push_back( oh_ );
+    }
+}
+
+/// Remove \props from \p mesh.
+template <typename T>
+void clearProps( std::vector<OpenMesh::HPropHandleT<T>>& props, TopologicalMesh& mesh ) {
+    for ( auto& oh : props )
+    {
+        mesh.remove_property( oh );
+    }
+    props.clear();
+}
+
+/// Remove \props from \p mesh.
+template <typename T>
+void clearProps( std::vector<OpenMesh::FPropHandleT<T>>& props, TopologicalMesh& mesh ) {
+    for ( auto& oh : props )
+    {
+        mesh.remove_property( oh );
+    }
+    props.clear();
+}
+
+/// Update \p copy properties from input.
+template <typename T>
+void commitProps( const std::vector<OpenMesh::HPropHandleT<T>>& input, TopologicalMesh& mesh,
+                  std::vector<OpenMesh::HPropHandleT<T>>& copy ) {
+    for ( uint i = 0; i < input.size(); ++i )
+    {
+        auto oh = input[i];
+        auto oh_ = copy[i];
+        // copy values
+#pragma omp parallel for
+        for ( int i = 0; i < mesh.n_halfedges(); ++i )
+        {
+            auto heh = mesh.halfedge_handle( i );
+            mesh.property( oh_, heh ) = mesh.property( oh, heh );
+        }
+    }
+}
+
+/// Copy \p props properties from \p input_heh to \p copy_heh
+template <typename T>
+void copyProps( const std::vector<OpenMesh::HPropHandleT<T>>& props,
+                const TopologicalMesh::HalfedgeHandle& input_heh,
+                const TopologicalMesh::HalfedgeHandle& copy_heh, TopologicalMesh& mesh ) {
+    for ( const auto& oh : props )
+    {
+        mesh.property( oh, copy_heh ) = mesh.property( oh, input_heh );
+    }
+}
+
+/// Copy \p props properties from \p input_heh to \p copy_heh
+template <typename T>
+void copyProps( const std::vector<OpenMesh::FPropHandleT<T>>& fprops,
+                const std::vector<OpenMesh::HPropHandleT<T>>& hprops,
+                const TopologicalMesh::FaceHandle& input_fh,
+                const TopologicalMesh::HalfedgeHandle& copy_heh, TopologicalMesh& mesh ) {
+    for ( uint i = 0; i < hprops.size(); ++i )
+    {
+        auto hp = hprops[i];
+        auto fp = fprops[i];
+        mesh.property( hp, copy_heh ) = mesh.property( fp, input_fh );
+    }
+}
+
+/// Interpolate \p props on edge center (after edge split).
+template <typename T>
+void interpolateProps( const std::vector<OpenMesh::HPropHandleT<T>>& props,
+                       const TopologicalMesh::HalfedgeHandle& old_heh,
+                       const TopologicalMesh::HalfedgeHandle& opp_old_heh,
+                       const TopologicalMesh::HalfedgeHandle& t_heh,
+                       const TopologicalMesh::HalfedgeHandle& new_heh,
+                       const TopologicalMesh::HalfedgeHandle& opp_new_heh, TopologicalMesh& mesh ) {
+    // get handle to first edge vertex
+    TopologicalMesh::HalfedgeHandle old_heh_prev;
+    for ( old_heh_prev = mesh.next_halfedge_handle( old_heh );
+          mesh.next_halfedge_handle( old_heh_prev ) != old_heh;
+          old_heh_prev = mesh.next_halfedge_handle( old_heh_prev ) )
+        ;
+    // interpolate properties
+    for ( const auto& oh : props )
+    {
+        mesh.property( oh, new_heh ) = mesh.property( oh, old_heh );
+        mesh.property( oh, old_heh ) =
+            0.5 * ( mesh.property( oh, old_heh ) + mesh.property( oh, old_heh_prev ) );
+        mesh.property( oh, opp_new_heh ) =
+            0.5 * ( mesh.property( oh, opp_old_heh ) + mesh.property( oh, t_heh ) );
+    }
+}
+
+/// Interpolate \p props on face center.
+template <typename T>
+void interpolateProps( const std::vector<OpenMesh::HPropHandleT<T>>& hprops,
+                       const std::vector<OpenMesh::FPropHandleT<T>>& fprops,
+                       const TopologicalMesh::FaceHandle& fh, TopologicalMesh& mesh ) {
+    auto heh = mesh.halfedge_handle( fh );
+    const int valence = mesh.valence( fh );
+    // sum all
+    for ( int i = 0; i < valence; ++i )
+    {
+        for ( int j = 0; j < hprops.size(); ++j )
+        {
+            auto hp = hprops[j];
+            auto fp = fprops[j];
+            mesh.property( fp, fh ) += mesh.property( hp, heh );
+        }
+        heh = mesh.next_halfedge_handle( heh );
+    }
+    // normalize
+    for ( int j = 0; j < fprops.size(); ++j )
+    {
+        auto fp = fprops[j];
+        mesh.property( fp, fh ) /= valence;
+    }
+}
+
+} // namespace Core
+} // namespace Ra

--- a/src/Core/Algorithm/Subdivision/SubdividerUtils.hpp
+++ b/src/Core/Algorithm/Subdivision/SubdividerUtils.hpp
@@ -4,7 +4,7 @@
 namespace Ra {
 namespace Core {
 
-/// Create copy \p input properties of \p mesh.
+/// Copy \p input properties of \p mesh.
 template <typename T>
 void addPropsCopy( const std::vector<OpenMesh::HPropHandleT<T>>& input, TopologicalMesh& mesh,
                    std::vector<OpenMesh::HPropHandleT<T>>& copy ) {

--- a/src/Core/Algorithm/Subdivision/SubdividerUtils.hpp
+++ b/src/Core/Algorithm/Subdivision/SubdividerUtils.hpp
@@ -133,8 +133,17 @@ void interpolateProps( const std::vector<OpenMesh::HPropHandleT<T>>& hprops,
                        const TopologicalMesh::FaceHandle& fh, TopologicalMesh& mesh ) {
     auto heh = mesh.halfedge_handle( fh );
     const int valence = mesh.valence( fh );
-    // sum all
-    for ( int i = 0; i < valence; ++i )
+
+    // init sum to first
+    for ( int j = 0; j < fprops.size(); ++j )
+    {
+        auto hp = hprops[j];
+        auto fp = fprops[j];
+        mesh.property( fp, fh ) = mesh.property( hp, heh );
+    }
+    heh = mesh.next_halfedge_handle( heh );
+    // sum others
+    for ( int i = 1; i < valence; ++i )
     {
         for ( int j = 0; j < hprops.size(); ++j )
         {
@@ -148,7 +157,7 @@ void interpolateProps( const std::vector<OpenMesh::HPropHandleT<T>>& hprops,
     for ( int j = 0; j < fprops.size(); ++j )
     {
         auto fp = fprops[j];
-        mesh.property( fp, fh ) /= valence;
+        mesh.property( fp, fh ) = mesh.property( fp, fh ) / valence;
     }
 }
 

--- a/src/Core/Algorithm/Subdivision/SubdividerUtils.hpp
+++ b/src/Core/Algorithm/Subdivision/SubdividerUtils.hpp
@@ -104,25 +104,14 @@ void copyProps( const std::vector<OpenMesh::FPropHandleT<T>>& fprops,
 /// Interpolate \p props on edge center (after edge split).
 template <typename T>
 void interpolateProps( const std::vector<OpenMesh::HPropHandleT<T>>& props,
-                       const TopologicalMesh::HalfedgeHandle& old_heh,
-                       const TopologicalMesh::HalfedgeHandle& opp_old_heh,
-                       const TopologicalMesh::HalfedgeHandle& t_heh,
-                       const TopologicalMesh::HalfedgeHandle& new_heh,
-                       const TopologicalMesh::HalfedgeHandle& opp_new_heh, TopologicalMesh& mesh ) {
-    // get handle to first edge vertex
-    TopologicalMesh::HalfedgeHandle old_heh_prev;
-    for ( old_heh_prev = mesh.next_halfedge_handle( old_heh );
-          mesh.next_halfedge_handle( old_heh_prev ) != old_heh;
-          old_heh_prev = mesh.next_halfedge_handle( old_heh_prev ) )
-        ;
+                       const TopologicalMesh::HalfedgeHandle& in_a,
+                       const TopologicalMesh::HalfedgeHandle& in_b,
+                       const TopologicalMesh::HalfedgeHandle& out, Scalar f,
+                       TopologicalMesh& mesh ) {
     // interpolate properties
     for ( const auto& oh : props )
     {
-        mesh.property( oh, new_heh ) = mesh.property( oh, old_heh );
-        mesh.property( oh, old_heh ) =
-            0.5 * ( mesh.property( oh, old_heh ) + mesh.property( oh, old_heh_prev ) );
-        mesh.property( oh, opp_new_heh ) =
-            0.5 * ( mesh.property( oh, opp_old_heh ) + mesh.property( oh, t_heh ) );
+        mesh.property( oh, out ) = f * ( mesh.property( oh, in_a ) + mesh.property( oh, in_b ) );
     }
 }
 

--- a/src/Core/Algorithm/Subdivision/SubdividerUtils.hpp
+++ b/src/Core/Algorithm/Subdivision/SubdividerUtils.hpp
@@ -61,7 +61,7 @@ void clearProps( std::vector<OpenMesh::FPropHandleT<T>>& props, TopologicalMesh&
 /// Update \p copy properties from input.
 template <typename T>
 void commitProps( const std::vector<OpenMesh::HPropHandleT<T>>& input, TopologicalMesh& mesh,
-                  std::vector<OpenMesh::HPropHandleT<T>>& copy ) {
+                  const std::vector<OpenMesh::HPropHandleT<T>>& copy ) {
     for ( uint i = 0; i < input.size(); ++i )
     {
         auto oh = input[i];
@@ -87,7 +87,7 @@ void copyProps( const std::vector<OpenMesh::HPropHandleT<T>>& props,
     }
 }
 
-/// Copy \p props properties from \p input_heh to \p copy_heh
+/// Copy \p fprops properties from \p input_fh to \p copy_heh
 template <typename T>
 void copyProps( const std::vector<OpenMesh::FPropHandleT<T>>& fprops,
                 const std::vector<OpenMesh::HPropHandleT<T>>& hprops,
@@ -115,7 +115,7 @@ void interpolateProps( const std::vector<OpenMesh::HPropHandleT<T>>& props,
     }
 }
 
-/// Interpolate \p props on face center.
+/// Interpolate \p hprops on face center.
 template <typename T>
 void interpolateProps( const std::vector<OpenMesh::HPropHandleT<T>>& hprops,
                        const std::vector<OpenMesh::FPropHandleT<T>>& fprops,

--- a/src/Core/File/deprecated/OBJFileManager.cpp
+++ b/src/Core/File/deprecated/OBJFileManager.cpp
@@ -56,10 +56,24 @@ bool OBJFileManager::importData( std::istream& file, TriangleMesh& data ) {
         if ( token == "f" )
         {
             Triangle f;
-            iss >> f[0] >> f[1] >> f[2];
-            f[0] -= 1;
-            f[1] -= 1;
-            f[2] -= 1;
+            std::string ltoken;
+            int count = 0;
+            // skip first space
+            std::getline( iss, ltoken, ' ' );
+            while ( std::getline( iss, ltoken, ' ' ) )
+            {
+                std::istringstream ss( ltoken );
+                if ( count < 3 )
+                {
+                    ss >> f[count];
+                    f[count] -= 1;
+                } else
+                {
+                    addLogErrorEntry( "MESH CONTAINS QUADS." );
+                    return false;
+                }
+                count++;
+            }
             data.m_triangles.push_back( f );
         }
     }

--- a/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.cpp
+++ b/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.cpp
@@ -68,8 +68,10 @@ void copyAttribToCore( TriangleMesh& triMesh, HandleAndValueVector<T>& data ) {
 TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh ) {
     struct hash_vec {
         size_t operator()( const Vector3& lvalue ) const {
-            return lvalue[0] + lvalue[1] + lvalue[2] + floor( lvalue[0] ) * 1000.f +
-                   floor( lvalue[1] ) * 1000.f + floor( lvalue[2] ) * 1000.f;
+            size_t hx = std::hash<Scalar>()( lvalue[0] );
+            size_t hy = std::hash<Scalar>()( lvalue[1] );
+            size_t hz = std::hash<Scalar>()( lvalue[2] );
+            return ( hx ^ ( hy << 1 ) ) ^ hz;
         }
     };
     // use a hashmap for fast search of existing vertex position
@@ -174,9 +176,10 @@ TriangleMesh TopologicalMesh::toTriangleMesh() {
 
     struct hash_vec {
         size_t operator()( const VertexData& lvalue ) const {
-            return lvalue._vertex[0] + lvalue._vertex[1] + lvalue._vertex[2] +
-                   floor( lvalue._vertex[0] ) * 1000.f + floor( lvalue._vertex[1] ) * 1000.f +
-                   floor( lvalue._vertex[2] ) * 1000.f;
+            size_t hx = std::hash<Scalar>()( lvalue._vertex[0] );
+            size_t hy = std::hash<Scalar>()( lvalue._vertex[1] );
+            size_t hz = std::hash<Scalar>()( lvalue._vertex[2] );
+            return ( hx ^ ( hy << 1 ) ) ^ hz;
         }
     };
 
@@ -192,12 +195,16 @@ TriangleMesh TopologicalMesh::toTriangleMesh() {
     std::vector<PropPair<Vector4>> vprop_vec4;
 
     // loop over all attribs and build correspondance pair
+    vprop_float.reserve( m_floatPph.size() );
     for ( auto oh : m_floatPph )
         addAttribPairToCore( out, this, oh, vprop_float );
+    vprop_vec2.reserve( m_vec2Pph.size() );
     for ( auto oh : m_vec2Pph )
         addAttribPairToCore( out, this, oh, vprop_vec2 );
+    vprop_vec3.reserve( m_vec3Pph.size() );
     for ( auto oh : m_vec3Pph )
         addAttribPairToCore( out, this, oh, vprop_vec3 );
+    vprop_vec4.reserve( m_vec4Pph.size() );
     for ( auto oh : m_vec4Pph )
         addAttribPairToCore( out, this, oh, vprop_vec4 );
 
@@ -253,10 +260,13 @@ TriangleMesh TopologicalMesh::toTriangleMesh() {
         }
         out.m_triangles.emplace_back( indices[0], indices[1], indices[2] );
     }
+
     CORE_ASSERT( vertexIndex == out.vertices().size(),
                  "Inconsistent number of faces in generated TriangleMesh." );
 
     return out;
-} // namespace Core
+}
+
+
 } // namespace Core
 } // namespace Ra

--- a/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.hpp
+++ b/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.hpp
@@ -16,15 +16,12 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-namespace Ra
-{
-namespace Core
-{
+namespace Ra {
+namespace Core {
 
 class TriangleMesh;
 
-struct TopologicalMeshTraits : OpenMesh::DefaultTraits
-{
+struct TopologicalMeshTraits : OpenMesh::DefaultTraits {
     using Point = Ra::Core::Vector3;
     using Normal = Ra::Core::Vector3;
 
@@ -38,8 +35,7 @@ struct TopologicalMeshTraits : OpenMesh::DefaultTraits
 /// vertex graph, using a half-edge representation.
 ///
 /// This integration is inspired by: https://gist.github.com/Unril/03fa353d0461ed6bd41d
-class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<TopologicalMeshTraits>
-{
+class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<TopologicalMeshTraits> {
   private:
     using base = OpenMesh::PolyMesh_ArrayKernelT<TopologicalMeshTraits>;
     using base::PolyMesh_ArrayKernelT;
@@ -48,6 +44,8 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     std::vector<OpenMesh::HPropHandleT<Vector2>> m_vec2Pph;
     std::vector<OpenMesh::HPropHandleT<Vector3>> m_vec3Pph;
     std::vector<OpenMesh::HPropHandleT<Vector4>> m_vec4Pph;
+
+    friend class LoopSubdivider;
 
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -60,7 +58,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     explicit TopologicalMesh( const Ra::Core::TriangleMesh& triMesh );
 
     /// Construct an empty topological mesh
-    explicit TopologicalMesh(){};
+    explicit TopologicalMesh() {}
 
     /// Obtain a triangleMesh from a topological mesh.
     /// This is a costly operation.

--- a/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.hpp
+++ b/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.hpp
@@ -46,6 +46,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     std::vector<OpenMesh::HPropHandleT<Vector4>> m_vec4Pph;
 
     friend class LoopSubdivider;
+    friend class CatmullClarkSubdivider;
 
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.hpp
+++ b/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.hpp
@@ -45,17 +45,14 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     std::vector<OpenMesh::HPropHandleT<Vector3>> m_vec3Pph;
     std::vector<OpenMesh::HPropHandleT<Vector4>> m_vec4Pph;
 
-    friend class LoopSubdivider;
-    friend class CatmullClarkSubdivider;
-
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
     /// Construct a topological mesh from a triangle mesh
     /// this is a costly operation.
     /// This operation merge vertex with same position, but keep vertex
-    /// attributes on halfedge, so that triMesh vertex with same 3D position are
-    /// represented only once in the topological mesh.
+    /// attributes on halfedge, so that triMesh vertices with the same 3D position
+    /// are represented only once in the topological mesh.
     explicit TopologicalMesh( const Ra::Core::TriangleMesh& triMesh );
 
     /// Construct an empty topological mesh
@@ -74,7 +71,17 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     /// return the normal of the vertex vh, when considering its membership to
     /// the face fh
     inline Normal& normal( VertexHandle vh, FaceHandle fh );
+
+    /// \name Const access to handles of the HalfEdge properties coming from
+    /// the TriangleMesh attributes.
+    ///@{
+    inline const std::vector<OpenMesh::HPropHandleT<float>>& getFloatPropsHandles() const;
+    inline const std::vector<OpenMesh::HPropHandleT<Vector2>>& getVector2PropsHandles() const;
+    inline const std::vector<OpenMesh::HPropHandleT<Vector3>>& getVector3PropsHandles() const;
+    inline const std::vector<OpenMesh::HPropHandleT<Vector4>>& getVector4PropsHandles() const;
+    ///@}
 };
+
 } // namespace Core
 } // namespace Ra
 

--- a/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.inl
+++ b/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.inl
@@ -3,16 +3,12 @@
 namespace Ra {
 namespace Core {
 
-
-//
-// TopologicalMesh functions
-//
-
 inline TopologicalMesh::Normal& TopologicalMesh::normal( TopologicalMesh::VertexHandle vh,
                                                          TopologicalMesh::FaceHandle fh ) {
     // find halfedge that point to vh and member of fh
     return property( halfedge_normals_pph(), halfedge_handle( vh, fh ) );
 }
+
 inline TopologicalMesh::HalfedgeHandle
 TopologicalMesh::halfedge_handle( TopologicalMesh::VertexHandle vh,
                                   TopologicalMesh::FaceHandle fh ) {
@@ -24,6 +20,26 @@ TopologicalMesh::halfedge_handle( TopologicalMesh::VertexHandle vh,
         }
     }
     return HalfedgeHandle();
+}
+
+inline const std::vector<OpenMesh::HPropHandleT<float>>&
+TopologicalMesh::getFloatPropsHandles() const {
+    return m_floatPph;
+}
+
+inline const std::vector<OpenMesh::HPropHandleT<Vector2>>&
+TopologicalMesh::getVector2PropsHandles() const {
+    return m_vec2Pph;
+}
+
+inline const std::vector<OpenMesh::HPropHandleT<Vector3>>&
+TopologicalMesh::getVector3PropsHandles() const {
+    return m_vec3Pph;
+}
+
+inline const std::vector<OpenMesh::HPropHandleT<Vector4>>&
+TopologicalMesh::getVector4PropsHandles() const {
+    return m_vec4Pph;
 }
 
 } // namespace Core

--- a/src/Core/Mesh/TriangleMesh.inl
+++ b/src/Core/Mesh/TriangleMesh.inl
@@ -67,13 +67,13 @@ inline bool TriangleMesh::append( const TriangleMesh& other ) {
     // Deal with all attributes the same way (vertices and normals too)
     other.m_vertexAttribs.for_each_attrib( [this]( const auto& attr ) {
         if ( attr->isFloat() )
-            append_attrib<float>( attr );
+            this->append_attrib<float>( attr );
         if ( attr->isVec2() )
-            append_attrib<Vector2>( attr );
+            this->append_attrib<Vector2>( attr );
         if ( attr->isVec3() )
-            append_attrib<Vector3>( attr );
+            this->append_attrib<Vector3>( attr );
         if ( attr->isVec4() )
-            append_attrib<Vector4>( attr );
+            this->append_attrib<Vector4>( attr );
     } );
 
     return true;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master`: for hotfixes not impacting the API
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Basic OpenMesh subdivision procedures do not deal with properties such as texture coordinates, additional normals and others.
The proposed subdivision procedures (Loop and CatmullClark schemes for now) deal with the `TopologicalMesh` properties which are stored on halfedges.
When adding new vertices, such properties are linearly interpolated along halfedges (edge mid-point) and faces (face centre).

Also, this PR fixes #349 .


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
