### PR TITLE
Remove dispatch of component registration methods

### DIFF
--- a/Plugins/Animation/src/AnimationPlugin.cpp
+++ b/Plugins/Animation/src/AnimationPlugin.cpp
@@ -28,7 +28,6 @@ void AnimationPluginC::registerPlugin( const Ra::PluginContext& context ) {
         path = QString( context.m_exportDir.c_str() );
     }
     m_system = new AnimationSystem;
-    m_system->setDataDir( path.toStdString() );
     context.m_engine->registerSystem( "AnimationSystem", m_system );
     context.m_engine->getSignalManager()->m_frameEndCallbacks.push_back(
         std::bind( &AnimationPluginC::updateAnimTime, this ) );
@@ -142,11 +141,11 @@ void AnimationPluginC::updateAnimTime() {
 }
 
 void AnimationPluginC::cacheFrame() {
-    m_system->cacheFrame();
+    m_system->cacheFrame( m_dataDir );
 }
 
 void AnimationPluginC::restoreFrame( int frame ) {
-    if ( m_system->restoreFrame( frame ) )
+    if ( m_system->restoreFrame( m_dataDir, frame ) )
     {
         m_widget->frameLoaded( frame );
     }
@@ -159,7 +158,7 @@ void AnimationPluginC::changeDataDir() {
     if ( !path.isEmpty() )
     {
         settings.setValue( "AnimDataDir", path );
-        m_system->setDataDir( path.toStdString() );
+        m_dataDir = path.toStdString();
     }
 }
 

--- a/Plugins/Animation/src/AnimationPlugin.hpp
+++ b/Plugins/Animation/src/AnimationPlugin.hpp
@@ -85,6 +85,9 @@ class AnimationPluginC : public QObject, Ra::Plugins::RadiumPluginInterface {
     void changeDataDir();
 
   private:
+    /// The data directory.
+    std::string m_dataDir;
+
     /// The AnimationSystem.
     class AnimationSystem* m_system;
 

--- a/Plugins/Animation/src/AnimationSystem.cpp
+++ b/Plugins/Animation/src/AnimationSystem.cpp
@@ -189,60 +189,53 @@ uint AnimationSystem::getMaxFrame() const {
     return m;
 }
 
-void AnimationSystem::cacheFrame( uint frameId ) const {
+void AnimationSystem::cacheFrame( const std::string& dir, uint frameId ) const {
     // deal with AnimationComponents
     for ( const auto& comp : m_components )
     {
-        static_cast<AnimationComponent*>( comp.second )->cacheFrame( m_dataDir, frameId );
+        static_cast<AnimationComponent*>( comp.second )->cacheFrame( dir, frameId );
     }
 
-    CoupledTimedSystem::cacheFrame( frameId );
+    CoupledTimedSystem::cacheFrame( dir, frameId );
 }
 
-bool AnimationSystem::restoreFrame( uint frameId ) {
+bool AnimationSystem::restoreFrame( const std::string& dir, uint frameId ) {
     static bool restoringCurrent = false;
     if ( !restoringCurrent )
     {
         // first save current, in case restoration fails.
-        cacheFrame( m_animFrame );
+        cacheFrame( dir, m_animFrame );
     }
     bool success = true;
     // deal with AnimationComponents
     for ( const auto& comp : m_components )
     {
-        success &=
-            static_cast<AnimationComponent*>( comp.second )->restoreFrame( m_dataDir, frameId );
+        success &= static_cast<AnimationComponent*>( comp.second )->restoreFrame( dir, frameId );
     }
     // if fail, restore current frame
     if ( !success && !restoringCurrent )
     {
         restoringCurrent = true;
-        restoreFrame( m_animFrame );
+        restoreFrame( dir, m_animFrame );
         restoringCurrent = false;
         return false;
     }
 
-    CORE_ASSERT( success, "Error while trying to restore current frame" );
-    success &= CoupledTimedSystem::restoreFrame( frameId );
-
+    success &= CoupledTimedSystem::restoreFrame( dir, frameId );
     // if fail, restore current frame
     if ( !success && !restoringCurrent )
     {
         restoringCurrent = true;
-        restoreFrame( m_animFrame );
+        restoreFrame( dir, m_animFrame );
         restoringCurrent = false;
         return false;
     }
-    CORE_ASSERT( success, "Error while trying to restore current frame" );
+
     if ( success )
     {
         m_animFrame = frameId;
     }
     return success;
-}
-
-void AnimationSystem::setDataDir( const std::string dir ) {
-    m_dataDir = dir;
 }
 
 } // namespace AnimationPlugin

--- a/Plugins/Animation/src/AnimationSystem.hpp
+++ b/Plugins/Animation/src/AnimationSystem.hpp
@@ -17,8 +17,8 @@ class ANIM_PLUGIN_API AnimationSystem : public Ra::Engine::CoupledTimedSystem {
     /// Create a new animation system
     AnimationSystem();
 
-    AnimationSystem(const AnimationSystem &) = delete;
-    AnimationSystem& operator=(const AnimationSystem&) = delete;
+    AnimationSystem( const AnimationSystem& ) = delete;
+    AnimationSystem& operator=( const AnimationSystem& ) = delete;
 
     /// Create a task for each animation component to advance the current animation.
     void generateTasks( Ra::Core::TaskQueue* taskQueue,
@@ -38,17 +38,14 @@ class ANIM_PLUGIN_API AnimationSystem : public Ra::Engine::CoupledTimedSystem {
     void reset() override;
 
     /// Saves all the state data related to the current frame into a cache file.
-    void cacheFrame() const { cacheFrame( m_animFrame ); }
+    void cacheFrame( const std::string& dir ) const { cacheFrame( dir, m_animFrame ); }
 
     /// Saves all the state data related to the given frame into a cache file.
-    void cacheFrame( uint frameId ) const override;
+    void cacheFrame( const std::string& dir, uint frameId ) const override;
 
     /// Restores the state data related to the \p frameID -th frame from the cache file.
     /// \returns true if the frame has been successfully restored, false otherwise.
-    bool restoreFrame( uint frameId ) override;
-
-    /// Set the directory where to store the animation data.
-    void setDataDir( const std::string dir );
+    bool restoreFrame( const std::string& dir, uint frameId ) override;
 
     /// Set on or off xray bone display.
     void setXray( bool on );
@@ -82,9 +79,6 @@ class ANIM_PLUGIN_API AnimationSystem : public Ra::Engine::CoupledTimedSystem {
     uint getMaxFrame() const;
 
   private:
-    /// The data directory.
-    std::string m_dataDir;
-
     /// Current frame
     uint m_animFrame;
 

--- a/src/Core/Mesh/TriangleMesh.inl
+++ b/src/Core/Mesh/TriangleMesh.inl
@@ -67,13 +67,13 @@ inline bool TriangleMesh::append( const TriangleMesh& other ) {
     // Deal with all attributes the same way (vertices and normals too)
     other.m_vertexAttribs.for_each_attrib( [this]( const auto& attr ) {
         if ( attr->isFloat() )
-            append_attrib<float>( attr );
+            this->append_attrib<float>( attr );
         if ( attr->isVec2() )
-            append_attrib<Vector2>( attr );
+            this->append_attrib<Vector2>( attr );
         if ( attr->isVec3() )
-            append_attrib<Vector3>( attr );
+            this->append_attrib<Vector3>( attr );
         if ( attr->isVec4() )
-            append_attrib<Vector4>( attr );
+            this->append_attrib<Vector4>( attr );
     } );
 
     return true;

--- a/src/Engine/Managers/CameraManager/CameraManager.cpp
+++ b/src/Engine/Managers/CameraManager/CameraManager.cpp
@@ -68,12 +68,18 @@ void CameraManager::registerComponent( const Entity* entity, Component* componen
 }
 
 void CameraManager::unregisterComponent( const Entity* entity, Component* component ) {
-    m_data->remove( reinterpret_cast<Camera*>( component ) );
     System::unregisterComponent( entity, component );
+    m_data->remove( reinterpret_cast<Camera*>( component ) );
 }
 
 void CameraManager::unregisterAllComponents( const Entity* entity ) {
-    m_data->clear();
+    for ( const auto& comp : this->m_components )
+    {
+        if ( comp.first == entity )
+        {
+            m_data->remove( reinterpret_cast<Camera*>( comp.second ) );
+        }
+    }
     System::unregisterAllComponents( entity );
 }
 

--- a/src/Engine/Managers/LightManager/LightManager.cpp
+++ b/src/Engine/Managers/LightManager/LightManager.cpp
@@ -143,21 +143,25 @@ void LightManager::handleAssetLoading( Entity* entity, const Asset::FileData* fi
 }
 
 void LightManager::registerComponent( const Entity* entity, Component* component ) {
-    System::registerComponent(entity, component);
-    m_data->add(reinterpret_cast<Light *>(component));
+    System::registerComponent( entity, component );
+    m_data->add( reinterpret_cast<Light*>( component ) );
 }
 
 void LightManager::unregisterComponent( const Entity* entity, Component* component ) {
-    m_data->remove( reinterpret_cast<Light *>(component) );
-    System::unregisterComponent(entity, component);
-
+    System::unregisterComponent( entity, component );
+    m_data->remove( reinterpret_cast<Light*>( component ) );
 }
 
 void LightManager::unregisterAllComponents( const Entity* entity ) {
-    m_data->clear();
-    System::unregisterAllComponents(entity);
+    for ( const auto& comp : this->m_components )
+    {
+        if ( comp.first == entity )
+        {
+            m_data->remove( reinterpret_cast<Light*>( comp.second ) );
+        }
+    }
+    System::unregisterAllComponents( entity );
 }
 
-
-  } // namespace Engine
+} // namespace Engine
 } // namespace Ra

--- a/src/Engine/Renderer/Mesh/Mesh.hpp
+++ b/src/Engine/Renderer/Mesh/Mesh.hpp
@@ -10,10 +10,8 @@
 #include <Core/Containers/VectorArray.hpp>
 #include <Core/Mesh/TriangleMesh.hpp>
 
-namespace Ra
-{
-namespace Engine
-{
+namespace Ra {
+namespace Engine {
 
 // FIXME(Charly): If I want to draw a mesh as lines, points, etc,
 //                should I send lines, ... to the GPU, or handle the way
@@ -29,16 +27,14 @@ namespace Engine
 /// with a specific render mode (e.g. GL_TRIANGLES or GL_LINES).
 /// It maintains the attributes and keeps them in sync with the GPU.
 /// \note Attribute names are used to automatic location binding when using shaders.
-class RA_ENGINE_API Mesh
-{
+class RA_ENGINE_API Mesh {
   public:
     /// List of all possible vertex attributes.
 
     // This is also the layout of the "dirty bit" and "vbo" arrays.
 
     /// Information which is in the mesh geometry
-    enum MeshData : uint
-    {
+    enum MeshData : uint {
         INDEX = 0,       /// Vertex indices
         VERTEX_POSITION, /// Vertex positions
         VERTEX_NORMAL,   /// Vertex normals
@@ -47,8 +43,7 @@ class RA_ENGINE_API Mesh
     };
 
     /// Optional vector 3 data.
-    enum Vec3Data : uint
-    {
+    enum Vec3Data : uint {
         VERTEX_TANGENT = 0, /// Vertex tangent 1
         VERTEX_BITANGENT,   /// Vertex tangent 2
         VERTEX_TEXCOORD,    /// U,V  texture coords (last coordinate not used)
@@ -57,8 +52,7 @@ class RA_ENGINE_API Mesh
     };
 
     /// Optional vector 4 data
-    enum Vec4Data : uint
-    {
+    enum Vec4Data : uint {
         VERTEX_COLOR = 0,  /// RGBA color.
         VERTEX_WEIGHTS,    /// Skinning weights (not used)
         VERTEX_WEIGHT_IDX, /// Associated weight bones
@@ -69,8 +63,7 @@ class RA_ENGINE_API Mesh
     /** Mesh render mode enum.
      * values taken from OpenGL specification
      */
-    enum MeshRenderMode : uint
-    {
+    enum MeshRenderMode : uint {
         RM_POINTS = 0x0000,
         RM_LINES = 0x0001,                    // decimal value: 1
         RM_LINE_LOOP = 0x0002,                // decimal value: 2
@@ -164,9 +157,10 @@ class RA_ENGINE_API Mesh
 
     /// Additionnal vertex vector 3 data handles, stored in Mesh, added
     std::array<Core::TriangleMesh::Vec3AttribHandle, MAX_VEC3> m_v3DataHandle;
+    Core::TriangleMesh::Vec3AttribHandle::Container m_dummy3;
     /// Additionnal vertex vector 4 data handles, stored in Mesh, added
     std::array<Core::TriangleMesh::Vec4AttribHandle, MAX_VEC4> m_v4DataHandle;
-    Core::TriangleMesh::Vec4AttribHandle::Container m_dummy;
+    Core::TriangleMesh::Vec4AttribHandle::Container m_dummy4;
 
     // Combined arrays store the flags in this order Mesh, then Vec3 then Vec4 data.
     // Following the enum declaration above.

--- a/src/Engine/Renderer/Mesh/Mesh.inl
+++ b/src/Engine/Renderer/Mesh/Mesh.inl
@@ -20,29 +20,33 @@ Core::TriangleMesh& Mesh::getGeometry() {
 
 const Core::Vector3Array& Mesh::getData( const Mesh::Vec3Data& type ) const {
     const int index = static_cast<uint>( type );
-    CORE_ASSERT( m_mesh.isValid( m_v3DataHandle[index] ), "Attrib must be initialized" );
-    return m_mesh.getAttrib( m_v3DataHandle[index] ).data();
+    const auto& h = m_v3DataHandle[index];
+    if ( !m_mesh.isValid( h ) )
+        return m_dummy3;
+    return m_mesh.getAttrib( h ).data();
 }
 
 const Core::Vector4Array& Mesh::getData( const Mesh::Vec4Data& type ) const {
     const int index = static_cast<uint>( type );
     const auto& h = m_v4DataHandle[index];
     if ( !m_mesh.isValid( h ) )
-        return m_dummy;
+        return m_dummy4;
     return m_mesh.getAttrib( h ).data();
 }
 
 Core::Vector3Array& Mesh::getData( const Mesh::Vec3Data& type ) {
     const int index = static_cast<uint>( type );
-    CORE_ASSERT( m_mesh.isValid( m_v3DataHandle[index] ), "Attrib must be initialized" );
-    return m_mesh.getAttrib( m_v3DataHandle[index] ).data();
+    const auto& h = m_v3DataHandle[index];
+    if ( !m_mesh.isValid( h ) )
+        return m_dummy3;
+    return m_mesh.getAttrib( h ).data();
 }
 
 Core::Vector4Array& Mesh::getData( const Mesh::Vec4Data& type ) {
     const int index = static_cast<uint>( type );
     const auto& h = m_v4DataHandle[index];
     if ( !m_mesh.isValid( h ) )
-        return m_dummy;
+        return m_dummy4;
     return m_mesh.getAttrib( h ).data();
 }
 

--- a/src/Engine/System/CouplingSystem.hpp
+++ b/src/Engine/System/CouplingSystem.hpp
@@ -13,7 +13,11 @@ namespace Engine {
 /// Base class for systems coupling multiple subsystems.
 ///
 /// Provides subsystem storage + dispatching methods for inheriting classes.
-/// Also dispatches by default the virtual methods from Ra::Engine::System.
+/// Also dispatches by default the generateTasks() and handleAssetLoading()
+/// methods from Ra::Engine::System.
+/// Note that Ra::Engine::Component registration methods from Ra::Engine::System
+/// are not dispatched by default, Ra::Engine::Systems managing only their own 
+/// Ra::Engine::Components.
 ///
 /// \see CoupledTimedSystem for practical usage
 /// \tparam BaseAbstractSystem Base class defining the subsystems API
@@ -22,11 +26,10 @@ namespace Engine {
 /// default implementation:
 ///
 /// \code
-/// void registerComponent( const Entity* entity, Component* component) override
-/// {
-///  // call default implementation
-///  BaseAbstractSystem::registerComponent(entity, component);
-///  dispatch([entity, component](const auto &s) { s->registerComponent(entity, component); });
+/// inline void generateTasks( Core::TaskQueue* taskQueue, const Engine::FrameInfo& frameInfo ) override {
+///     dispatch( [taskQueue, &frameInfo]( const auto& s ) {
+///         s->generateTasks( taskQueue, frameInfo );
+///     } );
 /// }
 /// \endcode
 template <typename _BaseAbstractSystem>

--- a/src/Engine/System/CouplingSystem.hpp
+++ b/src/Engine/System/CouplingSystem.hpp
@@ -52,20 +52,6 @@ class BaseCouplingSystem : public _BaseAbstractSystem {
             s->generateTasks( taskQueue, frameInfo );
         } );
     }
-    inline void registerComponent( const Entity* entity, Component* component ) override {
-        BaseAbstractSystem::registerComponent( entity, component );
-        dispatch(
-            [entity, component]( const auto& s ) { s->registerComponent( entity, component ); } );
-    }
-    inline void unregisterComponent( const Entity* entity, Component* component ) override {
-        BaseAbstractSystem::unregisterComponent( entity, component );
-        dispatch(
-            [entity, component]( const auto& s ) { s->unregisterComponent( entity, component ); } );
-    }
-    inline void unregisterAllComponents( const Entity* entity ) override {
-        BaseAbstractSystem::unregisterAllComponents( entity );
-        dispatch( [entity]( const auto& s ) { s->unregisterAllComponents( entity ); } );
-    }
     inline void handleAssetLoading( Entity* entity, const Asset::FileData* data ) override {
         BaseAbstractSystem::handleAssetLoading( entity, data );
         dispatch( [entity, data]( const auto& s ) { s->handleAssetLoading( entity, data ); } );

--- a/src/Engine/System/CouplingSystem.hpp
+++ b/src/Engine/System/CouplingSystem.hpp
@@ -40,7 +40,7 @@ class BaseCouplingSystem : public _BaseAbstractSystem {
     inline BaseCouplingSystem() {
         static_assert( std::is_base_of<Ra::Engine::System, BaseAbstractSystem>::value,
                        "BaseAbstractSystem must inherit Ra::Core::System" );
-    };
+    }
     virtual ~BaseCouplingSystem() {}
 
     BaseCouplingSystem( const BaseCouplingSystem<BaseAbstractSystem>& ) = delete;

--- a/src/Engine/System/System.hpp
+++ b/src/Engine/System/System.hpp
@@ -3,9 +3,8 @@
 
 #include <Engine/RaEngine.hpp>
 
-#include <vector>
 #include <memory>
-
+#include <vector>
 
 namespace Ra {
 namespace Core {
@@ -37,6 +36,16 @@ class RA_ENGINE_API System {
     virtual ~System();
 
     /**
+     * Factory method for component creation from file data.
+     * From a given file and the corresponding entity, the system will create the
+     * corresponding components, add them to the entity, and register the component.
+     * @note : Issue #325 - As this method register components and might also manage each component
+     * outside the m_components vectors (e.g in a buffer on the GPU) the methods, the
+     * registerComponent and unregister*Component must be virtual method that could be overriden.
+     */
+    virtual void handleAssetLoading( Entity* entity, const Asset::FileData* data ) {}
+
+    /**
      * @brief Pure virtual method to be overridden by any system.
      * A very basic version of this method could be to iterate on components
      * and just call Component::update() method on them.
@@ -49,7 +58,7 @@ class RA_ENGINE_API System {
 
     /**
      * Registers a component belonging to an entity, making it active within the system.
-     * @note If a system overrides this function, it must call the inherited method first to any specific stuff.
+     * @note If a system overrides this function, it must call the inherited method.
      * @param entity
      * @param component
      */
@@ -57,7 +66,7 @@ class RA_ENGINE_API System {
 
     /**
      * Unregisters a component. The system will not update it.
-     * @note If a system overrides this function, it must call the inherited method first to any specific stuff.
+     * @note If a system overrides this function, it must call the inherited method.
      * @param entity
      * @param component
      */
@@ -65,23 +74,13 @@ class RA_ENGINE_API System {
 
     /**
      * Removes all components belonging to a given entity.
-     * @note If a system overrides this function, it must call the inherited method first to any specific stuff.
+     * @note If a system overrides this function, it must call the inherited method.
      * @param entity
      */
     virtual void unregisterAllComponents( const Entity* entity );
 
     /// Returns the components stored for the given entity.
     std::vector<Component*> getEntityComponents( const Entity* entity );
-
-    /**
-     * Factory method for component creation from file data.
-     * From a given file and the corresponding entity, the system will create the
-     * corresponding components, add them to the entity, and register the component.
-     * @note : Issue #325 - As this method register components and might also manage each component outside the
-     * m_components vectors (e.g in a buffer on the GPU) the methods, the registerComponent and unregister*Component
-     * must be virtual method that could be overriden.
-     */
-    virtual void handleAssetLoading( Entity* entity, const Asset::FileData* data ) {}
 
   protected:
     /// List of active components.

--- a/src/Engine/System/TimedSystem.hpp
+++ b/src/Engine/System/TimedSystem.hpp
@@ -23,11 +23,11 @@ class RA_ENGINE_API AbstractTimedSystem : public System {
     virtual void reset() = 0;
 
     /// Saves all the state data related to the \p frameID -th frame into a cache file.
-    virtual void cacheFrame( uint frameID ) const = 0;
+    virtual void cacheFrame( const std::string& dir, uint frameID ) const = 0;
 
     /// Restores the state data related to the \p frameID -th frame from the cache file.
     /// \returns true if the frame has been successfully restored, false otherwise.
-    virtual bool restoreFrame( uint frameID ) = 0;
+    virtual bool restoreFrame( const std::string& dir, uint frameID ) = 0;
 };
 
 class RA_ENGINE_API CoupledTimedSystem : public BaseCouplingSystem<AbstractTimedSystem> {
@@ -41,12 +41,12 @@ class RA_ENGINE_API CoupledTimedSystem : public BaseCouplingSystem<AbstractTimed
     void reset() override {
         dispatch( []( const auto& s ) { s->reset(); } );
     }
-    void cacheFrame( uint frameID ) const override {
-        dispatch( [frameID]( const auto& s ) { s->cacheFrame( frameID ); } );
+    void cacheFrame( const std::string& dir, uint frameID ) const override {
+        dispatch( [&dir, frameID]( const auto& s ) { s->cacheFrame( dir, frameID ); } );
     }
-    bool restoreFrame( uint frameID ) override {
+    bool restoreFrame( const std::string& dir, uint frameID ) override {
         return conditionnaldispatch(
-            [frameID]( const auto& s ) { return s->restoreFrame( frameID ); } );
+            [&dir, frameID]( const auto& s ) { return s->restoreFrame( dir, frameID ); } );
     }
 };
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Is the Pull-Request done against the right branch:
  - `master`: for hotfixes not impacting the API
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix the default behavior of `CouplingSystem` regarding the `registerComponent`, `unregisterComponent` and `unregisterAllComponents` methods of `Ra::Engine::System`.
Also give the file directory to the AbstractTimedSystem for caching/restoring frame data, so that the  CouplingSystem and its subsytems use the same by default.

* **What is the current behavior?** (You can also link to an open issue here)
By default, the `CouplingSystem` dispatches the `registerComponent`, `unregisterComponent` and `unregisterAllComponents` to the coupled systems, which makes them register its own managed `Components`.
This is undesirable, since the `Systems` must only register `Components` they manage (create, run tasks over, link to some plugin interface).

* **What is the new behavior (if this is a feature change)?**
By default, there is no dispatch for these methods.
In the case one wants the coupled systems to also register `Components` related to the `CouplingSystem`, then one must declare/implement it explicitely.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
