### PR TITLE
add a flag to use cotire (enable by default).

### DIFF
--- a/Applications/HelloRadium/CMakeLists.txt
+++ b/Applications/HelloRadium/CMakeLists.txt
@@ -50,4 +50,4 @@ if (MSVC)
     set_property( TARGET ${app_target} PROPERTY IMPORTED_LOCATION "${RADIUM_BINARY_OUTPUT_PATH}" )
 endif(MSVC)
 
-cotire ( ${app_target} )
+radium_cotire( ${app_target} )

--- a/Applications/MainApplication/CMakeLists.txt
+++ b/Applications/MainApplication/CMakeLists.txt
@@ -70,4 +70,4 @@ if (MSVC)
     set_property( TARGET ${app_target} PROPERTY IMPORTED_LOCATION "${RADIUM_BINARY_OUTPUT_PATH}" )
 endif(MSVC)
 
-cotire ( ${app_target} )
+radium_cotire( ${app_target} )

--- a/Applications/SimpleSubdivideExample/CMakeLists.txt
+++ b/Applications/SimpleSubdivideExample/CMakeLists.txt
@@ -67,4 +67,4 @@ if (MSVC)
     set_property( TARGET ${app_target} PROPERTY IMPORTED_LOCATION "${RADIUM_SUBMODULES_INSTALL_DIRECTORY}/bin" )
 endif(MSVC)
 
-cotire ( ${app_target} )
+radium_cotire( ${app_target} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ option(RADIUM_TINYPLY_SUPPORT       "Enable TinyPly loader" ON)
 option(RADIUM_CAMERA_LOADER_SUPPORT "Enable Camera loader" ON)
 option(RADIUM_BUILD_APPS            "Choose to build or not radium applications" ON)
 option(RADIUM_FAST_MATH             "Enable Fast Math optimizations in Release Mode (ignored with MVSC)" OFF)
+option(RADIUM_USE_COTIRE            "Enable cotire precompiled headers" On)
 
 if ( NOT CMAKE_BUILD_TYPE )
   set( CMAKE_BUILD_TYPE Debug )
@@ -73,6 +74,7 @@ endif()
 
 
 # Set the compiler flags.
+include(RadiumFunctions)
 include(CompileFlags)
 
 if ( NOT CMAKE_PREFIX_PATH )

--- a/cmake/RadiumFunctions.cmake
+++ b/cmake/RadiumFunctions.cmake
@@ -1,0 +1,6 @@
+# Usefull helper for radium compilation
+function (radium_cotire)
+  if(${RADIUM_USE_COTIRE})
+    cotire(${ARGV})
+  endif()
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,7 +84,7 @@ target_link_libraries(
     ${core_target}
     ${core_libs}
 )
-cotire(${core_target})
+radium_cotire(${core_target})
 
 # Build IO
 set(io_target radiumIO)
@@ -148,7 +148,7 @@ else ( RADIUM_IO_IS_INTERFACE )
     set_property( TARGET ${io_target} PROPERTY POSITION_INDEPENDENT_CODE ON )
 
     if (NOT APPLE)
-        cotire(${io_target}) # see https://travis-ci.org/STORM-IRIT/Radium-Engine/jobs/432345198
+        radium_cotire(${io_target}) # see https://travis-ci.org/STORM-IRIT/Radium-Engine/jobs/432345198
     endif (NOT APPLE)
 endif ( RADIUM_IO_IS_INTERFACE )
 
@@ -255,7 +255,7 @@ target_link_libraries(
     ${guibase_libs}
     )
 
-#cotire(${guibase_target})
+#radium_cotire(${guibase_target})
 
 set(RADIUM_LIBRARIES ${RADIUM_LIBRARIES} "${core_target}" "${engine_target}" "${io_target}" "${guibase_target}" PARENT_SCOPE)
 set_property( TARGET ${core_target} PROPERTY POSITION_INDEPENDENT_CODE ON )


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master`: for hotfixes not impacting the API
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

add a flag to use cotire (on by default)

* **What is the current behavior?** (You can also link to an open issue here)

    cotire is always on 

* **What is the new behavior (if this is a feature change)?**

    user can disable cotire at compile time with -DRADIUM_USE_COTIRE=Off

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope


* **Other information**:
    have fun