### PR TITLE
Update Light asset : add management of area light sources

### DIFF
--- a/src/Core/File/AssetData.hpp
+++ b/src/Core/File/AssetData.hpp
@@ -11,6 +11,8 @@ class RA_CORE_API AssetData {
   public:
     AssetData( const std::string& name ) : m_name( name ) {}
 
+    AssetData (const AssetData &other) = default;
+
     virtual ~AssetData() {}
 
     inline virtual const std::string& getName() const { return m_name; }

--- a/src/Core/File/AssetData.hpp
+++ b/src/Core/File/AssetData.hpp
@@ -7,14 +7,24 @@
 namespace Ra {
 namespace Asset {
 
+/**
+ * General interface of an asset data.
+ *
+ *  Every asset data must have a name and must be copy constructible.
+ *
+ */
 class RA_CORE_API AssetData {
   public:
+    /// Construct an asset data given its name.
     AssetData( const std::string& name ) : m_name( name ) {}
 
+    /// Copy constructor. Default here
     AssetData (const AssetData &other) = default;
 
+    /// Simple delete operator
     virtual ~AssetData() {}
 
+    /// Acces to the name of the asset
     inline virtual const std::string& getName() const { return m_name; }
 
   protected:

--- a/src/Core/File/CameraData.hpp
+++ b/src/Core/File/CameraData.hpp
@@ -40,7 +40,7 @@ class RA_CORE_API CameraData : public AssetData {
     inline void setType( const CameraType& type );
 
     /// Return the transformation of the Camera.
-    inline Core::Matrix4 getFrame() const;
+    inline const Core::Matrix4& getFrame() const;
 
     /// Set the transformation of the Camera.
     inline void setFrame( const Core::Matrix4& frame );

--- a/src/Core/File/CameraData.inl
+++ b/src/Core/File/CameraData.inl
@@ -18,7 +18,7 @@ inline void CameraData::setType( const CameraType& type ) {
     m_type = type;
 }
 
-inline Core::Matrix4 CameraData::getFrame() const {
+inline const Core::Matrix4& CameraData::getFrame() const {
     return m_frame;
 }
 

--- a/src/Core/File/LightData.cpp
+++ b/src/Core/File/LightData.cpp
@@ -17,50 +17,30 @@ LightData::LightData( const std::string& name, const LightType& type ) :
     m_frame( Core::Matrix4::Identity() ),
     m_type( type ) {}
 
+LightData::LightData( const LightData& data ) : AssetData(data), m_frame(data.m_frame), m_type(data.m_type), m_color(data.m_color) {
+
+    switch (m_type) {
+    case POINT_LIGHT:
+        m_pointlight = data.m_pointlight;
+        break;
+    case SPOT_LIGHT:
+        m_spotlight = data.m_spotlight;
+        break;
+    case DIRECTIONAL_LIGHT:
+        m_dirlight = data.m_dirlight;
+        break;
+    case AREA_LIGHT:
+        m_arealight = data.m_arealight;
+        break;
+    default:
+        break;
+    }
+
+}
+
 /// DESTRUCTOR
 LightData::~LightData() {}
 
-#if 0
-// this will add a dependence on the core to the engine. Not a good idea ...
-Engine::Light* LightData::getLight() const {
-    switch (getType()) {
-    case DIRECTIONAL_LIGHT:
-    {
-        auto thelight = new Engine::DirectionalLight(m_name);
-        thelight->setColor( m_color );
-        thelight->setDirection( m_dirlight.direction );
-        return thelight;
-    }
-    case POINT_LIGHT:
-    {
-        auto thelight = new Engine::PointLight(m_name);
-        thelight->setColor(m_color);
-        thelight->setPosition(m_pointlight.position);
-        thelight->setAttenuation(m_pointlight.attenuation.constant, m_pointlight.attenuation.linear, m_pointlight.attenuation.quadratic);
-        return thelight;
-    }
-    case SPOT_LIGHT:
-    {
-        auto thelight = new Engine::SpotLight(m_name);
-        thelight->setColor(m_color);
-        thelight->setPosition(m_spotlight.position);
-        thelight->setDirection(m_spotlight.direction);
-        thelight->setAttenuation(m_spotlight.attenuation.constant, m_spotlight.attenuation.linear, m_spotlight.attenuation.quadratic);
-        thelight->setInnerAngleInRadians(m_spotlight.innerAngle);
-        thelight->setOuterAngleInRadians(m_spotlight.outerAngle);
-        return thelight;
-    }
-    case AREA_LIGHT:
-    {
-        // No arealight for now
-        return nullptr;
-    }
-    default:
-        return nullptr;
-    }
-}
-
-#endif
 
 } // namespace Asset
 } // namespace Ra

--- a/src/Core/File/LightData.hpp
+++ b/src/Core/File/LightData.hpp
@@ -47,7 +47,7 @@ class RA_CORE_API LightData : public AssetData {
     /// CONSTRUCTOR
     LightData( const std::string& name = "", const LightType& type = UNKNOWN );
 
-    LightData( const LightData& data ) = default;
+    LightData( const LightData& data );
 
     /// DESTRUCTOR
     ~LightData();
@@ -82,7 +82,7 @@ class RA_CORE_API LightData : public AssetData {
     inline void setLight( Core::Color color, Core::Vector3 position, Core::Vector3 direction,
                           Scalar inangle, Scalar outAngle, LightAttenuation attenuation );
     /// construct an area light
-    inline void setLight( Core::Color color, LightAttenuation attenuation );
+    inline void setLight( Core::Color color, Core::Vector3 cog, Core::Matrix3 spatialCov, Core::Matrix3 normalCov, LightAttenuation attenuation );
 
     /// QUERY
     inline bool isPointLight() const;
@@ -120,7 +120,11 @@ class RA_CORE_API LightData : public AssetData {
             LightAttenuation attenuation;
         } m_spotlight;
         struct {
-            // TODO (Mathias) : find how to represent arealight in a generic way
+            // TODO (Mathias) : this representation is usefull but might be improved
+            Core::Vector3 position;
+            // TODO : gives the eigenvalues/eigenvectors for spatial and normal covariance matrices.
+            Core::Matrix3 spatialCovariance;
+            Core::Matrix3 normalCovariance;
             LightAttenuation attenuation;
         } m_arealight;
     };

--- a/src/Core/File/LightData.hpp
+++ b/src/Core/File/LightData.hpp
@@ -152,7 +152,7 @@ class RA_CORE_API LightData : public AssetData {
     * class could not ensure such an invariant when this method is called.
     * @param type the type to set.
     */
-    inline void setType( const LightType& type );
+    [[deprecated( "Do not change the type of a LightData, use setLight that ensures data coherency." )]] inline void setType( const LightType& type );
 
     /**
      * Returns true if the light is a PointLight

--- a/src/Core/File/LightData.hpp
+++ b/src/Core/File/LightData.hpp
@@ -64,25 +64,16 @@ class RA_CORE_API LightData : public AssetData {
     inline void setFrame( const Core::Matrix4& frame );
 
     /// DATA
-    /*
-    inline std::shared_ptr<Ra::Engine::Light> getLight() const;
-    inline void setLight( std::shared_ptr<Ra::Engine::Light> light );
-    */
-#if 0
-    /// Acces to the data. The returned component must be attached to an entity after that.
-    // this will add a dependence on the core to the engine. Not a good idea ...
-    Ra::Engine::Light* getLight() const;
-#endif
 
     /// construct a directional light
-    inline void setLight( Core::Color color, Core::Vector3 direction );
+    inline void setLight(const Core::Color &color, const Core::Vector3 &direction);
     /// construct a point light
-    inline void setLight( Core::Color color, Core::Vector3 position, LightAttenuation attenuation );
+    inline void setLight(const Core::Color &color, const Core::Vector3 &position, LightAttenuation attenuation);
     /// construct a spot light
-    inline void setLight( Core::Color color, Core::Vector3 position, Core::Vector3 direction,
-                          Scalar inangle, Scalar outAngle, LightAttenuation attenuation );
+    inline void setLight(const Core::Color &color, const Core::Vector3 &position, const Core::Vector3 &direction,
+                         Scalar inangle, Scalar outAngle, LightAttenuation attenuation);
     /// construct an area light
-    inline void setLight( Core::Color color, Core::Vector3 cog, Core::Matrix3 spatialCov, Core::Matrix3 normalCov, LightAttenuation attenuation );
+    inline void setLight( const Core::Color &color, const Core::Vector3 &cog, const Core::Matrix3 &spatialCov, const Core::Matrix3 &normalCov, LightAttenuation attenuation );
 
     /// QUERY
     inline bool isPointLight() const;
@@ -99,8 +90,8 @@ class RA_CORE_API LightData : public AssetData {
     Core::Matrix4 m_frame;
     LightType m_type;
 
-    // This part is public so that systems handling lights could acces to the data.
-    // TODO (Mathias) : make these protected with getters ? Define independant types ?
+    // This part is public so that systems handling lights could access to the data.
+    // TODO : make these protected with getters ? Define independant types ?
   public:
     Core::Color m_color;
 
@@ -122,7 +113,6 @@ class RA_CORE_API LightData : public AssetData {
         struct {
             // TODO (Mathias) : this representation is usefull but might be improved
             Core::Vector3 position;
-            // TODO : gives the eigenvalues/eigenvectors for spatial and normal covariance matrices.
             Core::Matrix3 spatialCovariance;
             Core::Matrix3 normalCovariance;
             LightAttenuation attenuation;

--- a/src/Core/File/LightData.hpp
+++ b/src/Core/File/LightData.hpp
@@ -85,7 +85,7 @@ class RA_CORE_API LightData : public AssetData {
      * Acces to the local frame of the light.
      * @return the local frame
      */
-    inline Core::Matrix4 getFrame() const;
+    inline const Core::Matrix4& getFrame() const;
 
     /**
      * Set the local frame of the light.

--- a/src/Core/File/LightData.hpp
+++ b/src/Core/File/LightData.hpp
@@ -60,7 +60,7 @@ class RA_CORE_API LightData : public AssetData {
 
     /**
      * Light constructor.
-     * Must be calle explicitely with a name for the light and its type.
+     * Must be called explicitely with a name for the light and its type.
      */
     explicit LightData( const std::string& name = "", const LightType& type = UNKNOWN );
 
@@ -95,18 +95,23 @@ class RA_CORE_API LightData : public AssetData {
 
 /**
  * \defgroup HelperSetters Helper functions to set the various light parameters.
+ *
  * @{
  */
     /**
      * Construct a directional light.
      * A directional light is only defined by its color and its lighting direction.
      * No attenuation on directional.
+     *  \note The object on which this method is called is unconditionally promoted to ``DIRECTIONAL_LIGHT`` light, whatever
+     *  it was before the call and only the directional light part of the union is consistent after the call
      */
     inline void setLight(const Core::Color &color, const Core::Vector3 &direction);
 
     /**
     * Construct a point light.
     * A point light is defined by its color, its position and its attenuation.
+    *  \note The object on which this method is called is unconditionally promoted to ``POINT_LIGHT`` light, whatever
+    *  it was before the call and only the directional light part of the union is consistent after the call
     */
     inline void setLight(const Core::Color &color, const Core::Vector3 &position, LightAttenuation attenuation);
 
@@ -114,15 +119,18 @@ class RA_CORE_API LightData : public AssetData {
     * Construct a spot light.
     * A spot light is defined by its color, its position, the cone axis and light distribution
     * (constant inside inangle, quadratically deacreasing toward 0 fron inAngle to ouAngle) and its attenuation.
+    *  \note The object on which this method is called is unconditionally promoted to ``SPOT_LIGHT`` light, whatever
+    *  it was before the call and only the directional light part of the union is consistent after the call
     */
     inline void setLight(const Core::Color &color, const Core::Vector3 &position, const Core::Vector3 &direction,
                          Scalar inAngle, Scalar outAngle, LightAttenuation attenuation);
 
-    /// construct an area light
     /**
      * Construct a area light.
      * An area light, (isotropic with constant emision defined by its color) is approximated by its center and
      * the covariance matrices modelling the spatial extent as well as the elliptical distribution of normals.
+     * \note The object on which this method is called is unconditionally promoted to ``AREA_LIGHT`` light, whatever
+     *  it was before the call and only the directional light part of the union is consistent after the call
      */
     inline void setLight( const Core::Color &color, const Core::Vector3 &cog, const Core::Matrix3 &spatialCov,
                           const Core::Matrix3 &normalCov, LightAttenuation attenuation );

--- a/src/Core/File/LightData.inl
+++ b/src/Core/File/LightData.inl
@@ -71,10 +71,14 @@ inline void LightData::setLight( Core::Color color, Core::Vector3 position, Core
     m_spotlight.outerAngle = outAngle;
     m_spotlight.attenuation = attenuation;
 }
+
 /// construct an area light
-inline void LightData::setLight( Core::Color color, LightAttenuation attenuation ) {
+inline void LightData::setLight( Core::Color color, Core::Vector3 cog, Core::Matrix3 spatialCov, Core::Matrix3 normalCov, LightAttenuation attenuation ) {
     m_type = AREA_LIGHT;
     m_color = color;
+    m_arealight.position = cog;
+    m_arealight.spatialCovariance = spatialCov;
+    m_arealight.normalCovariance = normalCov;
     m_arealight.attenuation = attenuation;
 }
 

--- a/src/Core/File/LightData.inl
+++ b/src/Core/File/LightData.inl
@@ -33,27 +33,16 @@ inline void LightData::setFrame( const Core::Matrix4& frame ) {
     m_frame = frame;
 }
 
-/*
-/// Data
-inline std::shared_ptr<Ra::Engine::Light> LightData::getLight() const {
-    return m_light;
-}
-
-inline void LightData::setLight( std::shared_ptr<Ra::Engine::Light> light ) {
-    m_light = light;
-}
-*/
-
 /// construct a directional light
-inline void LightData::setLight( Core::Color color, Core::Vector3 direction ) {
+inline void LightData::setLight(const Core::Color &color, const Core::Vector3 &direction) {
     m_type = DIRECTIONAL_LIGHT;
     m_color = color;
     m_dirlight.direction = direction;
 }
 
 /// construct a point light
-inline void LightData::setLight( Core::Color color, Core::Vector3 position,
-                                 LightAttenuation attenuation ) {
+inline void LightData::setLight(const Core::Color &color, const Core::Vector3 &position,
+                                LightAttenuation attenuation) {
     m_type = POINT_LIGHT;
     m_color = color;
     m_pointlight.position = position;
@@ -61,8 +50,8 @@ inline void LightData::setLight( Core::Color color, Core::Vector3 position,
 }
 
 /// construct a spot light
-inline void LightData::setLight( Core::Color color, Core::Vector3 position, Core::Vector3 direction,
-                                 Scalar inangle, Scalar outAngle, LightAttenuation attenuation ) {
+inline void LightData::setLight(const Core::Color &color, const Core::Vector3 &position, const Core::Vector3 &direction,
+                                Scalar inangle, Scalar outAngle, LightAttenuation attenuation) {
     m_type = SPOT_LIGHT;
     m_color = color;
     m_spotlight.position = position;
@@ -73,7 +62,7 @@ inline void LightData::setLight( Core::Color color, Core::Vector3 position, Core
 }
 
 /// construct an area light
-inline void LightData::setLight( Core::Color color, Core::Vector3 cog, Core::Matrix3 spatialCov, Core::Matrix3 normalCov, LightAttenuation attenuation ) {
+inline void LightData::setLight(const Core::Color &color, const Core::Vector3 &cog, const Core::Matrix3 &spatialCov, const Core::Matrix3 &normalCov, LightAttenuation attenuation ) {
     m_type = AREA_LIGHT;
     m_color = color;
     m_arealight.position = cog;

--- a/src/Core/File/LightData.inl
+++ b/src/Core/File/LightData.inl
@@ -51,12 +51,12 @@ inline void LightData::setLight(const Core::Color &color, const Core::Vector3 &p
 
 /// construct a spot light
 inline void LightData::setLight(const Core::Color &color, const Core::Vector3 &position, const Core::Vector3 &direction,
-                                Scalar inangle, Scalar outAngle, LightAttenuation attenuation) {
+                                Scalar inAngle, Scalar outAngle, LightAttenuation attenuation) {
     m_type = SPOT_LIGHT;
     m_color = color;
     m_spotlight.position = position;
     m_spotlight.direction = direction;
-    m_spotlight.innerAngle = inangle;
+    m_spotlight.innerAngle = inAngle;
     m_spotlight.outerAngle = outAngle;
     m_spotlight.attenuation = attenuation;
 }

--- a/src/Core/File/LightData.inl
+++ b/src/Core/File/LightData.inl
@@ -25,7 +25,7 @@ inline void LightData::setType( const LightType& type ) {
 }
 
 /// FRAME
-inline Core::Matrix4 LightData::getFrame() const {
+inline const Core::Matrix4& LightData::getFrame() const {
     return m_frame;
 }
 

--- a/src/Engine/Managers/LightManager/LightManager.cpp
+++ b/src/Engine/Managers/LightManager/LightManager.cpp
@@ -140,7 +140,16 @@ void LightManager::handleAssetLoading( Entity* entity, const Asset::FileData* fi
         case Asset::LightData::AREA_LIGHT:
         {
             // No arealight for now (see pbrplugin)
-            comp = nullptr;
+            // TODO : manage real area light. For the moment, transform them in point light using given position
+            auto thelight = new Engine::PointLight( entity, data->getName() );
+            thelight->setColor( data->m_color );
+            thelight->setPosition( data->m_arealight.position );
+            thelight->setAttenuation( data->m_arealight.attenuation.constant,
+                                      data->m_arealight.attenuation.linear,
+                                      data->m_arealight.attenuation.quadratic );
+            comp = thelight;
+
+            //comp = nullptr;
             break;
         }
         default:

--- a/src/IO/AssimpLoader/AssimpLightDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpLightDataLoader.cpp
@@ -46,7 +46,7 @@ void AssimpLightDataLoader::loadData( const aiScene* scene,
     {
         Asset::LightData* light = new Asset::LightData();
         loadLightData( scene, *( scene->mLights[lightId] ), *light );
-        data.push_back( std::unique_ptr<Asset::LightData>( light ) );
+        data.emplace_back( light  );
     }
 
     if ( m_verbose )


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [x ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Allow the definition of area light sources in the asset that are compatible with punctual ones so that renderer that support only point light sources might use a crude approximation of area lights.

* **What is the current behavior?** (You can also link to an open issue here)
No support for area light.

* **What is the new behavior (if this is a feature change)?**
Support for a statistical representation of arealight.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
Update the doc on ``File::IO::LightData``
Tests are not in the Radium distribution but in a separate private plugin.
