### PR TITLE
Fix issue #378 - main-app crashes when clearing a scene from which the active camera was selected.

### DIFF
--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -534,6 +534,8 @@ void MainWindow::deleteCurrentItem() {
 }
 
 void MainWindow::resetScene() {
+    // Fix issue #378 : ask the viewer to switch back to the default camera
+    m_viewer->getCameraInterface()->resetToDefaultCamera();
     // To see why this call is important, please see deleteCurrentItem().
     m_selectionManager->clear();
     Engine::RadiumEngine::getInstance()->getEntityManager()->deleteEntities();

--- a/src/GuiBase/Viewer/CameraInterface.cpp
+++ b/src/GuiBase/Viewer/CameraInterface.cpp
@@ -36,6 +36,23 @@ Gui::CameraInterface::CameraInterface( uint width, uint height ) :
     setCameraZFar( 1000.0 );
 }
 
+void Gui::CameraInterface::resetToDefaultCamera() {
+    // get parameters from the current camera
+    // Thisis awfull and requires that the current camera is still alive ...
+    Scalar w = m_camera->getWidth();
+    Scalar h = m_camera->getHeight();
+    auto it = std::find_if(
+        Engine::SystemEntity::getInstance()->getComponents().cbegin(),
+        Engine::SystemEntity::getInstance()->getComponents().cend(),
+        []( const auto& c ) { return c->getName().compare( "CAMERA_DEFAULT" ) == 0; } );
+    if ( it != Engine::SystemEntity::getInstance()->getComponents().cend() )
+    {
+        m_camera = static_cast<Engine::Camera*>( ( *it ).get() );
+        m_camera->resize(w,h);
+        m_camera->show( false );
+    }
+}
+
 Gui::CameraInterface::~CameraInterface() {}
 
 void Gui::CameraInterface::resizeViewport( uint width, uint height ) {

--- a/src/GuiBase/Viewer/CameraInterface.hpp
+++ b/src/GuiBase/Viewer/CameraInterface.hpp
@@ -71,6 +71,15 @@ class CameraInterface : public QObject {
     /// \note CameraInterface doesn't have ownership.
     virtual void setCamera( Engine::Camera* camera ) = 0;
 
+    /**
+     * Set the Engine::Camera used to the default one.
+     * This method allow to have a quick fix of issue #378 before switching to Radium v2 development.
+     * TODO : have a cleaner camera management and control in the GuiBase Radium library.
+     * GuiBase Camera interface Must define a clean interface between the application and the Engine.
+     * This method is similar to the getCameraFromViewer, it should not be there ...
+     */
+     void resetToDefaultCamera();
+
     /// Set the Light attached to the camera.
     /// \note CameraInterface doesn't have ownership.
     void attachLight( Engine::Light* light );


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix issue #378 

* **What is the current behavior?** (You can also link to an open issue here)
When selecting a camera from a loaded scene, then clearing the scene, the Camera interface manage a dangling pointer toward a deleted ``Engine::Camera``. This make the main-app crash at the next draw event.

* **What is the new behavior (if this is a feature change)?**
Before clearing the scene, the CameraInterface switch back to the system default camera that has the lifetime of the application.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
This fix a a quick workaround and must not be considered for other use except in the actual main-app.
