### PR TITLE
Add gamma correction

### DIFF
--- a/Shaders/HdrToLdr/Hdr2Ldr.frag.glsl
+++ b/Shaders/HdrToLdr/Hdr2Ldr.frag.glsl
@@ -1,0 +1,14 @@
+out vec4 fragColor;
+
+in vec2 varTexcoord;
+
+uniform sampler2D screenTexture;
+uniform float gamma;
+void main()
+{
+    vec2 size = vec2(textureSize(screenTexture, 0));
+    vec4 pixel = vec4(texelFetch(screenTexture, ivec2(varTexcoord.xy * size), 0));
+    if (pixel.a != 0)
+        pixel.rgb=pow(pixel.rgb, vec3(1/gamma));
+    fragColor = pixel;
+}

--- a/Shaders/HdrToLdr/Hdr2Ldr.frag.glsl
+++ b/Shaders/HdrToLdr/Hdr2Ldr.frag.glsl
@@ -4,11 +4,24 @@ in vec2 varTexcoord;
 
 uniform sampler2D screenTexture;
 uniform float gamma;
+
+// from sRGB color space specification
+float tosRGB(float c) {
+  if (c <= 0.0031308) {
+    return 12.92*c;
+  } else {
+    return 1.055*pow(c, 1/gamma) - 0.055;
+  }
+}
 void main()
 {
     vec2 size = vec2(textureSize(screenTexture, 0));
     vec4 pixel = vec4(texelFetch(screenTexture, ivec2(varTexcoord.xy * size), 0));
-    if (pixel.a != 0)
-        pixel.rgb=pow(pixel.rgb, vec3(1/gamma));
+    // Pixel is linear, transform to sRGB
+    if (pixel.a != 0) {
+        pixel.r = tosRGB(pixel.r);
+        pixel.g = tosRGB(pixel.g);
+        pixel.b = tosRGB(pixel.b);
+    }
     fragColor = pixel;
 }

--- a/Shaders/HdrToLdr/Hdr2Ldr.vert.glsl
+++ b/Shaders/HdrToLdr/Hdr2Ldr.vert.glsl
@@ -1,0 +1,9 @@
+layout (location = 0) in vec3 position;
+
+out vec2 varTexcoord;
+
+void main()
+{
+    gl_Position = vec4(position, 1.0);
+    varTexcoord = (position.xy + 1.0) / 2.0;
+}

--- a/Shaders/Materials/BlinnPhong/BlinnPhongMaterial.glsl
+++ b/Shaders/Materials/BlinnPhong/BlinnPhongMaterial.glsl
@@ -98,16 +98,18 @@ vec3 getSpecularColor(Material material, vec2 texC) {
 
 vec3 computeMaterialInternal(Material material, vec2 texC, vec3 L, vec3 V, vec3 N, vec3 X, vec3 Y) {
     vec3 H =  normalize(L + V);
-    // http://www.thetenthplanet.de/archives/255 / VortexEngine BlinnPhong
+    // http://www.thetenthplanet.de/archives/255
     float Ns = getNs(material, texC);
     vec3 Kd = getKd(material, texC) / Pi;
-    float normalization = ((Ns + 2) * (Ns + 4)) / (8 * Pi * (exp2(-Ns * 0.5) + Ns));
+
+    // use the correct normalization factor for Blinn-Phong BRDF;
+    float normalization = (Ns + 1) / (8 * Pi * pow(dot(L, H), 3));
     vec3 Ks = getKs(material, texC) * normalization;
 
-    vec3 diff = max(dot(L,N), 0.0) * Kd;
+    vec3 diff = Kd;
     vec3 spec = pow(max(dot(N, H), 0.0), Ns) * Ks;
 
-    return diff + spec ;
+    return (diff + spec) * max(dot(L,N), 0.0) ;
 }
 
 

--- a/src/Engine/Renderer/RenderTechnique/ShaderProgramManager.cpp
+++ b/src/Engine/Renderer/RenderTechnique/ShaderProgramManager.cpp
@@ -27,7 +27,7 @@ void ShaderProgramManager::initialize() {
     // Create named strings which correspond to shader files that you want to use in shaders's
     // includes. NOTE: if you want to add a named string to handle a new shader include file, be
     // SURE that the name (first parameter) begin with a "/", otherwise it won't work !
-
+    // FIXME : are these initialization required here ? They will be better in Engine::Initialize ....
     m_files.push_back( globjects::File::create( "Shaders/Helpers.glsl" ) );
     m_files.push_back( globjects::File::create( "Shaders/Structs.glsl" ) );
     m_files.push_back( globjects::File::create( "Shaders/Tonemap.glsl" ) );

--- a/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
+++ b/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
@@ -56,7 +56,10 @@ void ForwardRenderer::initShaders() {
 
     m_shaderMgr->addShaderProgram( "Hdr2Ldr", "Shaders/HdrToLdr/Hdr2Ldr.vert.glsl",
                                    "Shaders/HdrToLdr/Hdr2Ldr.frag.glsl" );
-
+#ifndef NO_TRANSPARENCY
+    m_shaderMgr->addShaderProgram( "ComposeOIT", "Shaders/Basic2D.vert.glsl",
+                                   "Shaders/ComposeOIT.frag.glsl" );
+#endif
 }
 
 void ForwardRenderer::initBuffers() {
@@ -163,7 +166,7 @@ void ForwardRenderer::renderInternal( const RenderData& renderData ) {
     {
         ro->render( params, renderData, RenderTechnique::Z_PREPASS );
     }
-
+    // Transparent objects are not rendered in the Z-prepass, they do not influence the z-buffer
     // Light pass
     GL_ASSERT( glDepthFunc( GL_LEQUAL ) );
     GL_ASSERT( glDepthMask( GL_FALSE ) );
@@ -191,86 +194,62 @@ void ForwardRenderer::renderInternal( const RenderData& renderData ) {
         }
     } else
     {
-#if 0
-        // Fixme : could not create a light like this. Lights are components ...
-        // Solution : use the LightManager or the fact that a light is always associated with the
-        // camera so that the renderer could always access to at least the headlight
-        DirectionalLight l;
-        // l.setDirection( Core::Vector3( 0.3f, -1.0f, 0.0f ) );
-
-        RenderParameters params;
-        l.getRenderParameters( params );
-
-        for ( const auto& ro : m_fancyRenderObjects )
-        {
-            ro->render( params, renderData, RenderTechnique::LIGHTING_OPAQUE );
-        }
-#endif
+        LOG(logINFO) << "Opaque : no light sources, unable to render";
     }
 
 #ifndef NO_TRANSPARENCY
-    m_fbo->unbind();
-    m_oitFbo->bind();
-
-    GL_ASSERT( glDrawBuffers( 2, buffers ) );
-    GL_ASSERT( glClearBufferfv( GL_COLOR, 0, clearZeros.data() ) );
-    GL_ASSERT( glClearBufferfv( GL_COLOR, 1, clearOnes.data() ) );
-
-    GL_ASSERT( glDepthFunc( GL_LESS ) );
-    GL_ASSERT( glEnable( GL_BLEND ) );
-
-    GL_ASSERT( glBlendEquation( GL_FUNC_ADD ) );
-    GL_ASSERT( glBlendFunci( 0, GL_ONE, GL_ONE ) );
-    GL_ASSERT( glBlendFunci( 1, GL_ZERO, GL_ONE_MINUS_SRC_ALPHA ) );
-
-    if ( m_lightmanagers[0]->count() > 0 )
+    if (m_transparentRenderObjects.size() >0)
     {
-        // for ( const auto& l : m_lights )
-        for ( int i = 0; i < m_lightmanagers[0]->count(); ++i )
-        {
-            auto l = m_lightmanagers[0]->getLight( i );
-            RenderParameters params;
-            l->getRenderParameters( params );
+        m_fbo->unbind();
 
-            for ( const auto& ro : m_transparentRenderObjects )
+        m_oitFbo->bind();
+
+        GL_ASSERT(glDrawBuffers(2, buffers));
+        GL_ASSERT(glClearBufferfv(GL_COLOR, 0, clearZeros.data()));
+        GL_ASSERT(glClearBufferfv(GL_COLOR, 1, clearOnes.data()));
+
+        GL_ASSERT(glDepthFunc(GL_LESS));
+        GL_ASSERT(glEnable(GL_BLEND));
+
+        GL_ASSERT(glBlendEquation(GL_FUNC_ADD));
+        GL_ASSERT(glBlendFunci(0, GL_ONE, GL_ONE));
+        GL_ASSERT(glBlendFunci(1, GL_ZERO, GL_ONE_MINUS_SRC_ALPHA));
+
+        if (m_lightmanagers[0]->count() > 0)
+        {
+            // for ( const auto& l : m_lights )
+            for (int i = 0; i < m_lightmanagers[0]->count(); ++i)
             {
-                ro->render( params, renderData, RenderTechnique::LIGHTING_TRANSPARENT );
+                auto l = m_lightmanagers[0]->getLight(i);
+                RenderParameters params;
+                l->getRenderParameters(params);
+
+                for (const auto &ro : m_transparentRenderObjects)
+                {
+                    ro->render(params, renderData, RenderTechnique::LIGHTING_TRANSPARENT);
+                }
             }
         }
-    } else
-    {
-#    if 0
-        // Fixme : could not create a light like this. Lights are components ...
-        // Solution : use the LightManager or the fact that a light is always associated with the
-        // camera so that the renderer could always access to at least the headlight
-        DirectionalLight l;
-        // l.setDirection( Core::Vector3( 0.3f, -1.0f, 0.0f ) );
-
-        RenderParameters params;
-        l.getRenderParameters( params );
-
-        for ( const auto& ro : m_transparentRenderObjects )
+        else
         {
-            ro->render( params, renderData, RenderTechnique::LIGHTING_TRANSPARENT );
+            LOG(logINFO) << "Transparent : no light sources, unable to render";
         }
-#    endif
+
+        m_oitFbo->unbind();
+
+        m_fbo->bind();
+        GL_ASSERT(glDrawBuffers(1, buffers));
+
+        GL_ASSERT(glDepthFunc(GL_ALWAYS));
+        GL_ASSERT(glBlendFunc(GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA));
+
+        shader = m_shaderMgr->getShaderProgram("ComposeOIT");
+        shader->bind();
+        shader->setUniform("u_OITSumColor", m_textures[RendererTextures_OITAccum].get(), 0);
+        shader->setUniform("u_OITSumWeight", m_textures[RendererTextures_OITRevealage].get(), 1);
+
+        m_quadMesh->render();
     }
-
-    m_oitFbo->unbind();
-
-    m_fbo->bind();
-    GL_ASSERT( glDrawBuffers( 1, buffers ) );
-
-    GL_ASSERT( glDepthFunc( GL_ALWAYS ) );
-    GL_ASSERT( glBlendFunc( GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA ) );
-
-    shader = m_shaderMgr->getShaderProgram( "ComposeOIT" );
-    shader->bind();
-    shader->setUniform( "u_OITSumColor", m_textures[RendererTextures_OITAccum].get(), 0 );
-    shader->setUniform( "u_OITSumWeight", m_textures[RendererTextures_OITRevealage].get(), 1 );
-
-    m_quadMesh->render();
-
 #endif
     if ( m_wireframe )
     {
@@ -313,27 +292,7 @@ void ForwardRenderer::renderInternal( const RenderData& renderData ) {
             }
         } else
         {
-#if 0
-            // Fixme : could not create a light like this. Lights are components ...
-            // Solution : use the LightManager or the fact that a light is always associated with
-            // the camera so that the renderer could always access to at least the headlight
-            DirectionalLight l;
-            // l.setDirection( Core::Vector3( 0.3f, -1.0f, 0.0f ) );
-
-            RenderParameters params;
-            l.getRenderParameters( params );
-
-            for ( const auto& ro : m_fancyRenderObjects )
-            {
-                ro->render( params, renderData, RenderTechnique::LIGHTING_OPAQUE );
-            }
-
-            for ( size_t i = 0; i < m_fancyTransparentCount; ++i )
-            {
-                auto& ro = m_transparentRenderObjects[i];
-                ro->render( params, renderData, RenderTechnique::LIGHTING_OPAQUE );
-            }
-#endif
+            LOG(logINFO) << "Wireframe : no light sources, unable to render";
         }
 
         glPolygonMode( GL_FRONT_AND_BACK, GL_FILL );

--- a/src/Engine/Renderer/Texture/Texture.cpp
+++ b/src/Engine/Renderer/Texture/Texture.cpp
@@ -16,7 +16,7 @@ void Engine::Texture::Generate( uint w, GLenum format, void* data ) {
         m_texture = globjects::Texture::create( m_target );
     }
 
-    m_texture->image1D( 0, internalFormat, w, 0, format, GL_UNSIGNED_BYTE, data );
+    m_texture->image1D( 0, internalFormat, w, 0, format, dataType, data );
 
     updateParameters();
 

--- a/src/Engine/Renderer/Texture/TextureManager.cpp
+++ b/src/Engine/Renderer/Texture/TextureManager.cpp
@@ -32,6 +32,7 @@ TextureData& TextureManager::addTexture( const std::string& name, int width, int
 }
 
 TextureData TextureManager::loadTexture( const std::string& filename ){
+#if 0
     TextureData texData;
     texData.name = filename;
 
@@ -96,7 +97,72 @@ TextureData TextureManager::loadTexture( const std::string& filename ){
     texData.data = data;
     texData.type = GL_UNSIGNED_BYTE;
     return texData;
+#else
+    TextureData texData;
+    texData.name = filename;
 
+    stbi_set_flip_vertically_on_load( true );
+
+    int  n;
+    float* data = stbi_loadf( filename.c_str(), &(texData.width), &(texData.height), &n, 0 );
+
+    if ( !data )
+    {
+        LOG( logERROR ) << "Something went wrong when loading image \"" << filename << "\".";
+        texData.width = texData.height = -1;
+        return texData;
+    }
+
+    switch ( n )
+    {
+    case 1:
+    {
+        texData.format = GL_RED;
+        texData.internalFormat = GL_R8;
+    }
+        break;
+
+    case 2:
+    {
+        texData.format = GL_RG;
+        texData.internalFormat = GL_RG8;
+    }
+        break;
+
+    case 3:
+    {
+        texData.format = GL_RGB;
+        texData.internalFormat = GL_RGB8;
+    }
+        break;
+
+    case 4:
+    {
+        texData.format = GL_RGBA;
+        texData.internalFormat = GL_RGBA8;
+    }
+        break;
+    default:
+    {
+        texData.format = GL_RGBA;
+        texData.internalFormat = GL_RGBA8;
+    }
+        break;
+    }
+
+    if ( m_verbose )
+    {
+        LOG( logINFO ) << "Image stats (" << filename << ") :\n"
+                       << "\tPixels : " << n << std::endl
+                       << "\tFormat : " << texData.format <<  std::endl
+                       << "\tSize   : " << texData.width << ", " << texData.height;
+    }
+
+    CORE_ASSERT( data, "Data is null" );
+    texData.data = data;
+    texData.type = GL_FLOAT;
+    return texData;
+#endif
 }
 
 Texture* TextureManager::getOrLoadTexture( const TextureData& data ) {

--- a/src/GuiBase/Viewer/CameraInterface.cpp
+++ b/src/GuiBase/Viewer/CameraInterface.cpp
@@ -51,7 +51,7 @@ void Gui::CameraInterface::resetToDefaultCamera() {
         m_camera->resize(w,h);
         m_camera->show( false );
     }
-    else 
+    else
     {
         LOG(logWARNING) << "A living camera is required. The application might now behave unexpectedly." ;
     }

--- a/src/GuiBase/Viewer/CameraInterface.hpp
+++ b/src/GuiBase/Viewer/CameraInterface.hpp
@@ -1,6 +1,5 @@
 #ifndef RADIUMENGINE_CAMERAINTERFACE_HPP
 #define RADIUMENGINE_CAMERAINTERFACE_HPP
-#include <GuiBase/RaGuiBase.hpp>
 
 #include <memory>
 

--- a/src/GuiBase/Viewer/CameraInterface.hpp
+++ b/src/GuiBase/Viewer/CameraInterface.hpp
@@ -1,5 +1,6 @@
 #ifndef RADIUMENGINE_CAMERAINTERFACE_HPP
 #define RADIUMENGINE_CAMERAINTERFACE_HPP
+#include <GuiBase/RaGuiBase.hpp>
 
 #include <memory>
 

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -440,6 +440,8 @@ void Gui::Viewer::showEvent( QShowEvent* ev ) {
         // Entity
         auto light =
             new Engine::DirectionalLight( Ra::Engine::SystemEntity::getInstance(), "headlight" );
+        // Set the default light intensity so that it does not burn the objects
+        light->setColor(Ra::Core::Color(0.5, 0.5, 0.5, 1.0));
         m_camera->attachLight( light );
     }
 }

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -165,7 +165,6 @@ class RA_GUIBASE_API Viewer : public QWindow {
      * changeRenderer(rendererId);
      * getRenderer()->initialize();
      * auto light = Ra::Core::make_shared<Engine::DirectionalLight>();
-     * getRenderer()->addLight( light );
      * m_camera->attachLight( light );
      * \endcode
      */

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -321,7 +321,8 @@ void AssimpGeometryDataLoader::loadMaterial( const aiMaterial& material,
     if ( AI_SUCCESS == material.Get( AI_MATKEY_SHININESS, shininess ) )
     {
         blinnPhongMaterial->m_hasShininess = true;
-        blinnPhongMaterial->m_shininess = shininess;
+        // Assimp gives the Phong exponent, we use the Blinn-Phong exponent
+        blinnPhongMaterial->m_shininess = shininess*4;
     }
 
     if ( AI_SUCCESS == material.Get( AI_MATKEY_OPACITY, opacity ) )


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR brings a correct conversion between linear RGB and sRGB color space. All the lighting computations must be done in linear RGB colorspace and the input pictures (textures) and output images (displayed or saved) are in sRGB colorspace. When loading a texture via stb_image, the conversion is requested and manage by stb. After rendering, the linear space picture is transformed to sRGB before being displayed/saved. This PR also transform the Phong shininess exponent given by assimp to the blinn-phong exponent used in Radium. The correct normalisation of the blinn-phong bsdf is also part of this PR. The result is a default renderer that is able to generate pictures the same way blender/maya/pbrt all do in the same lighting and materials configurations.


* **What is the current behavior?** (You can also link to an open issue here)
All the rendering comutations are done in non linear colorspace, that was eroneous.

* **What is the new behavior (if this is a feature change)?**
All the coputations are done on linear rgb colorspace, that is better as lighting computations are linear computations.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
