### PR TITLE
Add subdiv ops

### DIFF
--- a/.ci/compile-official-plugins.sh
+++ b/.ci/compile-official-plugins.sh
@@ -2,6 +2,7 @@
 
 declare -a repositories=(
     "https://github.com/STORM-IRIT/Radium-PluginExample.git"
+    "https://gitlab.com/Storm-IRIT/radium-official-plugins/postprocesssubdivplugin.git"
 #    "https://github.com/STORM-IRIT/Radium-NanoGUIApp.git"
 #    "https://github.com/STORM-IRIT/Radium-AppExample.git"
     )

--- a/.ci/compile-official-plugins.sh
+++ b/.ci/compile-official-plugins.sh
@@ -24,11 +24,12 @@ NEW_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
 PLUGIN_FOLDER="plugins-$NEW_UUID"
 
 mkdir $PLUGIN_FOLDER
-cd $PLUGIN_FOLDER
 
  # Loop over plugins and: fetch, compile
 for repoUrl in "${repositories[@]}"
 do
+   cd $CHECKOUT_PATH
+   cd $PLUGIN_FOLDER
    repoName=$(getRepositoryName "$repoUrl")
    echo "Processing $repoName"
 

--- a/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.hpp
+++ b/src/Core/Algorithm/Subdivision/CatmullClarkSubdivider.hpp
@@ -14,8 +14,14 @@ namespace Core {
 /// \note We here consider that boundary halfedges do not store attributes.
 class RA_CORE_API CatmullClarkSubdivider
     : public OpenMesh::Subdivider::Uniform::SubdividerT<TopologicalMesh, Scalar> {
-  public:
+
     using base = OpenMesh::Subdivider::Uniform::SubdividerT<TopologicalMesh, Scalar>;
+    using V_OP = std::pair<Scalar, TopologicalMesh::VertexHandle>;
+    using V_OPS = std::pair<TopologicalMesh::VertexHandle, std::vector<V_OP>>;
+    using SV_OPS = std::vector<V_OPS>;
+    using P_OP = std::pair<Scalar, TopologicalMesh::HalfedgeHandle>;
+    using P_OPS = std::pair<TopologicalMesh::HalfedgeHandle, std::vector<P_OP>>;
+    using SP_OPS = std::vector<P_OPS>;
 
   public:
     CatmullClarkSubdivider() : base() {}
@@ -26,6 +32,30 @@ class RA_CORE_API CatmullClarkSubdivider
 
   public:
     const char* name( void ) const override { return "CatmullClarkSubdivider"; }
+
+    /// In the case one wants to apply the subdivision on the same mesh topology,
+    /// but with a different geometry (e.g. for an animated character),
+    /// one may want to just reapply the subdivision operations instead
+    /// for performance reasons.
+    /// This can be achieved with the following code:
+    // clang-format off
+    /// \code
+    /// // 1- apply subdivision once
+    /// Ra::Core::TriangleMesh triangleMesh;
+    /// Ra::Core::TopologicalMesh topoMesh( triangleMesh );
+    /// Ra::Core::CatmullClarkSubdivider subdiv( topoMesh );
+    /// subdiv( 2 );
+    /// // get back to TriangleMesh (mandatory before re-applying)
+    /// TriangleMesh subdividedMesh = topoMesh.toTriangleMesh();
+    ///
+    /// // 2- re-apply operations on new geometry (new_vertices, new_normals)
+    /// m_subdivider.recompute( new_vertices, new_normals, subdividedMesh.vertices(),
+    ///                         subdividedMesh.normals(), topoMesh );
+    /// \endcode
+    // clang-format on
+    void recompute( const Vector3Array& newCoarseVertices, const Vector3Array& newCoarseNormals,
+                    Vector3Array& newSubdivVertices, Vector3Array& newSubdivNormals,
+                    TopologicalMesh& mesh );
 
   protected:
     bool prepare( TopologicalMesh& _m ) override;
@@ -38,19 +68,19 @@ class RA_CORE_API CatmullClarkSubdivider
     // topology helpers
 
     /// Edge recomposition
-    void split_edge( TopologicalMesh& mesh, const TopologicalMesh::EdgeHandle& eh );
+    void split_edge( TopologicalMesh& mesh, const TopologicalMesh::EdgeHandle& eh, int iter );
 
     /// Face recomposition
-    void split_face( TopologicalMesh& mesh, const TopologicalMesh::FaceHandle& fh );
+    void split_face( TopologicalMesh& mesh, const TopologicalMesh::FaceHandle& fh, int iter );
 
     // geometry helpers
 
     /// compute edge midpoint
     void compute_midpoint( TopologicalMesh& mesh, const TopologicalMesh::EdgeHandle& eh,
-                           const bool update_points );
+                           const bool update_points, int iter );
 
     /// smooth input vertices
-    void update_vertex( TopologicalMesh& mesh, const TopologicalMesh::VertexHandle& vh );
+    void update_vertex( TopologicalMesh& mesh, const TopologicalMesh::VertexHandle& vh, int iter );
 
   private:
     /// crease weights
@@ -59,11 +89,11 @@ class RA_CORE_API CatmullClarkSubdivider
     /// old vertex new position
     OpenMesh::VPropHandleT<TopologicalMesh::Point> m_vpPos;
 
-    /// new edge midpoint position
-    OpenMesh::EPropHandleT<TopologicalMesh::Point> m_epPos;
+    /// new edge midpoint handle
+    OpenMesh::EPropHandleT<TopologicalMesh::VertexHandle> m_epH;
 
-    /// new face point position
-    OpenMesh::FPropHandleT<TopologicalMesh::Point> m_fpPos;
+    /// new face point handle
+    OpenMesh::FPropHandleT<TopologicalMesh::VertexHandle> m_fpH;
 
     /// deal with normals on faces
     OpenMesh::FPropHandleT<TopologicalMesh::Normal> m_normalPropF;
@@ -73,6 +103,17 @@ class RA_CORE_API CatmullClarkSubdivider
     std::vector<OpenMesh::FPropHandleT<Vector2>> m_vec2PropsF;
     std::vector<OpenMesh::FPropHandleT<Vector3>> m_vec3PropsF;
     std::vector<OpenMesh::FPropHandleT<Vector4>> m_vec4PropsF;
+
+    /// list of vertices computations
+    std::vector<SV_OPS> m_oldVertexOps;
+    std::vector<SV_OPS> m_newFaceVertexOps;
+    std::vector<SV_OPS> m_newEdgeVertexOps;
+    std::vector<SP_OPS> m_newEdgePropOps;
+    std::vector<SP_OPS> m_newFacePropOps;
+    SP_OPS m_triangulationPropOps;
+
+    /// old vertex halfedges
+    OpenMesh::HPropHandleT<TopologicalMesh::VertexHandle> m_hV;
 };
 
 } // namespace Core

--- a/src/Core/Algorithm/Subdivision/LoopSubdivider.cpp
+++ b/src/Core/Algorithm/Subdivision/LoopSubdivider.cpp
@@ -7,64 +7,90 @@ namespace Core {
 bool LoopSubdivider::prepare( TopologicalMesh& mesh ) {
     mesh.add_property( m_vpPos );
     mesh.add_property( m_epPos );
+    mesh.add_property( m_hV );
+    for ( int i = 0; i < mesh.n_halfedges(); ++i )
+    {
+        auto h = mesh.halfedge_handle( i );
+        if ( !mesh.is_boundary( h ) )
+        {
+            mesh.property( m_hV, h ) = mesh.to_vertex_handle( h );
+        }
+    }
     return true;
 }
 
 bool LoopSubdivider::cleanup( TopologicalMesh& mesh ) {
     mesh.remove_property( m_vpPos );
     mesh.remove_property( m_epPos );
+    mesh.remove_property( m_hV );
     return true;
 }
 
 bool LoopSubdivider::subdivide( TopologicalMesh& mesh, size_t n, const bool updatePoints ) {
+    m_oldVertexOps.clear();
+    m_newVertexOps.clear();
+    m_newEdgePropOps.clear();
+    m_newFacePropOps.clear();
+    m_oldVertexOps.resize( n );
+    m_newVertexOps.resize( n );
+    m_newEdgePropOps.resize( n );
+    m_newFacePropOps.resize( n );
+
     TopologicalMesh::FaceIter fit, f_end;
     TopologicalMesh::EdgeIter eit, e_end;
     TopologicalMesh::VertexIter vit;
 
-    // Do _n subdivisions
-    for ( size_t i = 0; i < n; ++i )
+    // Do n subdivisions
+    for ( size_t iter = 0; iter < n; ++iter )
     {
+        const int NV = mesh.n_vertices();
         if ( updatePoints )
         {
             // compute new positions for old vertices
+            m_oldVertexOps[iter].reserve( NV );
 #pragma omp parallel for
-            for ( uint i = 0; i < mesh.n_vertices(); ++i )
+            for ( uint i = 0; i < NV; ++i )
             {
                 const auto& vh = mesh.vertex_handle( i );
-                smooth( mesh, vh );
+                smooth( mesh, vh, iter );
             }
         }
 
         // Compute position for new vertices and store them in the edge property
+        m_newVertexOps[iter].reserve( mesh.n_edges() );
 #pragma omp parallel for
         for ( uint i = 0; i < mesh.n_edges(); ++i )
         {
             const auto& eh = mesh.edge_handle( i );
-            compute_midpoint( mesh, eh );
+            compute_midpoint( mesh, eh, iter );
         }
 
         // Split each edge at midpoint and store precomputed positions (stored in
         // edge property ep_pos_) in the vertex property vp_pos_;
         // Attention! Creating new edges, hence make sure the loop ends correctly.
         e_end = mesh.edges_end();
+        m_newEdgePropOps[iter].reserve( 3 * mesh.n_edges() );
         for ( eit = mesh.edges_begin(); eit != e_end; ++eit )
         {
-            split_edge( mesh, *eit );
+            split_edge( mesh, *eit, iter );
         }
+        m_newEdgePropOps[iter].shrink_to_fit();
 
         // Commit changes in topology and reconsitute consistency
         // Attention! Creating new faces, hence make sure the loop ends correctly.
         f_end = mesh.faces_end();
+        m_newFacePropOps[iter].reserve( 6 * mesh.n_faces() );
         for ( fit = mesh.faces_begin(); fit != f_end; ++fit )
         {
-            split_face( mesh, *fit );
+            split_face( mesh, *fit, iter );
         }
+        m_newFacePropOps[iter].shrink_to_fit();
 
         if ( updatePoints )
         {
             // Commit changes in geometry
 #pragma omp parallel for
-            for ( uint i = 0; i < mesh.n_vertices(); ++i )
+            for ( uint i = 0; i < NV; ++i )
             {
                 const auto& vh = mesh.vertex_handle( i );
                 mesh.set_point( vh, mesh.property( m_vpPos, vh ) );
@@ -79,7 +105,8 @@ bool LoopSubdivider::subdivide( TopologicalMesh& mesh, size_t n, const bool upda
     return true;
 }
 
-void LoopSubdivider::split_face( TopologicalMesh& mesh, const TopologicalMesh::FaceHandle& fh ) {
+void LoopSubdivider::split_face( TopologicalMesh& mesh, const TopologicalMesh::FaceHandle& fh,
+                                 int iter ) {
     using HeHandle = TopologicalMesh::HalfedgeHandle;
     // get where to cut
     HeHandle heh1( mesh.halfedge_handle( fh ) );
@@ -87,13 +114,13 @@ void LoopSubdivider::split_face( TopologicalMesh& mesh, const TopologicalMesh::F
     HeHandle heh3( mesh.next_halfedge_handle( mesh.next_halfedge_handle( heh2 ) ) );
 
     // Cutting off every corner of the 6_gon
-    corner_cutting( mesh, heh1 );
-    corner_cutting( mesh, heh2 );
-    corner_cutting( mesh, heh3 );
+    corner_cutting( mesh, heh1, iter );
+    corner_cutting( mesh, heh2, iter );
+    corner_cutting( mesh, heh3, iter );
 }
 
 void LoopSubdivider::corner_cutting( TopologicalMesh& mesh,
-                                     const TopologicalMesh::HalfedgeHandle& he ) {
+                                     const TopologicalMesh::HalfedgeHandle& he, int iter ) {
     using HeHandle = TopologicalMesh::HalfedgeHandle;
     using VHandle = TopologicalMesh::VertexHandle;
     using FHandle = TopologicalMesh::FaceHandle;
@@ -154,9 +181,12 @@ void LoopSubdivider::corner_cutting( TopologicalMesh& mesh,
     // deal with custom properties
     copyAllProps( mesh, heh1, heh4 );
     copyAllProps( mesh, heh5, heh3 );
+    m_newFacePropOps[iter].push_back( {heh4, {{1, heh1}}} );
+    m_newFacePropOps[iter].push_back( {heh3, {{1, heh5}}} );
 }
 
-void LoopSubdivider::split_edge( TopologicalMesh& mesh, const TopologicalMesh::EdgeHandle& eh ) {
+void LoopSubdivider::split_edge( TopologicalMesh& mesh, const TopologicalMesh::EdgeHandle& eh,
+                                 int iter ) {
     using HeHandle = TopologicalMesh::HalfedgeHandle;
     using VHandle = TopologicalMesh::VertexHandle;
     using FHandle = TopologicalMesh::FaceHandle;
@@ -171,10 +201,7 @@ void LoopSubdivider::split_edge( TopologicalMesh& mesh, const TopologicalMesh::E
     VHandle vh1( mesh.to_vertex_handle( heh ) );
 
     // new vertex
-    vh = mesh.new_vertex( mesh.property( m_epPos, eh ) );
-
-    // memorize position, since it will be set later
-    mesh.property( m_vpPos, vh ) = mesh.property( m_epPos, eh );
+    vh = mesh.property( m_epPos, eh );
 
     // Re-link mesh entities
     if ( mesh.is_boundary( eh ) )
@@ -206,6 +233,7 @@ void LoopSubdivider::split_edge( TopologicalMesh& mesh, const TopologicalMesh::E
 
         // deal with custom properties
         interpolateAllProps( mesh, t_heh, opp_heh, opp_new_heh, 0.5 );
+        m_newEdgePropOps[iter].push_back( {opp_new_heh, {{0.5, t_heh}, {0.5, opp_heh}}} );
     }
 
     if ( mesh.face_handle( heh ).is_valid() )
@@ -215,8 +243,10 @@ void LoopSubdivider::split_edge( TopologicalMesh& mesh, const TopologicalMesh::E
 
         // deal with custom properties
         copyAllProps( mesh, heh, new_heh );
+        m_newEdgePropOps[iter].push_back( {new_heh, {{1, heh}}} );
         HeHandle heh_prev = mesh.prev_halfedge_handle( heh );
         interpolateAllProps( mesh, heh_prev, new_heh, heh, 0.5 );
+        m_newEdgePropOps[iter].push_back( {heh, {{0.5, heh_prev}, {0.5, new_heh}}} );
     }
 
     mesh.set_halfedge_handle( vh, new_heh );
@@ -227,32 +257,51 @@ void LoopSubdivider::split_edge( TopologicalMesh& mesh, const TopologicalMesh::E
     mesh.adjust_outgoing_halfedge( vh1 );
 }
 
-void LoopSubdivider::compute_midpoint( TopologicalMesh& mesh,
-                                       const TopologicalMesh::EdgeHandle& eh ) {
+void LoopSubdivider::compute_midpoint( TopologicalMesh& mesh, const TopologicalMesh::EdgeHandle& eh,
+                                       int iter ) {
     TopologicalMesh::HalfedgeHandle heh = mesh.halfedge_handle( eh, 0 );
     TopologicalMesh::HalfedgeHandle opp_heh = mesh.halfedge_handle( eh, 1 );
 
     TopologicalMesh::Point pos = mesh.point( mesh.to_vertex_handle( heh ) );
     pos += mesh.point( mesh.to_vertex_handle( opp_heh ) );
 
+    std::vector<V_OP> ops;
+
     // boundary edge: just average vertex positions
     if ( mesh.is_boundary( eh ) )
     {
         pos *= 0.5;
+        ops.resize( 2 );
+        ops[0] = V_OP( 0.5, mesh.to_vertex_handle( heh ) );
+        ops[1] = V_OP( 0.5, mesh.to_vertex_handle( opp_heh ) );
     } else // inner edge: add neighbouring Vertices to sum
     {
         pos *= 3.0;
         pos += mesh.point( mesh.to_vertex_handle( mesh.next_halfedge_handle( heh ) ) );
         pos += mesh.point( mesh.to_vertex_handle( mesh.next_halfedge_handle( opp_heh ) ) );
         pos *= 1.0 / 8.0;
+        ops.resize( 4 );
+        ops[0] = V_OP( 3.f / 8.f, mesh.to_vertex_handle( heh ) );
+        ops[1] = V_OP( 3.f / 8.f, mesh.to_vertex_handle( opp_heh ) );
+        ops[2] = V_OP( 1.f / 8.f, mesh.to_vertex_handle( mesh.next_halfedge_handle( heh ) ) );
+        ops[3] = V_OP( 1.f / 8.f, mesh.to_vertex_handle( mesh.next_halfedge_handle( opp_heh ) ) );
     }
-    mesh.property( m_epPos, eh ) = pos;
+
+#pragma omp critical
+    {
+        auto vh = mesh.add_vertex( pos );
+        mesh.property( m_epPos, eh ) = vh;
+        m_newVertexOps[iter].push_back( V_OPS( vh, ops ) );
+    }
 }
 
-void LoopSubdivider::smooth( TopologicalMesh& mesh, const TopologicalMesh::VertexHandle& vh ) {
+void LoopSubdivider::smooth( TopologicalMesh& mesh, const TopologicalMesh::VertexHandle& vh,
+                             int iter ) {
     using VHandle = TopologicalMesh::VertexHandle;
 
     TopologicalMesh::Point pos( 0.0, 0.0, 0.0 );
+
+    std::vector<V_OP> ops;
 
     if ( mesh.is_boundary( vh ) ) // if boundary: Point 1-6-1
     {
@@ -260,39 +309,141 @@ void LoopSubdivider::smooth( TopologicalMesh& mesh, const TopologicalMesh::Verte
         TopologicalMesh::HalfedgeHandle prev_heh;
         heh = mesh.halfedge_handle( vh );
 
-        if ( heh.is_valid() )
-        {
-            assert( mesh.is_boundary( mesh.edge_handle( heh ) ) );
+        assert( mesh.is_boundary( mesh.edge_handle( heh ) ) );
 
-            prev_heh = mesh.prev_halfedge_handle( heh );
+        prev_heh = mesh.prev_halfedge_handle( heh );
 
-            VHandle to_vh = mesh.to_vertex_handle( heh );
-            VHandle from_vh = mesh.from_vertex_handle( prev_heh );
+        VHandle to_vh = mesh.to_vertex_handle( heh );
+        VHandle from_vh = mesh.from_vertex_handle( prev_heh );
 
-            // ( v_l + 6 v + v_r ) / 8
-            pos = mesh.point( vh );
-            pos *= 6.0;
-            pos += mesh.point( to_vh );
-            pos += mesh.point( from_vh );
-            pos *= 1.0 / 8.0;
-        } else
-            return;
+        // ( v_l + 6 v + v_r ) / 8
+        pos = mesh.point( vh );
+        pos *= 6.0;
+        pos += mesh.point( to_vh );
+        pos += mesh.point( from_vh );
+        pos *= 1.0 / 8.0;
+
+        ops.resize( 3 );
+        ops[2] = V_OP( 6.f / 8.f, vh );
+        ops[0] = V_OP( 1.f / 8.f, to_vh );
+        ops[1] = V_OP( 1.f / 8.f, from_vh );
     } else // inner vertex: (1-a) * p + a/n * Sum q, q in one-ring of p
     {
         TopologicalMesh::VertexVertexIter vvit;
-        size_t valence( 0 );
+        const int valence = mesh.valence( vh );
+        ops.resize( valence + 1 );
+        int i = 0;
 
         // Calculate Valence and sum up neighbour points
         for ( vvit = mesh.cvv_iter( vh ); vvit.is_valid(); ++vvit )
         {
-            ++valence;
             pos += mesh.point( *vvit );
+            ops[i++] = V_OP( m_weights[valence].second, *vvit );
         }
         pos *= m_weights[valence].second; // alpha(n)/n * Sum q, q in one-ring of p
         pos += m_weights[valence].first * mesh.point( vh ); // + (1-a)*p
+        ops[i] = V_OP( m_weights[valence].first, vh );
     }
 
     mesh.property( m_vpPos, vh ) = pos;
+
+#pragma omp critical
+    { m_oldVertexOps[iter].push_back( V_OPS( vh, ops ) ); }
+}
+
+void LoopSubdivider::recompute( const Vector3Array& newCoarseVertices,
+                                const Vector3Array& newCoarseNormals,
+                                Vector3Array& newSubdivVertices, Vector3Array& newSubdivNormals,
+                                TopologicalMesh& mesh ) {
+    // update vertices
+    auto inTriIndexProp = mesh.getInputTriangleMeshIndexPropHandle();
+    auto hNormalProp = mesh.halfedge_normals_pph();
+#pragma omp parallel for
+    for ( size_t i = 0; i < mesh.n_halfedges(); ++i )
+    {
+        auto h = mesh.halfedge_handle( i );
+        // set position on coarse mesh vertices
+        auto vh = mesh.property( m_hV, h );
+        if ( vh.idx() != -1 ) // avoid both boundary and non-coarse halfedges
+        {
+            auto idx = mesh.property( inTriIndexProp, h );
+            mesh.set_point( vh, newCoarseVertices[idx] );
+            mesh.property( hNormalProp, h ) = newCoarseNormals[idx];
+        }
+    }
+    // for each subdiv step
+    for ( int i = 0; i < m_oldVertexOps.size(); ++i )
+    {
+        // first update new vertices
+#pragma omp parallel for schedule( static )
+        for ( int j = 0; j < m_newVertexOps[i].size(); ++j )
+        {
+            Ra::Core::Vector3 pos( 0, 0, 0 );
+            const auto& ops = m_newVertexOps[i][j];
+            for ( const auto& op : ops.second )
+            {
+                pos += op.first * mesh.point( op.second );
+            }
+            mesh.set_point( ops.first, pos );
+        }
+        // then compute old vertices
+        std::vector<Ra::Core::Vector3> pos( m_oldVertexOps[i].size() );
+#pragma omp parallel for
+        for ( int j = 0; j < m_oldVertexOps[i].size(); ++j )
+        {
+            pos[j] = Ra::Core::Vector3( 0, 0, 0 );
+            const auto& ops = m_oldVertexOps[i][j];
+            for ( const auto& op : ops.second )
+            {
+                pos[j] += op.first * mesh.point( op.second );
+            }
+        }
+        // then commit pos for old vertices
+#pragma omp parallel for schedule( static )
+        for ( int j = 0; j < m_oldVertexOps[i].size(); ++j )
+        {
+            mesh.set_point( m_oldVertexOps[i][j].first, pos[j] );
+        }
+        // deal with normal on edge centers (other non-static properties can be updated the same
+        // way)
+        // This loop should not be parallelized!
+        for ( int j = 0; j < m_newEdgePropOps[i].size(); ++j )
+        {
+            Ra::Core::Vector3 nor( 0, 0, 0 );
+            const auto& ops = m_newEdgePropOps[i][j];
+            for ( const auto& op : ops.second )
+            {
+                nor += op.first * mesh.property( hNormalProp, op.second );
+            }
+            mesh.property( hNormalProp, ops.first ) = nor.normalized();
+        }
+        // deal with normal on faces centers (other non-static properties can be updated the same
+        // way)
+#pragma omp parallel for
+        for ( int j = 0; j < m_newFacePropOps[i].size(); ++j )
+        {
+            Ra::Core::Vector3 nor( 0, 0, 0 );
+            const auto& ops = m_newFacePropOps[i][j];
+            for ( const auto& op : ops.second )
+            {
+                nor += op.first * mesh.property( hNormalProp, op.second );
+            }
+            mesh.property( hNormalProp, ops.first ) = nor.normalized();
+        }
+    }
+    // update subdivided TriangleMesh vertices and normals
+    auto outTriIndexProp = mesh.getOutputTriangleMeshIndexPropHandle();
+#pragma omp parallel for
+    for ( int i = 0; i < mesh.n_halfedges(); ++i )
+    {
+        auto h = mesh.halfedge_handle( i );
+        if ( !mesh.is_boundary( h ) )
+        {
+            auto idx = mesh.property( outTriIndexProp, h );
+            newSubdivVertices[idx] = mesh.point( mesh.to_vertex_handle( h ) );
+            newSubdivNormals[idx] = mesh.property( hNormalProp, h );
+        }
+    }
 }
 
 } // namespace Core

--- a/src/Core/Algorithm/Subdivision/SubdividerUtils.hpp
+++ b/src/Core/Algorithm/Subdivision/SubdividerUtils.hpp
@@ -1,3 +1,5 @@
+#ifndef RADIUMENGINE_SUBDIVIDERUTILS_H
+#define RADIUMENGINE_SUBDIVIDERUTILS_H
 
 #include <Core/Mesh/TopologicalTriMesh/TopologicalMesh.hpp>
 
@@ -274,3 +276,5 @@ inline void interpolateAllPropsOnFaces( TopologicalMesh& mesh,
 
 } // namespace Core
 } // namespace Ra
+
+#endif // RADIUMENGINE_SUBDIVIDERUTILS_H

--- a/src/Core/File/MaterialData.hpp
+++ b/src/Core/File/MaterialData.hpp
@@ -33,9 +33,9 @@ namespace Asset {
  *      Make your loader instantiate the right "Asset" MaterialData class while loading material
  * data from a file.
  *
- *      The active system (FancyMesh is the Radium Default), will then automatically use your new
- * material and technique so that the rendering will be fine. When writing your own system, see
- * FancyMesh implementations as an example.
+ *      The active system (GeometrySystem is the Radium Default), will then automatically use your
+ * new material and technique so that the rendering will be fine. When writing your own system, see
+ * GeometrySystem implementation as an example.
  *
  *  That's all folks.
  */

--- a/src/Core/File/MaterialData.hpp
+++ b/src/Core/File/MaterialData.hpp
@@ -33,9 +33,9 @@ namespace Asset {
  *      Make your loader instantiate the right "Asset" MaterialData class while loading material
  * data from a file.
  *
- *      The active system (GeometrySystem is the Radium Default), will then automatically use your
- * new material and technique so that the rendering will be fine. When writing your own system, see
- * GeometrySystem implementation as an example.
+ *      The active system (FancyMesh is the Radium Default), will then automatically use your new
+ * material and technique so that the rendering will be fine. When writing your own system, see
+ * FancyMesh implementations as an example.
  *
  *  That's all folks.
  */

--- a/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.hpp
+++ b/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.hpp
@@ -40,6 +40,8 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     using base = OpenMesh::PolyMesh_ArrayKernelT<TopologicalMeshTraits>;
     using base::PolyMesh_ArrayKernelT;
 
+    OpenMesh::HPropHandleT<Ra::Core::Index> m_inputTriangleMeshIndexPph;
+    OpenMesh::HPropHandleT<Ra::Core::Index> m_outputTriangleMeshIndexPph;
     std::vector<OpenMesh::HPropHandleT<float>> m_floatPph;
     std::vector<OpenMesh::HPropHandleT<Vector2>> m_vec2Pph;
     std::vector<OpenMesh::HPropHandleT<Vector3>> m_vec3Pph;
@@ -61,7 +63,9 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     /// Return a triangleMesh from the topological mesh.
     /// This is a costly operation.
     /// \warning It uses the attributs defined on halfedges.
-    TriangleMesh toTriangleMesh() const;
+    /// \note Non-const because computes the property storing vertices indices within
+    ///       the output TriangleMesh.
+    TriangleMesh toTriangleMesh();
 
     // import other version of halfedge_handle method
     using base::halfedge_handle;
@@ -89,6 +93,15 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     /// If you work with vertex normals, please call this function on all vertex
     /// handle before convertion with toTriangleMesh
     void propagate_normal_to_halfedges( TopologicalMesh::VertexHandle vh );
+
+    /// Return a handle to the halfedge property storing vertices indices within
+    /// the TriangleMesh *this has been built on.
+    inline const OpenMesh::HPropHandleT<Index>& getInputTriangleMeshIndexPropHandle() const;
+
+    /// Return a handle to the halfedge property storing vertices indices within
+    /// the TriangleMesh returned by toTriangleMesh().
+    /// \note This property is valid only after toTriangleMesh() has been called.
+    inline const OpenMesh::HPropHandleT<Index>& getOutputTriangleMeshIndexPropHandle() const;
 
     /// \name Const access to handles of the HalfEdge properties coming from
     /// the TriangleMesh attributes.

--- a/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.inl
+++ b/src/Core/Mesh/TopologicalTriMesh/TopologicalMesh.inl
@@ -37,6 +37,16 @@ TopologicalMesh::halfedge_handle( TopologicalMesh::VertexHandle vh,
     return HalfedgeHandle();
 }
 
+inline const OpenMesh::HPropHandleT<Index>&
+TopologicalMesh::getInputTriangleMeshIndexPropHandle() const {
+    return m_inputTriangleMeshIndexPph;
+}
+
+inline const OpenMesh::HPropHandleT<Index>&
+TopologicalMesh::getOutputTriangleMeshIndexPropHandle() const {
+    return m_outputTriangleMeshIndexPph;
+}
+
 inline const std::vector<OpenMesh::HPropHandleT<float>>&
 TopologicalMesh::getFloatPropsHandles() const {
     return m_floatPph;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master`: for hotfixes not impacting the API
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add subdivision operations registration and replay.
Add Attribute in TopologicalMesh for the vertex index in the input/output TriangleMesh.

* **What is the current behavior?** (You can also link to an open issue here)
Performing subdivision at each frame (e.g. after skinning) is very slow.


* **What is the new behavior (if this is a feature change)?**
Performing subdivision at each frame takes 30ms on average for 2 subdivision iterations.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:
A Plugin for post-process subdivision has been added at `https://gitlab.com/Storm-IRIT/radium-official-plugins/postprocesssubdivplugin.git`.
Currently, when activated, the subdivision is performed at each frame, even if nothing changed (e.g. paused animation, or no animation at all). Moreover, there is no guarantee that the post-process subdivision will be done as the last task due to parallel scheduling of tasks.