### PR TITLE
Add support for official plugins in CI

### DIFF
--- a/.ci/compile-official-plugins.sh
+++ b/.ci/compile-official-plugins.sh
@@ -1,0 +1,41 @@
+declare -a repositories=(
+	"https://github.com/STORM-IRIT/Radium-PluginExample.git"
+	)
+
+# \param $1 input a repository url
+function getRepositoryName()
+{
+	local mails=$(echo $1 | tr "/" "\n")
+	local supername="${mails[-1]}"
+	return "${supername::-4}"
+}
+
+# Stop on error
+set -e
+
+cd $CHECKOUT_PATH
+
+mkdir plugins
+cd plugins
+
+ # Loop over plugins and: fetch, compile
+for repoUrl in "${repositories[@]}"
+do
+   local repoName=getRepositoryName $repoUrl
+   echo "Processing $repoName"
+
+   # fetch repo
+   git clone $repoUrl $repoName
+   cd $repoName
+   git submodule init
+   git submodule update --recursive
+
+   # build plugin
+   mkdir build
+   cd build
+
+   # \FIXME the CMAKE_MODULE_PATH needs to be updated once the installation procedure is working
+   cmake .. -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_PREFIX_PATH=${PREFIX_PATH} -DCMAKE_MODULE_PATH=$CHECKOUT_PATH/Radium-Engine/cmake
+   make -j 4
+
+done

--- a/.ci/compile-official-plugins.sh
+++ b/.ci/compile-official-plugins.sh
@@ -2,14 +2,15 @@
 
 declare -a repositories=(
     "https://github.com/STORM-IRIT/Radium-PluginExample.git"
+    "https://github.com/STORM-IRIT/Radium-NanoGUIApp.git"
     )
 
 # \param $1 input a repository url
 getRepositoryName ()
 {
-    local spliturl=($(echo $1 | tr '/' "\n"))
-    local supername="${spliturl[${#spliturl[@]}-1]}"
-    echo ${supername: : -4}
+    local spliturl=($(echo $1 | tr '/' "\n")) # split by /
+    local supername="${spliturl[${#spliturl[@]}-1]}" # get name.git
+    echo ${supername%????} # remove .git
 }
 
 # Stop on error
@@ -40,13 +41,11 @@ do
    cd build
 
    # \FIXME the CMAKE_MODULE_PATH needs to be updated once the installation procedure is working
-   cmake .. -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_PREFIX_PATH=${PREFIX_PATH} -DCMAKE_MODULE_PATH=$CHECKOUT_PATH/Radium-Engine/cmake
-   make -j 4
+   #cmake .. -DCMAKE_MODULE_PATH=$CHECKOUT_PATH/Radium-Engine/cmake-DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_PREFIX_PATH=${PREFIX_PATH} 
+   # make -j 4
 
    echo "Plugin $repoName done"
 done
-
-export SUPPORTED_PLUGINS_BUILD_OK="true"
 
 echo "All plugins have been compiled."
 

--- a/.ci/compile-official-plugins.sh
+++ b/.ci/compile-official-plugins.sh
@@ -1,13 +1,15 @@
+#!/bin/bash
+
 declare -a repositories=(
-	"https://github.com/STORM-IRIT/Radium-PluginExample.git"
-	)
+    "https://github.com/STORM-IRIT/Radium-PluginExample.git"
+    )
 
 # \param $1 input a repository url
-function getRepositoryName()
+getRepositoryName ()
 {
-	local mails=$(echo $1 | tr "/" "\n")
-	local supername="${mails[-1]}"
-	return "${supername::-4}"
+    local spliturl=($(echo $1 | tr '/' "\n"))
+    local supername="${spliturl[${#spliturl[@]}-1]}"
+    echo ${supername: : -4}
 }
 
 # Stop on error
@@ -21,7 +23,7 @@ cd plugins
  # Loop over plugins and: fetch, compile
 for repoUrl in "${repositories[@]}"
 do
-   local repoName=getRepositoryName $repoUrl
+   repoName=$(getRepositoryName "$repoUrl")
    echo "Processing $repoName"
 
    # fetch repo

--- a/.ci/compile-official-plugins.sh
+++ b/.ci/compile-official-plugins.sh
@@ -17,8 +17,11 @@ set -e
 
 cd $CHECKOUT_PATH
 
-mkdir plugins
-cd plugins
+NEW_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+PLUGIN_FOLDER="plugins-$NEW_UUID"
+
+mkdir $PLUGIN_FOLDER
+cd $PLUGIN_FOLDER
 
  # Loop over plugins and: fetch, compile
 for repoUrl in "${repositories[@]}"
@@ -40,4 +43,10 @@ do
    cmake .. -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_PREFIX_PATH=${PREFIX_PATH} -DCMAKE_MODULE_PATH=$CHECKOUT_PATH/Radium-Engine/cmake
    make -j 4
 
+   echo "Plugin $repoName done"
 done
+
+export SUPPORTED_PLUGINS_BUILD_OK="true"
+
+echo "All plugins have been compiled."
+

--- a/.ci/compile-official-plugins.sh
+++ b/.ci/compile-official-plugins.sh
@@ -2,7 +2,8 @@
 
 declare -a repositories=(
     "https://github.com/STORM-IRIT/Radium-PluginExample.git"
-    "https://github.com/STORM-IRIT/Radium-NanoGUIApp.git"
+#    "https://github.com/STORM-IRIT/Radium-NanoGUIApp.git"
+#    "https://github.com/STORM-IRIT/Radium-AppExample.git"
     )
 
 # \param $1 input a repository url
@@ -41,8 +42,8 @@ do
    cd build
 
    # \FIXME the CMAKE_MODULE_PATH needs to be updated once the installation procedure is working
-   #cmake .. -DCMAKE_MODULE_PATH=$CHECKOUT_PATH/Radium-Engine/cmake-DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_PREFIX_PATH=${PREFIX_PATH} 
-   # make -j 4
+   cmake .. -DCMAKE_MODULE_PATH=$CHECKOUT_PATH/cmake -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_PREFIX_PATH=${PREFIX_PATH}
+   make -j 4
 
    echo "Plugin $repoName done"
 done

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ sudo: true
 script:
   - make -j 4
 
- - if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ;
-        then ./ci/compile-official-plugins.sh ;
+  - |
+    if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ; then
+        cd $CHECKOUT_PATH
+        .ci/compile-official-plugins.sh
         export BUILD_DOC="Off"
     else
         if [ "$BUILD_DOC" = "On" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 sudo: true
 
 script:
-  - #make -j 4
+  - make -j 4
 
   - |
     # if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,15 @@ script:
   - make -j 4
 
   - |
-    if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ; then
+    # if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ; then
+    if [ "cron" = "cron" ] ; then
         cd $CHECKOUT_PATH
         .ci/compile-official-plugins.sh
         export BUILD_DOC="Off"
+        if [ "$SUPPORTED_PLUGINS_BUILD_OK" != "true" ] ; then
+            echo "Plugins compilation have failed. Aborting..."
+            exit 1
+        fi;
     else
         if [ "$BUILD_DOC" = "On" ]; then
           make doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ sudo: true
 
 script:
   - make -j 4
-  - |
-    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      cd ../Bundle-Clang/Release/bin/
-      otool -L ./main-app
-    fi;
-  - |
-    if [ "$BUILD_DOC" = "On" ]; then
-      make doc
+
+ - if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ;
+        then ./ci/compile-official-plugins.sh ;
+        export BUILD_DOC="Off"
+    else
+        if [ "$BUILD_DOC" = "On" ]; then
+          make doc
+        fi;
     fi;
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ script:
   - make -j 4
 
   - |
-    # if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ; then
-    if [ "cron" = "cron" ] ; then
+    if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ; then
         cd $CHECKOUT_PATH
         export BUILD_DOC="Off"
         if ! .ci/compile-official-plugins.sh ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,14 @@ language: cpp
 sudo: true
 
 script:
-  - make -j 4
+  - #make -j 4
 
   - |
     # if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ; then
     if [ "cron" = "cron" ] ; then
         cd $CHECKOUT_PATH
-        .ci/compile-official-plugins.sh
         export BUILD_DOC="Off"
-        if [ "$SUPPORTED_PLUGINS_BUILD_OK" != "true" ] ; then
+        if ! .ci/compile-official-plugins.sh ; then
             echo "Plugins compilation have failed. Aborting..."
             exit 1
         fi;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master`: for hotfixes not impacting the API
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Extend CI scripts to regularly test supported plugins compilation.

* **What is the current behavior?** (You can also link to an open issue here)

Plugins are packaged with Radium libraries and apps and tested alongside Radium.

* **What is the new behavior (if this is a feature change)?**

The CI scripts now expect cron-type triggered builds.
When it happens, the official plugins are fetched and compiled against the current version of Radium.

The list of plugins is defined in `./ci/compile-official-plugin.sh`, enumerated as repository urls (`https` for anonymous fetch).

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?

This PR will permit to remove plugins from Radium repository, while keeping regular testing.

* **Other information**:

Plugins are built only on jobs triggered by `cron` to avoid increasing the CI build time for PR evaluations.