### PR TITLE
Fix clamp ambiguity ;

### DIFF
--- a/Shaders/Materials/BlinnPhong/BlinnPhongMaterial.glsl
+++ b/Shaders/Materials/BlinnPhong/BlinnPhongMaterial.glsl
@@ -103,7 +103,7 @@ vec3 computeMaterialInternal(Material material, vec2 texC, vec3 L, vec3 V, vec3 
     vec3 Kd = getKd(material, texC) / Pi;
 
     // use the correct normalization factor for Blinn-Phong BRDF;
-    float normalization = (Ns + 1) / (8 * Pi * clamp(pow(dot(L, H), 3), 0.000001, 1000000));
+    float normalization = (Ns + 1) / (8 * Pi * clamp(pow(dot(L, H), 3), 0.000001f, 1000000f));
     vec3 Ks = getKs(material, texC) * normalization;
 
     vec3 diff = Kd;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Is the Pull-Request done against the right branch:
  - `master`: for hotfixes not impacting the API
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix #393


* **What is the current behavior?** (You can also link to an open issue here)
The BlinnPhong shaders does not compile due to ambiguity regarding clamp specialization.


* **What is the new behavior (if this is a feature change)?**
Forced specialization to use float parameters.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
