### PR TITLE
Conversion from sRGB to Linear RGB ... 

### DIFF
--- a/src/Engine/Renderer/Material/BlinnPhongMaterial.cpp
+++ b/src/Engine/Renderer/Material/BlinnPhongMaterial.cpp
@@ -31,7 +31,12 @@ void BlinnPhongMaterial::updateGL() {
     TextureManager* texManager = TextureManager::getInstance();
     for ( const auto& tex : m_pendingTextures )
     {
-        addTexture( tex.first, texManager->getOrLoadTexture( tex.second ) );
+        auto texture = texManager->getOrLoadTexture( tex.second );
+        // convert color textures from sRGB to Linear RGB
+        if (tex.first == TextureSemantic::TEX_DIFFUSE || tex.first == TextureSemantic::TEX_SPECULAR) {
+            texture->sRGBToLinearRGB(2.2);
+        }
+        addTexture( tex.first, texture );
     }
 
     m_pendingTextures.clear();

--- a/src/Engine/Renderer/Texture/Texture.cpp
+++ b/src/Engine/Renderer/Texture/Texture.cpp
@@ -7,7 +7,7 @@
 #include <cmath>
 
 namespace Ra {
-Engine::Texture::Texture( std::string name ) :
+Engine::Texture::Texture( const std::string &name ) :
     m_name {name},
     m_width {1},
     m_height {1},
@@ -166,13 +166,12 @@ void Engine::Texture::sRGBToLinearRGB(Scalar gamma)
 {
     if (! m_isLinear) {
         auto linearize = [gamma](float in)-> float {
-            constexpr float a = 0.055;
-            constexpr float b = 12.92;
+            // Constants are described at https://en.wikipedia.org/wiki/SRGB
             if (in < 0.04045) {
-                return in/b;
+                return in/ 12.92;
             } else
             {
-                return std::pow(((in + a) / (1 + a)), float(gamma));
+                return std::pow(((in + 0.055) / (1 + 0.055)), float(gamma));
             }
         };
         // Only RGB and RGBA texture contains color information

--- a/src/Engine/Renderer/Texture/Texture.hpp
+++ b/src/Engine/Renderer/Texture/Texture.hpp
@@ -30,7 +30,7 @@ class RA_ENGINE_API Texture final {
      * @param name Name of the texture
      *
      */
-    explicit Texture( std::string name = "" );
+    explicit Texture( const std::string &name = "" );
 
     /**
      * Texture desctructor. Both internal data and OpenGL stuff are deleted.

--- a/src/Engine/Renderer/Texture/Texture.hpp
+++ b/src/Engine/Renderer/Texture/Texture.hpp
@@ -204,6 +204,14 @@ class RA_ENGINE_API Texture final {
     uint height() const { return m_height; }
     globjects::Texture* texture() const { return m_texture.get(); }
 
+    /**
+     * Convert a color texture from sRGB to Linear RGB spaces.
+     * This will transform the internal representation of the texture to GL_FLOAT.
+     * Only GL_RGB[8, 16, 16F, 32F] and GL_RGBA[8, 16, 16F, 32F] are managed.
+     * Full transformation as described at https://en.wikipedia.org/wiki/SRGB
+     * @param gamma the gama value to use
+     */
+    void sRGBToLinearRGB(Scalar gamma);
   private:
     Texture( const Texture& ) = delete;
     void operator=( const Texture& ) = delete;
@@ -218,6 +226,9 @@ class RA_ENGINE_API Texture final {
     uint m_depth;
 
     std::unique_ptr<globjects::Texture> m_texture;
+
+    bool m_isMipMaped;
+    bool m_isLinear;
 };
 } // namespace Engine
 } // namespace Ra

--- a/src/Engine/Renderer/Texture/TextureManager.cpp
+++ b/src/Engine/Renderer/Texture/TextureManager.cpp
@@ -32,7 +32,6 @@ TextureData& TextureManager::addTexture( const std::string& name, int width, int
 }
 
 TextureData TextureManager::loadTexture( const std::string& filename ){
-#if 0
     TextureData texData;
     texData.name = filename;
 
@@ -97,72 +96,6 @@ TextureData TextureManager::loadTexture( const std::string& filename ){
     texData.data = data;
     texData.type = GL_UNSIGNED_BYTE;
     return texData;
-#else
-    TextureData texData;
-    texData.name = filename;
-
-    stbi_set_flip_vertically_on_load( true );
-
-    int  n;
-    float* data = stbi_loadf( filename.c_str(), &(texData.width), &(texData.height), &n, 0 );
-
-    if ( !data )
-    {
-        LOG( logERROR ) << "Something went wrong when loading image \"" << filename << "\".";
-        texData.width = texData.height = -1;
-        return texData;
-    }
-
-    switch ( n )
-    {
-    case 1:
-    {
-        texData.format = GL_RED;
-        texData.internalFormat = GL_R8;
-    }
-        break;
-
-    case 2:
-    {
-        texData.format = GL_RG;
-        texData.internalFormat = GL_RG8;
-    }
-        break;
-
-    case 3:
-    {
-        texData.format = GL_RGB;
-        texData.internalFormat = GL_RGB8;
-    }
-        break;
-
-    case 4:
-    {
-        texData.format = GL_RGBA;
-        texData.internalFormat = GL_RGBA8;
-    }
-        break;
-    default:
-    {
-        texData.format = GL_RGBA;
-        texData.internalFormat = GL_RGBA8;
-    }
-        break;
-    }
-
-    if ( m_verbose )
-    {
-        LOG( logINFO ) << "Image stats (" << filename << ") :\n"
-                       << "\tPixels : " << n << std::endl
-                       << "\tFormat : " << texData.format <<  std::endl
-                       << "\tSize   : " << texData.width << ", " << texData.height;
-    }
-
-    CORE_ASSERT( data, "Data is null" );
-    texData.data = data;
-    texData.type = GL_FLOAT;
-    return texData;
-#endif
 }
 
 Texture* TextureManager::getOrLoadTexture( const TextureData& data ) {


### PR DESCRIPTION
...is only applied on demand as its only make sense on color texture (and not on normals, roughness, ...)

* **Please check if the PR fulfills these requirements**
- [X] Is the Pull-Request done against the right branch:
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix : At loading, textures where always converted to linear RGB color space by stb_loadf. This is problematic for textures, such as normals, roughness, bump, ... that do not represent colors.

Now, the conversion from sRGB to Linear RGB must be explicitely requested by the user of the texture so that noly color textures will be transforme.


* **What is the current behavior?** (You can also link to an open issue here)

Textures are converted implicitely by stb_loadf

* **What is the new behavior (if this is a feature change)?**

User must request sRGBToLinearRGB(gamma) on the textures representing colors (see BlinnPhongMaterial)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:

Only GL_RGB[8, 16, 16F, 32F] and GL_RGBA[8, 16, 16F, 32F] textures are converted.