### PR TITLE
BUGFIX : missing bool in Texture::sRGBToLinear

### DIFF
--- a/src/Engine/Renderer/Texture/Texture.cpp
+++ b/src/Engine/Renderer/Texture/Texture.cpp
@@ -165,6 +165,7 @@ void Engine::Texture::updateParameters() {
 void Engine::Texture::sRGBToLinearRGB(Scalar gamma)
 {
     if (! m_isLinear) {
+        m_isLinear = true;
         auto linearize = [gamma](float in)-> float {
             // Constants are described at https://en.wikipedia.org/wiki/SRGB
             if (in < 0.04045) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Is the Pull-Request done against the right branch:
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: missing boolean change in Texture::sRGBToLinear.


* **What is the current behavior?** (You can also link to an open issue here)
Because of this missing affectation, when a color textures was used by several materials, it was converted several times. The appearance was the totally false.


* **What is the new behavior (if this is a feature change)?**
A shared texture will be converted once.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
