### PR TITLE
3 bug fixes ;

### DIFF
--- a/Plugins/Skinning/src/SkinningComponent.cpp
+++ b/Plugins/Skinning/src/SkinningComponent.cpp
@@ -258,6 +258,10 @@ void SkinningComponent::endSkinning() {
         m_frameData.m_currentPos = m_refData.m_referenceMesh.vertices();
         m_frameData.m_previousPos = m_refData.m_referenceMesh.vertices();
         m_frameData.m_currentNormal = m_refData.m_referenceMesh.normals();
+        m_frameData.m_refToCurrentRelPose =
+            Ra::Core::Animation::relativePose( m_frameData.m_currentPose, m_refData.m_refPose );
+        m_frameData.m_prevToCurrentRelPose = Ra::Core::Animation::relativePose(
+            m_frameData.m_currentPose, m_frameData.m_previousPose );
     }
 }
 

--- a/src/Core/Geometry/LoopSubdivider.cpp
+++ b/src/Core/Geometry/LoopSubdivider.cpp
@@ -5,6 +5,15 @@ namespace Core {
 namespace Geometry {
 
 bool LoopSubdivider::prepare( TopologicalMesh& mesh ) {
+    uint maxValence = 0;
+    for (auto v_it = mesh.vertices_begin(); v_it != mesh.vertices_end(); ++v_it )
+    {
+        if ( mesh.valence( *v_it ) > maxValence )
+        {
+            maxValence = mesh.valence( *v_it );
+        }
+    }
+    init_weights( maxValence + 1 );
     mesh.add_property( m_vpPos );
     mesh.add_property( m_epPos );
     mesh.add_property( m_hV );

--- a/src/Core/Geometry/LoopSubdivider.hpp
+++ b/src/Core/Geometry/LoopSubdivider.hpp
@@ -29,10 +29,9 @@ class RA_CORE_API LoopSubdivider
     using SP_OPS = std::vector<P_OPS>;
 
   public:
-    LoopSubdivider() : base() { init_weights(); }
+    LoopSubdivider() : base() {}
 
     explicit LoopSubdivider( TopologicalMesh& mesh ) : base() {
-        init_weights();
         attach( mesh );
     }
 
@@ -67,7 +66,7 @@ class RA_CORE_API LoopSubdivider
 
   protected:
     /// Pre-compute weights.
-    void init_weights( size_t max_valence = 50 ) {
+    void init_weights( size_t max_valence ) {
         m_weights.resize( max_valence );
         std::generate( m_weights.begin(), m_weights.end(), compute_weight() );
     }

--- a/src/Engine/Renderer/Mesh/Mesh.cpp
+++ b/src/Engine/Renderer/Mesh/Mesh.cpp
@@ -243,12 +243,14 @@ void Mesh::updateGL() {
         {
             if ( m_renderMode == RM_POINTS )
             {
+                m_numElements = m_mesh.vertices().size();
                 std::vector<int> indices( m_numElements );
                 std::iota( indices.begin(), indices.end(), 0 );
                 GL_ASSERT( glBufferData( GL_ELEMENT_ARRAY_BUFFER, m_numElements * sizeof( int ),
                                          indices.data(), GL_DYNAMIC_DRAW ) );
             } else
             {
+                m_numElements = m_mesh.m_triangles.size() * 3;
                 GL_ASSERT( glBufferData( GL_ELEMENT_ARRAY_BUFFER,
                                          m_mesh.m_triangles.size() * sizeof( Ra::Core::Vector3ui ),
                                          m_mesh.m_triangles.data(), GL_DYNAMIC_DRAW ) );

--- a/src/GuiBase/Viewer/Gizmo/GizmoManager.cpp
+++ b/src/GuiBase/Viewer/Gizmo/GizmoManager.cpp
@@ -116,14 +116,13 @@ bool GizmoManager::handleMouseReleaseEvent( QMouseEvent* event ) {
 bool GizmoManager::handleMouseMoveEvent( QMouseEvent* event ) {
     auto keyMap = Gui::KeyMappingManager::getInstance();
     // cannot call actionTriggered because event->button returns Qt::NO_BUTTON for moves
-    if ( ( event->buttons() &
-           keyMap->getKeyFromAction( Gui::KeyMappingManager::GIZMOMANAGER_MANIPULATION ) ) &&
+    if ( ( keyMap->actionTriggered( event, Gui::KeyMappingManager::GIZMOMANAGER_MANIPULATION ) ||
+           keyMap->actionTriggered( event, Gui::KeyMappingManager::GIZMOMANAGER_STEP ) ) &&
          currentGizmo() )
     {
         Core::Vector2 currentXY( event->x(), event->y() );
         const Engine::Camera& cam = CameraInterface::getCameraFromViewer( parent() );
-        bool step = ( int( event->buttons() ) | event->modifiers() ) ==
-                    keyMap->getKeyFromAction( Gui::KeyMappingManager::GIZMOMANAGER_STEP );
+        bool step = keyMap->actionTriggered( event, Gui::KeyMappingManager::GIZMOMANAGER_STEP );
         Core::Transform newTransform = currentGizmo()->mouseMove( cam, currentXY, step );
         setTransform( newTransform );
     }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Is the Pull-Request done against the right branch:
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes 3 bugs:
- `SkinningData` clean reset
- `LoopSubdivider` default valence
- `Engine::Mesh` indices update 

* **What is the current behavior?** (You can also link to an open issue here)
- When reseting the animation, the relative poses are not reset.
- The default valence for computing weights are not enough for the Hand model.
- When adding triangles to a mesh, these are not rendered even after `setDirty(INDEX)` because the value of `m_numElements`, which is used to tell the number of elements to display, is not updated.


* **What is the new behavior (if this is a feature change)?**
All fixed.
Though it would be better to get the max valence from the mesh, though I don't see how to...

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
