### PR TITLE
Disambiguate different clamps.

### DIFF
--- a/src/Core/Animation/Skeleton.cpp
+++ b/src/Core/Animation/Skeleton.cpp
@@ -225,7 +225,7 @@ Vector3 Skeleton::projectOnBone( int boneIdx, const Ra::Core::Vector3& pos ) con
     CORE_ASSERT( length_sq != 0.f, "bone has lenght 0, cannot project." );
 
     // Project on the line segment
-    const Scalar t = std::clamp( op.dot( dir ) / length_sq, (Scalar)0.0, (Scalar)1.0 );
+    const Scalar t = std::clamp( op.dot( dir ) / length_sq, Scalar(0), Scalar(1) );
     return start + ( t * dir );
 }
 

--- a/src/Core/Animation/Skeleton.cpp
+++ b/src/Core/Animation/Skeleton.cpp
@@ -1,5 +1,7 @@
 #include <Core/Animation/Skeleton.hpp>
 #include <Core/Math/LinearAlgebra.hpp> // Math::clamp
+
+#include <algorithm>
 #include <stack>
 
 namespace Ra {
@@ -223,7 +225,7 @@ Vector3 Skeleton::projectOnBone( int boneIdx, const Ra::Core::Vector3& pos ) con
     CORE_ASSERT( length_sq != 0.f, "bone has lenght 0, cannot project." );
 
     // Project on the line segment
-    const Scalar t = Math::clamp( op.dot( dir ) / length_sq, (Scalar)0.0, (Scalar)1.0 );
+    const Scalar t = std::clamp( op.dot( dir ) / length_sq, (Scalar)0.0, (Scalar)1.0 );
     return start + ( t * dir );
 }
 

--- a/src/Core/Geometry/DistanceQueries.inl
+++ b/src/Core/Geometry/DistanceQueries.inl
@@ -1,5 +1,6 @@
 #include <Core/Geometry/DistanceQueries.hpp>
-#include <Core/Math/LinearAlgebra.hpp> // Math::clamp
+
+#include <algorithm>
 
 namespace Ra {
 namespace Core {
@@ -18,7 +19,7 @@ inline RA_CORE_API Scalar projectOnSegment( const Vector3& q, const Vector3& a,
     {
         return 0;
     }
-    return Math::clamp( ( q - a ).dot( ab ) / ( ab.squaredNorm() ), Scalar( 0 ), Scalar( 1 ) );
+    return std::clamp( ( q - a ).dot( ab ) / ( ab.squaredNorm() ), Scalar( 0 ), Scalar( 1 ) );
 }
 
 inline RA_CORE_API Scalar pointToSegmentSq( const Vector3& q, const Vector3& a,

--- a/src/Core/Geometry/PolyLine.inl
+++ b/src/Core/Geometry/PolyLine.inl
@@ -1,5 +1,5 @@
 #include <Core/Geometry/PolyLine.hpp>
-#include <Core/Math/LinearAlgebra.hpp>
+#include <Core/Math/LinearAlgebra.hpp> // cotan, saturate (from Math.hpp)
 
 namespace Ra {
 namespace Core {

--- a/src/Core/Geometry/PolyLine.inl
+++ b/src/Core/Geometry/PolyLine.inl
@@ -1,4 +1,5 @@
 #include <Core/Geometry/PolyLine.hpp>
+#include <Core/Math/LinearAlgebra.hpp>
 
 namespace Ra {
 namespace Core {

--- a/src/Core/Geometry/Spline.inl
+++ b/src/Core/Geometry/Spline.inl
@@ -2,6 +2,8 @@
 
 #include <Core/Math/Math.hpp>
 
+#include <algorithm>
+
 namespace Ra {
 namespace Core {
 namespace Geometry {
@@ -55,7 +57,7 @@ inline void Spline<D, K>::setType( Type type ) {
 
 template <uint D, uint K>
 inline typename Spline<D, K>::Vector Spline<D, K>::f( Scalar u ) const {
-    u = Core::Math::clamp( u, Scalar( 0 ), Scalar( 1 ) );
+    u = std::clamp( u, Scalar( 0 ), Scalar( 1 ) );
     return eval( u, m_points, m_node, K );
 }
 
@@ -63,7 +65,7 @@ inline typename Spline<D, K>::Vector Spline<D, K>::f( Scalar u ) const {
 
 template <uint D, uint K>
 inline typename Spline<D, K>::Vector Spline<D, K>::df( Scalar u ) const {
-    u = Core::Math::clamp( u, Scalar( 0 ), Scalar( 1 ) );
+    u = std::clamp( u, Scalar( 0 ), Scalar( 1 ) );
     return eval( u, m_vecs, m_node, K - 1, 1 ) * Scalar( K - 1 );
 }
 

--- a/src/Core/Math/LinearAlgebra.hpp
+++ b/src/Core/Math/LinearAlgebra.hpp
@@ -47,14 +47,14 @@ inline Vector trunc( const Vector& v );
 
 /// Component-wise clamp() function on a floating-point vector.
 
-template <typename Derived>
-inline Eigen::MatrixBase<Derived> clamp( const Eigen::MatrixBase<Derived>& v,
-                                         const Eigen::MatrixBase<Derived>& min,
-                                         const Eigen::MatrixBase<Derived>& max );
+template <typename Derived, typename DerivedA, typename DerivedB>
+inline typename Derived::PlainMatrix clamp( const Eigen::MatrixBase<Derived>& v,
+                                            const Eigen::MatrixBase<DerivedA>& min,
+                                            const Eigen::MatrixBase<DerivedB>& max );
 /// Component-wise clamp() function on a floating-point vector.
 template <typename Derived>
-inline Eigen::MatrixBase<Derived> clamp( const Eigen::MatrixBase<Derived>& v, const Scalar& min,
-                                         const Scalar& max );
+inline typename Derived::PlainMatrix clamp( const Eigen::MatrixBase<Derived>& v, const Scalar& min,
+                                            const Scalar& max );
 
 /// Vector range check, works for any numeric vector.
 template <typename Vector_>

--- a/src/Core/Math/LinearAlgebra.inl
+++ b/src/Core/Math/LinearAlgebra.inl
@@ -38,17 +38,18 @@ inline Vector_ trunc( const Vector_& v ) {
         std::function<Scalar_( Scalar_ )>( static_cast<Scalar_ ( & )( Scalar_ )>( std::trunc ) ) );
 }
 
-template <typename Derived>
-inline Eigen::MatrixBase<Derived> clamp( const Eigen::MatrixBase<Derived>& v,
-                                         const Eigen::MatrixBase<Derived>& min,
-                                         const Eigen::MatrixBase<Derived>& max ) {
+template <typename Derived, typename DerivedA, typename DerivedB>
+inline typename Derived::PlainMatrix clamp( const Eigen::MatrixBase<Derived>& v,
+                                            const Eigen::MatrixBase<DerivedA>& min,
+                                            const Eigen::MatrixBase<DerivedB>& max ) {
     return v.cwiseMin( max ).cwiseMax( min );
 }
 
 template <typename Derived>
-inline Eigen::MatrixBase<Derived> clamp( const Eigen::MatrixBase<Derived>& v, const Scalar& min,
-                                         const Scalar& max ) {
-    return v.cwiseMin( max ).cwiseMax( min );
+inline typename Derived::PlainMatrix clamp( const Eigen::MatrixBase<Derived>& v, const Scalar& min,
+                                            const Scalar& max ) {
+    return v.unaryExpr( [min, max]( Scalar x ) { return std::clamp( x, min, max ); } );
+    //    return v.cwiseMin( max ).cwiseMax( min );
 }
 
 template <typename Vector_>

--- a/src/Core/Math/LinearAlgebra.inl
+++ b/src/Core/Math/LinearAlgebra.inl
@@ -49,7 +49,6 @@ template <typename Derived>
 inline typename Derived::PlainMatrix clamp( const Eigen::MatrixBase<Derived>& v, const Scalar& min,
                                             const Scalar& max ) {
     return v.unaryExpr( [min, max]( Scalar x ) { return std::clamp( x, min, max ); } );
-    //    return v.cwiseMin( max ).cwiseMax( min );
 }
 
 template <typename Vector_>

--- a/src/Core/Math/Math.hpp
+++ b/src/Core/Math/Math.hpp
@@ -57,10 +57,6 @@ inline constexpr int sign( const T& val );
 template <typename T>
 inline constexpr T signNZ( const T& val );
 
-/// Returns value v clamped between bounds min and max.
-template <typename T>
-inline constexpr T clamp( T v, T min, T max );
-
 /// Clamps the value between 0 and 1
 template <typename T>
 inline constexpr T saturate( T v );

--- a/src/Core/Math/Math.inl
+++ b/src/Core/Math/Math.inl
@@ -3,6 +3,7 @@
 namespace Ra {
 namespace Core {
 namespace Math {
+
 inline constexpr Scalar toRadians( Scalar a ) {
     return toRad * a;
 }
@@ -80,13 +81,8 @@ inline constexpr T signNZ( const T& val ) {
 }
 
 template <typename T>
-inline constexpr T clamp( T v, T min, T max ) {
-    return std::max( min, std::min( v, max ) );
-}
-
-template <typename T>
 inline constexpr T saturate( T v ) {
-    return clamp( v, static_cast<T>( 0 ), static_cast<T>( 1 ) );
+    return std::clamp( v, static_cast<T>( 0 ), static_cast<T>( 1 ) );
 }
 
 inline bool areApproxEqual( Scalar a, Scalar b, Scalar eps ) {

--- a/src/Engine/Renderer/RenderTechnique/RenderTechnique.hpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderTechnique.hpp
@@ -24,7 +24,8 @@ namespace Engine {
  */
 /**
  * Set of shaders to be used by the renderer to render objects with materials.
- * @see Render technique and materials section in the Material management in the Radium Engine documentation
+ * @see Render technique and materials section in the Material management in the Radium Engine
+ * documentation
  */
 class RA_ENGINE_API RenderTechnique final {
   public:
@@ -65,11 +66,11 @@ class RA_ENGINE_API RenderTechnique final {
     ConfigurationSet shaderConfig;
     ShaderSet shaders;
 
-    std::shared_ptr<Material> material { nullptr };
+    std::shared_ptr<Material> material{nullptr};
 
     // Change this if there is more than 8 configurations
-    unsigned char dirtyBits { Z_PREPASS | LIGHTING_OPAQUE | LIGHTING_TRANSPARENT };
-    unsigned char setPasses {NO_PASS};
+    unsigned char dirtyBits{Z_PREPASS | LIGHTING_OPAQUE | LIGHTING_TRANSPARENT};
+    unsigned char setPasses{NO_PASS};
 };
 
 ///////////////////////////////////////////////

--- a/src/Engine/Renderer/Renderer.cpp
+++ b/src/Engine/Renderer/Renderer.cpp
@@ -1,13 +1,9 @@
 #include <Engine/Renderer/Renderer.hpp>
 
-#include <globjects/Framebuffer.h>
-
-#include <iostream>
-
 #include <Core/Asset/FileData.hpp>
 #include <Core/Geometry/MeshPrimitives.hpp>
 #include <Core/Utils/Log.hpp>
-
+#include <Engine/Managers/LightManager/LightManager.hpp>
 #include <Engine/RadiumEngine.hpp>
 #include <Engine/Renderer/Camera/Camera.hpp>
 #include <Engine/Renderer/Material/Material.hpp>
@@ -21,7 +17,10 @@
 #include <Engine/Renderer/Texture/Texture.hpp>
 #include <Engine/Renderer/Texture/TextureManager.hpp>
 
-#include <Engine/Managers/LightManager/LightManager.hpp>
+#include <globjects/Framebuffer.h>
+
+#include <algorithm>
+#include <iostream>
 
 namespace Ra {
 namespace Engine {
@@ -617,14 +616,14 @@ std::unique_ptr<uchar[]> Renderer::grabFrame( size_t& w, size_t& h ) const {
             auto ou = 4 * ( ( tex->height() - 1 - j ) * tex->width() +
                             i ); // Index in the final image (note the j flipping).
 
-            writtenPixels[ou + 0] = (uchar)Ra::Core::Math::clamp( Scalar( pixels[in + 0] * 255.f ),
-                                                                  Scalar( 0 ), Scalar( 255 ) );
-            writtenPixels[ou + 1] = (uchar)Ra::Core::Math::clamp( Scalar( pixels[in + 1] * 255.f ),
-                                                                  Scalar( 0 ), Scalar( 255 ) );
-            writtenPixels[ou + 2] = (uchar)Ra::Core::Math::clamp( Scalar( pixels[in + 2] * 255.f ),
-                                                                  Scalar( 0 ), Scalar( 255 ) );
-            writtenPixels[ou + 3] = (uchar)Ra::Core::Math::clamp( Scalar( pixels[in + 3] * 255.f ),
-                                                                  Scalar( 0 ), Scalar( 255 ) );
+            writtenPixels[ou + 0] =
+                (uchar)std::clamp( Scalar( pixels[in + 0] * 255.f ), Scalar( 0 ), Scalar( 255 ) );
+            writtenPixels[ou + 1] =
+                (uchar)std::clamp( Scalar( pixels[in + 1] * 255.f ), Scalar( 0 ), Scalar( 255 ) );
+            writtenPixels[ou + 2] =
+                (uchar)std::clamp( Scalar( pixels[in + 2] * 255.f ), Scalar( 0 ), Scalar( 255 ) );
+            writtenPixels[ou + 3] =
+                (uchar)std::clamp( Scalar( pixels[in + 3] * 255.f ), Scalar( 0 ), Scalar( 255 ) );
         }
     }
     w = tex->width();

--- a/src/GuiBase/Viewer/TrackballCamera.cpp
+++ b/src/GuiBase/Viewer/TrackballCamera.cpp
@@ -1,17 +1,17 @@
 #include <GuiBase/Viewer/TrackballCamera.hpp>
 
-#include <QApplication>
-#include <QMessageBox>
-#include <iostream>
-
 #include <Core/Math/Math.hpp>
 #include <Core/Utils/Log.hpp>
 #include <Engine/Renderer/Camera/Camera.hpp>
 #include <Engine/Renderer/Light/Light.hpp>
 #include <GuiBase/Event/KeyEvent.hpp>
 #include <GuiBase/Event/MouseEvent.hpp>
-
 #include <GuiBase/Utils/KeyMappingManager.hpp>
+
+#include <QApplication>
+#include <QMessageBox>
+#include <algorithm>
+#include <iostream>
 
 namespace Ra {
 using Core::Math::Pi;
@@ -324,7 +324,7 @@ void Gui::TrackballCamera::handleCameraZoom( Scalar z ) {
     Scalar zoom = m_camera->getZoomFactor() - z * m_cameraSensitivity * m_quickCameraModifier;
     Scalar epsIn = 0.001;
     Scalar epsOut = 3.1;
-    m_camera->setZoomFactor( Core::Math::clamp( zoom, epsIn, epsOut ) );
+    m_camera->setZoomFactor( std::clamp( zoom, epsIn, epsOut ) );
 #else
     Scalar y = m_distFromCenter * z * m_cameraSensitivity * m_quickCameraModifier;
     Core::Vector3 F = m_camera->getDirection();

--- a/tests/CoreTests/src/algebra.cpp
+++ b/tests/CoreTests/src/algebra.cpp
@@ -1,7 +1,9 @@
 #include <Core/Math/LinearAlgebra.hpp>
+#include <Core/Math/Math.hpp>
 #include <Core/Types.hpp>
 #include <Tests.hpp>
 
+#include <algorithm>
 namespace Ra {
 namespace Testing {
 
@@ -36,6 +38,64 @@ void run() {
                "Twist should be around z" );
     RA_VERIFY( Ra::Core::AngleAxis( qs ).axis().dot( Ra::Core::Vector3::UnitZ() ) == 0,
                "Swing should be in xy" );
+
+    //    using std::clamp;
+    //    using Ra::Core::Math::clamp;
+    Scalar min = -12.;
+    Scalar max = +27.;
+    Scalar s = 0.6;
+
+    RA_VERIFY( s == std::clamp( s, min, max ), "Clamp fails on Scalar" );
+    RA_VERIFY( min == std::clamp( min, min, max ), "Clamp fails on Scalar" );
+    RA_VERIFY( max == std::clamp( max, min, max ), "Clamp fails on Scalar" );
+    RA_VERIFY( max == std::clamp( max + s, min, max ), "Clamp fails on Scalar" );
+    RA_VERIFY( min == std::clamp( min - s, min, max ), "Clamp fails on Scalar" );
+
+    Ra::Core::Vector3 v{Scalar( 0.1 ), Scalar( 0.2 ), Scalar( 0.3 )};
+    Ra::Core::Vector3 v2 = Ra::Core::Math::clamp( v, min, max );
+    RA_VERIFY( v2.isApprox( v ), "Clamp fails on Vector and scalar" );
+
+    v = Ra::Core::Math::clamp( Ra::Core::Vector3::Constant( s ), min, max );
+    v2 = Ra::Core::Vector3::Constant( s );
+    RA_VERIFY( v2.isApprox( v ), "Clamp fails on Vector and scalar" );
+
+    RA_VERIFY( Ra::Core::Vector3::Constant( min ).isApprox(
+                   Ra::Core::Math::clamp( Ra::Core::Vector3::Constant( min ), min, max ) ),
+               "Clamp fails on Vector and scalar" );
+
+    RA_VERIFY( Ra::Core::Vector3::Constant( max ).isApprox(
+                   Ra::Core::Math::clamp( Ra::Core::Vector3::Constant( max ), min, max ) ),
+               "Clamp fails on Vector and scalar" );
+    RA_VERIFY( Ra::Core::Vector3::Constant( max ).isApprox(
+                   Ra::Core::Math::clamp( Ra::Core::Vector3::Constant( max + s ), min, max ) ),
+               "Clamp fails on Vector and scalar" );
+    RA_VERIFY( Ra::Core::Vector3::Constant( min ).isApprox(
+                   Ra::Core::Math::clamp( Ra::Core::Vector3::Constant( min - s ), min, max ) ),
+               "Clamp fails on Vector and scalar" );
+
+    RA_VERIFY( Ra::Core::Vector3::Constant( min ).isApprox( Ra::Core::Math::clamp(
+                   Ra::Core::Vector3::Constant( min ), Ra::Core::Vector3::Constant( min ),
+                   Ra::Core::Vector3::Constant( max ) ) ),
+               "Component-wise clamp fails" );
+
+    RA_VERIFY( Ra::Core::Vector3::Constant( max ).isApprox( Ra::Core::Math::clamp(
+                   Ra::Core::Vector3::Constant( max ), Ra::Core::Vector3::Constant( min ),
+                   Ra::Core::Vector3::Constant( max ) ) ),
+               "Component-wise clamp fails" );
+    RA_VERIFY( Ra::Core::Vector3::Constant( max ).isApprox( Ra::Core::Math::clamp(
+                   Ra::Core::Vector3::Constant( max + s ), Ra::Core::Vector3::Constant( min ),
+                   Ra::Core::Vector3::Constant( max ) ) ),
+               "Component-wise clamp fails" );
+    RA_VERIFY( Ra::Core::Vector3::Constant( min ).isApprox( Ra::Core::Math::clamp(
+                   Ra::Core::Vector3::Constant( min - s ), Ra::Core::Vector3::Constant( min ),
+                   Ra::Core::Vector3::Constant( max ) ) ),
+               "Component-wise clamp fails" );
+
+    RA_VERIFY( Ra::Core::Vector3( min, max, s )
+                   .isApprox( Ra::Core::Math::clamp( Ra::Core::Vector3( min - s, max + s, s ),
+                                                     Ra::Core::Vector3::Constant( min ),
+                                                     Ra::Core::Vector3::Constant( max ) ) ),
+               "Component-wise clamp fails" );
 }
 } // namespace Testing
 } // namespace Ra

--- a/tests/CoreTests/src/geometry.cpp
+++ b/tests/CoreTests/src/geometry.cpp
@@ -1,4 +1,6 @@
 #include <Core/Geometry/DistanceQueries.hpp>
+#include <Core/Math/LinearAlgebra.hpp>
+#include <Core/Math/Math.hpp>
 #include <Tests.hpp>
 
 namespace Ra {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master`: for hotfixes not impacting the API
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix, `clamp(T, T, T)` and Vector version clash (since there is no partial template specialisation on function).

generic clamp has been move to `Ra::Core` (instead of math).
That's dirty, but temporary, please use std::clamp instead.
"Eigen" clamp has been redesign to work with all kind of expression (I hope ;)


* **What is the current behavior?** (You can also link to an open issue here)

`Ra::Core::Math::clamp` works on scalar type, not on vector types

* **What is the new behavior (if this is a feature change)?**
use std::clamp or Ra::Core on scalar types
`Ra::Core::Math::clamp(Vector, Scalar, Scalar)` or `Ra::Core::Math::clamp(Vector, Vector, Vector)` works as expected


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
