### PR TITLE
Small fixes : default light intensity and material documentation

### DIFF
--- a/Docs/material.md
+++ b/Docs/material.md
@@ -251,7 +251,6 @@ namespace Engine {
 
 class RA_ENGINE_API BlinnPhongMaterial final : public Material {
   public:
-    RA_CORE_ALIGNED_NEW
     explicit BlinnPhongMaterial( const std::string& name );
     ...
   private:

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -452,8 +452,7 @@ void Gui::Viewer::showEvent( QShowEvent* /*ev*/ ) {
         // Entity
         auto light =
             new Engine::DirectionalLight( Ra::Engine::SystemEntity::getInstance(), "headlight" );
-        // Set the default light intensity so that it does not burn the objects
-        light->setColor( Ra::Core::Utils::Color::Grey( Scalar( 0.5 ) ) );
+        light->setColor( Ra::Core::Utils::Color::Grey( Scalar( 1.0 ) ) );
         m_camera->attachLight( light );
     }
 }


### PR DESCRIPTION
   default light intensity set to one
   material documentation updated

* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

docs update and default light intensity set to 1 so that default rendering is fine wrt content creation software (blender, maya, ...)

* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:
