### PR TITLE
Checkbox in the engine object tree for visibility

### DIFF
--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -137,14 +137,13 @@ void MainWindow::createConnections() {
         this, &MainWindow::changeRenderObjectShader );
 
     // RO Stuff
-    connect( m_toggleRenderObjectButton, &QPushButton::clicked, this,
-             &MainWindow::toggleVisisbleRO );
     connect( m_itemModel, &GuiBase::ItemModel::visibilityROChanged, this, &MainWindow::setROVisible );
     connect( m_editRenderObjectButton, &QPushButton::clicked, this, &MainWindow::editRO );
     connect( m_exportMeshButton, &QPushButton::clicked, this, &MainWindow::exportCurrentMesh );
     connect( m_removeEntityButton, &QPushButton::clicked, this, &MainWindow::deleteCurrentItem );
     connect( m_clearSceneButton, &QPushButton::clicked, this, &MainWindow::resetScene );
     connect( m_fitCameraButton, &QPushButton::clicked, this, &MainWindow::fitCamera );
+    connect( m_showHideAllButton, &QPushButton::clicked, this, &MainWindow::showHideAllRO );
 
     // Renderer stuff
     connect(
@@ -461,6 +460,39 @@ void Gui::MainWindow::editRO() {
     {
         m_materialEditor->changeRenderObject( item.m_roIndex );
         m_materialEditor->show();
+    }
+}
+
+void Gui::MainWindow::showHideAllRO()
+{
+    bool allEntityInvisible = true;
+
+    const int j = 0;
+    for (int i = 0; i < m_itemModel->rowCount(); ++i )
+    {
+        auto idx = m_itemModel->index(i,j);
+        auto item = m_itemModel->getEntry(idx);
+        if ( item.isValid() && item.isSelectable() )
+        {
+            bool isVisible = m_itemModel->data(idx, Qt::CheckStateRole).toBool();
+            if ( isVisible )
+            {
+                allEntityInvisible = false;
+                break;
+            }
+        }
+    }
+
+    // if all entities are invisible : show all
+    // if at least one entity is visible : hide all
+    for (int i = 0; i < m_itemModel->rowCount(); ++i )
+    {
+        auto idx = m_itemModel->index(i,j);
+        auto item = m_itemModel->getEntry(idx);
+        if( item.isValid() && item.isSelectable() )
+        {
+            m_itemModel->setData(idx, allEntityInvisible, Qt::CheckStateRole);
+        }
     }
 }
 

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -139,6 +139,7 @@ void MainWindow::createConnections() {
     // RO Stuff
     connect( m_toggleRenderObjectButton, &QPushButton::clicked, this,
              &MainWindow::toggleVisisbleRO );
+    connect( m_itemModel, &GuiBase::ItemModel::visibilityROChanged, this, &MainWindow::setROVisible );
     connect( m_editRenderObjectButton, &QPushButton::clicked, this, &MainWindow::editRO );
     connect( m_exportMeshButton, &QPushButton::clicked, this, &MainWindow::exportCurrentMesh );
     connect( m_removeEntityButton, &QPushButton::clicked, this, &MainWindow::deleteCurrentItem );
@@ -449,23 +450,9 @@ void MainWindow::changeRenderObjectShader( const QString& shaderName ) {
     }
 }
 
-void Gui::MainWindow::toggleVisisbleRO() {
-    const ItemEntry& item = m_selectionManager->currentItem();
-    // If at least one RO is visible, turn them off.
-    bool hasVisible = false;
-    for ( auto roIdx : getItemROs( mainApp->m_engine.get(), item ) )
-    {
-        if ( mainApp->m_engine->getRenderObjectManager()->getRenderObject( roIdx )->isVisible() )
-        {
-            hasVisible = true;
-            break;
-        }
-    }
-    for ( auto roIdx : getItemROs( mainApp->m_engine.get(), item ) )
-    {
-        mainApp->m_engine->getRenderObjectManager()->getRenderObject( roIdx )->setVisible(
-            !hasVisible );
-    }
+void Gui::MainWindow::setROVisible(Core::Utils::Index roIndex, bool visible)
+{
+    mainApp->m_engine->getRenderObjectManager()->getRenderObject( roIndex )->setVisible( visible );
 }
 
 void Gui::MainWindow::editRO() {

--- a/Applications/MainApplication/Gui/MainWindow.hpp
+++ b/Applications/MainApplication/Gui/MainWindow.hpp
@@ -83,8 +83,8 @@ class MainWindow : public Ra::GuiBase::MainWindowInterface, private Ui::MainWind
     void reloadConfiguration();
     void loadConfiguration();
 
-    /// Slot for the "visible" button
-    void toggleVisisbleRO();
+    /// Slot for the tree view checkboxes
+    void setROVisible(Core::Utils::Index roIndex, bool visible);
 
     /// Reset the camera to see all visible objects
     void fitCamera();
@@ -159,7 +159,7 @@ class MainWindow : public Ra::GuiBase::MainWindowInterface, private Ui::MainWind
     void on_m_currentColorButton_clicked();
 
   private:
-    /// Stores the internal model of engine objects for selection.
+    /// Stores the internal model of engine objects for selection and visibility.
     GuiBase::ItemModel* m_itemModel;
 
     /// Stores and manages the current selection.

--- a/Applications/MainApplication/Gui/MainWindow.hpp
+++ b/Applications/MainApplication/Gui/MainWindow.hpp
@@ -97,6 +97,9 @@ class MainWindow : public Ra::GuiBase::MainWindowInterface, private Ui::MainWind
     /// Cleanup resources.
     void cleanup() override;
 
+    /// Show or hide all render objects
+    void showHideAllRO();
+
   signals:
     /// Emitted when the frame loads
     void fileLoading( const QString path );

--- a/Applications/MainApplication/Gui/ui/MainWindow.ui
+++ b/Applications/MainApplication/Gui/ui/MainWindow.ui
@@ -144,6 +144,13 @@
                 </property>
                </widget>
               </item>
+              <item row="0" column="0">
+               <widget class="QPushButton" name="m_showHideAllButton">
+                <property name="text">
+                 <string>Show/Hide All</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </item>
            </layout>
@@ -733,7 +740,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>m_entitiesTreeView</tabstop>
-  <tabstop>m_toggleRenderObjectButton</tabstop>
+  <tabstop>m_showHideAllButton</tabstop>
   <tabstop>m_editRenderObjectButton</tabstop>
   <tabstop>m_exportMeshButton</tabstop>
   <tabstop>m_removeEntityButton</tabstop>

--- a/Applications/MainApplication/Gui/ui/MainWindow.ui
+++ b/Applications/MainApplication/Gui/ui/MainWindow.ui
@@ -106,13 +106,6 @@
             </item>
             <item>
              <layout class="QGridLayout" name="gridLayout_4">
-              <item row="0" column="0">
-               <widget class="QPushButton" name="m_toggleRenderObjectButton">
-                <property name="text">
-                 <string>Toggle Visible</string>
-                </property>
-               </widget>
-              </item>
               <item row="0" column="1">
                <widget class="QPushButton" name="m_editRenderObjectButton">
                 <property name="enabled">

--- a/src/GuiBase/TreeModel/EntityTreeModel.cpp
+++ b/src/GuiBase/TreeModel/EntityTreeModel.cpp
@@ -128,6 +128,24 @@ void ItemModel::removeItem( const Engine::ItemEntry& ent ) {
     }
 }
 
+void ItemModel::onDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles)
+{
+    if( topLeft == bottomRight && roles.size() == 1 && roles.first() == Qt::CheckStateRole )
+    {
+        auto index = topLeft;
+        if( index.isValid() )
+        {
+            bool visible = getItem( index )->isChecked();
+            auto ent = getEntry( index );
+
+            if( ent.isValid() && ent.isRoNode() )
+            {
+                emit visibilityROChanged( ent.m_roIndex, visible );
+            }
+        }
+    }
+}
+
 int TreeItem::getIndexInParent() const {
     CORE_ASSERT( m_parent, "Looking for the root item's index." );
     for ( uint i = 0; i < m_parent->m_children.size(); ++i )

--- a/src/GuiBase/TreeModel/EntityTreeModel.hpp
+++ b/src/GuiBase/TreeModel/EntityTreeModel.hpp
@@ -33,6 +33,7 @@ class RA_GUIBASE_API ItemModel : public TreeModel {
         TreeModel( parent ),
         m_engine( engine ) {
         buildModel();
+        connect(this, &TreeModel::dataChanged, this, &ItemModel::onDataChanged);
     }
 
     // Other functions
@@ -50,6 +51,14 @@ class RA_GUIBASE_API ItemModel : public TreeModel {
     void addItem( const Engine::ItemEntry& ent );
 
     void removeItem( const Engine::ItemEntry& ent );
+
+  private slots:
+
+    void onDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles);
+
+  signals:
+
+    void visibilityROChanged(Ra::Core::Utils::Index roIndex, bool visible);
 
   protected:
     /// Internal function to build the tree.

--- a/src/GuiBase/TreeModel/TreeModel.hpp
+++ b/src/GuiBase/TreeModel/TreeModel.hpp
@@ -53,6 +53,9 @@ class RA_GUIBASE_API TreeItem {
     // Of course this won't work for the root item.
     int getIndexInParent() const;
 
+    bool isChecked() const { return m_checked; }
+    void setChecked( bool checked = true ) { m_checked = checked; }
+
   public:
     // Tree structure variables
 
@@ -61,6 +64,9 @@ class RA_GUIBASE_API TreeItem {
 
     /// Children of item in the tree.
     std::vector<std::unique_ptr<TreeItem>> m_children;
+
+private:
+    bool m_checked{true};
 };
 
 /// This class implement QAbstractItem model with the TreeItem as its model
@@ -94,6 +100,8 @@ class RA_GUIBASE_API TreeModel : public QAbstractItemModel {
      * @return
      */
     QVariant data( const QModelIndex& index, int role ) const override;
+
+    bool setData( const QModelIndex& index, const QVariant& value, int role ) override;
 
     /** Return the header data of the given section.
      *


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master`: for hotfixes not impacting the API
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds check-boxes to items in the engine object tree to toggle their visibility.

* **What is the current behavior?** (You can also link to an open issue here)
There is a 'visible' button that toggles visibility of the selected item.

* **What is the new behavior (if this is a feature change)?**
Items visibility is now controlled by the check-boxes in the tree view.
If a component is unchecked, then all of its render objects are also unchecked (same for entities and their components).  

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
Some limitations :
- I have quickly tested this with simple items : an entity containing a single component with a single render object. A test with more complex situation might be necessary
- For now, if one toggles the visibility of a render object 'programmatically', there is no way to update the associated check box in the tree.    
- If all the render objects of a component are unchecked, the checkbox of the component remains checked. (The information propagates top-down but not bottom-up).