### PR TITLE
Fix skeleton-based character animation import

### DIFF
--- a/Docs/animation.md
+++ b/Docs/animation.md
@@ -1,0 +1,49 @@
+# Animation in Radium
+
+The Radium Engine provides a set of classes dedicated to animation,
+which can be found in `Core/Animation`.
+
+## Animation Basics
+
+An `Animation` is a set of key poses, each associated to a key time.
+When looking for the pose at a specific animation time, 
+the 2 closest surrounding key poses are linearly interpolated to build the querried pose.
+
+Though the `Animation` class only provides keyframing for poses, which are sets of transformation matrices,
+the `KeyFrame` class provides a more generic interface, usable for any type of animated data.
+
+## Character Animation
+
+The Radium Engine also provides the basic classes for character animation.
+Starting from a `Handle`, which represents a deformation metaphor, such as `Cage` or `Skeleton`, 
+one can associate influence weights to each vertex of a mesh within a `WeightMatrix` (rows representing vertices, columns handles).
+These influence weights, or skinning weights, are then used by a skinning algorithm to deform 
+the associated mesh vertices w.r.t. the `Handle` deformation defined by the animation pose.
+
+## The Character Animation Plugins
+
+The Radium Engine provides one plugin specific to skeleton-based character animation 
+and another one specific to skeleton-based character skinning.
+This first one manages user interactions with the animation skeleton, enabling posing the character
+ and playing the animations.
+The second one is responsible for deforming the object's vertices according to the desired skinning method.
+
+## Importing skeleton-based character animation data into Radium
+
+In order to import animation related data into Radium, the default loader would be the `AssimpLoader`,
+ which deals with several standard animation formats (fbx, collada, ...).
+In case one need to develop his own loader because using a file format not managed by the Assimp library,
+the Radium Engine provides a set of classes in `Core/Asset` defining data wrappers filled by loaders (see the specific documentation -- which does not exist for now).
+For now, `FileLoader`s in the Radium Engine produce only one `FileData` per loaded file.
+
+Regarding character animation data, there are a few things to do in order to ensure correct import by the 
+animation and skinning plugins:
+ * The generated `FileData` must contain at least one `GeometryData`, exactly one `HandleData` and as much `AnimationData` as needed per animated object.
+   Note: for objects composed of several mesh parts, these must be referred by their name when filling the `HandleData`.
+ * The animation skeleton, i.e. the bones and hierarchy, must be loaded into the `HandleData`, as well as the skinning weights.
+   The bone hierarchy will be defined by the `EdgeData`.
+   Each bone will be represented by a `HandleComponentData`, storing the bone's name, transform in model space, offset matrix and its per- skinned mesh vertex skinning weights.
+   The offset matrix stores the transformation from mesh space to the noe's local space and is used to retrieve the bind pose.
+ * Animation keyframes, i.e. couples of time and pose (in local space), if any, must be loaded into an `AnimationData`.
+   The whole animation must be stored bone-wise in `HandleAnimations`, whose name must match the bone's.
+

--- a/Plugins/Animation/src/AnimationComponent.cpp
+++ b/Plugins/Animation/src/AnimationComponent.cpp
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <queue>
 
-#include <Core/Animation/HandleWeightOperation.hpp>
 #include <Core/Animation/KeyPose.hpp>
 #include <Core/Animation/KeyTransform.hpp>
 #include <Core/Animation/Pose.hpp>
@@ -161,8 +160,6 @@ void AnimationComponent::handleSkeletonLoading( const Ra::Core::Asset::HandleDat
 
     Ra::Core::Asset::createSkeleton( *data, m_skel );
 
-    std::map<uint, uint> indexTable;
-    createWeightMatrix( data, indexTable, 0 );
     m_refPose = m_skel.getPose( Handle::SpaceType::MODEL );
 
     setupSkeletonDisplay();
@@ -216,31 +213,6 @@ void AnimationComponent::handleAnimationLoading(
     m_animationTime = 0.0;
 }
 
-void AnimationComponent::createWeightMatrix( const Ra::Core::Asset::HandleData* data,
-                                             const std::map<uint, uint>& indexTable,
-                                             uint nbMeshVertices ) {
-    m_weights.resize( nbMeshVertices, data->getComponentDataSize() );
-
-    //    for ( const auto& it : indexTable )
-    //    {
-    //        const uint idx = it.first;
-    //        const uint col = it.second;
-    //        const uint size = data->getComponent( idx ).m_weight.size();
-    //        for ( uint i = 0; i < size; ++i )
-    //        {
-    //            const uint row = data->getComponent( idx ).m_weight[i].first;
-    //            const Scalar w = data->getComponent( idx ).m_weight[i].second;
-    //            m_weights.coeffRef( row, col ) = w;
-    //        }
-    //    }
-    //    Ra::Core::Animation::checkWeightMatrix( m_weights, false, true );
-
-    //    if ( Ra::Core::Animation::normalizeWeights( m_weights, true ) )
-    //    {
-    //        LOG( logINFO ) << "Skinning weights have been normalized";
-    //    }
-}
-
 void AnimationComponent::setupIO( const std::string& id ) {
     ComponentMessenger::CallbackTypes<Skeleton>::Getter skelOut =
         std::bind( &AnimationComponent::getSkeletonOutput, this );
@@ -250,11 +222,6 @@ void AnimationComponent::setupIO( const std::string& id ) {
         std::bind( &AnimationComponent::getRefPoseOutput, this );
     ComponentMessenger::getInstance()->registerOutput<Ra::Core::Animation::Pose>( getEntity(), this,
                                                                                   id, refpOut );
-
-    ComponentMessenger::CallbackTypes<WeightMatrix>::Getter wOut =
-        std::bind( &AnimationComponent::getWeightsOutput, this );
-    ComponentMessenger::getInstance()->registerOutput<Ra::Core::Animation::WeightMatrix>(
-        getEntity(), this, id, wOut );
 
     ComponentMessenger::CallbackTypes<bool>::Getter resetOut =
         std::bind( &AnimationComponent::getWasReset, this );
@@ -276,10 +243,6 @@ void AnimationComponent::setupIO( const std::string& id ) {
 
 const Ra::Core::Animation::Skeleton* AnimationComponent::getSkeletonOutput() const {
     return &m_skel;
-}
-
-const Ra::Core::Animation::WeightMatrix* AnimationComponent::getWeightsOutput() const {
-    return &m_weights;
 }
 
 const Ra::Core::Animation::RefPose* AnimationComponent::getRefPoseOutput() const {

--- a/Plugins/Animation/src/AnimationComponent.cpp
+++ b/Plugins/Animation/src/AnimationComponent.cpp
@@ -168,7 +168,7 @@ void AnimationComponent::handleSkeletonLoading( const Ra::Core::Asset::HandleDat
 }
 
 void AnimationComponent::handleAnimationLoading(
-    const std::vector<Ra::Core::Asset::AnimationData *> &data) {
+    const std::vector<Ra::Core::Asset::AnimationData*>& data ) {
     m_animations.clear();
     CORE_ASSERT( ( m_skel.size() != 0 ), "At least a skeleton should be loaded first." );
     if ( data.empty() )
@@ -390,13 +390,13 @@ void AnimationComponent::cacheFrame( const std::string& dir, int frame ) const {
     {
         return;
     }
-    file.write( (const char*)&m_animationID, sizeof( uint ) );
-    file.write( (const char*)&m_animationTimeStep, sizeof( bool ) );
-    file.write( (const char*)&m_animationTime, sizeof( Scalar ) );
-    file.write( (const char*)&m_speed, sizeof( Scalar ) );
-    file.write( (const char*)&m_slowMo, sizeof( bool ) );
+    file.write( reinterpret_cast<const char*>( &m_animationID ), sizeof m_animationID );
+    file.write( reinterpret_cast<const char*>( &m_animationTimeStep ), sizeof m_animationTimeStep );
+    file.write( reinterpret_cast<const char*>( &m_animationTime ), sizeof m_animationTime );
+    file.write( reinterpret_cast<const char*>( &m_speed ), sizeof m_speed );
+    file.write( reinterpret_cast<const char*>( &m_slowMo ), sizeof m_slowMo );
     const auto& pose = m_skel.getPose( Handle::SpaceType::LOCAL );
-    file.write( (const char*)pose.data(), sizeof( Ra::Core::Transform ) * pose.size() );
+    file.write( reinterpret_cast<const char*>( pose.data() ), ( sizeof pose[0] ) * pose.size() );
     LOG( logINFO ) << "Saving anim data at time: " << m_animationTime;
 }
 
@@ -407,13 +407,31 @@ bool AnimationComponent::restoreFrame( const std::string& dir, int frame ) {
     {
         return false;
     }
-    file.read( (char*)&m_animationID, sizeof( uint ) );
-    file.read( (char*)&m_animationTimeStep, sizeof( bool ) );
-    file.read( (char*)&m_animationTime, sizeof( Scalar ) );
-    file.read( (char*)&m_speed, sizeof( Scalar ) );
-    file.read( (char*)&m_slowMo, sizeof( bool ) );
+    if ( !file.read( reinterpret_cast<char*>( &m_animationID ), sizeof m_animationID ) )
+    {
+        return false;
+    }
+    if ( !file.read( reinterpret_cast<char*>( &m_animationTimeStep ), sizeof m_animationTimeStep ) )
+    {
+        return false;
+    }
+    if ( !file.read( reinterpret_cast<char*>( &m_animationTime ), sizeof m_animationTime ) )
+    {
+        return false;
+    }
+    if ( !file.read( reinterpret_cast<char*>( &m_speed ), sizeof m_speed ) )
+    {
+        return false;
+    }
+    if ( !file.read( reinterpret_cast<char*>( &m_slowMo ), sizeof m_slowMo ) )
+    {
+        return false;
+    }
     auto pose = m_skel.getPose( Handle::SpaceType::LOCAL );
-    file.read( (char*)pose.data(), sizeof( Ra::Core::Transform ) * pose.size() );
+    if ( !file.read( reinterpret_cast<char*>( pose.data() ), ( sizeof pose[0] ) * pose.size() ) )
+    {
+        return false;
+    }
     m_skel.setPose( pose, Handle::SpaceType::LOCAL );
 
     // update the render objects

--- a/Plugins/Animation/src/AnimationComponent.cpp
+++ b/Plugins/Animation/src/AnimationComponent.cpp
@@ -96,7 +96,8 @@ void AnimationComponent::setupSkeletonDisplay() {
     m_boneDrawables.clear();
     for ( uint i = 0; i < m_skel.size(); ++i )
     {
-        if ( !m_skel.m_graph.isLeaf( i ) && !m_skel.m_graph.isRoot( i ) )
+        if ( !m_skel.m_graph.isLeaf( i ) && !m_skel.m_graph.isRoot( i ) &&
+             m_skel.getLabel( i ).find( "_$AssimpFbx$_" ) == std::string::npos )
         {
             std::string name = m_skel.getLabel( i ) + "_" + std::to_string( i );
             m_boneDrawables.emplace_back(

--- a/Plugins/Animation/src/AnimationComponent.cpp
+++ b/Plugins/Animation/src/AnimationComponent.cpp
@@ -97,9 +97,9 @@ void AnimationComponent::setupSkeletonDisplay() {
     m_boneDrawables.clear();
     for ( uint i = 0; i < m_skel.size(); ++i )
     {
-        if ( !m_skel.m_graph.isLeaf( i ) )
+        if ( !m_skel.m_graph.isLeaf( i ) && !m_skel.m_graph.isRoot( i ) )
         {
-            std::string name = m_skel.getLabel( i ) + std::to_string( i );
+            std::string name = m_skel.getLabel( i ) + "_" + std::to_string( i );
             m_boneDrawables.emplace_back(
                 new SkeletonBoneRenderObject( name, this, i, getRoMgr() ) );
             m_renderObjects.push_back( m_boneDrawables.back()->getRenderObjectIndex() );
@@ -148,8 +148,7 @@ void AnimationComponent::reset() {
     m_wasReset = true;
 }
 
-void AnimationComponent::handleSkeletonLoading( const Ra::Core::Asset::HandleData* data,
-                                                uint nbMeshVertices ) {
+void AnimationComponent::handleSkeletonLoading( const Ra::Core::Asset::HandleData* data ) {
     std::string name( m_name );
     name.append( "_" + data->getName() );
 
@@ -160,10 +159,10 @@ void AnimationComponent::handleSkeletonLoading( const Ra::Core::Asset::HandleDat
 
     m_contentName = data->getName();
 
-    std::map<uint, uint> indexTable;
-    Ra::Core::Asset::createSkeleton( *data, m_skel, indexTable );
+    Ra::Core::Asset::createSkeleton( *data, m_skel );
 
-    createWeightMatrix( data, indexTable, nbMeshVertices );
+    std::map<uint, uint> indexTable;
+    createWeightMatrix( data, indexTable, 0 );
     m_refPose = m_skel.getPose( Handle::SpaceType::MODEL );
 
     setupSkeletonDisplay();
@@ -222,24 +221,24 @@ void AnimationComponent::createWeightMatrix( const Ra::Core::Asset::HandleData* 
                                              uint nbMeshVertices ) {
     m_weights.resize( nbMeshVertices, data->getComponentDataSize() );
 
-    for ( const auto& it : indexTable )
-    {
-        const uint idx = it.first;
-        const uint col = it.second;
-        const uint size = data->getComponent( idx ).m_weight.size();
-        for ( uint i = 0; i < size; ++i )
-        {
-            const uint row = data->getComponent( idx ).m_weight[i].first;
-            const Scalar w = data->getComponent( idx ).m_weight[i].second;
-            m_weights.coeffRef( row, col ) = w;
-        }
-    }
-    Ra::Core::Animation::checkWeightMatrix( m_weights, false, true );
+    //    for ( const auto& it : indexTable )
+    //    {
+    //        const uint idx = it.first;
+    //        const uint col = it.second;
+    //        const uint size = data->getComponent( idx ).m_weight.size();
+    //        for ( uint i = 0; i < size; ++i )
+    //        {
+    //            const uint row = data->getComponent( idx ).m_weight[i].first;
+    //            const Scalar w = data->getComponent( idx ).m_weight[i].second;
+    //            m_weights.coeffRef( row, col ) = w;
+    //        }
+    //    }
+    //    Ra::Core::Animation::checkWeightMatrix( m_weights, false, true );
 
-    if ( Ra::Core::Animation::normalizeWeights( m_weights, true ) )
-    {
-        LOG( logINFO ) << "Skinning weights have been normalized";
-    }
+    //    if ( Ra::Core::Animation::normalizeWeights( m_weights, true ) )
+    //    {
+    //        LOG( logINFO ) << "Skinning weights have been normalized";
+    //    }
 }
 
 void AnimationComponent::setupIO( const std::string& id ) {

--- a/Plugins/Animation/src/AnimationComponent.cpp
+++ b/Plugins/Animation/src/AnimationComponent.cpp
@@ -172,11 +172,11 @@ void AnimationComponent::handleAnimationLoading(
     CORE_ASSERT( ( m_skel.size() != 0 ), "At least a skeleton should be loaded first." );
     if ( data.empty() )
         return;
-    std::map<uint, uint> table;
-    std::set<Ra::Core::Animation::Time> keyTime;
 
     for ( uint n = 0; n < data.size(); ++n )
     {
+        std::map<uint, uint> table;
+        std::set<Ra::Core::Animation::Time> keyTime;
         auto handleAnim = data[n]->getFrames();
         for ( uint i = 0; i < m_skel.size(); ++i )
         {
@@ -189,6 +189,11 @@ void AnimationComponent::handleAnimationLoading(
                     keyTime.insert( set.begin(), set.end() );
                 }
             }
+        }
+
+        if ( keyTime.empty() )
+        {
+            continue;
         }
 
         Ra::Core::Animation::KeyPose keypose;

--- a/Plugins/Animation/src/AnimationComponent.hpp
+++ b/Plugins/Animation/src/AnimationComponent.hpp
@@ -24,7 +24,7 @@ class SkeletonBoneRenderObject;
 class ANIM_PLUGIN_API AnimationComponent : public Ra::Engine::Component {
   public:
     AnimationComponent( const std::string& name, Ra::Engine::Entity* entity );
-    virtual ~AnimationComponent();
+    ~AnimationComponent() override;
     AnimationComponent( const AnimationComponent& ) = delete;
     AnimationComponent& operator=( const AnimationComponent& ) = delete;
 
@@ -35,11 +35,7 @@ class ANIM_PLUGIN_API AnimationComponent : public Ra::Engine::Component {
     //
 
     /// Create the skeleton from the given data.
-    /// @param data the skeleton's joint transform hierarchy.
-    /// @param nbMeshVertices the number of single vertices.
-    // FIXME: nbMeshVertices is needed only for the genereation of
-    //        the skinning weights matrix.
-    void handleSkeletonLoading( const Ra::Core::Asset::HandleData* data, uint nbMeshVertices );
+    void handleSkeletonLoading( const Ra::Core::Asset::HandleData* data );
 
     /// Create the animations from the given data.
     void handleAnimationLoading( const std::vector<Ra::Core::Asset::AnimationData*>& data );

--- a/Plugins/Animation/src/AnimationComponent.hpp
+++ b/Plugins/Animation/src/AnimationComponent.hpp
@@ -24,7 +24,7 @@ class SkeletonBoneRenderObject;
 class ANIM_PLUGIN_API AnimationComponent : public Ra::Engine::Component {
   public:
     AnimationComponent( const std::string& name, Ra::Engine::Entity* entity );
-    ~AnimationComponent() override;
+    ~AnimationComponent();
     AnimationComponent( const AnimationComponent& ) = delete;
     AnimationComponent& operator=( const AnimationComponent& ) = delete;
 

--- a/Plugins/Animation/src/AnimationComponent.hpp
+++ b/Plugins/Animation/src/AnimationComponent.hpp
@@ -106,10 +106,6 @@ class ANIM_PLUGIN_API AnimationComponent : public Ra::Engine::Component {
                                const Ra::Core::Transform& transform ) override;
 
   private:
-    // Internal function to create the skinning weights.
-    void createWeightMatrix( const Ra::Core::Asset::HandleData* data,
-                             const std::map<uint, uint>& indexTable, uint nbMeshVertices );
-
     // Internal function to create the bone display objects.
     void setupSkeletonDisplay();
 
@@ -128,9 +124,6 @@ class ANIM_PLUGIN_API AnimationComponent : public Ra::Engine::Component {
 
     /// Referene Pose getter for CC.
     const Ra::Core::Animation::RefPose* getRefPoseOutput() const;
-
-    /// Skinning Weight Matrix getter for CC.
-    const Ra::Core::Animation::WeightMatrix* getWeightsOutput() const;
 
     /// Reset status getter for CC.
     const bool* getWasReset() const;
@@ -156,10 +149,6 @@ class ANIM_PLUGIN_API AnimationComponent : public Ra::Engine::Component {
 
     /// The animations.
     std::vector<Ra::Core::Animation::Animation> m_animations;
-
-    /// The Skinning Weight Matrix
-    // FIXME: this one should go in the SkinningComponent.
-    Ra::Core::Animation::WeightMatrix m_weights;
 
     /// Bones ROs.
     std::vector<std::unique_ptr<SkeletonBoneRenderObject>> m_boneDrawables;

--- a/Plugins/Animation/src/AnimationSystem.cpp
+++ b/Plugins/Animation/src/AnimationSystem.cpp
@@ -124,18 +124,8 @@ void AnimationSystem::handleAssetLoading( Ra::Engine::Entity* entity,
     // deal with AnimationComponents
     for ( const auto& skel : skelData )
     {
-        uint geomID = uint( -1 );
-        for ( uint i = 0; i < geomData.size(); ++i )
-        {
-            if ( skel->getName() == geomData[i]->getName() )
-            {
-                geomID = i;
-            }
-        }
-
         auto component = new AnimationComponent( "AC_" + skel->getName(), entity );
-        uint nbMeshVertices = geomData[geomID]->getVerticesSize();
-        component->handleSkeletonLoading( skel, nbMeshVertices );
+        component->handleSkeletonLoading( skel );
         component->handleAnimationLoading( animData );
 
         component->setXray( m_xrayOn );

--- a/Plugins/Skinning/src/SkinningComponent.hpp
+++ b/Plugins/Skinning/src/SkinningComponent.hpp
@@ -147,6 +147,7 @@ class SKIN_PLUGIN_API SkinningComponent : public Ra::Engine::Component {
     Ra::Core::AlignedStdVector<Ra::Core::DualQuaternion> m_DQ;
 
     /// The duplicate vertices map, used to recompute smooth normals.
+    // FIXME: implement proper normal skinning such as http://vcg.isti.cnr.it/deformFactors/
     std::vector<Ra::Core::Utils::Index> m_duplicatesMap;
 
     /// The skinning weights, stored per bone.

--- a/Plugins/Skinning/src/SkinningComponent.hpp
+++ b/Plugins/Skinning/src/SkinningComponent.hpp
@@ -57,7 +57,8 @@ class SKIN_PLUGIN_API SkinningComponent : public Ra::Engine::Component {
 
     /// Loads the skinning weights from the given Handledata.
     // TODO: for now, weights are stored in the AnimationComponent.
-    virtual void handleWeightsLoading( const Ra::Core::Asset::HandleData* data );
+    virtual void handleWeightsLoading( const Ra::Core::Asset::HandleData* data,
+                                       const std::string& meshName );
 
     /// @returns the reference skinning data.
     const Ra::Core::Skinning::RefData* getRefData() const { return &m_refData; }
@@ -94,6 +95,16 @@ class SKIN_PLUGIN_API SkinningComponent : public Ra::Engine::Component {
     std::string m_contentsName;
 
   private:
+    // Internal function to create the skinning weights.
+    void createWeightMatrix();
+
+    /// Skinning Weight Matrix getter for CC.
+    const Ra::Core::Animation::WeightMatrix* getWeightsOutput() const;
+
+  private:
+    /// The mesh name for Component communication.
+    std::string m_meshName;
+
     /// The refrence Skinning data.
     Ra::Core::Skinning::RefData m_refData;
 
@@ -123,6 +134,9 @@ class SKIN_PLUGIN_API SkinningComponent : public Ra::Engine::Component {
     /// The Skinning Method.
     SkinningType m_skinningType;
 
+    /// The Skinning Weight Matrix.
+    Ra::Core::Animation::WeightMatrix m_weights;
+
     /// Are all the required data available.
     bool m_isReady;
 
@@ -134,6 +148,9 @@ class SKIN_PLUGIN_API SkinningComponent : public Ra::Engine::Component {
 
     /// The duplicate vertices map, used to recompute smooth normals.
     std::vector<Ra::Core::Utils::Index> m_duplicatesMap;
+
+    /// The skinning weights, stored per bone.
+    std::map<std::string, std::vector<std::pair<uint, Scalar>>> m_loadedWeights;
 
     /// The STBS weights.
     Ra::Core::Animation::WeightMatrix m_weightSTBS;

--- a/Plugins/Skinning/src/SkinningPlugin.cpp
+++ b/Plugins/Skinning/src/SkinningPlugin.cpp
@@ -91,16 +91,19 @@ void SkinningPluginC::onCurrentChanged( const QModelIndex& current, const QModel
         auto comps = m_system->getEntityComponents( it.m_entity );
         if ( comps.size() != 0 )
         {
-            auto comp = static_cast<SkinningPlugin::SkinningComponent*>( comps[0] );
-            m_widget->setCurrent( it, comp );
-
-            using BoneMap = std::map<Ra::Core::Utils::Index, uint>;
-            auto CM = Ra::Engine::ComponentMessenger::getInstance();
-            auto BM = *CM->getterCallback<BoneMap>( it.m_entity, comp->m_contentsName )();
-            auto b_it = BM.find( it.m_roIndex );
-            if ( b_it != BM.end() )
+            for ( auto& comp : comps )
             {
-                comp->setWeightBone( b_it->second );
+                auto skin = static_cast<SkinningPlugin::SkinningComponent*>( comp );
+                m_widget->setCurrent( it, skin );
+
+                using BoneMap = std::map<Ra::Core::Utils::Index, uint>;
+                auto CM = Ra::Engine::ComponentMessenger::getInstance();
+                auto BM = *CM->getterCallback<BoneMap>( it.m_entity, skin->m_contentsName )();
+                auto b_it = BM.find( it.m_roIndex );
+                if ( b_it != BM.end() )
+                {
+                    skin->setWeightBone( b_it->second );
+                }
             }
         } else
         { m_widget->setCurrent( it, nullptr ); }

--- a/Plugins/Skinning/src/SkinningSystem.hpp
+++ b/Plugins/Skinning/src/SkinningSystem.hpp
@@ -40,24 +40,22 @@ class SKIN_PLUGIN_API SkinningSystem : public Ra::Engine::System {
 
     void handleAssetLoading( Ra::Engine::Entity* entity,
                              const Ra::Core::Asset::FileData* fileData ) override {
+        //        auto geomData = fileData->getGeometryData();
+        //        auto skelData = fileData->getHandleData();
+        //        if ( geomData.size() > 0 && skelData.size() > 0 )
+        //        {
+        //            for ( const auto& skel : skelData )
+        //            {
+        //                SkinningComponent* component = new SkinningComponent(
+        //                    "SkC_" + skel->getName(), SkinningComponent::LBS, entity );
+        //                component->handleWeightsLoading( skel );
+        //                registerComponent( entity, component );
 
-        auto geomData = fileData->getGeometryData();
-        auto skelData = fileData->getHandleData();
-
-        if ( geomData.size() > 0 && skelData.size() > 0 )
-        {
-            for ( const auto& skel : skelData )
-            {
-                SkinningComponent* component = new SkinningComponent(
-                    "SkC_" + skel->getName(), SkinningComponent::LBS, entity );
-                component->handleWeightsLoading( skel );
-                registerComponent( entity, component );
-
-                /*SkinningDisplayComponent* display = */ new SkinningDisplayComponent(
-                    "SkC_DSP_" + skel->getName(), skel->getName(), entity );
-                // display->display( component->getRefData() );
-            }
-        }
+        //                /*SkinningDisplayComponent* display = */ new SkinningDisplayComponent(
+        //                    "SkC_DSP_" + skel->getName(), skel->getName(), entity );
+        //                // display->display( component->getRefData() );
+        //            }
+        //        }
     }
 
     void showWeights( bool on ) {

--- a/Plugins/Skinning/src/SkinningSystem.hpp
+++ b/Plugins/Skinning/src/SkinningSystem.hpp
@@ -26,10 +26,11 @@ class SKIN_PLUGIN_API SkinningSystem : public Ra::Engine::System {
         {
             SkinningComponent* comp = static_cast<SkinningComponent*>( compEntry.second );
             Ra::Core::FunctionTask* skinTask = new Ra::Core::FunctionTask(
-                std::bind( &SkinningComponent::skin, comp ), "SkinnerTask" );
+                std::bind( &SkinningComponent::skin, comp ), "SkinnerTask_" + comp->getName() );
 
-            Ra::Core::FunctionTask* endTask = new Ra::Core::FunctionTask(
-                std::bind( &SkinningComponent::endSkinning, comp ), "SkinnerEndTask" );
+            Ra::Core::FunctionTask* endTask =
+                new Ra::Core::FunctionTask( std::bind( &SkinningComponent::endSkinning, comp ),
+                                            "SkinnerEndTask_" + comp->getName() );
 
             Ra::Core::TaskQueue::TaskId skinTaskId = taskQueue->registerTask( skinTask );
             Ra::Core::TaskQueue::TaskId endTaskId = taskQueue->registerTask( endTask );

--- a/src/Core/Animation/Interpolation.hpp
+++ b/src/Core/Animation/Interpolation.hpp
@@ -19,12 +19,18 @@ inline void interpolate( const Core::Quaternion& q0, const Core::Quaternion& q1,
 
 inline void interpolate( const Core::Transform& T0, const Core::Transform& T1, const Scalar t,
                          Core::Transform& result ) {
-    Core::Quaternion q;
-    Core::Vector3 tr;
-    interpolate( Core::Quaternion( T0.rotation() ), Core::Quaternion( T1.rotation() ), t, q );
-    interpolate( T0.translation(), T1.translation(), t, tr );
-    result.linear() = q.toRotationMatrix();
-    result.translation() = tr;
+    Ra::Core::Matrix3 T0R, T1R;
+    Ra::Core::Matrix3 T0S, T1S;
+    T0.computeRotationScaling( &T0R, &T0S );
+    T1.computeRotationScaling( &T1R, &T1S );
+
+    Ra::Core::Quaternion T0Rot = Ra::Core::Quaternion( T0R );
+    Ra::Core::Quaternion T1Rot = Ra::Core::Quaternion( T1R );
+    Ra::Core::Quaternion iR = T0Rot.slerp( t, T1Rot );
+    Ra::Core::Matrix3 iS = ( 1 - t ) * T0S + t * T1S;
+    Ra::Core::Vector3 iT = ( 1 - t ) * T0.translation() + t * T1.translation();
+
+    result.fromPositionOrientationScale( iT, iR, iS.diagonal() );
 }
 
 } // namespace Animation

--- a/src/Core/Animation/KeyFrame.hpp
+++ b/src/Core/Animation/KeyFrame.hpp
@@ -41,7 +41,7 @@ class KeyFrame {
     }
 
     inline FRAME at( const Time& t ) const {
-        if ( !m_time.contain( t ) )
+        if ( m_keyframe.empty() )
         {
             return defaultFrame();
         }

--- a/src/Core/Animation/PoseOperation.cpp
+++ b/src/Core/Animation/PoseOperation.cpp
@@ -1,4 +1,6 @@
+#include <Core/Animation/Interpolation.hpp>
 #include <Core/Animation/PoseOperation.hpp>
+
 #include <Eigen/Geometry>
 
 namespace Ra {
@@ -63,38 +65,10 @@ Pose interpolatePoses( const Pose& a, const Pose& b, const Scalar t ) {
 #pragma omp parallel for
     for ( int i = 0; i < int( size ); ++i )
     {
-        // interpolate between the transforms
-        Ra::Core::Transform aTransform = a[i];
-        Ra::Core::Transform bTransform = b[i];
-
-        Ra::Core::Quaternion aRot = Ra::Core::Quaternion( aTransform.rotation() );
-        Ra::Core::Quaternion bRot = Ra::Core::Quaternion( bTransform.rotation() );
-        Ra::Core::Quaternion interpRot = aRot.slerp( t, bRot );
-
-        Ra::Core::Vector3 interpTranslation =
-            ( 1.0 - t ) * aTransform.translation() + t * bTransform.translation();
-
-        Ra::Core::Transform interpolatedTransform;
-        interpolatedTransform.linear() = interpRot.toRotationMatrix();
-        interpolatedTransform.translation() = interpTranslation;
-
-        interpolatedPose[i] = interpolatedTransform;
+        interpolate( a[i], b[i], t, interpolatedPose[i] );
     }
 
     return interpolatedPose;
-}
-
-void interpolateTransforms( const Ra::Core::Transform& a, const Ra::Core::Transform& b,
-                            const Scalar t, Ra::Core::Transform& interpolated ) {
-    Ra::Core::Quaternion aRot = Ra::Core::Quaternion( a.rotation() );
-    Ra::Core::Quaternion bRot = Ra::Core::Quaternion( b.rotation() );
-    Ra::Core::Quaternion interpRot = aRot.slerp( t, bRot );
-
-    Ra::Core::Vector3 interpTranslation =
-        ( Scalar( 1. ) - t ) * a.translation() + t * b.translation();
-
-    interpolated.linear() = interpRot.toRotationMatrix();
-    interpolated.translation() = interpTranslation;
 }
 
 } // namespace Animation

--- a/src/Core/Animation/PoseOperation.hpp
+++ b/src/Core/Animation/PoseOperation.hpp
@@ -44,9 +44,6 @@ RA_CORE_API bool areEqual( const Pose& p0, const Pose& p1 );
 
 RA_CORE_API Pose interpolatePoses( const Pose& a, const Pose& b, const Scalar t );
 
-RA_CORE_API void interpolateTransforms( const Ra::Core::Transform& a, const Ra::Core::Transform& b,
-                                        Scalar t, Ra::Core::Transform& interpolated );
-
 } // namespace Animation
 } // namespace Core
 } // namespace Ra

--- a/src/Core/Asset/HandleData.cpp
+++ b/src/Core/Asset/HandleData.cpp
@@ -4,13 +4,11 @@ namespace Ra {
 namespace Core {
 namespace Asset {
 
-/// CONSTRUCTOR
 HandleComponentData::HandleComponentData() :
-    m_frame( Core::Transform::Identity() ),
     m_name( "" ),
+    m_frame( Core::Transform::Identity() ),
     m_weight() {}
 
-/// CONSTRUCTOR
 HandleData::HandleData( const std::string& name, const HandleType& type ) :
     AssetData( name ),
     m_frame( Core::Transform::Identity() ),
@@ -22,7 +20,6 @@ HandleData::HandleData( const std::string& name, const HandleType& type ) :
     m_edge(),
     m_face() {}
 
-/// DESTRUCTOR
 HandleData::~HandleData() {}
 
 } // namespace Asset

--- a/src/Core/Asset/HandleData.hpp
+++ b/src/Core/Asset/HandleData.hpp
@@ -23,6 +23,7 @@ struct RA_CORE_API HandleComponentData {
 
     std::string m_name;
     Core::Transform m_frame;
+    Core::Transform m_offset{Core::Transform::Identity()};
     std::map<std::string, std::vector<std::pair<uint, Scalar>>> m_weight;
 };
 

--- a/src/Core/Asset/HandleData.hpp
+++ b/src/Core/Asset/HandleData.hpp
@@ -16,103 +16,249 @@ namespace Ra {
 namespace Core {
 namespace Asset {
 
+/**
+ * A HandleComponentData stores the data of an animation Handle linked to an object.
+ */
 struct RA_CORE_API HandleComponentData {
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
     HandleComponentData();
 
-    /// Handle name
+    /// Handle name.
     std::string m_name;
 
-    /// Handle transformation in model space
+    /// Handle transformation in model space.
     Core::Transform m_frame;
 
-    /// Matrix from mesh space to local space
+    /// Matrix from mesh space to local space.
     Core::Transform m_offset{Core::Transform::Identity()};
 
     /// Per skinned-mesh vertex weigths.
     std::map<std::string, std::vector<std::pair<uint, Scalar>>> m_weight;
 };
 
+/**
+ * The HandleData class stores all the HandleComponentData linked to an object.
+ */
 class RA_CORE_API HandleData : public AssetData {
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    /// ENUM
+    /**
+     * The type of Handle system.
+     */
     enum HandleType { UNKNOWN = 1 << 0, POINT_CLOUD = 1 << 1, SKELETON = 1 << 2, CAGE = 1 << 3 };
 
-    /// CONSTRUCTOR
     HandleData( const std::string& name = "", const HandleType& type = UNKNOWN );
 
     HandleData( const HandleData& data ) = default;
 
-    /// DESTRUCTOR
     ~HandleData();
 
-    /// NAME
+    /// \name HandleSystem
+    /// \{
+
+    /**
+     * Set the name of the Handle system.
+     */
     inline void setName( const std::string& name );
 
-    /// TYPE
+    /**
+     * Return the type of the Handle system.
+     */
     inline HandleType getType() const;
+
+    /**
+     * Set the type of the Handle system.
+     */
     inline void setType( const HandleType& type );
 
-    /// FRAME
+    /**
+     * Return the transformation of the Handle system.
+     */
     inline Core::Transform getFrame() const;
+
+    /**
+     * Set the transformation of the Handle system.
+     */
     inline void setFrame( const Core::Transform& frame );
 
-    /// VERTEX SIZE
+    /**
+     * Add \p name to the list of bound mesh names.
+     */
+    inline void addBindMesh( const std::string& name );
+
+    /**
+     * Returns the list of bound mesh names.
+     */
+    inline const std::set<std::string>& getBindMeshes() const;
+    /// \}
+
+    /**
+     * Return the maximal number of vertices influenced by a Handle.
+     */
     inline uint getVertexSize() const;
+
+    /**
+     * Set the maximal number of vertices influenced by a Handle.
+     */
     inline void setVertexSize( uint size );
 
-    /// NAME TABLE
+    /**
+     * Set the map from Handle names to Handle storage index.
+     */
     inline void setNameTable( const std::map<std::string, uint>& nameTable );
 
-    /// DATA
-    inline uint getComponentDataSize() const;
-    inline const Core::AlignedStdVector<HandleComponentData>& getComponentData() const;
-    inline Core::AlignedStdVector<HandleComponentData>& getComponentData();
-    inline const HandleComponentData& getComponent( const uint i ) const;
-    inline HandleComponentData& getComponent( const uint i );
-    inline void setComponents( const Core::AlignedStdVector<HandleComponentData>& components );
-    inline const Core::AlignedStdVector<Core::Vector2i>& getEdgeData() const;
-    inline Core::AlignedStdVector<Core::Vector2i>& getEdgeData();
-    inline void setEdges( const Core::AlignedStdVector<Core::Vector2i>& edgeList );
-    inline const Core::AlignedStdVector<Core::VectorNi>& getFaceData() const;
-    inline Core::AlignedStdVector<Core::VectorNi>& getFaceData();
-    inline void setFaces( const Core::AlignedStdVector<Core::VectorNi>& faceList );
+    /**
+     * Recompute the map from Handle names to Handle storage index.
+     */
     inline void recomputeAllIndices();
 
-    /// SKINNED MESHES
-    inline void addBindMesh( const std::string& name );
-    inline const std::set<std::string>& getBindMeshes() const;
+    /// \name Data access
+    /// \{
 
-    /// QUERY
-    inline bool isPointCloud() const;
-    inline bool isSkeleton() const;
-    inline bool isCage() const;
-    inline bool hasComponents() const;
-    inline bool hasEdges() const;
-    inline bool hasFaces() const;
-    inline bool needsEndNodes() const;
-    inline int getIndexOf( const std::string& name ) const;
+    /**
+     * Return the number of Handles in the system.
+     */
+    inline uint getComponentDataSize() const;
 
+    /**
+     * Return the list of HandleComponentData.
+     */
+    inline const Core::AlignedStdVector<HandleComponentData>& getComponentData() const;
+
+    /**
+     * Return the list of HandleComponentData.
+     */
+    inline Core::AlignedStdVector<HandleComponentData>& getComponentData();
+
+    /**
+     * Return the \p i-th HandleComponentData.
+     */
+    inline const HandleComponentData& getComponent( const uint i ) const;
+
+    /**
+     * Return the \p i-th HandleComponentData.
+     */
+    inline HandleComponentData& getComponent( const uint i );
+
+    /**
+     * Set the HandleComponentData for the Handle system.
+     */
+    inline void setComponents( const Core::AlignedStdVector<HandleComponentData>& components );
+
+    /**
+     * Return the HandleSystem hierarchy, i.e.\ bones hierarchy.
+     */
+    inline const Core::AlignedStdVector<Core::Vector2i>& getEdgeData() const;
+
+    /**
+     * Return the HandleSystem hierarchy, i.e.\ bones hierarchy.
+     */
+    inline Core::AlignedStdVector<Core::Vector2i>& getEdgeData();
+
+    /**
+     * Set the HandleSystem linear hierarchy part, i.e.\ bones hierarchy.
+     */
+    inline void setEdges( const Core::AlignedStdVector<Core::Vector2i>& edgeList );
+
+    /**
+     * Return the HandleSystem N-Dimensional parts, i.e.\ cage polyhedra.
+     */
+    inline const Core::AlignedStdVector<Core::VectorNi>& getFaceData() const;
+
+    /**
+     * Return the HandleSystem N-Dimensional parts, i.e.\ cage polyhedra.
+     */
+    inline Core::AlignedStdVector<Core::VectorNi>& getFaceData();
+
+    /**
+     * Set the HandleSystem N-Dimensional parts, i.e.\ cage polyhedra.
+     */
+    inline void setFaces( const Core::AlignedStdVector<Core::VectorNi>& faceList );
+
+    /**
+     * Set whether the Handle system needs end bones.
+     */
     inline void needEndNodes( bool need );
+    /// \}
 
-    /// DEBUG
+    /// \name Status querries
+    /// \{
+
+    /**
+     * Return true if the Handle system is a Point Cloud.
+     */
+    inline bool isPointCloud() const;
+
+    /**
+     * Return true if the Handle system is a Skeleton.
+     */
+    inline bool isSkeleton() const;
+
+    /**
+     * Return true if the Handle system is a Cage.
+     */
+    inline bool isCage() const;
+
+    /**
+     * Return true if the Handle system has Handles.
+     */
+    inline bool hasComponents() const;
+
+    /**
+     * Return true if the Handle system has a hierarchy.
+     */
+    inline bool hasEdges() const;
+
+    /**
+     * Return true if the Handle system has N-Dimensional parts.
+     */
+    inline bool hasFaces() const;
+
+    /**
+     * Return true if the Handle system needs end bones.
+     */
+    inline bool needsEndNodes() const;
+
+    /**
+     * Return the storage index of the Handle with the given name
+     * if it exists, -1 otherwise.
+     */
+    inline int getIndexOf( const std::string& name ) const;
+    /// \}
+
+    /**
+     * Print stat info to the Debug output.
+     */
     inline void displayInfo() const;
 
-  protected:
-    /// VARIABLE
+  private:
+    /// The transformation of the Handle system.
     Core::Transform m_frame;
+
+    /// The type of the Handle system.
     HandleType m_type;
 
+    /// Whether the Handle System needs end bones.
     bool m_endNode;
+
+    /// The maximal number of vertices influenced by a Handle of the system.
     uint m_vertexSize;
+
+    /// The map from Handle name to storage index.
     std::map<std::string, uint> m_nameTable;
+
+    /// The list of bound mesh names.
     std::set<std::string> m_bindMeshes;
 
+    /// The list of HandleComponentData.
     Core::AlignedStdVector<HandleComponentData> m_component;
+
+    /// The HandleSystem hierarchy, i.e.\ bones hierarchy.
     Core::AlignedStdVector<Core::Vector2i> m_edge;
+
+    /// The HandleSystem N-Dimensional parts, i.e.\ cage polyhedra.
     Core::AlignedStdVector<Core::VectorNi> m_face;
 };
 

--- a/src/Core/Asset/HandleData.hpp
+++ b/src/Core/Asset/HandleData.hpp
@@ -21,9 +21,16 @@ struct RA_CORE_API HandleComponentData {
 
     HandleComponentData();
 
+    /// Handle name
     std::string m_name;
+
+    /// Handle transformation in model space
     Core::Transform m_frame;
+
+    /// Matrix from mesh space to local space
     Core::Transform m_offset{Core::Transform::Identity()};
+
+    /// Per skinned-mesh vertex weigths.
     std::map<std::string, std::vector<std::pair<uint, Scalar>>> m_weight;
 };
 
@@ -75,6 +82,7 @@ class RA_CORE_API HandleData : public AssetData {
     inline void setFaces( const Core::AlignedStdVector<Core::VectorNi>& faceList );
     inline void recomputeAllIndices();
 
+    /// SKINNED MESHES
     inline void addBindMesh( const std::string& name );
     inline const std::set<std::string>& getBindMeshes() const;
 

--- a/src/Core/Asset/HandleData.hpp
+++ b/src/Core/Asset/HandleData.hpp
@@ -2,6 +2,7 @@
 #define RADIUMENGINE_HANDLE_DATA_HPP
 
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -20,9 +21,9 @@ struct RA_CORE_API HandleComponentData {
 
     HandleComponentData();
 
-    Core::Transform m_frame;
     std::string m_name;
-    std::vector<std::pair<uint, Scalar>> m_weight;
+    Core::Transform m_frame;
+    std::map<std::string, std::vector<std::pair<uint, Scalar>>> m_weight;
 };
 
 class RA_CORE_API HandleData : public AssetData {
@@ -73,6 +74,9 @@ class RA_CORE_API HandleData : public AssetData {
     inline void setFaces( const Core::AlignedStdVector<Core::VectorNi>& faceList );
     inline void recomputeAllIndices();
 
+    inline void addBindMesh( const std::string& name );
+    inline const std::set<std::string>& getBindMeshes() const;
+
     /// QUERY
     inline bool isPointCloud() const;
     inline bool isSkeleton() const;
@@ -96,6 +100,7 @@ class RA_CORE_API HandleData : public AssetData {
     bool m_endNode;
     uint m_vertexSize;
     std::map<std::string, uint> m_nameTable;
+    std::set<std::string> m_bindMeshes;
 
     Core::AlignedStdVector<HandleComponentData> m_component;
     Core::AlignedStdVector<Core::Vector2i> m_edge;

--- a/src/Core/Asset/HandleData.inl
+++ b/src/Core/Asset/HandleData.inl
@@ -6,12 +6,10 @@ namespace Ra {
 namespace Core {
 namespace Asset {
 
-/// NAME
 inline void HandleData::setName( const std::string& name ) {
     m_name = name;
 }
 
-/// TYPE
 inline HandleData::HandleType HandleData::getType() const {
     return m_type;
 }
@@ -20,7 +18,6 @@ inline void HandleData::setType( const HandleType& type ) {
     m_type = type;
 }
 
-/// FRAME
 inline Core::Transform HandleData::getFrame() const {
     return m_frame;
 }
@@ -29,7 +26,6 @@ inline void HandleData::setFrame( const Core::Transform& frame ) {
     m_frame = frame;
 }
 
-/// VERTEX SIZE
 inline uint HandleData::getVertexSize() const {
     return m_vertexSize;
 }
@@ -37,12 +33,10 @@ inline void HandleData::setVertexSize( uint size ) {
     m_vertexSize = size;
 }
 
-/// TABLE
 inline void HandleData::setNameTable( const std::map<std::string, uint>& nameTable ) {
     m_nameTable = nameTable;
 }
 
-/// DATA
 inline uint HandleData::getComponentDataSize() const {
     return m_component.size();
 }
@@ -121,7 +115,6 @@ inline void HandleData::recomputeAllIndices() {
     }
 }
 
-/// QUERY
 inline bool HandleData::isPointCloud() const {
     return ( m_type == POINT_CLOUD );
 }
@@ -171,7 +164,6 @@ inline const std::set<std::string>& HandleData::getBindMeshes() const {
     return m_bindMeshes;
 }
 
-/// DEBUG
 inline void HandleData::displayInfo() const {
     using namespace Core::Utils; // log
     std::string type;

--- a/src/Core/Asset/HandleData.inl
+++ b/src/Core/Asset/HandleData.inl
@@ -163,6 +163,14 @@ inline void HandleData::needEndNodes( bool need ) {
     m_endNode = need;
 }
 
+inline void HandleData::addBindMesh( const std::string& name ) {
+    m_bindMeshes.insert( name );
+}
+
+inline const std::set<std::string>& HandleData::getBindMeshes() const {
+    return m_bindMeshes;
+}
+
 /// DEBUG
 inline void HandleData::displayInfo() const {
     using namespace Core::Utils; // log

--- a/src/Core/Asset/HandleToSkeleton.cpp
+++ b/src/Core/Asset/HandleToSkeleton.cpp
@@ -15,9 +15,8 @@ void addBone( const int parent,  // index of parent bone
               const Ra::Core::AlignedStdVector<Ra::Core::Asset::HandleComponentData>&
                   data,                                                       // handle bone data
               const Ra::Core::AlignedStdVector<Ra::Core::Vector2i>& edgeList, // list of edges
-              std::vector<bool>& processed,       // which ids have been processed
-              Core::Animation::Skeleton& skelOut, // skeleton being built
-              std::map<uint, uint>& indexTable )  // correspondance between data idx and bone idx
+              std::vector<bool>& processed,        // which ids have been processed
+              Core::Animation::Skeleton& skelOut ) // correspondance between bone name and bone idx
 {
     if ( !processed[dataID] )
     {
@@ -25,20 +24,18 @@ void addBone( const int parent,  // index of parent bone
         const auto& dd = data[dataID];
         uint index = skelOut.addBone( parent, dd.m_frame,
                                       Ra::Core::Animation::Handle::SpaceType::MODEL, dd.m_name );
-        indexTable[dataID] = index;
         for ( const auto& edge : edgeList )
         {
             if ( edge[0] == dataID )
             {
-                addBone( index, edge[1], data, edgeList, processed, skelOut, indexTable );
+                addBone( index, edge[1], data, edgeList, processed, skelOut );
             }
         }
     }
 }
 } // namespace
 
-void createSkeleton( const Ra::Core::Asset::HandleData& data, Core::Animation::Skeleton& skelOut,
-                     std::map<uint, uint>& indexTableOut ) {
+void createSkeleton( const Ra::Core::Asset::HandleData& data, Core::Animation::Skeleton& skelOut ) {
     const uint size = data.getComponentDataSize();
     auto component = data.getComponentData();
 
@@ -57,7 +54,7 @@ void createSkeleton( const Ra::Core::Asset::HandleData& data, Core::Animation::S
     std::vector<bool> processed( size, false );
     for ( const auto& r : root )
     {
-        addBone( -1, r, component, edgeList, processed, skelOut, indexTableOut );
+        addBone( -1, r, component, edgeList, processed, skelOut );
     }
 }
 } // namespace Asset

--- a/src/Core/Asset/HandleToSkeleton.cpp
+++ b/src/Core/Asset/HandleToSkeleton.cpp
@@ -10,10 +10,9 @@ namespace Asset {
 
 namespace {
 // Recursive function to add bones
-void addBone( const int parent,  // index of parent bone
-              const uint dataID, // index in map
-              const Ra::Core::AlignedStdVector<Ra::Core::Asset::HandleComponentData>&
-                  data,                                                       // handle bone data
+void addBone( const int parent,                        // index of parent bone
+              const uint dataID,                       // index in map
+              const Ra::Core::Asset::HandleData& data, // handle data
               const Ra::Core::AlignedStdVector<Ra::Core::Vector2i>& edgeList, // list of edges
               std::vector<bool>& processed,        // which ids have been processed
               Core::Animation::Skeleton& skelOut ) // correspondance between bone name and bone idx
@@ -21,8 +20,8 @@ void addBone( const int parent,  // index of parent bone
     if ( !processed[dataID] )
     {
         processed[dataID] = true;
-        const auto& dd = data[dataID];
-        uint index = skelOut.addBone( parent, dd.m_frame,
+        const auto& dd = data.getComponentData()[dataID];
+        uint index = skelOut.addBone( parent, data.getFrame() * dd.m_offset.inverse(),
                                       Ra::Core::Animation::Handle::SpaceType::MODEL, dd.m_name );
         for ( const auto& edge : edgeList )
         {
@@ -54,7 +53,7 @@ void createSkeleton( const Ra::Core::Asset::HandleData& data, Core::Animation::S
     std::vector<bool> processed( size, false );
     for ( const auto& r : root )
     {
-        addBone( -1, r, component, edgeList, processed, skelOut );
+        addBone( -1, r, data, edgeList, processed, skelOut );
     }
 }
 } // namespace Asset

--- a/src/Core/Asset/HandleToSkeleton.hpp
+++ b/src/Core/Asset/HandleToSkeleton.hpp
@@ -18,11 +18,10 @@ namespace Asset {
 
 class HandleData;
 
-/// Create a skeleton from a Handle Data extracted from a file
-/// Outputs the skeleton and a map from the component index in the handle data to the bone index.
+/// Create a skeleton from a Handle Data extracted from a file.
+/// Outputs the skeleton.
 void RA_CORE_API createSkeleton( const Ra::Core::Asset::HandleData& data,
-                                 Core::Animation::Skeleton& skelOut,
-                                 std::map<uint, uint>& indexTableOut );
+                                 Core::Animation::Skeleton& skelOut );
 
 } // namespace Asset
 } // namespace Core

--- a/src/IO/AssimpLoader/AssimpHandleDataLoader.hpp
+++ b/src/IO/AssimpLoader/AssimpHandleDataLoader.hpp
@@ -12,6 +12,7 @@ struct aiScene;
 struct aiNode;
 struct aiMesh;
 struct aiBone;
+struct aiString;
 
 namespace Ra {
 namespace Core {
@@ -35,7 +36,7 @@ class RA_IO_API AssimpHandleDataLoader : public Core::Asset::DataLoader<Core::As
     void loadData( const aiScene* scene,
                    std::vector<std::unique_ptr<Core::Asset::HandleData>>& data ) override;
 
-  protected:
+  private:
     /// QUERY
     bool sceneHasHandle( const aiScene* scene ) const;
     uint sceneHandleSize( const aiScene* scene ) const;
@@ -43,26 +44,15 @@ class RA_IO_API AssimpHandleDataLoader : public Core::Asset::DataLoader<Core::As
     /// LOAD
     void loadHandleData( const aiScene* scene,
                          std::vector<std::unique_ptr<Core::Asset::HandleData>>& data ) const;
-    void loadHandleComponentData( const aiScene* scene, const aiMesh* mesh,
-                                  Core::Asset::HandleData* data ) const;
-    void loadHandleComponentData( const aiScene* scene, const aiBone* bone,
-                                  Core::Asset::HandleComponentData& data ) const;
-    void loadHandleComponentData( const aiNode* node,
-                                  Core::Asset::HandleComponentData& data ) const;
-    void loadHandleTopologyData( const aiScene* scene, Core::Asset::HandleData* data ) const;
-    void loadHandleFrame( const aiNode* node, const Core::Transform& parentFrame,
-                          const std::map<uint, uint>& indexTable,
-                          std::vector<std::unique_ptr<Core::Asset::HandleData>>& data ) const;
-
-    /// NAME
-    void fetchName( const aiMesh& mesh, Core::Asset::HandleData& data,
-                    std::set<std::string>& usedNames ) const;
-
-    /// TYPE
-    void fetchType( const aiMesh& mesh, Core::Asset::HandleData& data ) const;
-
-    /// VERTEX SIZE
-    void fetchVertexSize( Core::Asset::HandleData& data ) const;
+    void loadHandleComponentDataFrame( const aiScene* scene, const aiString& boneName,
+                                       Core::Asset::HandleComponentData& data ) const;
+    void loadHandleComponentDataWeights( const aiBone* bone, const std::string& meshName,
+                                         Core::Asset::HandleComponentData& data ) const;
+    void
+    fillHandleData( const std::string& node,
+                    const std::vector<std::pair<std::string, std::string>>& edgeList,
+                    const std::map<std::string, Core::Asset::HandleComponentData>& mapBone2Data,
+                    std::map<std::string, uint>& nameTable, Core::Asset::HandleData* data ) const;
 };
 
 } // namespace IO


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master`: for hotfixes not impacting the API
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR attempts to fix the importation of skeleton-based character animation.

**The current implementation of skinning in Radium makes it impossible to correctly load all models.
The whole skinning process needs re-implementation, but this is out of the scope of this PR.**


* **What is the current behavior?** (You can also link to an open issue here)
The current implementation has several drawbacks:
 - does not handle one skeleton for several mesh pieces,
 - does not load skeleton in `bind` pose but in `as it is when exported` pose,
 - does not support scaling in loaded bone transformations.
All these make it nearly impossible to load any animated character from scratch.
One may (90% of the time) import the character into another software and tweak/export it again and again to make Radium load it (almost) properly.
Also, the skinning weight are stored within the `AnimationComponent`, while they are used within the `SkinningComponent`.


* **What is the new behavior (if this is a feature change)?**
- Each loaded `HandleData` now has a list of bound meshes it influences (vertex weights are sorted per mesh in each `HandleComponentData`), thus allowing to load and build only one skeleton per animated character, even in the case of several mesh parts.
- Samely, the `Skinning` plugin still creates one `SkinningComponent` per mesh part, but  storing the skinning weights related to it.
- Transforms are now correctly interpolated (position, rotation, scale).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:

 - fixes potential crash issue when querrying a keyFramed data from an empty container,
 - fix loaded animations registration,
 - adds some (sparse) documentation about animation in Radium.
 - fix #90 