### PR TITLE
Fix to convert int to TaskId.

### DIFF
--- a/src/Core/Tasks/TaskQueue.cpp
+++ b/src/Core/Tasks/TaskQueue.cpp
@@ -119,7 +119,7 @@ void TaskQueue::detectCycles() {
     std::vector<bool> visited( m_tasks.size(), false );
     std::stack<TaskId> pending;
 
-    for ( TaskId id = 0; id < m_tasks.size(); ++id )
+    for ( TaskId id{0}; id < m_tasks.size(); ++id )
     {
         if ( m_dependencies[id].size() == 0 )
         {


### PR DESCRIPTION


* **Please check if the PR fulfills these requirements**
- [x] Is the Pull-Request done against the right branch:
  - `master`: for hotfixes not impacting the API
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
Hot fix, no doc ;)
Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
Radium do not compile on my setup.
Apple LLVM version 10.0.0 (clang-1000.11.45.5)


* **What is the new behavior (if this is a feature change)?**
It compiles (at least on my setup)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
