### PR TITLE
Core/Utils/Color "linear RGB" and "sRGB" conversion

### DIFF
--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -401,11 +401,15 @@ void MainWindow::updateDisplayedTexture() {
     }
 }
 
+// FIXME : manage transition to and from viewer/renderer, taking into account the sRGB color space
 void MainWindow::updateBackgroundColor( QColor c ) {
     QSettings settings;
     if ( !c.isValid() )
     {
-        c = settings.value( "colors/background", QColor::fromRgb( 10, 10, 10 ) ).value<QColor>();
+        // get the default color or an already existing one
+        auto defColor = m_viewer->getBackgroundColor();
+        auto bgk = QColor::fromRgb( defColor.rgb()[0]*255, defColor.rgb()[1]*255, defColor.rgb()[2]*255 );
+        c = settings.value( "colors/background", bgk ).value<QColor>();
     } else
     { settings.setValue( "colors/background", c ); }
     QString qss = QString( "background-color: %1" ).arg( c.name() );

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -409,8 +409,7 @@ void MainWindow::updateBackgroundColor( QColor c ) {
     if ( !c.isValid() )
     {
         // get the default color or an already existing one
-        auto defColor = m_viewer->getBackgroundColor(); // assume linear RGB
-        defColor.tosRGB();
+        auto defColor = m_viewer->getBackgroundColor().tosRGB();
         auto bgk = QColor::fromRgb( defColor.rgb()[0]*255, defColor.rgb()[1]*255, defColor.rgb()[2]*255 );
         c = settings.value( "colors/background", bgk ).value<QColor>();
     } else
@@ -423,8 +422,7 @@ void MainWindow::updateBackgroundColor( QColor c ) {
     // update the background coolor of the viewer
     auto bgk = Core::Utils::Color( Scalar( c.redF() ), Scalar( c.greenF() ),
                                    Scalar( c.blueF() ), Scalar( 0 ) );
-    bgk.toLinRGB();
-    m_viewer->setBackgroundColor( bgk );
+    m_viewer->setBackgroundColor( bgk.toLinRGB() );
 }
 
 void MainWindow::changeRenderObjectShader( const QString& shaderName ) {
@@ -636,8 +634,7 @@ void MainWindow::onGLInitialized() {
 
 void Ra::Gui::MainWindow::on_m_currentColorButton_clicked() {
     // get the default color or an already existing one
-    auto defColor = m_viewer->getBackgroundColor(); // assume linear RGB
-    defColor.tosRGB();
+    auto defColor = m_viewer->getBackgroundColor().tosRGB();
     auto currentColor = QColor::fromRgb( defColor.rgb()[0]*255, defColor.rgb()[1]*255, defColor.rgb()[2]*255 );
     QColor c = QColorDialog::getColor( currentColor, this, "Renderer background color" );
     if ( c.isValid() )

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -409,7 +409,7 @@ void MainWindow::updateBackgroundColor( QColor c ) {
     if ( !c.isValid() )
     {
         // get the default color or an already existing one
-        auto defColor =  Core::Utils::Color::tosRGB(m_viewer->getBackgroundColor());
+        auto defColor = Core::Utils::Color::linearRGBTosRGB(m_viewer->getBackgroundColor());
         auto bgk = QColor::fromRgb( defColor.rgb()[0]*255, defColor.rgb()[1]*255, defColor.rgb()[2]*255 );
         c = settings.value( "colors/background", bgk ).value<QColor>();
     } else
@@ -420,8 +420,8 @@ void MainWindow::updateBackgroundColor( QColor c ) {
     m_currentColorButton->setStyleSheet( qss );
 
     // update the background coolor of the viewer
-    auto bgk = Core::Utils::Color::toLinRGB( Core::Utils::Color( Scalar( c.redF() ), Scalar( c.greenF() ),
-                                   Scalar( c.blueF() ), Scalar( 0 ) ) );
+    auto bgk = Core::Utils::Color::sRGBToLinearRGB(Core::Utils::Color(Scalar(c.redF()), Scalar(c.greenF()),
+                                                                      Scalar(c.blueF()), Scalar(0)));
     m_viewer->setBackgroundColor( bgk );
 }
 
@@ -634,7 +634,7 @@ void MainWindow::onGLInitialized() {
 
 void Ra::Gui::MainWindow::on_m_currentColorButton_clicked() {
     // get the default color or an already existing one
-    auto defColor =  Core::Utils::Color::tosRGB(m_viewer->getBackgroundColor());
+    auto defColor = Core::Utils::Color::linearRGBTosRGB(m_viewer->getBackgroundColor());
     auto currentColor = QColor::fromRgb( defColor.rgb()[0]*255, defColor.rgb()[1]*255, defColor.rgb()[2]*255 );
     QColor c = QColorDialog::getColor( currentColor, this, "Renderer background color" );
     if ( c.isValid() )

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -409,7 +409,7 @@ void MainWindow::updateBackgroundColor( QColor c ) {
     if ( !c.isValid() )
     {
         // get the default color or an already existing one
-        auto defColor = m_viewer->getBackgroundColor().tosRGB();
+        auto defColor =  Core::Utils::Color::tosRGB(m_viewer->getBackgroundColor());
         auto bgk = QColor::fromRgb( defColor.rgb()[0]*255, defColor.rgb()[1]*255, defColor.rgb()[2]*255 );
         c = settings.value( "colors/background", bgk ).value<QColor>();
     } else
@@ -420,9 +420,9 @@ void MainWindow::updateBackgroundColor( QColor c ) {
     m_currentColorButton->setStyleSheet( qss );
 
     // update the background coolor of the viewer
-    auto bgk = Core::Utils::Color( Scalar( c.redF() ), Scalar( c.greenF() ),
-                                   Scalar( c.blueF() ), Scalar( 0 ) );
-    m_viewer->setBackgroundColor( bgk.toLinRGB() );
+    auto bgk = Core::Utils::Color::toLinRGB( Core::Utils::Color( Scalar( c.redF() ), Scalar( c.greenF() ),
+                                   Scalar( c.blueF() ), Scalar( 0 ) ) );
+    m_viewer->setBackgroundColor( bgk );
 }
 
 void MainWindow::changeRenderObjectShader( const QString& shaderName ) {
@@ -634,7 +634,7 @@ void MainWindow::onGLInitialized() {
 
 void Ra::Gui::MainWindow::on_m_currentColorButton_clicked() {
     // get the default color or an already existing one
-    auto defColor = m_viewer->getBackgroundColor().tosRGB();
+    auto defColor =  Core::Utils::Color::tosRGB(m_viewer->getBackgroundColor());
     auto currentColor = QColor::fromRgb( defColor.rgb()[0]*255, defColor.rgb()[1]*255, defColor.rgb()[2]*255 );
     QColor c = QColorDialog::getColor( currentColor, this, "Renderer background color" );
     if ( c.isValid() )

--- a/Shaders/HdrToLdr/Hdr2Ldr.frag.glsl
+++ b/Shaders/HdrToLdr/Hdr2Ldr.frag.glsl
@@ -3,14 +3,13 @@ out vec4 fragColor;
 in vec2 varTexcoord;
 
 uniform sampler2D screenTexture;
-uniform float gamma;
 
 // from sRGB color space specification
 float tosRGB(float c) {
   if (c <= 0.0031308) {
     return 12.92*c;
   } else {
-    return 1.055*pow(c, 1/gamma) - 0.055;
+    return 1.055*pow(c, 1./2.4) - 0.055;
   }
 }
 void main()

--- a/src/Core/Utils/Color.hpp
+++ b/src/Core/Utils/Color.hpp
@@ -6,16 +6,17 @@
 #include <Eigen/Geometry> //homogeneous
 #include <random>
 
+
+namespace Ra {
+namespace Core {
+namespace Utils {
+
 /**
  * gamma value for sRGB color space transfer function
  * @see https://en.wikipedia.org/wiki/SRGB
  * @see http://www.color.org/srgb.pdf
  */
-static constexpr Scalar SRGB_GAMMA=2.4_ra;
-
-namespace Ra {
-namespace Core {
-namespace Utils {
+  static constexpr Scalar SRGB_GAMMA=2.4_ra;
 
 /*!
  * Colors are defined as vector4, i.e. 4 Scalars in RGBA order.

--- a/src/Core/Utils/Color.hpp
+++ b/src/Core/Utils/Color.hpp
@@ -11,7 +11,7 @@
  * @see https://en.wikipedia.org/wiki/SRGB
  * @see http://www.color.org/srgb.pdf
  */
-#define SRGB_GAMMA 2.4_ra
+static constexpr Scalar SRGB_GAMMA=2.4_ra;
 
 namespace Ra {
 namespace Core {
@@ -45,25 +45,29 @@ class ColorBase : public Eigen::Matrix<_Scalar, 4, 1> {
     operator VectorType() { return *this; }
 
     /// convert the color expressed in sRGB color space to linear RGB
-    inline void toLinRGB( _Scalar gamma = SRGB_GAMMA) {
-        for (auto &u : rgb()) {
+    inline ColorBase toLinRGB( _Scalar gamma = SRGB_GAMMA) const {
+        ColorBase<_Scalar> c( *this );
+        for (auto &u : c.rgb()) {
             if (u < 0.04045_ra) {
                 u /=12.92_ra;
             } else {
                 u = std::pow((u+0.055_ra)/1.055_ra, gamma);
             }
         }
+        return c;
     }
 
     /// convert the color expressed in linear RGB color space to sRGB
-    inline void tosRGB( _Scalar gamma = SRGB_GAMMA) {
-        for (auto &u : rgb()) {
+    inline ColorBase tosRGB( _Scalar gamma = SRGB_GAMMA) const {
+        ColorBase<_Scalar> c( *this );
+        for (auto &u : c.rgb()) {
             if (u < 0.0031308_ra) {
                 u *=12.92_ra;
             } else {
                 u = 1.055_ra*std::pow(u, 1_ra/gamma)-0.055_ra;
             }
         }
+        return c;
     }
 
     template <typename Derived>

--- a/src/Core/Utils/Color.hpp
+++ b/src/Core/Utils/Color.hpp
@@ -11,13 +11,6 @@ namespace Ra {
 namespace Core {
 namespace Utils {
 
-/**
- * gamma value for sRGB color space transfer function
- * @see https://en.wikipedia.org/wiki/SRGB
- * @see http://www.color.org/srgb.pdf
- */
-  static constexpr Scalar SRGB_GAMMA=2.4_ra;
-
 /*!
  * Colors are defined as vector4, i.e. 4 Scalars in RGBA order.
  * displayable colors should have all their coordinates between 0 and 1.
@@ -46,26 +39,26 @@ class ColorBase : public Eigen::Matrix<_Scalar, 4, 1> {
     operator VectorType() { return *this; }
 
     /// convert the color expressed in sRGB color space to linear RGB
-    inline ColorBase toLinRGB( _Scalar gamma = SRGB_GAMMA) const {
-        ColorBase<_Scalar> c( *this );
+    static inline ColorBase toLinRGB(const ColorBase &srgb) {
+        ColorBase<_Scalar> c( srgb );
         for (auto &u : c.rgb()) {
             if (u < 0.04045_ra) {
                 u /=12.92_ra;
             } else {
-                u = std::pow((u+0.055_ra)/1.055_ra, gamma);
+                u = std::pow((u+0.055_ra)/1.055_ra, 2.4_ra);
             }
         }
         return c;
     }
 
     /// convert the color expressed in linear RGB color space to sRGB
-    inline ColorBase tosRGB( _Scalar gamma = SRGB_GAMMA) const {
-        ColorBase<_Scalar> c( *this );
+    static inline ColorBase tosRGB(const ColorBase &lrgb) {
+        ColorBase<_Scalar> c( lrgb );
         for (auto &u : c.rgb()) {
             if (u < 0.0031308_ra) {
                 u *=12.92_ra;
             } else {
-                u = 1.055_ra*std::pow(u, 1_ra/gamma)-0.055_ra;
+                u = 1.055_ra*std::pow(u, 1_ra/2.4_ra)-0.055_ra;
             }
         }
         return c;

--- a/src/Core/Utils/Color.hpp
+++ b/src/Core/Utils/Color.hpp
@@ -37,6 +37,28 @@ class ColorBase : public Eigen::Matrix<_Scalar, 4, 1> {
     /// cast operator, mandatory to use Vector arithmetic
     operator VectorType() { return *this; }
 
+    /// convert the color expressed in sRGB color space to linear RGB
+    inline void toLinRGB( _Scalar gamma = 2.2_ra) {
+        for (auto &u : rgb()) {
+            if (u < 0.04045_ra) {
+                u /=12.92_ra;
+            } else {
+                u = std::pow((u+0.055_ra)/1.055_ra, gamma);
+            }
+        }
+    }
+
+    /// convert the color expressed in linear RGB color space to sRGB
+    inline void tosRGB( _Scalar gamma = 2.2_ra) {
+        for (auto &u : rgb()) {
+            if (u < 0.0031308_ra) {
+                u *=12.92_ra;
+            } else {
+                u = 1.055_ra*std::pow(u, 1_ra/gamma)-0.055_ra;
+            }
+        }
+    }
+
     template <typename Derived>
     static inline ColorBase fromRGB( const Eigen::MatrixBase<Derived>& rgb,
                                      Scalar alpha = Scalar( 1. ) ) {

--- a/src/Core/Utils/Color.hpp
+++ b/src/Core/Utils/Color.hpp
@@ -6,6 +6,13 @@
 #include <Eigen/Geometry> //homogeneous
 #include <random>
 
+/**
+ * gamma value for sRGB color space transfer function
+ * @see https://en.wikipedia.org/wiki/SRGB
+ * @see http://www.color.org/srgb.pdf
+ */
+#define SRGB_GAMMA 2.4_ra
+
 namespace Ra {
 namespace Core {
 namespace Utils {
@@ -38,7 +45,7 @@ class ColorBase : public Eigen::Matrix<_Scalar, 4, 1> {
     operator VectorType() { return *this; }
 
     /// convert the color expressed in sRGB color space to linear RGB
-    inline void toLinRGB( _Scalar gamma = 2.2_ra) {
+    inline void toLinRGB( _Scalar gamma = SRGB_GAMMA) {
         for (auto &u : rgb()) {
             if (u < 0.04045_ra) {
                 u /=12.92_ra;
@@ -49,7 +56,7 @@ class ColorBase : public Eigen::Matrix<_Scalar, 4, 1> {
     }
 
     /// convert the color expressed in linear RGB color space to sRGB
-    inline void tosRGB( _Scalar gamma = 2.2_ra) {
+    inline void tosRGB( _Scalar gamma = SRGB_GAMMA) {
         for (auto &u : rgb()) {
             if (u < 0.0031308_ra) {
                 u *=12.92_ra;

--- a/src/Core/Utils/Color.hpp
+++ b/src/Core/Utils/Color.hpp
@@ -39,7 +39,7 @@ class ColorBase : public Eigen::Matrix<_Scalar, 4, 1> {
     operator VectorType() { return *this; }
 
     /// convert the color expressed in sRGB color space to linear RGB
-    static inline ColorBase toLinRGB(const ColorBase &srgb) {
+    static inline ColorBase sRGBToLinearRGB(const ColorBase &srgb) {
         ColorBase<_Scalar> c( srgb );
         for (auto &u : c.rgb()) {
             if (u < 0.04045_ra) {
@@ -52,7 +52,7 @@ class ColorBase : public Eigen::Matrix<_Scalar, 4, 1> {
     }
 
     /// convert the color expressed in linear RGB color space to sRGB
-    static inline ColorBase tosRGB(const ColorBase &lrgb) {
+    static inline ColorBase linearRGBTosRGB(const ColorBase &lrgb) {
         ColorBase<_Scalar> c( lrgb );
         for (auto &u : c.rgb()) {
             if (u < 0.0031308_ra) {

--- a/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
+++ b/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
@@ -430,7 +430,6 @@ void ForwardRenderer::postProcessInternal( const ViewingParameters& renderData )
     const ShaderProgram* shader = m_shaderMgr->getShaderProgram( "Hdr2Ldr" );
     shader->bind();
     shader->setUniform( "screenTexture", m_textures[RendererTextures_HDR].get(), 0 );
-    shader->setUniform( "gamma", Ra::Core::Utils::SRGB_GAMMA );
     m_quadMesh->render();
 
     GL_ASSERT( glDepthMask( GL_TRUE ) );

--- a/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
+++ b/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
@@ -430,7 +430,7 @@ void ForwardRenderer::postProcessInternal( const ViewingParameters& renderData )
     const ShaderProgram* shader = m_shaderMgr->getShaderProgram( "Hdr2Ldr" );
     shader->bind();
     shader->setUniform( "screenTexture", m_textures[RendererTextures_HDR].get(), 0 );
-    shader->setUniform( "gamma", 2.2 );
+    shader->setUniform( "gamma", SRGB_GAMMA );
     m_quadMesh->render();
 
     GL_ASSERT( glDepthMask( GL_TRUE ) );

--- a/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
+++ b/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
@@ -430,7 +430,7 @@ void ForwardRenderer::postProcessInternal( const ViewingParameters& renderData )
     const ShaderProgram* shader = m_shaderMgr->getShaderProgram( "Hdr2Ldr" );
     shader->bind();
     shader->setUniform( "screenTexture", m_textures[RendererTextures_HDR].get(), 0 );
-    shader->setUniform( "gamma", SRGB_GAMMA );
+    shader->setUniform( "gamma", Ra::Core::Utils::SRGB_GAMMA );
     m_quadMesh->render();
 
     GL_ASSERT( glDepthMask( GL_TRUE ) );

--- a/src/Engine/Renderer/Texture/Texture.cpp
+++ b/src/Engine/Renderer/Texture/Texture.cpp
@@ -162,7 +162,7 @@ void Engine::Texture::updateParameters() {
     GL_CHECK_ERROR;
 }
 
-void Engine::Texture::linearize( Scalar gamma ) {
+void Engine::Texture::linearize( ) {
     if ( m_texture != nullptr )
     {
         LOG( logERROR ) << "Only non OpenGL initialized texture can be linearized.";
@@ -190,24 +190,22 @@ void Engine::Texture::linearize( Scalar gamma ) {
                         << " can't be linearized." << m_textureParameters.name;
         return;
     }
-    sRGBToLinearRGB( reinterpret_cast<uint8_t*>( m_textureParameters.texels ), numcomp, hasAlpha,
-                     gamma );
+    sRGBToLinearRGB( reinterpret_cast<uint8_t*>( m_textureParameters.texels ), numcomp, hasAlpha );
 }
 
-void Engine::Texture::sRGBToLinearRGB( uint8_t* texels, uint numCommponent, bool hasAlphaChannel,
-                                       Scalar gamma ) {
+void Engine::Texture::sRGBToLinearRGB( uint8_t* texels, uint numCommponent, bool hasAlphaChannel) {
     if ( !m_isLinear )
     {
         m_isLinear = true;
         // auto linearize = [gamma](float in)-> float {
-        auto linearize = [gamma]( uint8_t in ) -> uint8_t {
+        auto linearize = []( uint8_t in ) -> uint8_t {
             // Constants are described at https://en.wikipedia.org/wiki/SRGB
             float c = float( in ) / 255;
             if ( c < 0.04045 )
             {
                 c = c / 12.92f;
             } else
-            { c = std::pow( ( ( c + 0.055f ) / ( 1.055f ) ), float( gamma ) ); }
+            { c = std::pow( ( ( c + 0.055f ) / ( 1.055f ) ), 2.4f ); }
             return uint8_t( c * 255 );
         };
         uint numvalues = hasAlphaChannel ? numCommponent - 1 : numCommponent;

--- a/src/Engine/Renderer/Texture/Texture.cpp
+++ b/src/Engine/Renderer/Texture/Texture.cpp
@@ -207,7 +207,7 @@ void Engine::Texture::sRGBToLinearRGB( uint8_t* texels, uint numCommponent, bool
             {
                 c = c / 12.92f;
             } else
-            { c = std::pow( ( ( c + 0.055f ) / ( 1.f + 0.055f ) ), float( gamma ) ); }
+            { c = std::pow( ( ( c + 0.055f ) / ( 1.055f ) ), float( gamma ) ); }
             return uint8_t( c * 255 );
         };
         uint numvalues = hasAlphaChannel ? numCommponent - 1 : numCommponent;

--- a/src/Engine/Renderer/Texture/Texture.hpp
+++ b/src/Engine/Renderer/Texture/Texture.hpp
@@ -239,7 +239,6 @@ class RA_ENGINE_API Texture final {
      * @param gamma the gama value to use (sRGB is 2.4)
      * @note only 8 bit (GL_UNSIGNED_BYTE data format) textures are managed by this operator.
      */
-    // FIXME : replace the 2.4 constant by SRGB_GAMMA without requiring to include Eigen ...
     void sRGBToLinearRGB( uint8_t* texels, uint numCommponent, bool hasAlphaChannel,
                           Scalar gamma = SRGB_GAMMA );
 

--- a/src/Engine/Renderer/Texture/Texture.hpp
+++ b/src/Engine/Renderer/Texture/Texture.hpp
@@ -188,9 +188,9 @@ class RA_ENGINE_API Texture final {
      * This will transform the internal representation of the texture to GL_FLOAT.
      * Only GL_RGB[8, 16, 16F, 32F] and GL_RGBA[8, 16, 16F, 32F] are managed.
      * Full transformation as described at https://en.wikipedia.org/wiki/SRGB
-     * @param gamma the gama value to use (sRGB is 2.4)
+     * The gama value  used is the sRGB one  2.4
      */
-    void linearize( Scalar gamma = Scalar( 2.4 ) );
+    void linearize(  );
 
     /**
      * @return the pixel format of the texture
@@ -239,8 +239,7 @@ class RA_ENGINE_API Texture final {
      * @param gamma the gama value to use (sRGB is 2.4)
      * @note only 8 bit (GL_UNSIGNED_BYTE data format) textures are managed by this operator.
      */
-    void sRGBToLinearRGB( uint8_t* texels, uint numCommponent, bool hasAlphaChannel,
-                          Scalar gamma = Ra::Core::Utils::SRGB_GAMMA );
+    void sRGBToLinearRGB( uint8_t* texels, uint numCommponent, bool hasAlphaChannel );
 
     /// Link to glObject texture
     std::unique_ptr<globjects::Texture> m_texture;

--- a/src/Engine/Renderer/Texture/Texture.hpp
+++ b/src/Engine/Renderer/Texture/Texture.hpp
@@ -8,6 +8,8 @@
 
 #include <Engine/Renderer/OpenGL/OpenGL.hpp>
 
+#include <Core/Utils/Color.hpp>
+
 namespace globjects {
 class Texture;
 }
@@ -239,7 +241,7 @@ class RA_ENGINE_API Texture final {
      */
     // FIXME : replace the 2.4 constant by SRGB_GAMMA without requiring to include Eigen ...
     void sRGBToLinearRGB( uint8_t* texels, uint numCommponent, bool hasAlphaChannel,
-                          Scalar gamma = 2.4_ra );
+                          Scalar gamma = SRGB_GAMMA );
 
     /// Link to glObject texture
     std::unique_ptr<globjects::Texture> m_texture;

--- a/src/Engine/Renderer/Texture/Texture.hpp
+++ b/src/Engine/Renderer/Texture/Texture.hpp
@@ -240,7 +240,7 @@ class RA_ENGINE_API Texture final {
      * @note only 8 bit (GL_UNSIGNED_BYTE data format) textures are managed by this operator.
      */
     void sRGBToLinearRGB( uint8_t* texels, uint numCommponent, bool hasAlphaChannel,
-                          Scalar gamma = SRGB_GAMMA );
+                          Scalar gamma = Ra::Core::Utils::SRGB_GAMMA );
 
     /// Link to glObject texture
     std::unique_ptr<globjects::Texture> m_texture;

--- a/src/Engine/Renderer/Texture/Texture.hpp
+++ b/src/Engine/Renderer/Texture/Texture.hpp
@@ -188,7 +188,6 @@ class RA_ENGINE_API Texture final {
      * This will transform the internal representation of the texture to GL_FLOAT.
      * Only GL_RGB[8, 16, 16F, 32F] and GL_RGBA[8, 16, 16F, 32F] are managed.
      * Full transformation as described at https://en.wikipedia.org/wiki/SRGB
-     * The gama value  used is the sRGB one  2.4
      */
     void linearize(  );
 

--- a/src/Engine/Renderer/Texture/Texture.hpp
+++ b/src/Engine/Renderer/Texture/Texture.hpp
@@ -237,8 +237,9 @@ class RA_ENGINE_API Texture final {
      * @param gamma the gama value to use (sRGB is 2.4)
      * @note only 8 bit (GL_UNSIGNED_BYTE data format) textures are managed by this operator.
      */
+    // FIXME : replace the 2.4 constant by SRGB_GAMMA without requiring to include Eigen ...
     void sRGBToLinearRGB( uint8_t* texels, uint numCommponent, bool hasAlphaChannel,
-                          Scalar gamma = Scalar( 2.4 ) );
+                          Scalar gamma = 2.4_ra );
 
     /// Link to glObject texture
     std::unique_ptr<globjects::Texture> m_texture;

--- a/src/GuiBase/BaseApplication.cpp
+++ b/src/GuiBase/BaseApplication.cpp
@@ -209,7 +209,6 @@ BaseApplication::BaseApplication( int argc, char** argv, const WindowFactory& fa
     // Register the GeometrySystem converting loaded assets to meshes
     m_engine->registerSystem( "GeometrySystem", new Ra::Engine::GeometrySystem, 1000 );
 
-    Ra::Engine::RadiumEngine::getInstance()->getEntityManager()->createEntity( "Test" );
     // Load plugins
     if ( !loadPlugins( pluginsPath, parser.values( pluginLoadOpt ),
                        parser.values( pluginIgnoreOpt ) ) )
@@ -287,17 +286,6 @@ void BaseApplication::setupScene() {
     frame->setPickable( false );
     Engine::SystemEntity::uiCmp()->addRenderObject( frame );
 
-    // FIXME (Florian): this should disappear
-    auto em = Ra::Engine::RadiumEngine::getInstance()->getEntityManager();
-    Ra::Engine::Entity* e =
-        em->entityExists( "Test" )
-            ? Ra::Engine::RadiumEngine::getInstance()->getEntityManager()->getEntity( "Test" )
-            : Ra::Engine::RadiumEngine::getInstance()->getEntityManager()->createEntity( "Test" );
-
-    for ( auto& c : e->getComponents() )
-    {
-        c->initialize();
-    }
 }
 
 bool BaseApplication::loadFile( QString path ) {

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -114,7 +114,7 @@ int Gui::Viewer::addRenderer( std::shared_ptr<Engine::Renderer> e ) {
 void Gui::Viewer::setBackgroundColor( const Core::Utils::Color& background ) {
     m_backgroundColor = background;
     for ( auto renderer : m_renderers )
-        renderer->setBackgroundColor( background );
+        renderer->setBackgroundColor( m_backgroundColor );
 }
 
 void Gui::Viewer::enableDebug() {

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -220,7 +220,7 @@ class RA_GUIBASE_API Viewer : public WindowQt {
     [[deprecated]] QThread* m_renderThread = nullptr; // We have to use a QThread for MT rendering
 #endif
 
-    Core::Utils::Color m_backgroundColor;
+    Core::Utils::Color m_backgroundColor{Core::Utils::Color::Grey( 0.0392_ra, 0_ra )};
 };
 
 } // namespace Gui


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Is the Pull-Request done against the right branch:
  - `master-v1`: for changes related to the Radium Stable Release V1.
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR add two operators on Core::Utils::ColorBase to convert a color between sRGB and linear RGB color space.
This is then used, in the mainapp, to make the background color selection user friendly as, after selection, the renderer background will match exactly the chosen color.
 
* **What is the current behavior?** (You can also link to an open issue here)
The color chooser for the background does not show the real background color.
The background color chooser is not initialized from the actual background.

* **What is the new behavior (if this is a feature change)?**
The background color chooser is initialized with the actual background and the colors matches.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
There is still some strange behavior with the QSettings (at least on MacOs) that prevents to edit the QSettings from another app.
