### PR TITLE
Fix typo making the skinning plugin crash in debug ;

### DIFF
--- a/Plugins/Skinning/src/SkinningComponent.cpp
+++ b/Plugins/Skinning/src/SkinningComponent.cpp
@@ -139,7 +139,7 @@ void SkinningComponent::initialize() {
         // Do some debug checks:  Attempt to write to the mesh and check the weights match skeleton
         // and mesh.
         ON_ASSERT( bool skinnable = compMsg->canRw<Ra::Core::Geometry::TriangleMesh>(
-                       getEntity(), m_contentsName ) );
+                       getEntity(), m_meshName ) );
         CORE_ASSERT(
             skinnable,
             "Mesh cannot be skinned. It could be because the mesh is set to nondeformable" );


### PR DESCRIPTION
UPDATE the form below to describe your PR.


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
In Debug, the skinning plugin requests data from the `ComponentMessenger` with the bad id, making the app crash.


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
