### PR TITLE
Fix paintplugin

### DIFF
--- a/Plugins/MeshPaint/src/MeshPaintComponent.cpp
+++ b/Plugins/MeshPaint/src/MeshPaintComponent.cpp
@@ -72,18 +72,12 @@ void MeshPaintComponent::startPaint( bool on ) {
 
         // If any, save colors from the CPU object, otherwise set default color and notify GPU
         // object
-        m_currentColorAttribHdl = triangleMesh.getAttribHandle<Ra::Core::Vector4>( colAttribName );
-        if ( m_currentColorAttribHdl.idx().isInvalid() )
+        m_currentColorAttribHdl = triangleMesh.addAttrib<Ra::Core::Vector4>( colAttribName );
+        m_baseColors            = triangleMesh.getAttrib( m_currentColorAttribHdl ).data();
+        if ( m_baseColors.size() == 0 )
         {
-            m_baseColors.clear();
             triangleMesh.colorize( Ra::Core::Utils::Color::Skin() );
-            m_currentColorAttribHdl =
-                triangleMesh.getAttribHandle<Ra::Core::Vector4>( colAttribName );
             m_mesh->setDirty( Ra::Engine::Mesh::VERTEX_COLOR, true );
-        }
-        else
-        {
-            m_baseColors = triangleMesh.getAttrib( m_currentColorAttribHdl ).data(); // copy
         }
     }
     else

--- a/Plugins/MeshPaint/src/MeshPaintPlugin.cpp
+++ b/Plugins/MeshPaint/src/MeshPaintPlugin.cpp
@@ -50,6 +50,7 @@ void MeshPaintPluginC::registerPlugin( const Ra::Plugins::Context& context ) {
     connect( m_widget, &MeshPaintUI::paintColor, this, &MeshPaintPluginC::activePaintColor );
     connect( m_widget, &MeshPaintUI::colorChanged, this, &MeshPaintPluginC::changePaintColor );
     connect( m_widget, &MeshPaintUI::bakeToDiffuse, this, &MeshPaintPluginC::bakeToDiffuse );
+    connect( this, &MeshPaintPluginC::askForUpdate, &context, &Ra::Plugins::Context::askForUpdate );
 }
 
 bool MeshPaintPluginC::doAddWidget( QString& name ) {
@@ -81,6 +82,7 @@ QAction* MeshPaintPluginC::getAction( int /*id*/ ) {
 void MeshPaintPluginC::activePaintColor( bool on ) {
     m_isPainting = on;
     m_system->startPaintMesh( on );
+    askForUpdate();
 }
 
 void MeshPaintPluginC::changePaintColor( const QColor& color ) {
@@ -93,12 +95,16 @@ void MeshPaintPluginC::changePaintColor( const QColor& color ) {
 void MeshPaintPluginC::bakeToDiffuse() {
     if ( m_isPainting &&
          Ra::Core::Utils::Index::Invalid() != m_selectionManager->currentItem().m_roIndex )
-    { m_system->bakeToDiffuse(); } }
+    { m_system->bakeToDiffuse(); }
+    askForUpdate();
+}
 
 void MeshPaintPluginC::onCurrentChanged( const QModelIndex& /*current*/,
                                          const QModelIndex& /*prev*/ ) {
     if ( m_isPainting &&
          Ra::Core::Utils::Index::Invalid() != m_selectionManager->currentItem().m_roIndex )
-    { m_system->paintMesh( m_PickingManager->getCurrent(), m_paintColor ); } }
+    { m_system->paintMesh( m_PickingManager->getCurrent(), m_paintColor ); }
+    askForUpdate();
+}
 
 } // namespace MeshPaintPlugin

--- a/Plugins/MeshPaint/src/MeshPaintPlugin.hpp
+++ b/Plugins/MeshPaint/src/MeshPaintPlugin.hpp
@@ -47,6 +47,9 @@ class MeshPaintPluginC : public QObject, Ra::Plugins::RadiumPluginInterface
     bool doAddAction( int& nb ) override;
     QAction* getAction( int id ) override;
 
+  signals:
+    void askForUpdate();
+
   public slots:
     void onCurrentChanged( const QModelIndex& current, const QModelIndex& prev );
     void activePaintColor( bool on );


### PR DESCRIPTION
UPDATE the form below to describe your PR.


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix #437 



* **What is the current behavior?** (You can also link to an open issue here)
When de-activating mesh paint and re-activating it on a mesh with no previous `per-vertex` colors, the mesh ends up all black and painting colors does not work.
Actually this is due to the fact that, when de-activating colors painting, the colors are set back to what they were before painting, which in this case is `none`.
Thus when re-activating painting, since the mesh has the color attribute, the plugin just copies it and no validity check is done.
Hence when painting the colors, colors are set in an empty container (this should crash but somehow does not).


* **What is the new behavior (if this is a feature change)?**
- On color painting activation, the plugin request the addition of a color attribute to the mesh.
If there is only one, this one is selected as the `to be painted` and previous colors are saved.
Otherwise, a new one is created and filled with a default color.
- On color painting de-activation, the colors are set to what they were beforehand, i.e. either the saved ones or none.
Note that removing the created attribute would be preferred, but the actual management of attributes doesn't clear the data on GPU side.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
