### PR TITLE
Refactor KeyMappingManager.

### DIFF
--- a/Applications/MainApplication/Gui/ColorWidget.cpp
+++ b/Applications/MainApplication/Gui/ColorWidget.cpp
@@ -25,10 +25,8 @@ void ColorWidget::colorChanged() {
     repaint();
 }
 
-void ColorWidget::mousePressEvent( QMouseEvent* e ) {
-    if ( KeyMappingManager::getInstance()->actionTriggered(
-             e, KeyMappingManager::COLORWIDGET_PRESSBUTTON ) )
-    {
+void ColorWidget::mousePressEvent( QMouseEvent* /*event*/ ) {
+
         QColor color = QColorDialog::getColor( m_currentColor );
         if ( color != m_currentColor )
         {
@@ -37,7 +35,6 @@ void ColorWidget::mousePressEvent( QMouseEvent* e ) {
 
             emit newColorPicked( m_currentColor );
         }
-    }
 }
 } // namespace Gui
 } // namespace Ra

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -94,6 +94,12 @@ void MainWindow::createConnections() {
              &QAction::toggled,
              m_viewer->getGizmoManager(),
              &GizmoManager::setLocal );
+    // to update display when mode is changed
+    connect( actionToggle_Local_Global,
+             &QAction::toggled,
+             mainApp,
+             &Ra::GuiBase::BaseApplication::askForUpdate);
+
     connect( actionGizmoOff, &QAction::triggered, this, &MainWindow::gizmoShowNone );
     connect( actionGizmoTranslate, &QAction::triggered, this, &MainWindow::gizmoShowTranslate );
     connect( actionGizmoRotate, &QAction::triggered, this, &MainWindow::gizmoShowRotate );
@@ -112,10 +118,7 @@ void MainWindow::createConnections() {
     // Connect picking results (TODO Val : use events to dispatch picking directly)
     connect( m_viewer, &Viewer::toggleBrushPicking, this, &MainWindow::toggleCirclePicking );
     connect( m_viewer, &Viewer::rightClickPicking, this, &MainWindow::handlePicking );
-    connect( m_viewer,
-             &Viewer::leftClickPicking,
-             m_viewer->getGizmoManager(),
-             &GizmoManager::handlePickingResult );
+    // leftClickPicking is obsolete with the new input manager
 
     connect( m_avgFramesCount,
              static_cast<void ( QSpinBox::* )( int )>( &QSpinBox::valueChanged ),
@@ -135,8 +138,6 @@ void MainWindow::createConnections() {
 
     // Make selected item event visible to plugins
     connect( this, &MainWindow::selectedItem, mainApp, &MainApplication::onSelectedItem );
-    connect(
-        this, &MainWindow::selectedItem, m_viewer->getGizmoManager(), &GizmoManager::setEditable );
     connect(
         this, &MainWindow::selectedItem, m_viewer->getGizmoManager(), &GizmoManager::setEditable );
 

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -543,7 +543,6 @@ void MainWindow::onRendererReady() {
 
 void MainWindow::onFrameComplete() {
     tab_edition->updateValues();
-    m_viewer->getGizmoManager()->updateValues();
 }
 
 void MainWindow::addRenderer( std::string name, std::shared_ptr<Engine::Renderer> e ) {

--- a/Configs/alternative.xml
+++ b/Configs/alternative.xml
@@ -1,56 +1,18 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 
 <keymaps>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="mouse" value="LeftButton"></information>
-        <information id="action" value="TRACKBALLCAMERA_MANIPULATION"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_A"></information>
-        <information id="action" value="TRACKBALLCAMERA_ROTATE_AROUND"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="ControlModifier" type="mouse" value="RightButton"></information>
-        <information id="action" value="GIZMOMANAGER_MANIPULATION"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="ControlModifier" type="mouse" value="LeftButton"></information>
-        <information id="action" value="GIZMOMANAGER_STEP"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="mouse" value="RightButton"></information>
-        <information id="action" value="VIEWER_BUTTON_PICKING_QUERY"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_V"></information>
-        <information id="action" value="FEATUREPICKING_VERTEX"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_E"></information>
-        <information id="action" value="FEATUREPICKING_EDGE"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_T"></information>
-        <information id="action" value="FEATUREPICKING_TRIANGLE"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_C"></information>
-        <information id="action" value="FEATUREPICKING_MULTI_CIRCLE"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="mouse" value="RightButton"></information>
-        <information id="action" value="VIEWER_BUTTON_CAST_RAY_QUERY"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_R"></information>
-        <information id="action" value="VIEWER_RAYCAST_QUERY"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="ControlModifier" type="key" value="Key_W"></information>
-        <information id="action" value="VIEWER_TOGGLE_WIREFRAME"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="mouse" value="LeftButton"></information>
-        <information id="action" value="COLORWIDGET_PRESSBUTTON"></information>
-    </keymap>
+    <keymap key="" modifiers="" buttons="LeftButton" action="TRACKBALLCAMERA_MANIPULATION"/>
+    <keymap key="" modifiers="" buttons="LeftButton" action="TRACKBALLCAMERA_ROTATE"/>
+    <keymap key="" modifiers="ShiftModifier" buttons="LeftButton" action="TRACKBALLCAMERA_PAN"/>
+    <keymap key="" modifiers="ControlModifier" buttons="LeftButton" action="TRACKBALLCAMERA_ZOOM"/>
+    <keymap key="Key_A" modifiers="" buttons="" action="TRACKBALLCAMERA_ROTATE_AROUND"/>
+    <keymap key="" modifiers="ControlModifier" buttons="RightButton" action="GIZMOMANAGER_MANIPULATION"/>
+    <keymap key="" modifiers="ControlModifier" buttons="LeftButton" action="GIZMOMANAGER_STEP"/>
+    <keymap key="" modifiers="" buttons="RightButton" action="VIEWER_PICKING"/>
+    <keymap key="Key_V" modifiers="" buttons="RightButton" action="VIEWER_PICKING_VERTEX"/>
+    <keymap key="Key_E" modifiers="" buttons="RightButton" action="VIEWER_PICKING_EDGE"/>
+    <keymap key="Key_T" modifiers="" buttons="RightButton" action="VIEWER_PICKING_TRIANGLE"/>
+    <keymap key="Key_C" modifiers="" buttons="" action="VIEWER_PICKING_MULTI_CIRCLE"/>
+    <keymap key="Key_W" modifiers="ControlModifier" buttons="" action="VIEWER_TOGGLE_WIREFRAME"/>
+    <keymap key="Key_R" modifiers="" buttons="RightButton" action="VIEWER_RAYCAST"/>
 </keymaps>

--- a/Configs/alternative.xml
+++ b/Configs/alternative.xml
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 
 <keymaps>
-    <keymap key="" modifiers="" buttons="LeftButton" action="TRACKBALLCAMERA_MANIPULATION"/>
-    <keymap key="" modifiers="" buttons="LeftButton" action="TRACKBALLCAMERA_ROTATE"/>
-    <keymap key="" modifiers="ShiftModifier" buttons="LeftButton" action="TRACKBALLCAMERA_PAN"/>
-    <keymap key="" modifiers="ControlModifier" buttons="LeftButton" action="TRACKBALLCAMERA_ZOOM"/>
-    <keymap key="Key_A" modifiers="" buttons="" action="TRACKBALLCAMERA_ROTATE_AROUND"/>
-    <keymap key="" modifiers="ControlModifier" buttons="RightButton" action="GIZMOMANAGER_MANIPULATION"/>
-    <keymap key="" modifiers="ControlModifier" buttons="LeftButton" action="GIZMOMANAGER_STEP"/>
-    <keymap key="" modifiers="" buttons="RightButton" action="VIEWER_PICKING"/>
-    <keymap key="Key_V" modifiers="" buttons="RightButton" action="VIEWER_PICKING_VERTEX"/>
-    <keymap key="Key_E" modifiers="" buttons="RightButton" action="VIEWER_PICKING_EDGE"/>
-    <keymap key="Key_T" modifiers="" buttons="RightButton" action="VIEWER_PICKING_TRIANGLE"/>
-    <keymap key="Key_C" modifiers="" buttons="" action="VIEWER_PICKING_MULTI_CIRCLE"/>
-    <keymap key="Key_W" modifiers="ControlModifier" buttons="" action="VIEWER_TOGGLE_WIREFRAME"/>
-    <keymap key="Key_R" modifiers="" buttons="RightButton" action="VIEWER_RAYCAST"/>
+    <keymap context="CameraContext" key="" modifiers="" buttons="LeftButton" action="TRACKBALLCAMERA_ROTATE"/>
+    <keymap context="CameraContext" key="" modifiers="ShiftModifier" buttons="LeftButton" action="TRACKBALLCAMERA_PAN"/>
+    <keymap context="CameraContext" key="" modifiers="ControlModifier" buttons="LeftButton"
+            action="TRACKBALLCAMERA_ZOOM"/>
+    <keymap context="CameraContext" key="Key_A" modifiers="" buttons="" action="TRACKBALLCAMERA_ROTATE_AROUND"/>
+    <keymap context="GizmoContext" key="" modifiers="ControlModifier" buttons="RightButton"
+            action="GIZMOMANAGER_MANIPULATION"/>
+    <keymap context="GizmoContext" key="" modifiers="ControlModifier" buttons="LeftButton" action="GIZMOMANAGER_STEP"/>
+    <keymap context="ViewerContext" key="" modifiers="" buttons="RightButton" action="VIEWER_PICKING"/>
+    <keymap context="ViewerContext" key="Key_V" modifiers="" buttons="RightButton" action="VIEWER_PICKING_VERTEX"/>
+    <keymap context="ViewerContext" key="Key_E" modifiers="" buttons="RightButton" action="VIEWER_PICKING_EDGE"/>
+    <keymap context="ViewerContext" key="Key_T" modifiers="" buttons="RightButton" action="VIEWER_PICKING_TRIANGLE"/>
+    <keymap context="ViewerContext" key="Key_C" modifiers="" buttons="" action="VIEWER_PICKING_MULTI_CIRCLE"/>
+    <keymap context="ViewerContext" key="Key_W" modifiers="ControlModifier" buttons=""
+            action="VIEWER_TOGGLE_WIREFRAME"/>
+    <keymap context="ViewerContext" key="Key_R" modifiers="" buttons="RightButton" action="VIEWER_RAYCAST"/>
+    <keymap context="ViewerContext" key="" modifiers="ShiftModifier" buttons="" wheel="true"
+            action="VIEWER_SCALE_BRUSH"/>
 </keymaps>

--- a/Configs/default.xml
+++ b/Configs/default.xml
@@ -1,56 +1,22 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 
+<!--
+<keymap key="" modifiers="" buttons="" action="" />
+-->
+
 <keymaps>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="mouse" value="MiddleButton"></information>
-        <information id="action" value="TRACKBALLCAMERA_MANIPULATION"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_A"></information>
-        <information id="action" value="TRACKBALLCAMERA_ROTATE_AROUND"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="mouse" value="LeftButton"></information>
-        <information id="action" value="GIZMOMANAGER_MANIPULATION"></information>
-    </keymap>
-   <keymap>
-        <information id="type" modifier="ControlModifier" type="mouse" value="LeftButton"></information>
-        <information id="action" value="GIZMOMANAGER_STEP"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="mouse" value="RightButton"></information>
-        <information id="action" value="VIEWER_BUTTON_PICKING_QUERY"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_V"></information>
-        <information id="action" value="FEATUREPICKING_VERTEX"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_E"></information>
-        <information id="action" value="FEATUREPICKING_EDGE"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_T"></information>
-        <information id="action" value="FEATUREPICKING_TRIANGLE"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_C"></information>
-        <information id="action" value="FEATUREPICKING_MULTI_CIRCLE"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="AltModifier" type="mouse" value="LeftButton"></information>
-        <information id="action" value="VIEWER_BUTTON_CAST_RAY_QUERY"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_R"></information>
-        <information id="action" value="VIEWER_RAYCAST_QUERY"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_Z"></information>
-        <information id="action" value="VIEWER_TOGGLE_WIREFRAME"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="ShiftModifier" type="mouse" value="LeftButton"></information>
-        <information id="action" value="COLORWIDGET_PRESSBUTTON"></information>
-    </keymap>
+    <keymap key="" modifiers="" buttons="MiddleButton" action="TRACKBALLCAMERA_MANIPULATION"/>
+    <keymap key="" modifiers="" buttons="MiddleButton" action="TRACKBALLCAMERA_ROTATE"/>
+    <keymap key="" modifiers="ShiftModifier" buttons="MiddleButton" action="TRACKBALLCAMERA_PAN"/>
+    <keymap key="" modifiers="ControlModifier" buttons="MiddleButton" action="TRACKBALLCAMERA_ZOOM"/>
+    <keymap key="Key_A" modifiers="" buttons="" action="TRACKBALLCAMERA_ROTATE_AROUND"/>
+    <keymap key="" modifiers="" buttons="LeftButton" action="GIZMOMANAGER_MANIPULATION"/>
+    <keymap key="" modifiers="ControlModifier" buttons="LeftButton" action="GIZMOMANAGER_STEP"/>
+    <keymap key="" modifiers="" buttons="RightButton" action="VIEWER_PICKING"/>
+    <keymap key="Key_V" modifiers="" buttons="RightButton" action="VIEWER_PICKING_VERTEX"/>
+    <keymap key="Key_E" modifiers="" buttons="RightButton" action="VIEWER_PICKING_EDGE"/>
+    <keymap key="Key_T" modifiers="" buttons="RightButton" action="VIEWER_PICKING_TRIANGLE"/>
+    <keymap key="Key_C" modifiers="" buttons="" action="VIEWER_PICKING_MULTI_CIRCLE"/>
+    <keymap key="Key_Z" modifiers="" buttons="" action="VIEWER_TOGGLE_WIREFRAME"/>
+    <keymap key="Key_R" modifiers="AltModifier" buttons="LeftButton" action="VIEWER_RAYCAST"/>
 </keymaps>

--- a/Configs/default.xml
+++ b/Configs/default.xml
@@ -5,18 +5,22 @@
 -->
 
 <keymaps>
-    <keymap key="" modifiers="" buttons="MiddleButton" action="TRACKBALLCAMERA_MANIPULATION"/>
-    <keymap key="" modifiers="" buttons="MiddleButton" action="TRACKBALLCAMERA_ROTATE"/>
-    <keymap key="" modifiers="ShiftModifier" buttons="MiddleButton" action="TRACKBALLCAMERA_PAN"/>
-    <keymap key="" modifiers="ControlModifier" buttons="MiddleButton" action="TRACKBALLCAMERA_ZOOM"/>
-    <keymap key="Key_A" modifiers="" buttons="" action="TRACKBALLCAMERA_ROTATE_AROUND"/>
-    <keymap key="" modifiers="" buttons="LeftButton" action="GIZMOMANAGER_MANIPULATION"/>
-    <keymap key="" modifiers="ControlModifier" buttons="LeftButton" action="GIZMOMANAGER_STEP"/>
-    <keymap key="" modifiers="" buttons="RightButton" action="VIEWER_PICKING"/>
-    <keymap key="Key_V" modifiers="" buttons="RightButton" action="VIEWER_PICKING_VERTEX"/>
-    <keymap key="Key_E" modifiers="" buttons="RightButton" action="VIEWER_PICKING_EDGE"/>
-    <keymap key="Key_T" modifiers="" buttons="RightButton" action="VIEWER_PICKING_TRIANGLE"/>
-    <keymap key="Key_C" modifiers="" buttons="" action="VIEWER_PICKING_MULTI_CIRCLE"/>
-    <keymap key="Key_Z" modifiers="" buttons="" action="VIEWER_TOGGLE_WIREFRAME"/>
-    <keymap key="Key_R" modifiers="AltModifier" buttons="LeftButton" action="VIEWER_RAYCAST"/>
+    <keymap context="CameraContext" key="" modifiers="" buttons="MiddleButton" action="TRACKBALLCAMERA_MANIPULATION"/>
+    <keymap context="CameraContext" key="" modifiers="" buttons="MiddleButton" action="TRACKBALLCAMERA_ROTATE"/>
+    <keymap context="CameraContext" key="" modifiers="ShiftModifier" buttons="MiddleButton"
+            action="TRACKBALLCAMERA_PAN"/>
+    <keymap context="CameraContext" key="" modifiers="ControlModifier" buttons="MiddleButton"
+            action="TRACKBALLCAMERA_ZOOM"/>
+    <keymap context="CameraContext" key="Key_A" modifiers="" buttons="" action="TRACKBALLCAMERA_ROTATE_AROUND"/>
+    <keymap context="GizmoContext" key="" modifiers="" buttons="LeftButton" action="GIZMOMANAGER_MANIPULATION"/>
+    <keymap context="GizmoContext" key="" modifiers="ControlModifier" buttons="LeftButton" action="GIZMOMANAGER_STEP"/>
+    <keymap context="ViewerContext" key="" modifiers="" buttons="RightButton" action="VIEWER_PICKING"/>
+    <keymap context="ViewerContext" key="Key_V" modifiers="" buttons="RightButton" action="VIEWER_PICKING_VERTEX"/>
+    <keymap context="ViewerContext" key="Key_E" modifiers="" buttons="RightButton" action="VIEWER_PICKING_EDGE"/>
+    <keymap context="ViewerContext" key="Key_T" modifiers="" buttons="RightButton" action="VIEWER_PICKING_TRIANGLE"/>
+    <keymap context="ViewerContext" key="Key_C" modifiers="" buttons="" action="VIEWER_PICKING_MULTI_CIRCLE"/>
+    <keymap context="ViewerContext" key="Key_Z" modifiers="" buttons="" action="VIEWER_TOGGLE_WIREFRAME"/>
+    <keymap context="ViewerContext" key="Key_R" modifiers="AltModifier" buttons="LeftButton" action="VIEWER_RAYCAST"/>
+    <keymap context="ViewerContext" key="" modifiers="ShiftModifier" buttons="" wheel="true"
+            action="VIEWER_SCALE_BRUSH"/>
 </keymaps>

--- a/Configs/macos.xml
+++ b/Configs/macos.xml
@@ -1,56 +1,20 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
-
+<!--
+<keymap key="" modifiers="" buttons="" action="" />
+-->
 <keymaps>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="mouse" value="LeftButton"></information>
-        <information id="action" value="TRACKBALLCAMERA_MANIPULATION"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_A"></information>
-        <information id="action" value="TRACKBALLCAMERA_ROTATE_AROUND"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="MetaModifier" type="mouse" value="RightButton"></information>
-        <information id="action" value="GIZMOMANAGER_MANIPULATION"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="ControlModifier" type="mouse" value="LeftButton"></information>
-        <information id="action" value="GIZMOMANAGER_STEP"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="mouse" value="RightButton"></information>
-        <information id="action" value="VIEWER_BUTTON_PICKING_QUERY"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_V"></information>
-        <information id="action" value="FEATUREPICKING_VERTEX"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_E"></information>
-        <information id="action" value="FEATUREPICKING_EDGE"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_T"></information>
-        <information id="action" value="FEATUREPICKING_TRIANGLE"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_C"></information>
-        <information id="action" value="FEATUREPICKING_MULTI_CIRCLE"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="mouse" value="RightButton"></information>
-        <information id="action" value="VIEWER_BUTTON_CAST_RAY_QUERY"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="key" value="Key_R"></information>
-        <information id="action" value="VIEWER_RAYCAST_QUERY"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="ControlModifier" type="key" value="Key_W"></information>
-        <information id="action" value="VIEWER_TOGGLE_WIREFRAME"></information>
-    </keymap>
-    <keymap>
-        <information id="type" modifier="NoModifier" type="mouse" value="LeftButton"></information>
-        <information id="action" value="COLORWIDGET_PRESSBUTTON"></information>
-    </keymap>
+    <keymap key="" modifiers="" buttons="LeftButton" action="TRACKBALLCAMERA_MANIPULATION"/>
+    <keymap key="" modifiers="" buttons="LeftButton" action="TRACKBALLCAMERA_ROTATE"/>
+    <keymap key="" modifiers="ShiftModifier" buttons="LeftButton" action="TRACKBALLCAMERA_PAN"/>
+    <keymap key="" modifiers="ControlModifier" buttons="LeftButton" action="TRACKBALLCAMERA_ZOOM"/>
+    <keymap key="Key_A" modifiers="" buttons="" action="TRACKBALLCAMERA_ROTATE_AROUND"/>
+    <keymap key="" modifiers="MetaModifier" buttons="RightButton" action="GIZMOMANAGER_MANIPULATION" />
+    <keymap key="" modifiers="ControlModifier" buttons="LeftButton" action="GIZMOMANAGER_STEP" />
+    <keymap key="" modifiers="" buttons="RightButton" action="VIEWER_PICKING" />
+    <keymap key="Key_V" modifiers="" buttons="RightButton" action="VIEWER_PICKING_VERTEX" />
+    <keymap key="Key_E" modifiers="" buttons="RightButton" action="VIEWER_PICKING_EDGE" />
+    <keymap key="Key_T" modifiers="" buttons="RightButton" action="VIEWER_PICKING_TRIANGLE" />
+    <keymap key="Key_C" modifiers="" buttons="" action="VIEWER_PICKING_MULTI_CIRCLE" />
+    <keymap key="Key_W" modifiers="ControlModifier" buttons="" action="VIEWER_TOGGLE_WIREFRAME" />
+    <keymap key="Key_W" modifiers="" buttons="LeftButton" action="VIEWER_RAYCAST" />
 </keymaps>

--- a/Configs/macos.xml
+++ b/Configs/macos.xml
@@ -3,18 +3,21 @@
 <keymap key="" modifiers="" buttons="" action="" />
 -->
 <keymaps>
-    <keymap key="" modifiers="" buttons="LeftButton" action="TRACKBALLCAMERA_MANIPULATION"/>
-    <keymap key="" modifiers="" buttons="LeftButton" action="TRACKBALLCAMERA_ROTATE"/>
-    <keymap key="" modifiers="ShiftModifier" buttons="LeftButton" action="TRACKBALLCAMERA_PAN"/>
-    <keymap key="" modifiers="ControlModifier" buttons="LeftButton" action="TRACKBALLCAMERA_ZOOM"/>
-    <keymap key="Key_A" modifiers="" buttons="" action="TRACKBALLCAMERA_ROTATE_AROUND"/>
-    <keymap key="" modifiers="MetaModifier" buttons="RightButton" action="GIZMOMANAGER_MANIPULATION" />
-    <keymap key="" modifiers="ControlModifier" buttons="LeftButton" action="GIZMOMANAGER_STEP" />
-    <keymap key="" modifiers="" buttons="RightButton" action="VIEWER_PICKING" />
-    <keymap key="Key_V" modifiers="" buttons="RightButton" action="VIEWER_PICKING_VERTEX" />
-    <keymap key="Key_E" modifiers="" buttons="RightButton" action="VIEWER_PICKING_EDGE" />
-    <keymap key="Key_T" modifiers="" buttons="RightButton" action="VIEWER_PICKING_TRIANGLE" />
-    <keymap key="Key_C" modifiers="" buttons="" action="VIEWER_PICKING_MULTI_CIRCLE" />
-    <keymap key="Key_W" modifiers="ControlModifier" buttons="" action="VIEWER_TOGGLE_WIREFRAME" />
-    <keymap key="Key_W" modifiers="" buttons="LeftButton" action="VIEWER_RAYCAST" />
+    <keymap context="CameraContext" key="" modifiers="" buttons="LeftButton" action="TRACKBALLCAMERA_ROTATE"/>
+    <keymap context="CameraContext" key="" modifiers="ShiftModifier" buttons="LeftButton" action="TRACKBALLCAMERA_PAN"/>
+    <keymap context="CameraContext" key="" modifiers="ControlModifier" buttons="LeftButton"
+            action="TRACKBALLCAMERA_ZOOM"/>
+    <keymap context="CameraContext" key="Key_A" modifiers="" buttons="" action="TRACKBALLCAMERA_ROTATE_AROUND"/>
+    <keymap context="GizmoContext" key="" modifiers="" buttons="LeftButton" action="GIZMOMANAGER_MANIPULATION"/>
+    <keymap context="GizmoContext" key="" modifiers="ControlModifier" buttons="LeftButton" action="GIZMOMANAGER_STEP"/>
+    <keymap context="ViewerContext" key="" modifiers="" buttons="RightButton" action="VIEWER_PICKING"/>
+    <keymap context="ViewerContext" key="Key_V" modifiers="" buttons="RightButton" action="VIEWER_PICKING_VERTEX"/>
+    <keymap context="ViewerContext" key="Key_E" modifiers="" buttons="RightButton" action="VIEWER_PICKING_EDGE"/>
+    <keymap context="ViewerContext" key="Key_T" modifiers="" buttons="RightButton" action="VIEWER_PICKING_TRIANGLE"/>
+    <keymap context="ViewerContext" key="Key_C" modifiers="" buttons="" action="VIEWER_PICKING_MULTI_CIRCLE"/>
+    <keymap context="ViewerContext" key="Key_W" modifiers="ControlModifier" buttons=""
+            action="VIEWER_TOGGLE_WIREFRAME"/>
+    <keymap context="ViewerContext" key="Key_W" modifiers="" buttons="LeftButton" action="VIEWER_RAYCAST"/>
+    <keymap context="ViewerContext" key="" modifiers="ShiftModifier" buttons="" wheel="true"
+            action="VIEWER_SCALE_BRUSH"/>
 </keymaps>

--- a/Configs/macos.xml
+++ b/Configs/macos.xml
@@ -10,6 +10,9 @@
     <keymap context="CameraContext" key="Key_A" modifiers="" buttons="" action="TRACKBALLCAMERA_ROTATE_AROUND"/>
     <keymap context="GizmoContext" key="" modifiers="" buttons="LeftButton" action="GIZMOMANAGER_MANIPULATION"/>
     <keymap context="GizmoContext" key="" modifiers="ControlModifier" buttons="LeftButton" action="GIZMOMANAGER_STEP"/>
+    <keymap context="GizmoContext" key="" modifiers="ShiftModifier" buttons="LeftButton" action="GIZMOMANAGER_WHOLE"/>
+    <keymap context="GizmoContext" key="" modifiers="ControlModifier,ShiftModifier" buttons="LeftButton"
+            action="GIZMOMANAGER_STEP_WHOLE"/>
     <keymap context="ViewerContext" key="" modifiers="" buttons="RightButton" action="VIEWER_PICKING"/>
     <keymap context="ViewerContext" key="Key_V" modifiers="" buttons="RightButton" action="VIEWER_PICKING_VERTEX"/>
     <keymap context="ViewerContext" key="Key_E" modifiers="" buttons="RightButton" action="VIEWER_PICKING_EDGE"/>

--- a/Configs/test-not-working.xml
+++ b/Configs/test-not-working.xml
@@ -5,15 +5,14 @@
 -->
 
 <keymaps>
-    <keymap context="CameraContext" key="" modifiers="" buttons="MiddleButton" action="TRACKBALLCAMERA_ROTATE"/>
-    <keymap context="CameraContext" key="" modifiers="ShiftModifier" buttons="MiddleButton"
-            action="TRACKBALLCAMERA_PAN"/>
-    <keymap context="CameraContext" key="" modifiers="ControlModifier" buttons="MiddleButton"
-            action="TRACKBALLCAMERA_ZOOM"/>
-    <keymap context="CameraContext" key="Key_A" modifiers="" buttons="" action="TRACKBALLCAMERA_ROTATE_AROUND"/>
+    
     <keymap context="GizmoContext" key="" modifiers="" buttons="LeftButton" action="GIZMOMANAGER_MANIPULATION"/>
     <keymap context="GizmoContext" key="" modifiers="ControlModifier" buttons="LeftButton" action="GIZMOMANAGER_STEP"/>
+    <keymap context="GizmoContext" key="" modifiers="ShiftModifier" buttons="LeftButton" action="GIZMOMANAGER_WHOLE"/>
+    <keymap context="GizmoContext" key="" modifiers="ControlModifier,ShiftModifier" buttons="LeftButton"
+            action="GIZMOMANAGER_STEP_WHOLE"/>
     <keymap context="ViewerContext" key="" modifiers="" buttons="RightButton" action="VIEWER_PICKING"/>
+    <keymap context="ViewerContext" key="" modifiers="" buttons="RightButton" action="VIEWER_PICKING_VERTEX"/>
     <keymap context="ViewerContext" key="Key_V" modifiers="" buttons="RightButton" action="VIEWER_PICKING_VERTEX"/>
     <keymap context="ViewerContext" key="Key_E" modifiers="" buttons="RightButton" action="VIEWER_PICKING_EDGE"/>
     <keymap context="ViewerContext" key="Key_T" modifiers="" buttons="RightButton" action="VIEWER_PICKING_TRIANGLE"/>

--- a/Docs/keymapping.md
+++ b/Docs/keymapping.md
@@ -2,26 +2,45 @@
 
 ## Usage
 
-You can find KeyMappingAction enumeration in `KeyMappingManager.hpp` which contains all of the actions you can handle. If you wish to add an action, just add a value to the enum (try to keep it clear, it currently uses FILENAME_ACTION_NAME notation).
+You can find KeyMappingAction enumeration in `KeyMappingManager.hpp` which contains all of the actions you can handle. If you wish to add an action, just add a value to the enum (try to keep it clear).
 
 Then, you will need to add into every configuration file (`Configs/` folder) an entry which will bind your action to a key :
 
-    <keymap>
-        <information id="type" modifier="MODIFIER" type="TYPE" value="VALUE"></information>
-        <information id="action" value="FILENAME_ACTION_NAME"></information>
-    </keymap>
+```xml
+<keymaps>
+    <keymap key="KEY" modifiers="MODIFIERS" buttons="BUTTONS" action="ACTION" />
+    <!-- as many entry as needed -->
+</keymaps>
+```
 
-* MODIFIER represents the modifier used (needs to be a `Qt::Modifier` enum value) to trigger the action.
-* TYPE represents the type of event used to trigger the action (can be `mouse` or `key`).
-* VALUE represents the value of the type you want in order to trigger the action (i.e. `LeftButton` if type is mouse or `Key_Z` if type is key, for example).
-* FILENAME_ACTION_NAME represents the KeyMappingAction enum's value you want to trigger.
+* `KEY` represents the key that need to be pressed to trigger the event (ie `Key_Z`, for example), "" or "-1" or absent correspond to no key needed.
+* `MODIFIERS` represents the modifier used along with key or mouse button (needs to be a `Qt::Modifier` enum value) to trigger the action.
+* `BUTTONS` represents the button to trigger the event (i.e. `LeftButton`, for example).
+* `ACTION` represents the KeyMappingAction enum's value you want to trigger.
 
-## Constraints
+If only a key is defined then it's a `keyPressedEvent`. 
+If buttons is defined, then it's a `mouse[move/press/release]Event`, that optionally take modifiers and key into account.
 
-Some KeyMappingAction enumeration's values may be dependant. It is currently the case with :
+## Implementation note
 
-* `VIEWER_LEFT_BUTTON_PICKING_QUERY` and `GIZMOMANAGER_MANIPULATION`
+Try to limit keyMapping to your Viewer class. Then event of the viewer class call the corresponding methods of your other classes.
+
+For instance see `Viewer.cpp` `Viewer::mousePressEvent`
+
+```c++
+// [...]
+    auto keyMap    = Gui::KeyMappingManager::getInstance();
+    auto buttons   = event->buttons();
+    auto modifiers = event->modifiers();
+    auto key       = lastActiveKey();
+    auto action    = keyMap->getAction( buttons, modifiers, key );
+
+    if ( action == Gui::KeyMappingManager::TRACKBALLCAMERA_MANIPULATION )
+    { m_camera->handleMousePressEvent( event ); }
+// [...]
+
+ ```  
 
 ## Limits
 
-* Modifier value isn't used if you're using the `mouse` type, you can just ignore this field for this type.
+* Multiple keys/modifiers/buttons are not yet implemented.

--- a/Docs/keymapping.md
+++ b/Docs/keymapping.md
@@ -18,8 +18,9 @@ Default values are in \[ \]
 * `CONTEXT` \[AppContext\] epresents the context, for instance the class that will try to catch this keymapping
 * `KEY` \[no def\] represents the key that need to be pressed to trigger the event (ie `Key_Z`, for example), "" or "-1" or absent correspond to no key needed.
 * `MODIFIERS` \[NoModifiers\]represents the modifier used along with key or mouse button (needs to be a `Qt::Modifier` enum value) to trigger the action.
+Multiples modifiers can be specified, separated by commas as in `"ControlModifier,ShiftModifier"`.
 * `BUTTONS` \[NoButtons\] represents the button to trigger the event (i.e. `LeftButton`, for example).
-* `WHEEL` \[false\] if not true, it's a wheel event !
+* `WHEEL` \[false\] if true, it's a wheel event ! (anything else is false).
 
 If only a key is defined then it's a `keyPressedEvent`. 
 If buttons is defined, then it's a `mouse[move/press/release]Event`, that optionally take modifiers and key into account.
@@ -105,4 +106,4 @@ For instance see `Viewer.cpp` `Viewer::mousePressEvent`
 
 ## Limits
 
-* Multiple keys/modifiers/buttons are not yet implemented.
+* Multiple keys/buttons are not yet implemented.

--- a/Docs/keymapping.md
+++ b/Docs/keymapping.md
@@ -2,43 +2,105 @@
 
 ## Usage
 
-You can find KeyMappingAction enumeration in `KeyMappingManager.hpp` which contains all of the actions you can handle. If you wish to add an action, just add a value to the enum (try to keep it clear).
-
-Then, you will need to add into every configuration file (`Configs/` folder) an entry which will bind your action to a key :
+You first need to add into every configuration file (in `Configs/` folder) an entry which will bind your action to a key.
+This file as an only `keymaps` node, with `keymap` per binding. 
 
 ```xml
 <keymaps>
-    <keymap key="KEY" modifiers="MODIFIERS" buttons="BUTTONS" action="ACTION" />
+    <keymap context="CONTEXT" key="KEY" modifiers="MODIFIERS" buttons="BUTTONS" wheel="WHEEL" action="ACTION" />
     <!-- as many entry as needed -->
 </keymaps>
 ```
 
-* `KEY` represents the key that need to be pressed to trigger the event (ie `Key_Z`, for example), "" or "-1" or absent correspond to no key needed.
-* `MODIFIERS` represents the modifier used along with key or mouse button (needs to be a `Qt::Modifier` enum value) to trigger the action.
-* `BUTTONS` represents the button to trigger the event (i.e. `LeftButton`, for example).
-* `ACTION` represents the KeyMappingAction enum's value you want to trigger.
+Default values are in \[ \]
+
+* `ACTION` *mendatory* represents the KeyMappingAction enum's value you want to trigger.
+* `CONTEXT` \[AppContext\] epresents the context, for instance the class that will try to catch this keymapping
+* `KEY` \[no def\] represents the key that need to be pressed to trigger the event (ie `Key_Z`, for example), "" or "-1" or absent correspond to no key needed.
+* `MODIFIERS` \[NoModifiers\]represents the modifier used along with key or mouse button (needs to be a `Qt::Modifier` enum value) to trigger the action.
+* `BUTTONS` \[NoButtons\] represents the button to trigger the event (i.e. `LeftButton`, for example).
+* `WHEEL` \[false\] if not true, it's a wheel event !
 
 If only a key is defined then it's a `keyPressedEvent`. 
 If buttons is defined, then it's a `mouse[move/press/release]Event`, that optionally take modifiers and key into account.
+If wheel is true, then it's a wheel event, that optionally take modifiers, buttons and key into account.
+
+On the implementation side, your class `C` need (could) derive from `KeyMappingManageable<C>`, it defines the static member variable
+`m_keyMappingContext`.
+
+Then you need to define your specific actions as static member of your class
+
+```
+class MyClass :public KeyManageable<MyClass> {
+
+// calleback when a configuration file is loaded, coudl check if the context and action are present.
+static void registerKeyMapping(){
+    m_keyMappingContext = Gui::KeyMappingManager::getInstance()->getContext( "MyClassContext" );
+    m_myAction =  Gui::KeyMappingManager::getInstance()->getActionIndex( "MyActionName" );
+}
+
+//[...]
+static KeyMappingManager::KeyMappingAction m_myAction;
+// [...]
+};
+
+
+// typically in .ccp  file
+KeyMappingManager::KeyMappingAction m_myAction;
+
+// then typically in main baseApplication ctor or Viewer ctor, but after KeyMappingManager instance is created :
+KeyMappingManager::getInstance()->addListener(MyClass:registerKeyMapping);
+
+```
+
+It could be done with a specific macro :
+
+```c++
+// in header
+#define KeyMappingMyClass \
+    KMA_VALUE( MY_ACTION )   
+    
+#define KMA_VALUE( XX ) static KeyMappingManager::KeyMappingAction XX;
+    KeyMappingMyClass
+#undef KMA_VALUE
+
+// in source
+#define KMA_VALUE( XX ) Gui::KeyMappingManager::KeyMappingAction MyClass::XX;
+KeyMappingMyClass
+#undef KMA_VALUE
+
+void MyClass::registerKeyMapping() {
+    m_keyMappingContext = Gui::KeyMappingManager::getInstance()->getContext( "MyClassContext" );
+    if ( m_keyMappingContext.isInvalid() )
+        LOG( logINFO ) << "MyuClassContext not defined (maybe the configuration file do not contains it";
+#define KMA_VALUE( XX ) \
+    XX = Gui::KeyMappingManager::getInstance()->getActionIndex( m_keyMappingContext, #XX );
+    KeyMappingMyClass
+#undef KMA_VALUE
+}
+
+```
 
 ## Implementation note
 
-Try to limit keyMapping to your Viewer class. Then event of the viewer class call the corresponding methods of your other classes.
+The viewer is the main entry point to dispatch key and mouse event.
+The idea is that at a key press or mouse press event, the viewer is capable of determining which class will receive the events.
 
 For instance see `Viewer.cpp` `Viewer::mousePressEvent`
 
 ```c++
-// [...]
-    auto keyMap    = Gui::KeyMappingManager::getInstance();
+//[...]
     auto buttons   = event->buttons();
     auto modifiers = event->modifiers();
-    auto key       = lastActiveKey();
-    auto action    = keyMap->getAction( buttons, modifiers, key );
+    auto key       = activeKey();
 
-    if ( action == Gui::KeyMappingManager::TRACKBALLCAMERA_MANIPULATION )
-    { m_camera->handleMousePressEvent( event ); }
-// [...]
-
+    // nothing under mouse ? juste move the camera ...
+    if ( result.m_roIdx.isInvalid() )
+    {
+        auto accepted = m_camera->handleMousePressEvent( event, buttons, modifiers, key );
+        if ( accepted ) { m_activeContext = m_camera->getContext(); }
+        else
+  //[...]  
  ```  
 
 ## Limits

--- a/src/Core/Geometry/Area.cpp
+++ b/src/Core/Geometry/Area.cpp
@@ -199,7 +199,8 @@ Scalar mixedArea( const Vector3& v, const VectorArray<Vector3>& p ) {
         {
             if ( ( ( ( p[i] - v ).normalized() ).dot( ( p[i - 1] - v ).normalized() ) ) <
                  Scalar( 0. ) )
-            { area += triangleArea( v, p[i], p[i - 1] ) / Scalar( 2. ); } else
+            { area += triangleArea( v, p[i], p[i - 1] ) / Scalar( 2. ); }
+            else
             { area += triangleArea( v, p[i], p[i - 1] ) / Scalar( 4. ); }
         }
     }

--- a/src/Core/Geometry/DistanceQueries.inl
+++ b/src/Core/Geometry/DistanceQueries.inl
@@ -255,7 +255,8 @@ inline RA_CORE_API LineToTriangleOutput lineToTriSq( const Vector3& lineOrigin,
         Vector3 basis[3]; // {D, U, V}
         basis[0] = lineDirection;
         if ( std::abs( basis[0][0] ) > std::abs( basis[0][1] ) )
-        { basis[1] = {-basis[0][2], (Scalar)0, basis[0][0]}; } else
+        { basis[1] = {-basis[0][2], (Scalar)0, basis[0][0]}; }
+        else
         { basis[1] = {(Scalar)0, basis[0][2], -basis[0][1]}; }
         basis[2] = basis[0].cross( basis[1] );
         // Orthonormalize basis

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -210,8 +210,7 @@ TriangleMesh TopologicalMesh::toTriangleMesh() {
 
     if ( !get_property_handle( m_outputTriangleMeshIndexPph, "OutputTriangleMeshIndices" ) )
     { add_property( m_outputTriangleMeshIndexPph, "OutputTriangleMeshIndices" ); }
-    std::vector<PropPair<float>>
-        vprop_float;
+    std::vector<PropPair<float>> vprop_float;
     std::vector<PropPair<Vector2>> vprop_vec2;
     std::vector<PropPair<Vector3>> vprop_vec3;
     std::vector<PropPair<Vector4>> vprop_vec4;

--- a/src/Core/Tasks/TaskQueue.cpp
+++ b/src/Core/Tasks/TaskQueue.cpp
@@ -274,8 +274,9 @@ void TaskQueue::printTaskGraph( std::ostream& output ) const {
         if ( std::find_if( m_tasks.begin(), m_tasks.end(), [=]( const auto& task ) {
                  return task->getName() == t2name;
              } ) == m_tasks.end() )
-        { t2name += "?"; } output << "\"" << task1->getName() << "\""
-                                  << " -> ";
+        { t2name += "?"; }
+        output << "\"" << task1->getName() << "\""
+               << " -> ";
         output << "\"" << t2name << "\"" << std::endl;
     }
 
@@ -287,8 +288,9 @@ void TaskQueue::printTaskGraph( std::ostream& output ) const {
         if ( std::find_if( m_tasks.begin(), m_tasks.end(), [=]( const auto& task ) {
                  return task->getName() == t1name;
              } ) == m_tasks.end() )
-        { t1name += "?"; } output << "\"" << t1name << "\""
-                                  << " -> ";
+        { t1name += "?"; }
+        output << "\"" << t1name << "\""
+               << " -> ";
         output << "\"" << t2->getName() << "\"" << std::endl;
     }
 

--- a/src/Core/Utils/Index.hpp
+++ b/src/Core/Utils/Index.hpp
@@ -1,13 +1,14 @@
 #ifndef RADIUMENGINE_INDEX_HPP
 #define RADIUMENGINE_INDEX_HPP
 
+#include <Core/RaCore.hpp>
 #include <limits>
 
 namespace Ra {
 namespace Core {
 namespace Utils {
 
-class Index
+class RA_CORE_API Index
 {
   public:
     /// CONSTRUCTOR

--- a/src/Engine/Component/GeometryComponent.cpp
+++ b/src/Engine/Component/GeometryComponent.cpp
@@ -108,8 +108,7 @@ void TriangleMeshComponent::generateTriangleMesh( const Ra::Core::Asset::Geometr
     if ( data->hasTextureCoordinates() )
     { m_displayMesh->addData( Mesh::VERTEX_TEXCOORD, data->getTexCoords() ); }
 
-    if ( data->hasColors() )
-    { m_displayMesh->addData( Mesh::VERTEX_COLOR, data->getColors() ); }
+    if ( data->hasColors() ) { m_displayMesh->addData( Mesh::VERTEX_COLOR, data->getColors() ); }
 
     // To be discussed: Should not weights be part of the geometry ?
     //        mesh->addData( Mesh::VERTEX_WEIGHTS, meshData.weights );

--- a/src/Engine/Renderer/Camera/Camera.hpp
+++ b/src/Engine/Renderer/Camera/Camera.hpp
@@ -166,11 +166,11 @@ class RA_ENGINE_API Camera : public Component
     /// attributes. A rework of the rendering architecture will be done soon.
     /// Thus these attributes might disappear.
     ///@{
-    Scalar m_zNear{0.1}; ///< Z Near plane distance
-    Scalar m_zFar{1000}; ///< Z Far plane distance
-    Scalar m_width{1};   ///< Viewport width (in pixels)
-    Scalar m_height{1};  ///< Viewport height (in pixels)
-    Scalar m_aspect{1};  ///< Aspect ratio, i.e. width/height. Precomputed for updateProjMatrix.
+    Scalar m_zNear{0.1_ra}; ///< Z Near plane distance
+    Scalar m_zFar{1000_ra}; ///< Z Far plane distance
+    Scalar m_width{1_ra};   ///< Viewport width (in pixels)
+    Scalar m_height{1_ra};  ///< Viewport height (in pixels)
+    Scalar m_aspect{1_ra};  ///< Aspect ratio, i.e. width/height. Precomputed for updateProjMatrix.
     ///@}
 };
 

--- a/src/Engine/Renderer/Mesh/Mesh.cpp
+++ b/src/Engine/Renderer/Mesh/Mesh.cpp
@@ -282,7 +282,8 @@ void Mesh::updateGL() {
         for ( int i = 0; i < MAX_VEC3; i++ )
         {
             if ( m_mesh.isValid( m_v3DataHandle[i] ) )
-            { sendGLData( this, m_mesh.getAttrib( m_v3DataHandle[i] ).data(), MAX_MESH + i ); } }
+            { sendGLData( this, m_mesh.getAttrib( m_v3DataHandle[i] ).data(), MAX_MESH + i ); }
+        }
 
         for ( int i = 0; i < MAX_VEC4; i++ )
         {

--- a/src/Engine/Renderer/RenderObject/Primitives/DrawPrimitives.cpp
+++ b/src/Engine/Renderer/RenderObject/Primitives/DrawPrimitives.cpp
@@ -22,7 +22,8 @@ namespace DrawPrimitives {
 RenderObject* Primitive( Component* component, const MeshPtr& mesh ) {
     ShaderConfiguration config;
     if ( mesh->getRenderMode() == GL_LINES )
-    { config = ShaderConfigurationFactory::getConfiguration( "Lines" ); } else
+    { config = ShaderConfigurationFactory::getConfiguration( "Lines" ); }
+    else
     { config = ShaderConfigurationFactory::getConfiguration( "Plain" ); }
 
     auto mat = Core::make_shared<BlinnPhongMaterial>( "Default material" );

--- a/src/Engine/Renderer/Renderer.cpp
+++ b/src/Engine/Renderer/Renderer.cpp
@@ -162,6 +162,7 @@ void Renderer::initialize( uint width, uint height ) {
     glReadBuffer( GL_BACK );
 }
 
+
 void Renderer::render( const ViewingParameters& data ) {
     CORE_ASSERT( RadiumEngine::getInstance() != nullptr, "Engine is not initialized." );
 
@@ -477,7 +478,7 @@ void Renderer::doPicking( const ViewingParameters& renderData ) {
     m_pickingFbo->unbind();
 }
 
-void Renderer::drawScreenInternal() {
+void Renderer::restoreExternalFBOInternal() {
     glViewport( m_qtViewport[0], m_qtViewport[1], m_qtViewport[2], m_qtViewport[3] );
 
     if ( m_qtPlz == 0 )
@@ -490,6 +491,11 @@ void Renderer::drawScreenInternal() {
         GL_ASSERT( glBindFramebuffer( GL_FRAMEBUFFER, m_qtPlz ) );
         GL_ASSERT( glDrawBuffers( 1, buffers ) );
     }
+}
+
+void Renderer::drawScreenInternal() {
+
+    restoreExternalFBOInternal();
     // Display the final screen
     {
         GL_ASSERT( glDepthFunc( GL_ALWAYS ) );
@@ -569,7 +575,8 @@ void Renderer::resize( uint w, uint h ) {
 
 void Renderer::displayTexture( const std::string& texName ) {
     if ( m_secondaryTextures.find( texName ) != m_secondaryTextures.end() )
-    { m_displayedTexture = m_secondaryTextures[texName]; } else
+    { m_displayedTexture = m_secondaryTextures[texName]; }
+    else
     { m_displayedTexture = m_fancyTexture.get(); }
 }
 

--- a/src/Engine/Renderer/Renderer.hpp
+++ b/src/Engine/Renderer/Renderer.hpp
@@ -73,7 +73,8 @@ class RA_ENGINE_API Renderer
         TRIANGLE,  ///< Pick a triangle of a mesh
         C_VERTEX,  ///< Picks all vertices of a mesh within a screen space circle
         C_EDGE,    ///< Picks all edges of a mesh within a screen space circle
-        C_TRIANGLE ///< Picks all triangles of a mesh within a screen space circle
+        C_TRIANGLE, ///< Picks all triangles of a mesh within a screen space circle
+        NONE, ///< Do not pick ;)
     };
 
     /**
@@ -337,6 +338,7 @@ class RA_ENGINE_API Renderer
   private:
     // 0.
     void saveExternalFBOInternal();
+    void restoreExternalFBOInternal();
 
     // 1.
     void feedRenderQueuesInternal( const ViewingParameters& renderData );

--- a/src/Engine/Renderer/Renderer.hpp
+++ b/src/Engine/Renderer/Renderer.hpp
@@ -288,6 +288,8 @@ class RA_ENGINE_API Renderer
 
     virtual std::unique_ptr<uchar[]> grabFrame( size_t& w, size_t& h ) const;
 
+    PickingResult doPickingNow( const PickingQuery& query, const ViewingParameters& renderData );
+
   protected:
     /**
      * @brief initializeInternal
@@ -433,6 +435,7 @@ class RA_ENGINE_API Renderer
     std::vector<PickingResult> m_pickingResults;
 
     Core::Utils::Color m_backgroundColor{Core::Utils::Color::Grey( 0.0392_ra, 0_ra )};
+    void preparePicking( const ViewingParameters& renderData );
 };
 
 } // namespace Engine

--- a/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
+++ b/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
@@ -467,7 +467,7 @@ void ForwardRenderer::resizeInternal() {
     if ( m_fbo->checkStatus() != GL_FRAMEBUFFER_COMPLETE )
     { LOG( logERROR ) << "FBO Error (ForwardRenderer::m_fbo): " << m_fbo->checkStatus(); }
 
-    #ifndef NO_TRANSPARENCY
+#ifndef NO_TRANSPARENCY
     m_oitFbo->bind();
     m_oitFbo->attachTexture( GL_DEPTH_ATTACHMENT, m_textures[RendererTextures_Depth]->texture() );
     m_oitFbo->attachTexture( GL_COLOR_ATTACHMENT0,
@@ -476,7 +476,7 @@ void ForwardRenderer::resizeInternal() {
                              m_textures[RendererTextures_OITRevealage]->texture() );
     if ( m_fbo->checkStatus() != GL_FRAMEBUFFER_COMPLETE )
     { LOG( logERROR ) << "FBO Error (ForwardRenderer::m_oitFbo) : " << m_fbo->checkStatus(); }
-    #endif
+#endif
 
     m_postprocessFbo->bind();
     m_postprocessFbo->attachTexture( GL_DEPTH_ATTACHMENT,

--- a/src/Engine/Renderer/Texture/Texture.cpp
+++ b/src/Engine/Renderer/Texture/Texture.cpp
@@ -145,7 +145,9 @@ void Engine::Texture::updateData( void* data ) {
     }
     break;
     default:
-    { CORE_ASSERT( 0, "Unsupported texture type ?" ); }
+    {
+        CORE_ASSERT( 0, "Unsupported texture type ?" );
+    }
     break;
     }
     GL_CHECK_ERROR;

--- a/src/GuiBase/BaseApplication.cpp
+++ b/src/GuiBase/BaseApplication.cpp
@@ -36,6 +36,7 @@
 #    include <IO/AssimpLoader/AssimpFileLoader.hpp>
 #endif
 
+#include <GuiBase/Viewer/TrackballCamera.hpp>
 #include <QCommandLineParser>
 #include <QDir>
 #include <QOpenGLContext>
@@ -199,6 +200,8 @@ BaseApplication::BaseApplication( int argc,
     // Create the instance of the keymapping manager, before creating
     // Qt main windows, which may throw events on Microsoft Windows
     Gui::KeyMappingManager::createInstance();
+    Gui::KeyMappingManager::getInstance()->addListener(Gui::TrackballCamera::registerKeyMapping);
+    Gui::KeyMappingManager::getInstance()->addListener(Gui::Viewer::registerKeyMapping);
 
     // Create engine
     m_engine.reset( Engine::RadiumEngine::createInstance() );

--- a/src/GuiBase/Utils/KeyMappingManager.cpp
+++ b/src/GuiBase/Utils/KeyMappingManager.cpp
@@ -29,41 +29,43 @@ KeyMappingManager::KeyMappingManager() :
     loadConfiguration( keymappingfilename.toStdString().c_str() );
 }
 
-void KeyMappingManager::bindKeyToAction( int keyCode, KeyMappingAction action ) {
-    auto f = std::find_if( m_mapping.begin(), m_mapping.end(), [&keyCode]( const auto& a ) {
-        return a.second == keyCode;
-    } );
-    if ( f != m_mapping.end() )
+KeyMappingManager::KeyMappingAction
+KeyMappingManager::getAction( Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers, int key ) {
+    MouseBinding binding{buttons, modifiers, key};
+
+    auto action = m_mappingAction.find( binding );
+
+    if ( action != m_mappingAction.end() ) { return action->second; }
+    return KEYMAPPING_ACTION_NUMBER;
+}
+
+void KeyMappingManager::bindKeyToAction( int keyCode,
+                                         Qt::KeyboardModifiers modifiers,
+                                         Qt::MouseButtons buttons,
+                                         KeyMappingAction action ) {
+    MouseBinding binding{buttons, modifiers, keyCode};
+    auto f = m_mappingAction.find( binding );
+    if ( f != m_mappingAction.end() )
     {
-        LOG( logWARNING ) << "Binding action " << action << " to code " << keyCode
-                          << ", which is already used for action " << f->first << ".";
+        LOG( logWARNING ) << "Binding action " << action << " to "
+                          << "buttons [" << enumNamesFromMouseButtons( buttons ) << "] "
+                          << "modifiers [" << enumNamesFromKeyboardModifiers( modifiers ) << "] "
+                          << "keycode [" << keyCode << "]"
+                          << ", which is already used for action " << f->second << ".";
     }
-    m_mapping[action] = keyCode;
-}
-
-int KeyMappingManager::getKeyFromAction( KeyMappingAction action ) {
-    return m_mapping[action];
-}
-
-bool KeyMappingManager::actionTriggered( QMouseEvent* event, KeyMappingAction action ) {
-    return ( int( event->buttons() ) | event->modifiers() ) == getKeyFromAction( action );
-}
-
-bool KeyMappingManager::actionTriggered( QKeyEvent* event, KeyMappingAction action ) {
-    return ( event->key() | event->modifiers() ) == getKeyFromAction( action );
+    m_mappingAction[binding] = action;
 }
 
 void KeyMappingManager::loadConfiguration( const char* filename ) {
     // if no filename is given, load default configuration
     if ( !filename ) { filename = "Configs/default.xml"; }
 
-    if ( m_file ) { delete m_file; }
-
+    delete m_file;
     m_file = new QFile( filename );
 
     if ( !m_file->open( QIODevice::ReadOnly ) )
     {
-        if ( strcmp( filename, "Configs/default.xml" ) )
+        if ( strcmp( filename, "Configs/default.xml" ) != 0 )
         {
             LOG( logERROR ) << "Failed to open keymapping configuration file ! "
                             << m_file->fileName().toStdString();
@@ -87,16 +89,19 @@ void KeyMappingManager::loadConfiguration( const char* filename ) {
         return;
     }
 
-    QSettings settings;
-    settings.setValue( "keymapping/config", m_file->fileName() );
-
+    // Store setting only if not default
+    if ( !strcmp( filename, "Configs/default.xml" ) )
+    {
+        QSettings settings;
+        settings.setValue( "keymapping/config", m_file->fileName() );
+    }
     m_file->close();
 
     loadConfigurationInternal();
 }
 
 void KeyMappingManager::loadConfigurationInternal() {
-    m_mapping.clear();
+    m_mappingAction.clear();
 
     QDomElement domElement = m_domDocument.documentElement();
     QDomNode node          = domElement.firstChild();
@@ -110,9 +115,7 @@ void KeyMappingManager::loadConfigurationInternal() {
     while ( !node.isNull() )
     {
         QDomElement nodeElement = node.toElement();
-
         loadConfigurationTagsInternal( nodeElement );
-
         node = node.nextSibling();
     }
 }
@@ -120,61 +123,57 @@ void KeyMappingManager::loadConfigurationInternal() {
 void KeyMappingManager::loadConfigurationTagsInternal( QDomElement& node ) {
     if ( node.tagName() == "keymap" )
     {
-        QDomNode nodeChild = node.firstChild();
 
-        std::string keyString      = nodeChild.toElement().attribute( "value" ).toStdString();
-        std::string typeString     = nodeChild.toElement().attribute( "type" ).toStdString();
-        std::string modifierString = nodeChild.toElement().attribute( "modifier" ).toStdString();
-
-        nodeChild = nodeChild.nextSibling();
-
-        std::string actionString = nodeChild.toElement().attribute( "value" ).toStdString();
-
-        loadConfigurationMappingInternal( typeString, modifierString, keyString, actionString );
+        QDomElement e = node.toElement();
+        std::string keyString = e.attribute( "key" ).toStdString();
+        std::string modifiersString =
+            node.toElement().attribute( "modifiers", "NoModifier" ).toStdString();
+        std::string buttonsString =
+            node.toElement().attribute( "buttons", "NoButton" ).toStdString();
+        std::string actionString = node.toElement().attribute( "action" ).toStdString();
+        loadConfigurationMappingInternal( keyString, modifiersString, buttonsString, actionString );
     }
     else
     {
         LOG( logERROR ) << "Unrecognized XML keymapping configuration file tag \""
                         << qPrintable( node.tagName() ) << "\" !";
         LOG( logERROR ) << "Trying to load default configuration...";
-
-        loadConfiguration( "Configs/default.xml" );
+        loadConfiguration();
 
         return;
     }
 }
 
-void KeyMappingManager::loadConfigurationMappingInternal( const std::string& typeString,
-                                                          const std::string& modifierString,
-                                                          const std::string& keyString,
+void KeyMappingManager::loadConfigurationMappingInternal( const std::string& keyString,
+                                                          const std::string& modifiersString,
+                                                          const std::string& buttonsString,
                                                           const std::string& actionString ) {
-    KeyMappingAction actionValue =
-        static_cast<KeyMappingAction>( m_metaEnumAction.keyToValue( actionString.c_str() ) );
-    Qt::KeyboardModifier modifierValue = getQtModifierValue( modifierString );
 
-    if ( typeString == "key" )
+    auto actionValue                     = m_metaEnumAction.keyToValue( actionString.c_str() );
+    Qt::KeyboardModifiers modifiersValue = getQtModifiersValue( modifiersString );
+    auto keyValue                        = m_metaEnumKey.keyToValue( keyString.c_str() );
+    auto buttonsValue                    = getQtMouseButtonsValue( buttonsString );
+
+    if ( actionValue == -1 )
     {
-        int keyValue = m_metaEnumKey.keyToValue( keyString.c_str() );
-
-        if ( keyValue == -1 )
-        {
-            LOG( logERROR ) << "Unrecognized \"" << keyString << "\" key !";
-            LOG( logERROR ) << "Trying to load default configuration...";
-
-            loadConfiguration( "Configs/default.xml" );
-        }
-        else
-        { bindKeyToAction( keyValue | modifierValue, actionValue ); }
+        LOG( logERROR ) << "No valid action [" << actionString << "] specified for binding key ["
+                        << keyString << "], and buttons[" << buttonsString << "]";
     }
-    else if ( typeString == "mouse" )
+    else if ( keyValue == -1 && buttonsValue == Qt::NoButton )
     {
-        int buttonValue = getQtMouseButtonValue( keyString );
-        bindKeyToAction( buttonValue | modifierValue, actionValue );
+        LOG( logERROR ) << "No key nor mouse buttons specified for action [" << actionString
+                        << "] with key [" << keyString << "], and buttons[" << buttonsString << "]";
+        LOG( logERROR ) << "Trying to load default configuration...";
+    }
+    else
+    {
+        bindKeyToAction(
+            keyValue, modifiersValue, buttonsValue, static_cast<KeyMappingAction>( actionValue ) );
     }
 }
 
-Qt::KeyboardModifier KeyMappingManager::getQtModifierValue( const std::string& modifierString ) {
-    Qt::KeyboardModifier modifier = Qt::NoModifier;
+Qt::KeyboardModifiers KeyMappingManager::getQtModifiersValue( const std::string& modifierString ) {
+    Qt::KeyboardModifiers modifier = Qt::NoModifier;
 
     if ( modifierString == "ShiftModifier" ) { modifier = Qt::ShiftModifier; }
     else if ( modifierString == "ControlModifier" )
@@ -191,8 +190,8 @@ Qt::KeyboardModifier KeyMappingManager::getQtModifierValue( const std::string& m
     return modifier;
 }
 
-Qt::MouseButton KeyMappingManager::getQtMouseButtonValue( const std::string& keyString ) {
-    Qt::MouseButton key = Qt::NoButton;
+Qt::MouseButtons KeyMappingManager::getQtMouseButtonsValue( const std::string& keyString ) {
+    Qt::MouseButtons key = Qt::NoButton;
 
     if ( keyString == "LeftButton" ) { key = Qt::LeftButton; }
     else if ( keyString == "RightButton" )
@@ -219,6 +218,53 @@ void KeyMappingManager::reloadConfiguration() {
 
 KeyMappingManager::~KeyMappingManager() {
     if ( m_file->isOpen() ) { m_file->close(); }
+}
+
+std::string KeyMappingManager::enumNamesFromMouseButtons( const Qt::MouseButtons& buttons ) {
+    std::string returnText;
+    if ( buttons == Qt::NoButton ) return "NoButton";
+    if ( buttons & Qt::LeftButton ) returnText += "LeftButton ";
+    if ( buttons & Qt::RightButton ) returnText += "RightButton ";
+    if ( buttons & Qt::MiddleButton ) returnText += "MiddleButton ";
+    if ( buttons & Qt::BackButton ) returnText += "BackButton ";
+    if ( buttons & Qt::ForwardButton ) returnText += "ForwardButton ";
+    if ( buttons & Qt::TaskButton ) returnText += "TaskButton ";
+    if ( buttons & Qt::ExtraButton4 ) returnText += "ExtraButton4 ";
+    if ( buttons & Qt::ExtraButton5 ) returnText += "ExtraButton5 ";
+    if ( buttons & Qt::ExtraButton6 ) returnText += "ExtraButton6 ";
+    if ( buttons & Qt::ExtraButton7 ) returnText += "ExtraButton7 ";
+    if ( buttons & Qt::ExtraButton8 ) returnText += "ExtraButton8 ";
+    if ( buttons & Qt::ExtraButton9 ) returnText += "ExtraButton9 ";
+    if ( buttons & Qt::ExtraButton10 ) returnText += "ExtraButton10 ";
+    if ( buttons & Qt::ExtraButton11 ) returnText += "ExtraButton11 ";
+    if ( buttons & Qt::ExtraButton12 ) returnText += "ExtraButton12 ";
+    if ( buttons & Qt::ExtraButton13 ) returnText += "ExtraButton13 ";
+    if ( buttons & Qt::ExtraButton14 ) returnText += "ExtraButton14 ";
+    if ( buttons & Qt::ExtraButton15 ) returnText += "ExtraButton15 ";
+    if ( buttons & Qt::ExtraButton16 ) returnText += "ExtraButton16 ";
+    if ( buttons & Qt::ExtraButton17 ) returnText += "ExtraButton17 ";
+    if ( buttons & Qt::ExtraButton18 ) returnText += "ExtraButton18 ";
+    if ( buttons & Qt::ExtraButton19 ) returnText += "ExtraButton19 ";
+    if ( buttons & Qt::ExtraButton20 ) returnText += "ExtraButton20 ";
+    if ( buttons & Qt::ExtraButton21 ) returnText += "ExtraButton21 ";
+    if ( buttons & Qt::ExtraButton22 ) returnText += "ExtraButton22 ";
+    if ( buttons & Qt::ExtraButton23 ) returnText += "ExtraButton23 ";
+    if ( buttons & Qt::ExtraButton24 ) returnText += "ExtraButton24 ";
+    return returnText;
+}
+
+std::string
+KeyMappingManager::enumNamesFromKeyboardModifiers( const Qt::KeyboardModifiers& buttons ) {
+    std::string returnText;
+    if ( buttons == Qt::NoModifier ) return "NoModifier";
+    if ( buttons & Qt::ShiftModifier ) returnText += "ShiftModifier ";
+    if ( buttons & Qt::ControlModifier ) returnText += "ControlModifier ";
+    if ( buttons & Qt::AltModifier ) returnText += "AltModifier ";
+    if ( buttons & Qt::MetaModifier ) returnText += "MetaModifier ";
+    if ( buttons & Qt::KeypadModifier ) returnText += "KeypadModifier ";
+    if ( buttons & Qt::GroupSwitchModifier ) returnText += "GroupSwitchModifier ";
+
+    return returnText;
 }
 
 RA_SINGLETON_IMPLEMENTATION( KeyMappingManager );

--- a/src/GuiBase/Utils/Keyboard.cpp
+++ b/src/GuiBase/Utils/Keyboard.cpp
@@ -8,18 +8,26 @@
 namespace Ra {
 namespace Gui {
 std::map<int, bool> g_keypresses;
+// store the last key pressed, still pressed.
+int g_activeKey = -1;
 
 void keyPressed( int code ) {
     g_keypresses[code] = true;
+    g_activeKey = code;
 }
 
 void keyReleased( int code ) {
     g_keypresses[code] = false;
+    if(code == g_activeKey)
+        g_activeKey = -1;
 }
 
 bool isKeyPressed( int code ) {
     // Default constructed bool is false, so this should be enough
     return g_keypresses[code];
 }
+
+int activeKey() { return g_activeKey;}
+
 } // namespace Gui
 } // namespace Ra

--- a/src/GuiBase/Utils/Keyboard.cpp
+++ b/src/GuiBase/Utils/Keyboard.cpp
@@ -8,18 +8,18 @@
 namespace Ra {
 namespace Gui {
 std::map<int, bool> g_keypresses;
+
 // store the last key pressed, still pressed.
 int g_activeKey = -1;
 
 void keyPressed( int code ) {
     g_keypresses[code] = true;
-    g_activeKey = code;
+    g_activeKey        = code;
 }
 
 void keyReleased( int code ) {
     g_keypresses[code] = false;
-    if(code == g_activeKey)
-        g_activeKey = -1;
+    if ( code == g_activeKey ) g_activeKey = -1;
 }
 
 bool isKeyPressed( int code ) {
@@ -27,7 +27,9 @@ bool isKeyPressed( int code ) {
     return g_keypresses[code];
 }
 
-int activeKey() { return g_activeKey;}
+int activeKey() {
+    return g_activeKey;
+}
 
 } // namespace Gui
 } // namespace Ra

--- a/src/GuiBase/Utils/Keyboard.hpp
+++ b/src/GuiBase/Utils/Keyboard.hpp
@@ -3,9 +3,10 @@
 
 namespace Ra {
 namespace Gui {
-bool isKeyPressed( int code );
-void keyPressed( int code );
-void keyReleased( int code );
+bool isKeyPressed( int code ); /// is the key corresponding to \param code currently pressed
+int activeKey(); /// return the last, still pressed, key code, -1 if no key currently pressed
+void keyPressed( int code );  /// set the key corresponding to \param code as pressed
+void keyReleased( int code ); /// set the key corresponding to \param code as released
 } // namespace Gui
 } // namespace Ra
 

--- a/src/GuiBase/Utils/Keyboard.hpp
+++ b/src/GuiBase/Utils/Keyboard.hpp
@@ -3,10 +3,10 @@
 
 namespace Ra {
 namespace Gui {
-bool isKeyPressed( int code ); /// is the key corresponding to \param code currently pressed
-int activeKey(); /// return the last, still pressed, key code, -1 if no key currently pressed
-void keyPressed( int code );  /// set the key corresponding to \param code as pressed
-void keyReleased( int code ); /// set the key corresponding to \param code as released
+bool isKeyPressed( int code ); ///< is the key corresponding to \param code currently pressed
+int activeKey(); ///< return the last, still pressed, key code, -1 if no key currently pressed
+void keyPressed( int code );  ///< set the key corresponding to \param code as pressed
+void keyReleased( int code ); ///< set the key corresponding to \param code as released
 } // namespace Gui
 } // namespace Ra
 

--- a/src/GuiBase/Viewer/CameraInterface.hpp
+++ b/src/GuiBase/Viewer/CameraInterface.hpp
@@ -12,6 +12,8 @@
 #include <Core/Types.hpp>
 #include <Core/Utils/Log.hpp>
 
+#include <GuiBase/Utils/KeyMappingManager.hpp>
+
 namespace Ra {
 namespace Engine {
 class Camera;
@@ -43,18 +45,24 @@ class RA_GUIBASE_API CameraInterface : public QObject
     Core::Matrix4 getViewMatrix() const;
 
     /// @return true if the event has been taken into account, false otherwise
-    virtual bool handleMousePressEvent( QMouseEvent* event ) = 0;
+    virtual bool handleMousePressEvent( QMouseEvent* event,
+                                        const KeyMappingManager::KeyMappingAction& action ) = 0;
     /// @return true if the event has been taken into account, false otherwise
-    virtual bool handleMouseReleaseEvent( QMouseEvent* event ) = 0;
+    virtual bool handleMouseReleaseEvent( QMouseEvent* event,
+                                          const KeyMappingManager::KeyMappingAction& action ) = 0;
     /// @return true if the event has been taken into account, false otherwise
-    virtual bool handleMouseMoveEvent( QMouseEvent* event ) = 0;
+    virtual bool handleMouseMoveEvent( QMouseEvent* event,
+                                       const KeyMappingManager::KeyMappingAction& action ) = 0;
     /// @return true if the event has been taken into account, false otherwise
-    virtual bool handleWheelEvent( QWheelEvent* event ) = 0;
+    virtual bool handleWheelEvent( QWheelEvent* event,
+                                   const KeyMappingManager::KeyMappingAction& action ) = 0;
 
     /// @return true if the event has been taken into account, false otherwise
-    virtual bool handleKeyPressEvent( QKeyEvent* event ) = 0;
+    virtual bool handleKeyPressEvent( QKeyEvent* event,
+                                      const KeyMappingManager::KeyMappingAction& action ) = 0;
     /// @return true if the event has been taken into account, false otherwise
-    virtual bool handleKeyReleaseEvent( QKeyEvent* event ) = 0;
+    virtual bool handleKeyReleaseEvent( QKeyEvent* event,
+                                        const KeyMappingManager::KeyMappingAction& action ) = 0;
 
     /// Pointer access to the camera.
     const Engine::Camera* getCamera() const { return m_camera; }

--- a/src/GuiBase/Viewer/CameraInterface.hpp
+++ b/src/GuiBase/Viewer/CameraInterface.hpp
@@ -25,7 +25,7 @@ namespace Ra {
 namespace Gui {
 
 /// The CameraInterface class is the generic class for camera manipulators.
-class RA_GUIBASE_API CameraInterface : public QObject
+class RA_GUIBASE_API CameraInterface : public QObject, public KeyMappingManageable<CameraInterface>
 {
     Q_OBJECT
 
@@ -46,23 +46,24 @@ class RA_GUIBASE_API CameraInterface : public QObject
 
     /// @return true if the event has been taken into account, false otherwise
     virtual bool handleMousePressEvent( QMouseEvent* event,
-                                        const KeyMappingManager::KeyMappingAction& action ) = 0;
+                                        const Qt::MouseButtons& buttons,
+                                        const Qt::KeyboardModifiers& modifiers,
+                                        int key ) = 0;
     /// @return true if the event has been taken into account, false otherwise
-    virtual bool handleMouseReleaseEvent( QMouseEvent* event,
-                                          const KeyMappingManager::KeyMappingAction& action ) = 0;
+    virtual bool handleMouseReleaseEvent( QMouseEvent* event ) = 0;
     /// @return true if the event has been taken into account, false otherwise
     virtual bool handleMouseMoveEvent( QMouseEvent* event,
-                                       const KeyMappingManager::KeyMappingAction& action ) = 0;
+                                       const Qt::MouseButtons& buttons,
+                                       const Qt::KeyboardModifiers& modifiers,
+                                       int key ) = 0;
     /// @return true if the event has been taken into account, false otherwise
-    virtual bool handleWheelEvent( QWheelEvent* event,
-                                   const KeyMappingManager::KeyMappingAction& action ) = 0;
+    virtual bool handleWheelEvent( QWheelEvent* event ) = 0;
 
     /// @return true if the event has been taken into account, false otherwise
     virtual bool handleKeyPressEvent( QKeyEvent* event,
                                       const KeyMappingManager::KeyMappingAction& action ) = 0;
     /// @return true if the event has been taken into account, false otherwise
-    virtual bool handleKeyReleaseEvent( QKeyEvent* event,
-                                        const KeyMappingManager::KeyMappingAction& action ) = 0;
+    virtual bool handleKeyReleaseEvent( QKeyEvent* event ) = 0;
 
     /// Pointer access to the camera.
     const Engine::Camera* getCamera() const { return m_camera; }

--- a/src/GuiBase/Viewer/Gizmo/Gizmo.hpp
+++ b/src/GuiBase/Viewer/Gizmo/Gizmo.hpp
@@ -71,8 +71,10 @@ class Gizmo
 
     /// Called when the mouse movement is recorder with the camera parameters and the current pixel
     /// coordinates.
-    virtual Core::Transform
-    mouseMove( const Engine::Camera& cam, const Core::Vector2& nextXY, bool stepped = false ) = 0;
+    virtual Core::Transform mouseMove( const Engine::Camera& cam,
+                                       const Core::Vector2& nextXY,
+                                       bool stepped = false,
+                                       bool whole = false) = 0;
 
   protected:
     static bool findPointOnAxis( const Engine::Camera& cam,

--- a/src/GuiBase/Viewer/Gizmo/Gizmo.hpp
+++ b/src/GuiBase/Viewer/Gizmo/Gizmo.hpp
@@ -63,11 +63,13 @@ class Gizmo
     /// Called when one of the drawables of the gizmo has been selected.
     virtual void selectConstraint( int drawableIndex ) = 0;
 
+    virtual bool isSelected() = 0;
+
     /// Called when the gizmo is first clicked, with the camera parameters and the initial pixel
     /// coordinates.
     virtual void setInitialState( const Engine::Camera& cam, const Core::Vector2& initialXY ) = 0;
 
-    /// Called when the mose movement is recorder with the camera parameters and the current pixel
+    /// Called when the mouse movement is recorder with the camera parameters and the current pixel
     /// coordinates.
     virtual Core::Transform
     mouseMove( const Engine::Camera& cam, const Core::Vector2& nextXY, bool stepped = false ) = 0;

--- a/src/GuiBase/Viewer/Gizmo/GizmoManager.hpp
+++ b/src/GuiBase/Viewer/Gizmo/GizmoManager.hpp
@@ -26,14 +26,17 @@ class RA_GUIBASE_API GizmoManager : public QObject, public GuiBase::TransformEdi
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
     enum GizmoType { NONE, TRANSLATION, ROTATION, SCALE };
 
-    GizmoManager( QObject* parent = nullptr );
-    ~GizmoManager();
+    explicit GizmoManager( QObject* parent = nullptr );
+    ~GizmoManager() = default;
 
   public:
     /// Receive mouse events and transmit them to the gizmos.
-    virtual bool handleMousePressEvent( QMouseEvent* event );
-    virtual bool handleMouseReleaseEvent( QMouseEvent* event );
-    virtual bool handleMouseMoveEvent( QMouseEvent* event );
+    virtual bool handleMousePressEvent( QMouseEvent* event,
+                                        const KeyMappingManager::KeyMappingAction& action );
+    virtual bool handleMouseReleaseEvent( QMouseEvent* event,
+                                          const KeyMappingManager::KeyMappingAction& action );
+    virtual bool handleMouseMoveEvent( QMouseEvent* event,
+                                       const KeyMappingManager::KeyMappingAction& action );
 
   public slots:
     /// Set the object being currently edited

--- a/src/GuiBase/Viewer/Gizmo/GizmoManager.hpp
+++ b/src/GuiBase/Viewer/Gizmo/GizmoManager.hpp
@@ -33,7 +33,9 @@ class RA_GUIBASE_API GizmoManager : public QObject,
 
 #define KeyMappingGizmo                    \
     KMA_VALUE( GIZMOMANAGER_MANIPULATION ) \
-    KMA_VALUE( GIZMOMANAGER_STEP )
+    KMA_VALUE( GIZMOMANAGER_STEP )         \
+    KMA_VALUE( GIZMOMANAGER_WHOLE )        \
+    KMA_VALUE( GIZMOMANAGER_STEP_WHOLE )
 
 #define KMA_VALUE( XX ) static KeyMappingManager::KeyMappingAction XX;
     KeyMappingGizmo
@@ -74,6 +76,8 @@ class RA_GUIBASE_API GizmoManager : public QObject,
     void updateValues() override;
 
   private:
+    bool isValidAction( const Gui::KeyMappingManager::KeyMappingAction& action ) const;
+
     // Helper method to change the current gizmo
     void updateGizmo();
 

--- a/src/GuiBase/Viewer/Gizmo/GizmoManager.hpp
+++ b/src/GuiBase/Viewer/Gizmo/GizmoManager.hpp
@@ -18,7 +18,9 @@ namespace Gui {
 /// This class interfaces the gizmos with the ui commands.
 /// It allows to change the gizmo type when editing an editable transform object
 /// Note :  currently the scale gizmo is not implemented so it will just return a null pointer
-class RA_GUIBASE_API GizmoManager : public QObject, public GuiBase::TransformEditor
+class RA_GUIBASE_API GizmoManager : public QObject,
+                                    public GuiBase::TransformEditor,
+                                    public KeyMappingManageable<GizmoManager>
 {
     Q_OBJECT
 
@@ -29,14 +31,28 @@ class RA_GUIBASE_API GizmoManager : public QObject, public GuiBase::TransformEdi
     explicit GizmoManager( QObject* parent = nullptr );
     ~GizmoManager() = default;
 
+#define KeyMappingGizmo                    \
+    KMA_VALUE( GIZMOMANAGER_MANIPULATION ) \
+    KMA_VALUE( GIZMOMANAGER_STEP )
+
+#define KMA_VALUE( XX ) static KeyMappingManager::KeyMappingAction XX;
+    KeyMappingGizmo
+#undef KMA_VALUE
+
+        static void
+        registerKeyMapping();
+
   public:
     /// Receive mouse events and transmit them to the gizmos.
     virtual bool handleMousePressEvent( QMouseEvent* event,
-                                        const KeyMappingManager::KeyMappingAction& action );
-    virtual bool handleMouseReleaseEvent( QMouseEvent* event,
-                                          const KeyMappingManager::KeyMappingAction& action );
+                                        const Qt::MouseButtons& buttons,
+                                        const Qt::KeyboardModifiers& modifiers,
+                                        int key );
+    virtual bool handleMouseReleaseEvent( QMouseEvent* event );
     virtual bool handleMouseMoveEvent( QMouseEvent* event,
-                                       const KeyMappingManager::KeyMappingAction& action );
+                                       const Qt::MouseButtons& buttons,
+                                       const Qt::KeyboardModifiers& modifiers,
+                                       int key );
 
   public slots:
     /// Set the object being currently edited

--- a/src/GuiBase/Viewer/Gizmo/RotateGizmo.cpp
+++ b/src/GuiBase/Viewer/Gizmo/RotateGizmo.cpp
@@ -123,8 +123,10 @@ void RotateGizmo::selectConstraint( int drawableIdx ) {
     }
 }
 
-Core::Transform
-RotateGizmo::mouseMove( const Engine::Camera& cam, const Core::Vector2& nextXY, bool stepped ) {
+Core::Transform RotateGizmo::mouseMove( const Engine::Camera& cam,
+                                        const Core::Vector2& nextXY,
+                                        bool stepped,
+                                        bool whole ) {
     static const Scalar step = Ra::Core::Math::Pi / 10_ra;
 
     if ( m_selectedAxis == -1 ) return m_transform;

--- a/src/GuiBase/Viewer/Gizmo/RotateGizmo.cpp
+++ b/src/GuiBase/Viewer/Gizmo/RotateGizmo.cpp
@@ -108,7 +108,6 @@ void RotateGizmo::selectConstraint( int drawableIdx ) {
         mesh->setDirty( Engine::Mesh::VERTEX_COLOR );
     }
     // prepare selection
-    int oldAxis    = m_selectedAxis;
     m_selectedAxis = -1;
     if ( drawableIdx >= 0 )
     {
@@ -121,11 +120,6 @@ void RotateGizmo::selectConstraint( int drawableIdx ) {
             mesh->getTriangleMesh().colorize( Core::Utils::Color::Yellow() );
             mesh->setDirty( Engine::Mesh::VERTEX_COLOR );
         }
-    }
-    if ( m_selectedAxis != oldAxis )
-    {
-        m_start   = false;
-        m_stepped = false;
     }
 }
 
@@ -218,6 +212,8 @@ RotateGizmo::mouseMove( const Engine::Camera& cam, const Core::Vector2& nextXY, 
 
 void RotateGizmo::setInitialState( const Engine::Camera& /*cam*/, const Core::Vector2& initialXY ) {
     m_initialPix = initialXY;
+    m_start      = false;
+    m_stepped    = false;
 }
 
 } // namespace Gui

--- a/src/GuiBase/Viewer/Gizmo/RotateGizmo.hpp
+++ b/src/GuiBase/Viewer/Gizmo/RotateGizmo.hpp
@@ -20,6 +20,8 @@ class RotateGizmo : public Gizmo
                           const Core::Transform& worldTo,
                           const Core::Transform& t ) override;
     void selectConstraint( int drawableIndex ) override;
+    bool isSelected() override { return m_selectedAxis != -1; }
+
     void setInitialState( const Engine::Camera& cam, const Core::Vector2& initialXY ) override;
     Core::Transform mouseMove( const Engine::Camera& cam,
                                const Core::Vector2& nextXY,

--- a/src/GuiBase/Viewer/Gizmo/RotateGizmo.hpp
+++ b/src/GuiBase/Viewer/Gizmo/RotateGizmo.hpp
@@ -25,7 +25,8 @@ class RotateGizmo : public Gizmo
     void setInitialState( const Engine::Camera& cam, const Core::Vector2& initialXY ) override;
     Core::Transform mouseMove( const Engine::Camera& cam,
                                const Core::Vector2& nextXY,
-                               bool stepped = false ) override;
+                               bool stepped,
+                               bool whole ) override;
 
   private:
     Core::Vector2 m_initialPix; ///< The pixel location when edition starts.

--- a/src/GuiBase/Viewer/Gizmo/ScaleGizmo.cpp
+++ b/src/GuiBase/Viewer/Gizmo/ScaleGizmo.cpp
@@ -178,14 +178,14 @@ void ScaleGizmo::selectConstraint( int drawableIdx ) {
         mesh->setDirty( Engine::Mesh::VERTEX_COLOR );
 }
 
-Core::Transform
-ScaleGizmo::mouseMove( const Engine::Camera& cam, const Core::Vector2& nextXY, bool stepped ) {
+Core::Transform ScaleGizmo::mouseMove( const Engine::Camera& cam,
+                                       const Core::Vector2& nextXY,
+                                       bool stepped,
+                                       bool whole ) {
     static const Scalar step = .2_ra;
 
     // Recolor gizmo
 
-    ///!\todo Since one will never happen, find a way to handle this compatible with keybinding
-    bool whole = isKeyPressed( 0x01000020 ); // shift 16777248
     if ( whole )
     {
         for ( const auto& mesh : roMeshes() )

--- a/src/GuiBase/Viewer/Gizmo/ScaleGizmo.cpp
+++ b/src/GuiBase/Viewer/Gizmo/ScaleGizmo.cpp
@@ -21,6 +21,8 @@
 namespace Ra {
 namespace Gui {
 
+using namespace Ra::Core::Utils;
+
 const std::string colorAttribName = Engine::Mesh::getAttribName( Engine::Mesh::VERTEX_COLOR );
 
 ScaleGizmo::ScaleGizmo( Engine::Component* c,
@@ -49,9 +51,7 @@ ScaleGizmo::ScaleGizmo( Engine::Component* c,
         arrowColor[i]                 = 1_ra;
 
         Core::Vector3 cylinderEnd = Core::Vector3::Zero();
-        Core::Vector3 arrowEnd    = Core::Vector3::Zero();
         cylinderEnd[i]            = ( 1_ra - arrowFrac );
-        arrowEnd[i]               = 1_ra;
 
         Core::Geometry::TriangleMesh cylinder = Core::Geometry::makeCylinder(
             Core::Vector3::Zero(), arrowScale * cylinderEnd, radius, 32, arrowColor );
@@ -127,7 +127,7 @@ void ScaleGizmo::updateTransform( Gizmo::Mode mode,
         displayTransform.rotate( R );
     }
 
-    for ( auto roIdx : roIds() )
+    for ( const auto& roIdx : roIds() )
     {
         Engine::RadiumEngine::getInstance()
             ->getRenderObjectManager()
@@ -146,8 +146,6 @@ void ScaleGizmo::selectConstraint( int drawableIdx ) {
     roMeshes()[5]->getTriangleMesh().colorize( Core::Utils::Color::Blue() );
 
     // prepare selection
-    int oldAxis     = m_selectedAxis;
-    int oldPlane    = m_selectedPlane;
     m_selectedAxis  = -1;
     m_selectedPlane = -1;
     if ( drawableIdx >= 0 )
@@ -175,13 +173,8 @@ void ScaleGizmo::selectConstraint( int drawableIdx ) {
             }
         }
     }
-    if ( m_selectedAxis != oldAxis || m_selectedPlane != oldPlane )
-    {
-        m_initialPix = Core::Vector2::Zero();
-        m_start      = false;
-    }
 
-    for ( auto mesh : roMeshes() )
+    for ( const auto& mesh : roMeshes() )
         mesh->setDirty( Engine::Mesh::VERTEX_COLOR );
 }
 
@@ -190,10 +183,12 @@ ScaleGizmo::mouseMove( const Engine::Camera& cam, const Core::Vector2& nextXY, b
     static const Scalar step = .2_ra;
 
     // Recolor gizmo
+
+    ///!\todo Since one will never happen, find a way to handle this compatible with keybinding
     bool whole = isKeyPressed( 0x01000020 ); // shift 16777248
     if ( whole )
     {
-        for ( auto mesh : roMeshes() )
+        for ( const auto& mesh : roMeshes() )
             mesh->getTriangleMesh().colorize( Core::Utils::Color::Yellow() );
     }
     else
@@ -221,7 +216,7 @@ ScaleGizmo::mouseMove( const Engine::Camera& cam, const Core::Vector2& nextXY, b
         }
     }
 
-    for ( auto mesh : roMeshes() )
+    for ( const auto& mesh : roMeshes() )
         mesh->setDirty( Engine::Mesh::VERTEX_COLOR );
 
     if ( m_selectedAxis == -1 && m_selectedPlane == -1 && !whole ) { return m_transform; }
@@ -282,10 +277,10 @@ ScaleGizmo::mouseMove( const Engine::Camera& cam, const Core::Vector2& nextXY, b
     return m_transform;
 }
 
-void ScaleGizmo::setInitialState( const Engine::Camera& cam, const Core::Vector2& initialXY ) {
-    const Core::Vector3 origin    = m_transform.translation();
-    const Core::Vector2 orgScreen = cam.project( origin );
-    m_initialPix                  = orgScreen - initialXY;
+void ScaleGizmo::setInitialState( const Engine::Camera& /*cam*/,
+                                  const Core::Vector2& /*initialXY*/ ) {
+    m_initialPix = Core::Vector2::Zero();
+    m_start      = false;
 }
 
 } // namespace Gui

--- a/src/GuiBase/Viewer/Gizmo/ScaleGizmo.hpp
+++ b/src/GuiBase/Viewer/Gizmo/ScaleGizmo.hpp
@@ -25,10 +25,9 @@ class ScaleGizmo : public Gizmo
                           const Core::Transform& worldTo,
                           const Core::Transform& t ) override;
     void selectConstraint( int drawableIndex ) override;
+    bool isSelected() override { return m_selectedAxis != -1 || m_selectedPlane != -1; }
     void setInitialState( const Engine::Camera& cam, const Core::Vector2& initialXY ) override;
-    Core::Transform mouseMove( const Engine::Camera& cam,
-                               const Core::Vector2& nextXY,
-                               bool stepped = false ) override;
+    Core::Transform mouseMove( const Engine::Camera& cam, const Core::Vector2& nextXY, bool stepped ) override;
 
   private:
     Ra::Core::Vector3 m_prevScale;  ///< The previously applied scale.
@@ -37,7 +36,7 @@ class ScaleGizmo : public Gizmo
     Core::Vector2 m_initialPix;     ///< The pixel position when edition starts.
     int m_selectedAxis;             ///< The axis to scale in.
     int m_selectedPlane;            ///< The plane to scale in.
-    bool m_start;                   ///< Did the edition start.
+    bool m_start{false};            ///< Did the edition start.
 };
 
 } // namespace Gui

--- a/src/GuiBase/Viewer/Gizmo/ScaleGizmo.hpp
+++ b/src/GuiBase/Viewer/Gizmo/ScaleGizmo.hpp
@@ -27,7 +27,10 @@ class ScaleGizmo : public Gizmo
     void selectConstraint( int drawableIndex ) override;
     bool isSelected() override { return m_selectedAxis != -1 || m_selectedPlane != -1; }
     void setInitialState( const Engine::Camera& cam, const Core::Vector2& initialXY ) override;
-    Core::Transform mouseMove( const Engine::Camera& cam, const Core::Vector2& nextXY, bool stepped ) override;
+    Core::Transform mouseMove( const Engine::Camera& cam,
+                               const Core::Vector2& nextXY,
+                               bool stepped,
+                               bool whole ) override;
 
   private:
     Ra::Core::Vector3 m_prevScale;  ///< The previously applied scale.

--- a/src/GuiBase/Viewer/Gizmo/TranslateGizmo.cpp
+++ b/src/GuiBase/Viewer/Gizmo/TranslateGizmo.cpp
@@ -143,8 +143,6 @@ void TranslateGizmo::selectConstraint( int drawableIdx ) {
     roMeshes()[5]->getTriangleMesh().colorize( Core::Utils::Color::Blue() );
 
     // prepare selection
-    int oldAxis     = m_selectedAxis;
-    int oldPlane    = m_selectedPlane;
     m_selectedAxis  = -1;
     m_selectedPlane = -1;
     if ( drawableIdx >= 0 )
@@ -171,11 +169,6 @@ void TranslateGizmo::selectConstraint( int drawableIdx ) {
                     Core::Utils::Color::Yellow() );
             }
         }
-    }
-    if ( m_selectedAxis != oldAxis || m_selectedPlane != oldPlane )
-    {
-        m_initialPix = Core::Vector2::Zero();
-        m_start      = false;
     }
 
     for ( auto mesh : roMeshes() )
@@ -229,10 +222,10 @@ TranslateGizmo::mouseMove( const Engine::Camera& cam, const Core::Vector2& nextX
     return m_transform;
 }
 
-void TranslateGizmo::setInitialState( const Engine::Camera& cam, const Core::Vector2& initialXY ) {
-    const Core::Vector3 origin    = m_transform.translation();
-    const Core::Vector2 orgScreen = cam.project( origin );
-    m_initialPix                  = orgScreen - initialXY;
+void TranslateGizmo::setInitialState( const Engine::Camera& /*cam*/,
+                                      const Core::Vector2& /*initialXY*/ ) {
+    m_initialPix = Core::Vector2::Zero();
+    m_start      = false;
 }
 
 } // namespace Gui

--- a/src/GuiBase/Viewer/Gizmo/TranslateGizmo.cpp
+++ b/src/GuiBase/Viewer/Gizmo/TranslateGizmo.cpp
@@ -175,8 +175,10 @@ void TranslateGizmo::selectConstraint( int drawableIdx ) {
         mesh->setDirty( Engine::Mesh::VERTEX_COLOR );
 }
 
-Core::Transform
-TranslateGizmo::mouseMove( const Engine::Camera& cam, const Core::Vector2& nextXY, bool stepped ) {
+Core::Transform TranslateGizmo::mouseMove( const Engine::Camera& cam,
+                                           const Core::Vector2& nextXY,
+                                           bool stepped,
+                                           bool whole ) {
     static const Scalar step = .2_ra;
 
     if ( m_selectedAxis == -1 && m_selectedPlane == -1 ) return m_transform;

--- a/src/GuiBase/Viewer/Gizmo/TranslateGizmo.hpp
+++ b/src/GuiBase/Viewer/Gizmo/TranslateGizmo.hpp
@@ -20,6 +20,7 @@ class TranslateGizmo : public Gizmo
                           const Core::Transform& worldTo,
                           const Core::Transform& t ) override;
     void selectConstraint( int drawableIndex ) override;
+    bool isSelected() override { return m_selectedAxis != -1 || m_selectedPlane != -1; }
     void setInitialState( const Engine::Camera& cam, const Core::Vector2& initialXY ) override;
     Core::Transform mouseMove( const Engine::Camera& cam,
                                const Core::Vector2& nextXY,

--- a/src/GuiBase/Viewer/Gizmo/TranslateGizmo.hpp
+++ b/src/GuiBase/Viewer/Gizmo/TranslateGizmo.hpp
@@ -24,7 +24,8 @@ class TranslateGizmo : public Gizmo
     void setInitialState( const Engine::Camera& cam, const Core::Vector2& initialXY ) override;
     Core::Transform mouseMove( const Engine::Camera& cam,
                                const Core::Vector2& nextXY,
-                               bool stepped = false ) override;
+                               bool stepped,
+                               bool whole ) override;
 
   private:
     Ra::Core::Vector3 m_startPoint;   ///< The picked 3D point on the gizmo.

--- a/src/GuiBase/Viewer/TrackballCamera.cpp
+++ b/src/GuiBase/Viewer/TrackballCamera.cpp
@@ -4,6 +4,7 @@
 #include <Core/Utils/Log.hpp>
 #include <Engine/Renderer/Camera/Camera.hpp>
 #include <Engine/Renderer/Light/Light.hpp>
+#include <GuiBase/Utils/Keyboard.hpp>
 
 #include <GuiBase/Utils/KeyMappingManager.hpp>
 
@@ -62,25 +63,29 @@ const Core::Vector3& Gui::TrackballCamera::getTrackballCenter() const {
     return m_trackballCenter;
 }
 
-bool Gui::TrackballCamera::handleMousePressEvent( QMouseEvent* event ) {
+bool Gui::TrackballCamera::handleMousePressEvent(
+    QMouseEvent* event,
+    const KeyMappingManager::KeyMappingAction& action ) {
     bool handled = false;
     m_lastMouseX = event->pos().x();
     m_lastMouseY = event->pos().y();
 
-    /* TODO: Better handling of rotation/pan/zoom with KeyMappingManager */
-    if ( event->modifiers().testFlag( Qt::NoModifier ) )
+    if ( action == Gui::KeyMappingManager::TRACKBALLCAMERA_MANIPULATION )
     {
         m_cameraRotateMode = true;
         handled            = true;
     }
-
-    if ( event->modifiers().testFlag( Qt::ShiftModifier ) )
+    if ( action == Gui::KeyMappingManager::TRACKBALLCAMERA_ROTATE )
+    {
+        m_cameraRotateMode = true;
+        handled            = true;
+    }
+    if ( action == Gui::KeyMappingManager::TRACKBALLCAMERA_PAN )
     {
         m_cameraPanMode = true;
         handled         = true;
     }
-
-    if ( event->modifiers().testFlag( Qt::ControlModifier ) )
+    if ( action == Gui::KeyMappingManager::TRACKBALLCAMERA_ZOOM )
     {
         m_cameraZoomMode = true;
         handled          = true;
@@ -89,7 +94,9 @@ bool Gui::TrackballCamera::handleMousePressEvent( QMouseEvent* event ) {
     return handled;
 }
 
-bool Gui::TrackballCamera::handleMouseMoveEvent( QMouseEvent* event ) {
+bool Gui::TrackballCamera::handleMouseMoveEvent(
+    QMouseEvent* event,
+    const KeyMappingManager::KeyMappingAction& action ) {
     Scalar dx = ( event->pos().x() - m_lastMouseX ) / m_camera->getWidth();
     Scalar dy = ( event->pos().y() - m_lastMouseY ) / m_camera->getHeight();
 
@@ -117,7 +124,9 @@ bool Gui::TrackballCamera::handleMouseMoveEvent( QMouseEvent* event ) {
     return true;
 }
 
-bool Gui::TrackballCamera::handleMouseReleaseEvent( QMouseEvent* /*event*/ ) {
+bool Gui::TrackballCamera::handleMouseReleaseEvent(
+    QMouseEvent* /*event*/,
+    const KeyMappingManager::KeyMappingAction& action ) {
     m_cameraRotateMode    = false;
     m_cameraPanMode       = false;
     m_cameraZoomMode      = false;
@@ -126,7 +135,8 @@ bool Gui::TrackballCamera::handleMouseReleaseEvent( QMouseEvent* /*event*/ ) {
     return true;
 }
 
-bool Gui::TrackballCamera::handleWheelEvent( QWheelEvent* event ) {
+bool Gui::TrackballCamera::handleWheelEvent( QWheelEvent* event,
+                                             const KeyMappingManager::KeyMappingAction& action ) {
     handleCameraZoom( ( event->angleDelta().y() * 0.01_ra + event->angleDelta().x() * 0.01_ra ) *
                       m_wheelSpeedModifier );
 
@@ -141,9 +151,15 @@ bool Gui::TrackballCamera::handleWheelEvent( QWheelEvent* event ) {
     return true;
 }
 
-bool Gui::TrackballCamera::handleKeyPressEvent( QKeyEvent* e ) {
-    if ( Gui::KeyMappingManager::getInstance()->actionTriggered(
-             e, Gui::KeyMappingManager::TRACKBALLCAMERA_ROTATE_AROUND ) )
+void Gui::TrackballCamera::toggleRotateAround() {
+    m_rotateAround = !m_rotateAround;
+}
+
+bool Gui::TrackballCamera::handleKeyPressEvent(
+    QKeyEvent* e,
+    const KeyMappingManager::KeyMappingAction& action ) {
+
+    if ( action == Gui::KeyMappingManager::TRACKBALLCAMERA_ROTATE_AROUND )
     {
         m_rotateAround = !m_rotateAround;
         return true;
@@ -152,7 +168,9 @@ bool Gui::TrackballCamera::handleKeyPressEvent( QKeyEvent* e ) {
     return false;
 }
 
-bool Gui::TrackballCamera::handleKeyReleaseEvent( QKeyEvent* /*e*/ ) {
+bool Gui::TrackballCamera::handleKeyReleaseEvent(
+    QKeyEvent* /*e*/,
+    const KeyMappingManager::KeyMappingAction& action ) {
     return false;
 }
 

--- a/src/GuiBase/Viewer/TrackballCamera.cpp
+++ b/src/GuiBase/Viewer/TrackballCamera.cpp
@@ -34,12 +34,6 @@ void Gui::TrackballCamera::registerKeyMapping() {
     XX = Gui::KeyMappingManager::getInstance()->getActionIndex( m_keyMappingContext, #XX );
     KeyMappingCamera
 #undef KMA_VALUE
-
-            LOG( Core::Utils::logINFO )
-        << "register camera have" << m_keyMappingContext << " " << TRACKBALLCAMERA_ROTATE
-        << " check "
-        << Gui::KeyMappingManager::getInstance()->getActionIndex( m_keyMappingContext,
-                                                                  "TRACKBALLCAMERA_ROTATE" );
 }
 
 Gui::TrackballCamera::TrackballCamera( uint width, uint height ) :
@@ -55,7 +49,7 @@ Gui::TrackballCamera::TrackballCamera( uint width, uint height ) :
     resetCamera();
 }
 
-Gui::TrackballCamera::~TrackballCamera() {}
+Gui::TrackballCamera::~TrackballCamera() = default;
 
 void Gui::TrackballCamera::resetCamera() {
     m_camera->setFrame( Core::Transform::Identity() );
@@ -97,18 +91,9 @@ bool Gui::TrackballCamera::handleMousePressEvent( QMouseEvent* event,
     m_lastMouseX = event->pos().x();
     m_lastMouseY = event->pos().y();
 
-    auto action =
-        KeyMappingManager::getInstance()->getAction( m_keyMappingContext, buttons, modifiers, key );
+    auto action = KeyMappingManager::getInstance()->getAction(
+        m_keyMappingContext, buttons, modifiers, key, false );
 
-    LOG( Core::Utils::logINFO ) << "camera mouse press event got "
-                                << KeyMappingManager::getInstance()->getActionName(
-                                       m_keyMappingContext, action );
-
-    if ( action == TRACKBALLCAMERA_MANIPULATION )
-    {
-        m_cameraRotateMode = true;
-        handled            = true;
-    }
     if ( action == TRACKBALLCAMERA_ROTATE )
     {
         m_cameraRotateMode = true;
@@ -124,7 +109,6 @@ bool Gui::TrackballCamera::handleMousePressEvent( QMouseEvent* event,
         m_cameraZoomMode = true;
         handled          = true;
     }
-    LOG( Core::Utils::logINFO ) << "handle " << handled;
 
     return handled;
 }
@@ -132,7 +116,7 @@ bool Gui::TrackballCamera::handleMousePressEvent( QMouseEvent* event,
 bool Gui::TrackballCamera::handleMouseMoveEvent( QMouseEvent* event,
                                                  const Qt::MouseButtons& buttons,
                                                  const Qt::KeyboardModifiers& modifiers,
-                                                 int key ) {
+                                                 int /*key*/ ) {
 
     // auto action = KeyMappingManager::getInstance()->getAction( context, buttons, modifiers, key
     // );
@@ -161,7 +145,7 @@ bool Gui::TrackballCamera::handleMouseMoveEvent( QMouseEvent* event,
 
     emit cameraChanged( m_camera->getPosition(), m_trackballCenter );
 
-    return true;
+    return m_cameraRotateMode || m_cameraPanMode || m_cameraZoomMode;
 }
 
 bool Gui::TrackballCamera::handleMouseReleaseEvent( QMouseEvent* /*event*/ ) {
@@ -174,6 +158,7 @@ bool Gui::TrackballCamera::handleMouseReleaseEvent( QMouseEvent* /*event*/ ) {
 }
 
 bool Gui::TrackballCamera::handleWheelEvent( QWheelEvent* event ) {
+
     handleCameraZoom( ( event->angleDelta().y() * 0.01_ra + event->angleDelta().x() * 0.01_ra ) *
                       m_wheelSpeedModifier );
 
@@ -193,7 +178,7 @@ void Gui::TrackballCamera::toggleRotateAround() {
 }
 
 bool Gui::TrackballCamera::handleKeyPressEvent(
-    QKeyEvent* e,
+    QKeyEvent* /*event*/,
     const KeyMappingManager::KeyMappingAction& action ) {
 
     if ( action == TRACKBALLCAMERA_ROTATE_AROUND )

--- a/src/GuiBase/Viewer/TrackballCamera.cpp
+++ b/src/GuiBase/Viewer/TrackballCamera.cpp
@@ -27,7 +27,9 @@ void Gui::TrackballCamera::registerKeyMapping() {
     if ( m_keyMappingContext.isInvalid() )
     {
         LOG( Ra::Core::Utils::logINFO )
-            << "ViewerContext not defined (maybe the configuration file do not contains it";
+            << "CameraContext not defined (maybe the configuration file do not contains it)";
+        LOG( Ra::Core::Utils::logERROR ) << "CameraContext all keymapping invalide !";
+        return;
     }
 
 #define KMA_VALUE( XX ) \

--- a/src/GuiBase/Viewer/TrackballCamera.hpp
+++ b/src/GuiBase/Viewer/TrackballCamera.hpp
@@ -16,15 +16,17 @@ class RA_GUIBASE_API TrackballCamera : public CameraInterface
     TrackballCamera( uint width, uint height );
     virtual ~TrackballCamera();
 
-    bool handleMousePressEvent( QMouseEvent* event ) override;
-    bool handleMouseReleaseEvent( QMouseEvent* event ) override;
-    bool handleMouseMoveEvent( QMouseEvent* event ) override;
-    bool handleWheelEvent( QWheelEvent* event ) override;
+    bool handleMousePressEvent( QMouseEvent* event, const KeyMappingManager::KeyMappingAction &action ) override;
+    bool handleMouseReleaseEvent( QMouseEvent* event, const KeyMappingManager::KeyMappingAction &action ) override;
+    bool handleMouseMoveEvent( QMouseEvent* event, const KeyMappingManager::KeyMappingAction &action ) override;
+    bool handleWheelEvent( QWheelEvent* event, const KeyMappingManager::KeyMappingAction &action ) override;
 
-    bool handleKeyPressEvent( QKeyEvent* event ) override;
-    bool handleKeyReleaseEvent( QKeyEvent* event ) override;
+    bool handleKeyPressEvent( QKeyEvent* event , const KeyMappingManager::KeyMappingAction &action) override;
+    bool handleKeyReleaseEvent( QKeyEvent* event , const KeyMappingManager::KeyMappingAction &action) override;
 
-    void setCamera( Engine::Camera* camera ) override;
+
+    void toggleRotateAround();
+        void setCamera( Engine::Camera* camera ) override;
 
     /// Set the distance from the camera to the target point.
     /// \note doesn't modify the camera.

--- a/src/GuiBase/Viewer/TrackballCamera.hpp
+++ b/src/GuiBase/Viewer/TrackballCamera.hpp
@@ -16,17 +16,25 @@ class RA_GUIBASE_API TrackballCamera : public CameraInterface
     TrackballCamera( uint width, uint height );
     virtual ~TrackballCamera();
 
-    bool handleMousePressEvent( QMouseEvent* event, const KeyMappingManager::KeyMappingAction &action ) override;
-    bool handleMouseReleaseEvent( QMouseEvent* event, const KeyMappingManager::KeyMappingAction &action ) override;
-    bool handleMouseMoveEvent( QMouseEvent* event, const KeyMappingManager::KeyMappingAction &action ) override;
-    bool handleWheelEvent( QWheelEvent* event, const KeyMappingManager::KeyMappingAction &action ) override;
+    static void registerKeyMapping();
 
-    bool handleKeyPressEvent( QKeyEvent* event , const KeyMappingManager::KeyMappingAction &action) override;
-    bool handleKeyReleaseEvent( QKeyEvent* event , const KeyMappingManager::KeyMappingAction &action) override;
+    bool handleMousePressEvent( QMouseEvent* event,
+                                const Qt::MouseButtons& buttons,
+                                const Qt::KeyboardModifiers& modifiers,
+                                int key ) override;
+    bool handleMouseReleaseEvent( QMouseEvent* event ) override;
+    bool handleMouseMoveEvent( QMouseEvent* event,
+                               const Qt::MouseButtons& buttons,
+                               const Qt::KeyboardModifiers& modifiers,
+                               int key ) override;
+    bool handleWheelEvent( QWheelEvent* event ) override;
 
+    bool handleKeyPressEvent( QKeyEvent* event,
+                              const KeyMappingManager::KeyMappingAction& action ) override;
+    bool handleKeyReleaseEvent( QKeyEvent* event ) override;
 
     void toggleRotateAround();
-        void setCamera( Engine::Camera* camera ) override;
+    void setCamera( Engine::Camera* camera ) override;
 
     /// Set the distance from the camera to the target point.
     /// \note doesn't modify the camera.
@@ -87,6 +95,19 @@ class RA_GUIBASE_API TrackballCamera : public CameraInterface
     bool m_cameraPanMode;
     bool m_cameraZoomMode;
     // TODO(Charly): fps mode
+
+    // static KeyMappingManager::Context m_keyMappingContext;
+
+#define KeyMappingCamera                      \
+    KMA_VALUE( TRACKBALLCAMERA_MANIPULATION ) \
+    KMA_VALUE( TRACKBALLCAMERA_ROTATE )       \
+    KMA_VALUE( TRACKBALLCAMERA_PAN )          \
+    KMA_VALUE( TRACKBALLCAMERA_ZOOM )         \
+    KMA_VALUE( TRACKBALLCAMERA_ROTATE_AROUND )
+
+#define KMA_VALUE( XX ) static KeyMappingManager::KeyMappingAction XX;
+    KeyMappingCamera
+#undef KMA_VALUE
 };
 
 } // namespace Gui

--- a/src/GuiBase/Viewer/TrackballCamera.hpp
+++ b/src/GuiBase/Viewer/TrackballCamera.hpp
@@ -71,10 +71,10 @@ class RA_GUIBASE_API TrackballCamera : public CameraInterface
     Core::Vector3 m_trackballCenter;
 
     /// x-position of the mouse on the screen at the manipulation start.
-    Scalar m_lastMouseX;
+    Scalar m_lastMouseX{0_ra};
 
     /// y-position of the mouse on the screen at the manipulation start.
-    Scalar m_lastMouseY;
+    Scalar m_lastMouseY{0_ra};
 
     /// Additional factor for camera sensitivity.
     Scalar m_quickCameraModifier;
@@ -83,8 +83,8 @@ class RA_GUIBASE_API TrackballCamera : public CameraInterface
     Scalar m_wheelSpeedModifier;
 
     /// Polar coordinates of the Camera w.r.t. the trackball center.
-    Scalar m_phi;
-    Scalar m_theta;
+    Scalar m_phi{0_ra};
+    Scalar m_theta{0_ra};
 
     /// The distance from the camera to the trackball center.
     Scalar m_distFromCenter;

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -64,7 +64,9 @@ void Gui::Viewer::registerKeyMapping() {
     if ( m_keyMappingContext.isInvalid() )
     {
         LOG( logINFO )
-            << "ViewerContext not defined (maybe the configuration file do not contains it";
+            << "ViewerContext not defined (maybe the configuration file do not contains it)";
+        LOG( Ra::Core::Utils::logERROR ) << "ViewerContext all keymapping invalide !";
+        return;
     }
 
 #define KMA_VALUE( XX ) \
@@ -346,8 +348,7 @@ void Gui::Viewer::mousePressEvent( QMouseEvent* event ) {
     if ( result.m_roIdx.isInvalid() )
     {
         if ( m_camera->handleMousePressEvent( event, buttons, modifiers, key ) )
-        { m_activeContext = TrackballCamera::getContext(); }
-        else
+        { m_activeContext = TrackballCamera::getContext(); } else
         {
             // should not pass here, since viewerContext is only for valid picking ...
             m_activeContext = KeyMappingManageable::getContext();
@@ -358,8 +359,7 @@ void Gui::Viewer::mousePressEvent( QMouseEvent* event ) {
         // something under the mouse, let's check if it's a gizmo ro
         getGizmoManager()->handlePickingResult( result.m_roIdx );
         if ( getGizmoManager()->handleMousePressEvent( event, buttons, modifiers, key ) )
-        { m_activeContext = GizmoManager::getContext(); }
-        // if not, try to do camera stuff
+        { m_activeContext = GizmoManager::getContext(); } // if not, try to do camera stuff
         else if ( m_camera->handleMousePressEvent( event, buttons, modifiers, key ) )
         { m_activeContext = TrackballCamera::getContext(); }
         else
@@ -393,8 +393,7 @@ void Gui::Viewer::mouseReleaseEvent( QMouseEvent* event ) {
     if ( m_activeContext == TrackballCamera::getContext() )
     { m_camera->handleMouseReleaseEvent( event ); }
     if ( m_activeContext == GizmoManager::getContext() )
-    { m_gizmoManager->handleMouseReleaseEvent( event ); }
-    m_activeContext = -1;
+    { m_gizmoManager->handleMouseReleaseEvent( event ); } m_activeContext = -1;
     emit needUpdate();
 }
 

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -17,7 +17,7 @@
 #include <Engine/Renderer/Renderer.hpp>
 
 #include <GuiBase/Viewer/WindowQt.hpp>
-
+#include <GuiBase/Utils/KeyMappingManager.hpp>
 // Forward declarations
 class QOpenGLContext;
 class QSurfaceFormat;
@@ -155,7 +155,7 @@ class RA_GUIBASE_API Viewer : public WindowQt
      * m_camera->attachLight( light );
      * \endcode
      */
-    int addRenderer( std::shared_ptr<Engine::Renderer> e );
+    int addRenderer( const std::shared_ptr<Engine::Renderer>& e );
 
     void setBackgroundColor( const Core::Utils::Color& background );
     const Core::Utils::Color& getBackgroundColor() const { return m_backgroundColor; }
@@ -188,7 +188,7 @@ class RA_GUIBASE_API Viewer : public WindowQt
     void keyPressEvent( QKeyEvent* event ) override;
     void keyReleaseEvent( QKeyEvent* event ) override;
 
-    Engine::Renderer::PickingMode getPickingMode() const;
+    Engine::Renderer::PickingMode getPickingMode(const Ra::Gui::KeyMappingManager::KeyMappingAction &action) const;
     /// We intercept the mouse events in this widget to get the coordinates of the mouse
     /// in screen space.
     void mousePressEvent( QMouseEvent* event ) override;

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -119,11 +119,8 @@ class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewe
   signals:
     bool glInitialized(); //! Emitted when GL context is ready. We except call to addRenderer here
     void rendererReady(); //! Emitted when the rendered is correctly initialized
-    void leftClickPicking(
-        int id ); //! Emitted when the result of a left click picking is known (for gizmo manip)
-    void rightClickPicking(
-        const Ra::Engine::Renderer::PickingResult&
-            result ); //! Emitted when the resut of a right click picking is known (for selection)
+    void rightClickPicking( const Ra::Engine::Renderer::PickingResult& result );
+    //! Emitted when the resut of a right click picking is known (for selection)
 
     void toggleBrushPicking(
         bool on ); //! Emitted when the corresponding key is released (see keyReleaseEvent)
@@ -201,7 +198,7 @@ class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewe
     void showEvent( QShowEvent* ev ) override;
 
   public:
-    Scalar m_dt;
+    Scalar m_dt{0.1_ra};
 
   protected:
     /// Owning pointer to the renderers.
@@ -227,16 +224,15 @@ class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewe
 
     Core::Utils::Color m_backgroundColor{Core::Utils::Color::Grey( 0.0392_ra, 0_ra )};
 
-#define KeyMappingViewer                      \
-    KMA_VALUE( VIEWER_PICKING )               \
-    KMA_VALUE( VIEWER_PICKING_VERTEX )        \
-    KMA_VALUE( VIEWER_PICKING_EDGE )          \
-    KMA_VALUE( VIEWER_PICKING_TRIANGLE )      \
-    KMA_VALUE( VIEWER_PICKING_MULTI_CIRCLE )  \
-    KMA_VALUE( VIEWER_BUTTON_CAST_RAY_QUERY ) \
-    KMA_VALUE( VIEWER_RAYCAST )               \
-    KMA_VALUE( VIEWER_TOGGLE_WIREFRAME )      \
-    KMA_VALUE( COLORWIDGET_PRESSBUTTON )
+#define KeyMappingViewer                     \
+    KMA_VALUE( VIEWER_PICKING )              \
+    KMA_VALUE( VIEWER_PICKING_VERTEX )       \
+    KMA_VALUE( VIEWER_PICKING_EDGE )         \
+    KMA_VALUE( VIEWER_PICKING_TRIANGLE )     \
+    KMA_VALUE( VIEWER_PICKING_MULTI_CIRCLE ) \
+    KMA_VALUE( VIEWER_RAYCAST )              \
+    KMA_VALUE( VIEWER_SCALE_BRUSH )          \
+    KMA_VALUE( VIEWER_TOGGLE_WIREFRAME )
 
 #define KMA_VALUE( x ) static KeyMappingManager::KeyMappingAction x;
     KeyMappingViewer

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -16,8 +16,8 @@
 #include <Engine/RadiumEngine.hpp>
 #include <Engine/Renderer/Renderer.hpp>
 
-#include <GuiBase/Viewer/WindowQt.hpp>
 #include <GuiBase/Utils/KeyMappingManager.hpp>
+#include <GuiBase/Viewer/WindowQt.hpp>
 // Forward declarations
 class QOpenGLContext;
 class QSurfaceFormat;
@@ -51,7 +51,7 @@ namespace Gui {
  * the camera and the rest of the application
  * * Expose the asynchronous rendering interface
  */
-class RA_GUIBASE_API Viewer : public WindowQt
+class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewer>
 {
     Q_OBJECT
 
@@ -61,6 +61,8 @@ class RA_GUIBASE_API Viewer : public WindowQt
 
     /// Destructor
     ~Viewer() override;
+
+    static void registerKeyMapping();
 
     /// create gizmos
     void createGizmoManager();
@@ -188,7 +190,8 @@ class RA_GUIBASE_API Viewer : public WindowQt
     void keyPressEvent( QKeyEvent* event ) override;
     void keyReleaseEvent( QKeyEvent* event ) override;
 
-    Engine::Renderer::PickingMode getPickingMode(const Ra::Gui::KeyMappingManager::KeyMappingAction &action) const;
+    Engine::Renderer::PickingMode
+    getPickingMode( const Ra::Gui::KeyMappingManager::KeyMappingAction& action ) const;
     /// We intercept the mouse events in this widget to get the coordinates of the mouse
     /// in screen space.
     void mousePressEvent( QMouseEvent* event ) override;
@@ -223,6 +226,23 @@ class RA_GUIBASE_API Viewer : public WindowQt
 #endif
 
     Core::Utils::Color m_backgroundColor{Core::Utils::Color::Grey( 0.0392_ra, 0_ra )};
+
+#define KeyMappingViewer                      \
+    KMA_VALUE( VIEWER_PICKING )               \
+    KMA_VALUE( VIEWER_PICKING_VERTEX )        \
+    KMA_VALUE( VIEWER_PICKING_EDGE )          \
+    KMA_VALUE( VIEWER_PICKING_TRIANGLE )      \
+    KMA_VALUE( VIEWER_PICKING_MULTI_CIRCLE )  \
+    KMA_VALUE( VIEWER_BUTTON_CAST_RAY_QUERY ) \
+    KMA_VALUE( VIEWER_RAYCAST )               \
+    KMA_VALUE( VIEWER_TOGGLE_WIREFRAME )      \
+    KMA_VALUE( COLORWIDGET_PRESSBUTTON )
+
+#define KMA_VALUE( x ) static KeyMappingManager::KeyMappingAction x;
+    KeyMappingViewer
+#undef KMA_VALUE
+
+        KeyMappingManager::Context m_activeContext{-1};
 };
 
 } // namespace Gui

--- a/src/GuiBase/Viewer/WindowQt.cpp
+++ b/src/GuiBase/Viewer/WindowQt.cpp
@@ -4,8 +4,8 @@
 #include <QDebug>
 #include <QOpenGLContext>
 #include <QResizeEvent>
-#include <QSurfaceFormat>
 #include <QScreen>
+#include <QSurfaceFormat>
 
 #include <Core/Utils/Log.hpp>
 
@@ -56,8 +56,8 @@ WindowQt::~WindowQt() {
 }
 
 void WindowQt::screenChanged() {
-    QSize s { size().width(), size().height() };
-    QResizeEvent patchEvent { s, s };
+    QSize s{size().width(), size().height()};
+    QResizeEvent patchEvent{s, s};
     resize( &patchEvent );
 }
 

--- a/src/IO/AssimpLoader/AssimpHandleDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpHandleDataLoader.cpp
@@ -126,7 +126,8 @@ aiNode* findBoneChild( aiNode* node,
     {
         if ( meshBoneOffset.find( assimpToCore( node->mChildren[i]->mName ) ) !=
              meshBoneOffset.end() )
-        { return node->mChildren[i]; } }
+        { return node->mChildren[i]; }
+    }
     // not found, go down
     for ( uint i = 0; i < node->mNumChildren; ++i )
     {


### PR DESCRIPTION
Simpler conf file, simpler call.
Action are sent to camera and gizmoManager instead of letting them call the keybindingManager


THIS PR is to start to discuss the design of a new keyMappingManager, along with some simplification about interaction.

I think to add a context to keyMapping (so you can call getAction("CameraContext" ...)
And the context will be determine by the viewer according to either some state or what is under the mouse (with a pickingQuery directly from the mouse press event).

Comments are welcom, then I will create the real PR.
