### PR TITLE
Fix getOrthogonalVectors.

### DIFF
--- a/src/Core/Geometry/MeshPrimitives.cpp
+++ b/src/Core/Geometry/MeshPrimitives.cpp
@@ -275,9 +275,10 @@ TriangleMesh makeCylinder( const Vector3& a,
     Vector3 ab  = b - a;
     Vector3 dir = ab.normalized();
 
-    //  Create two circles normal centered on A and B and normal to ab;
+    //  Create two circles normal centered on A and B and normal to ab (use dir, since first vector
+    //  must be normalized)
     Vector3 xPlane, yPlane;
-    Math::getOrthogonalVectors( ab, xPlane, yPlane );
+    Math::getOrthogonalVectors( dir, xPlane, yPlane );
     xPlane.normalize();
     yPlane.normalize();
 
@@ -536,7 +537,7 @@ TriangleMesh makeTube( const Vector3& a,
 
     //  Create two circles normal centered on A and B and normal to ab;
     Vector3 xPlane, yPlane;
-    Math::getOrthogonalVectors( ab, xPlane, yPlane );
+    Math::getOrthogonalVectors( dir, xPlane, yPlane );
     xPlane.normalize();
     yPlane.normalize();
 
@@ -630,7 +631,7 @@ TriangleMesh makeCone( const Vector3& base,
 
     //  Create two circles normal centered on A and B and normal to ab;
     Vector3 xPlane, yPlane;
-    Math::getOrthogonalVectors( ab, xPlane, yPlane );
+    Math::getOrthogonalVectors( dir, xPlane, yPlane );
     xPlane.normalize();
     yPlane.normalize();
 

--- a/src/Engine/Renderer/RenderObject/Primitives/DrawPrimitives.cpp
+++ b/src/Engine/Renderer/RenderObject/Primitives/DrawPrimitives.cpp
@@ -73,7 +73,7 @@ MeshPtr
 Vector( const Core::Vector3& start, const Core::Vector3& v, const Core::Utils::Color& color ) {
     Core::Vector3 end = start + v;
     Core::Vector3 a, b;
-    Core::Math::getOrthogonalVectors( v, a, b );
+    Core::Math::getOrthogonalVectors( v.normalized(), a, b );
     a.normalize();
     Scalar l = v.norm();
 
@@ -324,11 +324,12 @@ MeshPtr Normal( const Core::Vector3& point,
                 Scalar scale ) {
     // Display an arrow (just like the Vector() function)
     // plus the normal plane.
-    Core::Vector3 n = scale * normal.normalized();
-
-    Core::Vector3 end = point + n;
     Core::Vector3 a, b;
+    Core::Vector3 n = normal.normalized();
     Core::Math::getOrthogonalVectors( n, a, b );
+
+    n                 = scale * n;
+    Core::Vector3 end = point + n;
     a.normalize();
     b.normalize();
 

--- a/src/Engine/Renderer/RenderObject/Primitives/DrawPrimitives.hpp
+++ b/src/Engine/Renderer/RenderObject/Primitives/DrawPrimitives.hpp
@@ -59,6 +59,7 @@ RA_ENGINE_API MeshPtr QuadStrip( const Core::Vector3& a,
 
 /// Displays circle computed with given center and radius,
 /// in plane normal to given vector in wireframe
+/// @note normal must be a normalized vector.
 RA_ENGINE_API MeshPtr Circle( const Core::Vector3& center,
                               const Core::Vector3& normal,
                               Scalar radius,
@@ -67,6 +68,7 @@ RA_ENGINE_API MeshPtr Circle( const Core::Vector3& center,
 
 /// Displays arc of a circle computed with given center, radius and angle
 /// in plane normal to given vector in wireframe
+/// @note normal must be a normalized vector.
 RA_ENGINE_API MeshPtr CircleArc( const Core::Vector3& center,
                                  const Core::Vector3& normal,
                                  Scalar radius,
@@ -87,6 +89,7 @@ RA_ENGINE_API MeshPtr Capsule( const Core::Vector3& p1,
 
 /// Displays disk (filled circle) computed with given center and radius,
 /// in plane normal to given vector in wireframe
+/// @note normal must be a normalized vector.
 RA_ENGINE_API MeshPtr Disk( const Core::Vector3& center,
                             const Core::Vector3& normal,
                             Scalar radius,


### PR DESCRIPTION
First vector must be normalized to obtain good results (see "flat" Guizmo's cylinder for instance).

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)
Cylinder may be flat (for instance the TranslateGizmo has flat x and y axis).
This is due to the fact that getOrthogonalVectors wants the first argument to be normalized.
(it's already present in the doc of the function, but was not always true).

* **What is the new behavior (if this is a feature change)?**
normalize vector before calling to the aformentionned function.

