### PR TITLE
Fix missing gizmo manager

### DIFF
--- a/Applications/HelloRadium/minimalapp.cpp
+++ b/Applications/HelloRadium/minimalapp.cpp
@@ -3,6 +3,7 @@
 #include <minimalapp.hpp>
 
 #include <GuiBase/Utils/KeyMappingManager.hpp>
+#include <GuiBase/Viewer/TrackballCamera.hpp>
 
 MinimalApp::MinimalApp( int& argc, char** argv ) :
     QApplication( argc, argv ),
@@ -22,6 +23,8 @@ MinimalApp::MinimalApp( int& argc, char** argv ) :
     m_engine->initialize();
 
     Ra::Gui::KeyMappingManager::createInstance();
+    Ra::Gui::KeyMappingManager::getInstance()->addListener(Ra::Gui::TrackballCamera::registerKeyMapping);
+    Ra::Gui::KeyMappingManager::getInstance()->addListener(Ra::Gui::Viewer::registerKeyMapping);
 
     // Initialize taskqueue.
     m_task_queue.reset( new Ra::Core::TaskQueue( std::thread::hardware_concurrency() - 1 ) );
@@ -42,7 +45,11 @@ MinimalApp::MinimalApp( int& argc, char** argv ) :
 }
 
 MinimalApp::~MinimalApp() {
+    // need to clean up everithing before engine is cleaned up.
+    m_task_queue.release();
+    m_viewer.release();
     m_engine->cleanup();
+    m_engine.release();
 }
 
 void MinimalApp::onGLInitialized() {

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -47,7 +47,6 @@ MainWindow::MainWindow( QWidget* parent ) : MainWindowInterface( parent ) {
     connect( m_viewer, &Viewer::glInitialized, this, &MainWindow::onGLInitialized );
     connect( m_viewer, &Viewer::rendererReady, this, &MainWindow::onRendererReady );
 
-    m_viewer->createGizmoManager();
     m_viewer->setObjectName( QStringLiteral( "m_viewer" ) );
 
     QWidget* viewerwidget = QWidget::createWindowContainer( m_viewer );

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -88,6 +88,7 @@ Gui::Viewer::Viewer( QScreen* screen ) :
     m_renderThread( nullptr )
 #endif
 {
+    createGizmoManager();
 }
 
 Gui::Viewer::~Viewer() {

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -64,8 +64,6 @@ class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewe
 
     static void registerKeyMapping();
 
-    /// create gizmos
-    void createGizmoManager();
 
     //
     // Accessors
@@ -168,6 +166,9 @@ class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewe
     void onResized();
 
   protected:
+    /// create gizmos
+    void createGizmoManager();
+
     /// Initialize renderer internal state + configure lights.
     void intializeRenderer( Engine::Renderer* renderer );
 


### PR DESCRIPTION
UPDATE the form below to describe your PR.


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Applications other than main app crashed at event management and exit.

* **What is the current behavior?** (You can also link to an open issue here)
Viewer does not establish a proper invariant on gizmoManager at creation. The application crash at event management.
Gizmos, are deleted at exit but the renderObject manager is already destroyed by engine cleanup. The application crash

* **What is the new behavior (if this is a feature change)?**
Viewer creates a gizmoManager at creation so that the invariant is verified.
Resources are first released before renderObjectManager is destroyed.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
