### PR TITLE
Delete buffers, should fix #438

### DIFF
--- a/Applications/MainApplication/Gui/ColorWidget.cpp
+++ b/Applications/MainApplication/Gui/ColorWidget.cpp
@@ -27,14 +27,14 @@ void ColorWidget::colorChanged() {
 
 void ColorWidget::mousePressEvent( QMouseEvent* /*event*/ ) {
 
-        QColor color = QColorDialog::getColor( m_currentColor );
-        if ( color != m_currentColor )
-        {
-            m_currentColor = color;
-            colorChanged();
+    QColor color = QColorDialog::getColor( m_currentColor );
+    if ( color != m_currentColor )
+    {
+        m_currentColor = color;
+        colorChanged();
 
-            emit newColorPicked( m_currentColor );
-        }
+        emit newColorPicked( m_currentColor );
+    }
 }
 } // namespace Gui
 } // namespace Ra

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -98,7 +98,7 @@ void MainWindow::createConnections() {
     connect( actionToggle_Local_Global,
              &QAction::toggled,
              mainApp,
-             &Ra::GuiBase::BaseApplication::askForUpdate);
+             &Ra::GuiBase::BaseApplication::askForUpdate );
 
     connect( actionGizmoOff, &QAction::triggered, this, &MainWindow::gizmoShowNone );
     connect( actionGizmoTranslate, &QAction::triggered, this, &MainWindow::gizmoShowTranslate );
@@ -509,7 +509,8 @@ void Gui::MainWindow::showHideAllRO() {
         auto idx  = m_itemModel->index( i, j );
         auto item = m_itemModel->getEntry( idx );
         if ( item.isValid() && item.isSelectable() )
-        { m_itemModel->setData( idx, allEntityInvisible, Qt::CheckStateRole ); } }
+        { m_itemModel->setData( idx, allEntityInvisible, Qt::CheckStateRole ); }
+    }
     mainApp->askForUpdate();
 }
 

--- a/Plugins/Animation/src/AnimationComponent.cpp
+++ b/Plugins/Animation/src/AnimationComponent.cpp
@@ -383,11 +383,13 @@ bool AnimationComponent::restoreFrame( const std::string& dir, int frame ) {
     if ( !file.read( reinterpret_cast<char*>( &m_animationTimeStep ), sizeof m_animationTimeStep ) )
     { return false; }
     if ( !file.read( reinterpret_cast<char*>( &m_animationTime ), sizeof m_animationTime ) )
-    { return false; } if ( !file.read( reinterpret_cast<char*>( &m_speed ), sizeof m_speed ) )
-    { return false; } if ( !file.read( reinterpret_cast<char*>( &m_slowMo ), sizeof m_slowMo ) )
-    { return false; } auto pose = m_skel.getPose( Handle::SpaceType::LOCAL );
+    { return false; }
+    if ( !file.read( reinterpret_cast<char*>( &m_speed ), sizeof m_speed ) ) { return false; }
+    if ( !file.read( reinterpret_cast<char*>( &m_slowMo ), sizeof m_slowMo ) ) { return false; }
+    auto pose = m_skel.getPose( Handle::SpaceType::LOCAL );
     if ( !file.read( reinterpret_cast<char*>( pose.data() ), ( sizeof pose[0] ) * pose.size() ) )
-    { return false; } m_skel.setPose( pose, Handle::SpaceType::LOCAL );
+    { return false; }
+    m_skel.setPose( pose, Handle::SpaceType::LOCAL );
 
     // update the render objects
     for ( auto& bone : m_boneDrawables )

--- a/Plugins/CameraManip/src/CameraManipPlugin.cpp
+++ b/Plugins/CameraManip/src/CameraManipPlugin.cpp
@@ -148,7 +148,8 @@ void CameraManipPluginC::onCurrentChanged( const QModelIndex& current, const QMo
         const Ra::Engine::ItemEntry& ent = m_selectionManager->currentItem();
         if ( ent.m_component == nullptr ) { return; }
         if ( ent.m_component->getName().compare( 0, 7, "CAMERA_" ) == 0 )
-        { m_widget->ui->m_useCamera->setEnabled( true ); } }
+        { m_widget->ui->m_useCamera->setEnabled( true ); }
+    }
 }
 
 } // namespace CameraManipPlugin

--- a/Plugins/MeshFeatureTracking/src/MeshFeatureTrackingComponent.cpp
+++ b/Plugins/MeshFeatureTracking/src/MeshFeatureTrackingComponent.cpp
@@ -60,12 +60,14 @@ void MeshFeatureTrackingComponent::setScale( Scalar scale ) {
 
 int MeshFeatureTrackingComponent::getMaxV() const {
     if ( m_data.m_mode != PickingMode::RO && getRoMgr()->exists( m_pickedRoIdx ) )
-    { return int( m_pickedMesh->getNumVertices() ); } return 0;
+    { return int( m_pickedMesh->getNumVertices() ); }
+    return 0;
 }
 
 int MeshFeatureTrackingComponent::getMaxT() const {
     if ( m_data.m_mode != PickingMode::RO && getRoMgr()->exists( m_pickedRoIdx ) )
-    { return int( m_pickedMesh->getNumFaces() ); } return 0;
+    { return int( m_pickedMesh->getNumFaces() ); }
+    return 0;
 }
 
 namespace { // anonymous namespace for line mesh indices retrieval from triangles -- according to

--- a/Plugins/MeshPaint/src/MeshPaintComponent.cpp
+++ b/Plugins/MeshPaint/src/MeshPaintComponent.cpp
@@ -124,7 +124,8 @@ void MeshPaintComponent::paintMesh( const Ra::Engine::Renderer::PickingResult& p
 
     // check it's for us
     if ( *m_renderObjectReader() != picking.m_roIdx || picking.m_mode == Ra::Engine::Renderer::RO )
-    { return; } auto pickingRenderMode = m_mesh->pickingRenderMode();
+    { return; }
+    auto pickingRenderMode = m_mesh->pickingRenderMode();
 
     if ( pickingRenderMode == Ra::Engine::Displayable::NO_PICKING ) { return; }
 
@@ -135,9 +136,10 @@ void MeshPaintComponent::paintMesh( const Ra::Engine::Renderer::PickingResult& p
            m_mesh->getRenderMode() == Ra::Engine::Mesh::RM_LINE_STRIP_ADJACENCY ||
            m_mesh->getRenderMode() == Ra::Engine::Mesh::RM_TRIANGLE_STRIP ||
            m_mesh->getRenderMode() == Ra::Engine::Mesh::RM_TRIANGLE_FAN ) )
-    { return; } if ( pickingRenderMode == Ra::Engine::Displayable::PKM_POINTS &&
-                     ( picking.m_mode != Ra::Engine::Renderer::VERTEX &&
-                       picking.m_mode != Ra::Engine::Renderer::C_VERTEX ) )
+    { return; }
+    if ( pickingRenderMode == Ra::Engine::Displayable::PKM_POINTS &&
+         ( picking.m_mode != Ra::Engine::Renderer::VERTEX &&
+           picking.m_mode != Ra::Engine::Renderer::C_VERTEX ) )
     {
         return;
     } // Could also be accessed using

--- a/Plugins/MeshPaint/src/MeshPaintComponent.cpp
+++ b/Plugins/MeshPaint/src/MeshPaintComponent.cpp
@@ -76,6 +76,7 @@ void MeshPaintComponent::startPaint( bool on ) {
         if ( m_currentColorAttribHdl.idx().isInvalid() )
         {
             m_baseColors.clear();
+            m_isBaseColorValid = false;
             triangleMesh.colorize( Ra::Core::Utils::Color::Skin() );
             m_currentColorAttribHdl =
                 triangleMesh.getAttribHandle<Ra::Core::Vector4>( colAttribName );
@@ -83,6 +84,8 @@ void MeshPaintComponent::startPaint( bool on ) {
         }
         else
         {
+            m_isBaseColorValid = true;
+
             m_baseColors = triangleMesh.getAttrib( m_currentColorAttribHdl ).data(); // copy
         }
     }
@@ -94,8 +97,15 @@ void MeshPaintComponent::startPaint( bool on ) {
         // Could also be accessed using
         // auto triangleMesh = compMess->get<Ra::Core::Geometry::TriangleMesh>( getEntity(),
         // m_dataId ); however here we skip the search in the component map
-        Ra::Core::Geometry::TriangleMesh& triangleMesh           = m_mesh->getTriangleMesh();
-        triangleMesh.getAttrib( m_currentColorAttribHdl ).data() = m_baseColors;
+        Ra::Core::Geometry::TriangleMesh& triangleMesh = m_mesh->getTriangleMesh();
+        if ( m_isBaseColorValid )
+            triangleMesh.getAttrib( m_currentColorAttribHdl ).data() = m_baseColors;
+        else
+        {
+            triangleMesh.removeAttrib( m_currentColorAttribHdl );
+            CORE_ASSERT( !triangleMesh.isValid( m_currentColorAttribHdl ),
+                         "Color attrib should be invalid now" );
+        }
         m_mesh->setDirty( Ra::Engine::Mesh::VERTEX_COLOR );
     }
 }
@@ -114,6 +124,7 @@ void MeshPaintComponent::bakePaintToDiffuse() {
     // m_dataId ); however here we skip the search in the component map
     Ra::Core::Geometry::TriangleMesh& triangleMesh = m_mesh->getTriangleMesh();
     m_baseColors = triangleMesh.getAttrib( m_currentColorAttribHdl ).data();
+    m_isBaseColorValid = true;
 }
 
 void MeshPaintComponent::paintMesh( const Ra::Engine::Renderer::PickingResult& picking,

--- a/Plugins/MeshPaint/src/MeshPaintComponent.hpp
+++ b/Plugins/MeshPaint/src/MeshPaintComponent.hpp
@@ -60,6 +60,7 @@ class MESH_PAINT_PLUGIN_API MeshPaintComponent : public Ra::Engine::Component
     // Initial RO shader config when not painting
     Ra::Engine::ShaderConfiguration m_baseConfig;
     Ra::Core::Vector4Array m_baseColors;
+    bool m_isBaseColorValid{false};
     Ra::Core::Utils::AttribHandle<Ra::Core::Vector4> m_currentColorAttribHdl;
 };
 

--- a/Plugins/MeshPaint/src/MeshPaintPlugin.cpp
+++ b/Plugins/MeshPaint/src/MeshPaintPlugin.cpp
@@ -50,6 +50,7 @@ void MeshPaintPluginC::registerPlugin( const Ra::Plugins::Context& context ) {
     connect( m_widget, &MeshPaintUI::paintColor, this, &MeshPaintPluginC::activePaintColor );
     connect( m_widget, &MeshPaintUI::colorChanged, this, &MeshPaintPluginC::changePaintColor );
     connect( m_widget, &MeshPaintUI::bakeToDiffuse, this, &MeshPaintPluginC::bakeToDiffuse );
+    connect( this, &MeshPaintPluginC::askForUpdate, &context, &Ra::Plugins::Context::askForUpdate );
 }
 
 bool MeshPaintPluginC::doAddWidget( QString& name ) {
@@ -81,6 +82,7 @@ QAction* MeshPaintPluginC::getAction( int /*id*/ ) {
 void MeshPaintPluginC::activePaintColor( bool on ) {
     m_isPainting = on;
     m_system->startPaintMesh( on );
+    askForUpdate();
 }
 
 void MeshPaintPluginC::changePaintColor( const QColor& color ) {
@@ -94,6 +96,7 @@ void MeshPaintPluginC::bakeToDiffuse() {
     if ( m_isPainting &&
          Ra::Core::Utils::Index::Invalid() != m_selectionManager->currentItem().m_roIndex )
     { m_system->bakeToDiffuse(); }
+    askForUpdate();
 }
 
 void MeshPaintPluginC::onCurrentChanged( const QModelIndex& /*current*/,
@@ -101,6 +104,7 @@ void MeshPaintPluginC::onCurrentChanged( const QModelIndex& /*current*/,
     if ( m_isPainting &&
          Ra::Core::Utils::Index::Invalid() != m_selectionManager->currentItem().m_roIndex )
     { m_system->paintMesh( m_PickingManager->getCurrent(), m_paintColor ); }
+    askForUpdate();
 }
 
 } // namespace MeshPaintPlugin

--- a/Plugins/MeshPaint/src/MeshPaintPlugin.cpp
+++ b/Plugins/MeshPaint/src/MeshPaintPlugin.cpp
@@ -93,12 +93,14 @@ void MeshPaintPluginC::changePaintColor( const QColor& color ) {
 void MeshPaintPluginC::bakeToDiffuse() {
     if ( m_isPainting &&
          Ra::Core::Utils::Index::Invalid() != m_selectionManager->currentItem().m_roIndex )
-    { m_system->bakeToDiffuse(); } }
+    { m_system->bakeToDiffuse(); }
+}
 
 void MeshPaintPluginC::onCurrentChanged( const QModelIndex& /*current*/,
                                          const QModelIndex& /*prev*/ ) {
     if ( m_isPainting &&
          Ra::Core::Utils::Index::Invalid() != m_selectionManager->currentItem().m_roIndex )
-    { m_system->paintMesh( m_PickingManager->getCurrent(), m_paintColor ); } }
+    { m_system->paintMesh( m_PickingManager->getCurrent(), m_paintColor ); }
+}
 
 } // namespace MeshPaintPlugin

--- a/Plugins/MeshPaint/src/MeshPaintPlugin.hpp
+++ b/Plugins/MeshPaint/src/MeshPaintPlugin.hpp
@@ -47,6 +47,9 @@ class MeshPaintPluginC : public QObject, Ra::Plugins::RadiumPluginInterface
     bool doAddAction( int& nb ) override;
     QAction* getAction( int id ) override;
 
+  signals:
+    void askForUpdate();
+
   public slots:
     void onCurrentChanged( const QModelIndex& current, const QModelIndex& prev );
     void activePaintColor( bool on );

--- a/Plugins/Skinning/src/Display/SkinningDisplayComponent.hpp
+++ b/Plugins/Skinning/src/Display/SkinningDisplayComponent.hpp
@@ -86,7 +86,8 @@ class SKIN_PLUGIN_API SkinningDisplayComponent : public Ra::Engine::Component
                     const uint i = it.row();
                     const uint j = it.col();
                     if ( partition[i] != partition[j] )
-                    { Seg.coeffRef( partition[i], partition[j] ) = 1.0; } }
+                    { Seg.coeffRef( partition[i], partition[j] ) = 1.0; }
+                }
             }
 
             std::vector<uint> assignedColor( weights.cols(), uint( -1 ) );
@@ -102,7 +103,8 @@ class SKIN_PLUGIN_API SkinningDisplayComponent : public Ra::Engine::Component
                 {
                     const uint j = it.row();
                     if ( assignedColor[j] != uint( -1 ) && option.size() > 1 )
-                    { option.erase( assignedColor[j] ); } }
+                    { option.erase( assignedColor[j] ); }
+                }
 
                 uint random = std::rand() % std::max<uint>( option.size(), 1 );
                 auto it     = option.begin();

--- a/Plugins/Skinning/src/SkinningComponent.cpp
+++ b/Plugins/Skinning/src/SkinningComponent.cpp
@@ -374,7 +374,8 @@ void SkinningComponent::createWeightMatrix() {
     Ra::Core::Animation::checkWeightMatrix( m_refData.m_weights, false, true );
 
     if ( Ra::Core::Animation::normalizeWeights( m_refData.m_weights, true ) )
-    { LOG( logINFO ) << "Skinning weights have been normalized"; } }
+    { LOG( logINFO ) << "Skinning weights have been normalized"; }
+}
 
 void SkinningComponent::setupIO( const std::string& id ) {
     using DualQuatVector = Ra::Core::AlignedStdVector<Ra::Core::DualQuaternion>;

--- a/scripts/format-all.sh
+++ b/scripts/format-all.sh
@@ -2,4 +2,4 @@
 
 ROOT=`git rev-parse --show-toplevel`
 
-find "${ROOT}/src/" "${ROOT}/Applications/"  "${ROOT}/Plugins/" \( -name \*.cpp -or -name \*.hpp -or -name \*.inl \) -exec clang-format-6.0 -i -style=file  "{}" \;
+find "${ROOT}/src/" "${ROOT}/Applications/"  "${ROOT}/Plugins/" \( -name \*.cpp -or -name \*.hpp -or -name \*.inl \) -exec clang-format -i -style=file  "{}" \;

--- a/src/Core/Asset/HandleToSkeleton.cpp
+++ b/src/Core/Asset/HandleToSkeleton.cpp
@@ -32,7 +32,8 @@ void addBone( const int parent,                        // index of parent bone
         for ( const auto& edge : edgeList )
         {
             if ( edge[0] == dataID )
-            { addBone( index, edge[1], data, edgeList, processed, skelOut ); } }
+            { addBone( index, edge[1], data, edgeList, processed, skelOut ); }
+        }
     }
 }
 } // namespace

--- a/src/Core/Containers/AdjacencyList.cpp
+++ b/src/Core/Containers/AdjacencyList.cpp
@@ -124,10 +124,12 @@ AdjacencyList::ConsistencyStatus AdjacencyList::computeConsistencyStatus() const
         for ( const auto& child : m_child.at( node ) )
         {
             if ( m_parent.at( child ) != node )
-            { return ConsistencyStatus::InconsistentParentIndex; } }
+            { return ConsistencyStatus::InconsistentParentIndex; }
+        }
 
         if ( isLeaf( node ) != ( m_child.at( node ).size() == 0 ) )
-        { return ConsistencyStatus::NonLeafNodeWithoutChild; } }
+        { return ConsistencyStatus::NonLeafNodeWithoutChild; }
+    }
     return ConsistencyStatus::Valid;
 }
 

--- a/src/Core/Utils/Attribs.cpp
+++ b/src/Core/Utils/Attribs.cpp
@@ -50,7 +50,8 @@ bool AttribManager::hasSameAttribs( const AttribManager& other ) {
     for ( const auto& attr : m_attribsIndex )
     {
         if ( other.m_attribsIndex.find( attr.first ) == other.m_attribsIndex.cend() )
-        { return false; } }
+        { return false; }
+    }
     // the other way
     for ( const auto& attr : other.m_attribsIndex )
     {

--- a/src/Core/Utils/Attribs.hpp
+++ b/src/Core/Utils/Attribs.hpp
@@ -246,7 +246,8 @@ class RA_CORE_API AttribManager
     /// Return true if \p h correspond to an existing attribute in *this.
     template <typename T>
     bool isValid( const AttribHandle<T>& h ) const {
-        return h.m_idx != Index::Invalid() && m_attribsIndex.at( h.attribName() ) == h.m_idx;
+        auto itr = m_attribsIndex.find( h.attribName() );
+        return h.m_idx != Index::Invalid() && itr != m_attribsIndex.end() && itr->second == h.m_idx;
     }
 
     /*!

--- a/src/Engine/Renderer/Camera/Camera.inl
+++ b/src/Engine/Renderer/Camera/Camera.inl
@@ -38,7 +38,8 @@ inline void Camera::setDirection( const Core::Vector3& direction ) {
     // Special case if two directions are exactly opposites we constrain.
     // to rotate around the up vector.
     if ( c.isApprox( Core::Vector3::Zero() ) && d < 0.0 )
-    { T.rotate( Core::AngleAxis( Core::Math::PiDiv2, Core::Vector3::UnitY() ) ); } else
+    { T.rotate( Core::AngleAxis( Core::Math::PiDiv2, Core::Vector3::UnitY() ) ); }
+    else
     { T.rotate( Core::Quaternion::FromTwoVectors( d0, d1 ) ); }
     applyTransform( T );
 }

--- a/src/Engine/Renderer/Mesh/Mesh.cpp
+++ b/src/Engine/Renderer/Mesh/Mesh.cpp
@@ -8,6 +8,8 @@
 namespace Ra {
 namespace Engine {
 
+using namespace Ra::Core::Utils;
+
 // Template parameter must be a Core::VectorNArray
 template <typename ContainedType>
 inline void
@@ -281,16 +283,28 @@ void Mesh::updateGL() {
 
         for ( int i = 0; i < MAX_VEC3; i++ )
         {
+
+            auto idx = MAX_MESH + i;
             if ( m_mesh.isValid( m_v3DataHandle[i] ) )
-            { sendGLData( this, m_mesh.getAttrib( m_v3DataHandle[i] ).data(), MAX_MESH + i ); }
+            { sendGLData( this, m_mesh.getAttrib( m_v3DataHandle[i] ).data(), idx ); }
+            else if ( m_vbos[idx] != 0 )
+            {
+                GL_ASSERT( glDisableVertexAttribArray( idx - 1 ) );
+                GL_ASSERT( glDeleteBuffers( 1, &( m_vbos[idx] ) ) );
+                m_vbos[idx] = 0;
+            }
         }
 
         for ( int i = 0; i < MAX_VEC4; i++ )
         {
+            auto idx = MAX_MESH + MAX_VEC3 + i;
             if ( m_mesh.isValid( m_v4DataHandle[i] ) )
+            { sendGLData( this, m_mesh.getAttrib( m_v4DataHandle[i] ).data(), idx ); }
+            else if ( m_vbos[idx] != 0 )
             {
-                sendGLData(
-                    this, m_mesh.getAttrib( m_v4DataHandle[i] ).data(), MAX_MESH + MAX_VEC3 + i );
+                GL_ASSERT( glDisableVertexAttribArray( idx - 1 ) );
+                GL_ASSERT( glDeleteBuffers( 1, &( m_vbos[idx] ) ) );
+                m_vbos[idx] = 0;
             }
         }
 

--- a/src/Engine/Renderer/RenderObject/RenderObject.cpp
+++ b/src/Engine/Renderer/RenderObject/RenderObject.cpp
@@ -198,7 +198,8 @@ void RenderObject::hasBeenRenderedOnce() {
     if ( m_hasLifetime )
     {
         if ( --m_lifetime <= 0 )
-        { RadiumEngine::getInstance()->getRenderObjectManager()->renderObjectExpired( m_idx ); } }
+        { RadiumEngine::getInstance()->getRenderObjectManager()->renderObjectExpired( m_idx ); }
+    }
 }
 
 void RenderObject::hasExpired() {

--- a/src/Engine/Renderer/RenderObject/RenderObjectManager.cpp
+++ b/src/Engine/Renderer/RenderObject/RenderObjectManager.cpp
@@ -110,7 +110,8 @@ size_t RenderObjectManager::getNumFaces() const {
         size_t( 0 ),
         []( size_t a, const std::shared_ptr<RenderObject>& ro ) -> size_t {
             if ( ro->isVisible() && ro->getType() == Ra::Engine::RenderObjectType::Geometry )
-            { return a + ro->getMesh()->getNumFaces(); } else
+            { return a + ro->getMesh()->getNumFaces(); }
+            else
             { return a; }
         } );
     return result;
@@ -124,7 +125,8 @@ size_t RenderObjectManager::getNumVertices() const {
         size_t( 0 ),
         []( size_t a, const std::shared_ptr<RenderObject>& ro ) -> size_t {
             if ( ro->isVisible() && ro->getType() == Ra::Engine::RenderObjectType::Geometry )
-            { return a + ro->getMesh()->getNumVertices(); } else
+            { return a + ro->getMesh()->getNumVertices(); }
+            else
             { return a; }
         } );
     return result;

--- a/src/Engine/Renderer/RenderTechnique/RenderTechnique.cpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderTechnique.cpp
@@ -91,8 +91,8 @@ const ShaderConfiguration& RenderTechnique::getConfiguration( PassName pass ) co
 //      LIGHTING_TRANSPARENT = Nothing
 Ra::Engine::RenderTechnique RenderTechnique::createDefaultRenderTechnique() {
     if ( RadiumDefaultRenderTechnique != nullptr )
-    { return *( RadiumDefaultRenderTechnique.get() ); } std::shared_ptr<Material> mat(
-        new BlinnPhongMaterial( "DefaultGray" ) );
+    { return *( RadiumDefaultRenderTechnique.get() ); }
+    std::shared_ptr<Material> mat( new BlinnPhongMaterial( "DefaultGray" ) );
     auto rt = new Ra::Engine::RenderTechnique;
     rt->setMaterial( mat );
     auto builder = EngineRenderTechniques::getDefaultTechnique( "BlinnPhong" );

--- a/src/Engine/Renderer/Renderer.hpp
+++ b/src/Engine/Renderer/Renderer.hpp
@@ -67,14 +67,14 @@ class RA_ENGINE_API Renderer
      * Picking mode
      */
     enum PickingMode {
-        RO = 0,    ///< Pick a mesh
-        VERTEX,    ///< Pick a vertex of a mesh
-        EDGE,      ///< Pick an edge of a mesh
-        TRIANGLE,  ///< Pick a triangle of a mesh
-        C_VERTEX,  ///< Picks all vertices of a mesh within a screen space circle
-        C_EDGE,    ///< Picks all edges of a mesh within a screen space circle
+        RO = 0,     ///< Pick a mesh
+        VERTEX,     ///< Pick a vertex of a mesh
+        EDGE,       ///< Pick an edge of a mesh
+        TRIANGLE,   ///< Pick a triangle of a mesh
+        C_VERTEX,   ///< Picks all vertices of a mesh within a screen space circle
+        C_EDGE,     ///< Picks all edges of a mesh within a screen space circle
         C_TRIANGLE, ///< Picks all triangles of a mesh within a screen space circle
-        NONE, ///< Do not pick ;)
+        NONE,       ///< Do not pick ;)
     };
 
     /**

--- a/src/Engine/Renderer/Texture/Texture.cpp
+++ b/src/Engine/Renderer/Texture/Texture.cpp
@@ -145,9 +145,7 @@ void Engine::Texture::updateData( void* data ) {
     }
     break;
     default:
-    {
-        CORE_ASSERT( 0, "Unsupported texture type ?" );
-    }
+    { CORE_ASSERT( 0, "Unsupported texture type ?" ); }
     break;
     }
     GL_CHECK_ERROR;

--- a/src/GuiBase/TreeModel/EntityTreeModel.cpp
+++ b/src/GuiBase/TreeModel/EntityTreeModel.cpp
@@ -135,7 +135,8 @@ void ItemModel::onDataChanged( const QModelIndex& topLeft,
             auto ent     = getEntry( index );
 
             if ( ent.isValid() && ent.isRoNode() )
-            { emit visibilityROChanged( ent.m_roIndex, visible ); } }
+            { emit visibilityROChanged( ent.m_roIndex, visible ); }
+        }
     }
 }
 

--- a/src/GuiBase/TreeModel/TreeModel.cpp
+++ b/src/GuiBase/TreeModel/TreeModel.cpp
@@ -58,7 +58,8 @@ bool TreeModel::setData( const QModelIndex& index, const QVariant& value, int ro
 
 QVariant TreeModel::headerData( int section, Qt::Orientation orientation, int role ) const {
     if ( section == 0 && orientation == Qt::Horizontal && role == Qt::DisplayRole )
-    { return QVariant( QString::fromStdString( getHeaderString() ) ); } else
+    { return QVariant( QString::fromStdString( getHeaderString() ) ); }
+    else
     { return QVariant(); }
 }
 
@@ -69,7 +70,8 @@ QModelIndex TreeModel::index( int row, int column, const QModelIndex& parent ) c
     // Grab the parent and make an index of the child.
     TreeItem* parentItem = getItem( parent );
     if ( parentItem && row < parentItem->m_children.size() )
-    { return createIndex( row, column, parentItem->m_children[row].get() ); } else
+    { return createIndex( row, column, parentItem->m_children[row].get() ); }
+    else
     { return QModelIndex(); }
 }
 

--- a/src/GuiBase/Utils/KeyMappingManager.cpp
+++ b/src/GuiBase/Utils/KeyMappingManager.cpp
@@ -38,7 +38,6 @@ KeyMappingManager::getAction( const KeyMappingManager::Context& context,
     if ( ( key == Qt::Key_Shift ) || ( key == Qt::Key_Control ) || ( key == Qt::Key_Alt ) ||
          ( key == Qt::Key_Meta ) )
     { key = -1; }
-
     KeyMappingManager::MouseBinding binding{buttons, modifiers, key, wheel};
 
     auto action = m_mappingAction[context].find( binding );

--- a/src/GuiBase/Viewer/CameraInterface.cpp
+++ b/src/GuiBase/Viewer/CameraInterface.cpp
@@ -23,7 +23,8 @@ Gui::CameraInterface::CameraInterface( uint width, uint height ) :
         Engine::SystemEntity::getInstance()->getComponents().cend(),
         []( const auto& c ) { return c->getName().compare( "CAMERA_DEFAULT" ) == 0; } );
     if ( it != Engine::SystemEntity::getInstance()->getComponents().cend() )
-    { m_camera = static_cast<Engine::Camera*>( ( *it ).get() ); } else
+    { m_camera = static_cast<Engine::Camera*>( ( *it ).get() ); }
+    else
     {
         m_camera = new Engine::Camera( Engine::SystemEntity::getInstance(),
                                        "CAMERA_DEFAULT",

--- a/src/GuiBase/Viewer/Gizmo/Gizmo.hpp
+++ b/src/GuiBase/Viewer/Gizmo/Gizmo.hpp
@@ -74,7 +74,7 @@ class Gizmo
     virtual Core::Transform mouseMove( const Engine::Camera& cam,
                                        const Core::Vector2& nextXY,
                                        bool stepped = false,
-                                       bool whole = false) = 0;
+                                       bool whole   = false ) = 0;
 
   protected:
     static bool findPointOnAxis( const Engine::Camera& cam,

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -348,7 +348,8 @@ void Gui::Viewer::mousePressEvent( QMouseEvent* event ) {
     if ( result.m_roIdx.isInvalid() )
     {
         if ( m_camera->handleMousePressEvent( event, buttons, modifiers, key ) )
-        { m_activeContext = TrackballCamera::getContext(); } else
+        { m_activeContext = TrackballCamera::getContext(); }
+        else
         {
             // should not pass here, since viewerContext is only for valid picking ...
             m_activeContext = KeyMappingManageable::getContext();
@@ -393,7 +394,8 @@ void Gui::Viewer::mouseReleaseEvent( QMouseEvent* event ) {
     if ( m_activeContext == TrackballCamera::getContext() )
     { m_camera->handleMouseReleaseEvent( event ); }
     if ( m_activeContext == GizmoManager::getContext() )
-    { m_gizmoManager->handleMouseReleaseEvent( event ); } m_activeContext = -1;
+    { m_gizmoManager->handleMouseReleaseEvent( event ); }
+    m_activeContext = -1;
     emit needUpdate();
 }
 

--- a/src/IO/deprecated/FileManager.inl
+++ b/src/IO/deprecated/FileManager.inl
@@ -37,7 +37,8 @@ inline bool FileManager<DATA, Binary>::load( const std::string& filename,
         file.open( filename + "." + fileExtension(),
                    std::ios_base::in | ( Binary ? std::ios_base::binary : std::ios_base::in ) );
         if ( !( status = file.is_open() ) )
-        { addLogErrorEntry( "Error occured while opening the file. HINT: FILENAME IS WRONG." ); } }
+        { addLogErrorEntry( "Error occured while opening the file. HINT: FILENAME IS WRONG." ); }
+    }
     if ( status )
     {
         addLogEntry( "File opened successfully." );
@@ -67,7 +68,8 @@ inline bool FileManager<DATA, Binary>::save( const std::string& filename,
                         std::ios_base::out | std::ios_base::trunc |
                             ( Binary ? std::ios_base::binary : std::ios_base::out ) );
     if ( !( status = file.is_open() ) )
-    { addLogErrorEntry( "Error occured while opening the file." ); } if ( status )
+    { addLogErrorEntry( "Error occured while opening the file." ); }
+    if ( status )
     {
         addLogEntry( "File opened successfully." );
         addLogEntry( "Starting to export the data..." );

--- a/src/IO/deprecated/OBJFileManager.hpp
+++ b/src/IO/deprecated/OBJFileManager.hpp
@@ -7,7 +7,7 @@
 namespace Ra {
 namespace IO {
 
-class RA_IO_API[[deprecated]] OBJFileManager : public FileManager<Core::Geometry::TriangleMesh>
+class RA_IO_API [[deprecated]] OBJFileManager : public FileManager<Core::Geometry::TriangleMesh>
 {
   public:
     /// CONSTRUCTOR

--- a/src/IO/deprecated/OFFFileManager.hpp
+++ b/src/IO/deprecated/OFFFileManager.hpp
@@ -12,7 +12,7 @@ namespace IO {
  * The class OFFFileManager handles the loading and storing of TriangleMesh in the standard OFF
  * format.
  */
-class RA_IO_API[[deprecated]] OFFFileManager : public FileManager<Core::Geometry::TriangleMesh>
+class RA_IO_API [[deprecated]] OFFFileManager : public FileManager<Core::Geometry::TriangleMesh>
 {
   public:
     /// CONSTRUCTOR


### PR DESCRIPTION
Replacement proposal for #438, but I'm not sure to catch all the issues, so please check ;)

I also reformat all code (in a separate commit), according to last script version.
So please check by commit to not get disturbed by the numerous changes.

---------------------- Update pull request manifest -----------------------
UPDATE the form below to describe your PR.


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix #437 


* **What is the current behavior?** (You can also link to an open issue here)
When de-activating mesh paint and re-activating it on a mesh with no previous `per-vertex` colors, the mesh ends up all black and painting colors does not work.
Actually this is due to the fact that, when de-activating colors painting, the colors are set back to what they were before painting, which in this case is `none`.
Thus when re-activating painting, since the mesh has the color attribute, the plugin just copies it and no validity check is done.
Hence when painting the colors, colors are set in an empty container (this should crash but somehow does not).

* **What is the new behavior (if this is a feature change)?**
- On color painting activation, the plugin request the addition of a color attribute to the mesh.
If there is only one, this one is selected as the `to be painted` and previous colors are saved.
Otherwise, a new one is created and filled with a default color.
- On color painting de-activation, the colors are set to what they were beforehand, i.e. either the saved ones or the created attribute is removed.