### PR TITLE
guard dependency in cmake by cmake option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,8 +226,9 @@ else()
     )
 endif()
 add_dependencies(radium_configs radiumCore)
-add_dependencies( main-app radium_configs ) # temporary fix, needs to be handled by main-app
-
+if(RADIUM_BUILD_APPS)
+    add_dependencies( main-app radium_configs ) # temporary fix, needs to be handled by main-app
+endif(RADIUM_BUILD_APPS)
 
 ################################################################################
 # Tests                                                                        #


### PR DESCRIPTION
UPDATE the form below to describe your PR.

Fix cmake when using 
RADIUM_BUILD_APPS=Off