### PR TITLE
Add core assert to guard Camera's m_RO access.

### DIFF
--- a/src/Engine/Renderer/Camera/Camera.cpp
+++ b/src/Engine/Renderer/Camera/Camera.cpp
@@ -49,10 +49,13 @@ void Camera::initialize() {
 }
 
 void Camera::show( bool on ) {
+    CORE_ASSERT( m_RO, "Camera's render object must be initialize with Camera::intialize()" );
     m_RO->setVisible( on );
 }
 
 void Camera::applyTransform( const Core::Transform& T ) {
+    CORE_ASSERT( m_RO, "Camera's render object must be initialize with Camera::intialize()" );
+
     Core::Transform t1 = Core::Transform::Identity();
     Core::Transform t2 = Core::Transform::Identity();
     t1.translation()   = -getPosition();


### PR DESCRIPTION
UPDATE the form below to describe your PR.


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR uses core assert to check that camera is initialized before refere to it's m_RO, without this, a program that forgot to initialize the camera will segfault.
I found it usefull to use core assert, so that in release there is no performance penalities. 
