### PR TITLE
Keymapping fix

### DIFF
--- a/Applications/HelloRadium/minimalapp.cpp
+++ b/Applications/HelloRadium/minimalapp.cpp
@@ -22,10 +22,11 @@ MinimalApp::MinimalApp( int& argc, char** argv ) :
     m_engine.reset( Ra::Engine::RadiumEngine::createInstance() );
     m_engine->initialize();
 
+    ///\todo update when a basic viewer is implemented ... (to call setupKeyMappingCallbacks)
     Ra::Gui::KeyMappingManager::createInstance();
     Ra::Gui::KeyMappingManager::getInstance()->addListener(
-        Ra::Gui::TrackballCamera::registerKeyMapping );
-    Ra::Gui::KeyMappingManager::getInstance()->addListener( Ra::Gui::Viewer::registerKeyMapping );
+        Ra::Gui::TrackballCamera::configureKeyMapping );
+    Ra::Gui::KeyMappingManager::getInstance()->addListener( Ra::Gui::Viewer::configureKeyMapping );
 
     // Initialize taskqueue.
     m_task_queue.reset( new Ra::Core::TaskQueue( std::thread::hardware_concurrency() - 1 ) );

--- a/Docs/keymapping.md
+++ b/Docs/keymapping.md
@@ -27,7 +27,7 @@ If buttons is defined, then it's a `mouse[move/press/release]Event`, that option
 If wheel is true, then it's a wheel event, that optionally take modifiers, buttons and key into account.
 
 On the implementation side, your class `C` need (could) derive from `KeyMappingManageable<C>`, it defines the static member variable
-`m_keyMappingContext`.
+`m_keyMappingContext`, and the static function `configureKeyMapping()`, that calls `configureKeyMapping_impl()`, which have to be implemented in your class `C`.
 
 Then you need to define your specific actions as static member of your class
 
@@ -50,7 +50,7 @@ static KeyMappingManager::KeyMappingAction m_myAction;
 KeyMappingManager::KeyMappingAction m_myAction;
 
 // then typically in main baseApplication ctor or Viewer ctor, but after KeyMappingManager instance is created :
-KeyMappingManager::getInstance()->addListener(MyClass:registerKeyMapping);
+KeyMappingManager::getInstance()->addListener(MyClass:configureKeyMapping);
 
 ```
 

--- a/Docs/keymapping.md
+++ b/Docs/keymapping.md
@@ -34,8 +34,8 @@ Then you need to define your specific actions as static member of your class
 ```
 class MyClass :public KeyManageable<MyClass> {
 
-// calleback when a configuration file is loaded, coudl check if the context and action are present.
-static void registerKeyMapping(){
+// callback when a configuration file is loaded, could check if the context and action are present.
+static void configureKeyMapping(){
     m_keyMappingContext = Gui::KeyMappingManager::getInstance()->getContext( "MyClassContext" );
     m_myAction =  Gui::KeyMappingManager::getInstance()->getActionIndex( "MyActionName" );
 }
@@ -59,7 +59,7 @@ It could be done with a specific macro :
 ```c++
 // in header
 #define KeyMappingMyClass \
-    KMA_VALUE( MY_ACTION )   
+    KMA_VALUE( MY_ACTION )
     
 #define KMA_VALUE( XX ) static KeyMappingManager::KeyMappingAction XX;
     KeyMappingMyClass
@@ -70,10 +70,10 @@ It could be done with a specific macro :
 KeyMappingMyClass
 #undef KMA_VALUE
 
-void MyClass::registerKeyMapping() {
+void MyClass::configureKeyMapping() {
     m_keyMappingContext = Gui::KeyMappingManager::getInstance()->getContext( "MyClassContext" );
     if ( m_keyMappingContext.isInvalid() )
-        LOG( logINFO ) << "MyuClassContext not defined (maybe the configuration file do not contains it";
+        LOG( logINFO ) << "MyClassContext not defined (maybe the configuration file does not contain it";
 #define KMA_VALUE( XX ) \
     XX = Gui::KeyMappingManager::getInstance()->getActionIndex( m_keyMappingContext, #XX );
     KeyMappingMyClass
@@ -101,8 +101,8 @@ For instance see `Viewer.cpp` `Viewer::mousePressEvent`
         auto accepted = m_camera->handleMousePressEvent( event, buttons, modifiers, key );
         if ( accepted ) { m_activeContext = m_camera->getContext(); }
         else
-  //[...]  
- ```  
+  //[...]
+ ```
 
 ## Limits
 

--- a/src/GuiBase/BaseApplication.cpp
+++ b/src/GuiBase/BaseApplication.cpp
@@ -205,8 +205,8 @@ BaseApplication::BaseApplication( int argc,
     // Create the instance of the keymapping manager, before creating
     // Qt main windows, which may throw events on Microsoft Windows
     Gui::KeyMappingManager::createInstance();
-    Gui::KeyMappingManager::getInstance()->addListener( Gui::Viewer::registerKeyMapping );
 
+    Gui::Viewer::setupKeyMappingCallbacks();
     // Create engine
     m_engine.reset( Engine::RadiumEngine::createInstance() );
     m_engine->initialize();

--- a/src/GuiBase/Utils/KeyMappingManager.cpp
+++ b/src/GuiBase/Utils/KeyMappingManager.cpp
@@ -196,7 +196,7 @@ void KeyMappingManager::loadConfiguration( const char* filename ) {
     {
         LOG( logERROR ) << "Can't associate XML file to QDomDocument !";
         LOG( logERROR ) << "Trying to load default configuration...";
-
+        m_file->close();
         loadConfiguration();
         return;
     }
@@ -369,10 +369,7 @@ Qt::MouseButtons KeyMappingManager::getQtMouseButtonsValue( const std::string& k
 }
 
 void KeyMappingManager::reloadConfiguration() {
-    if ( !m_file->isOpen() ) { return; }
-
     QString filename = m_file->fileName();
-    m_file->close();
     loadConfiguration( filename.toStdString().c_str() );
 }
 

--- a/src/GuiBase/Utils/KeyMappingManager.hpp
+++ b/src/GuiBase/Utils/KeyMappingManager.hpp
@@ -32,6 +32,7 @@ class RA_GUIBASE_API KeyMappingManager
     /// calls the listener callback then.
     void loadConfiguration( const char* filename = nullptr );
 
+    /// reload last open file.
     void reloadConfiguration();
 
     /// Return the action associated to the binding buttons + modifiers + key

--- a/src/GuiBase/Utils/KeyMappingManager.hpp
+++ b/src/GuiBase/Utils/KeyMappingManager.hpp
@@ -164,33 +164,14 @@ template <typename T>
 class KeyMappingManageable
 {
   public:
-    /*
-        /// @return true if the event has been taken into account, false otherwise
-        virtual bool handleMouseReleaseEvent( QMouseEvent* event ) { return false; }
-
-        /// @return true if the event has been taken into account, false otherwise
-        virtual bool handleMouseMoveEvent( QMouseEvent* event,
-                                           const Qt::MouseButtons& buttons,
-                                           const Qt::KeyboardModifiers& modifiers,
-                                           int key ) {
-            return false;
-        }
-
-        /// @return true if the event has been taken into account, false otherwise
-        virtual bool handleWheelEvent( QWheelEvent* event ) { return false; }
-
-        /// @return true if the event has been taken into account, false otherwise
-        virtual bool handleKeyPressEvent( QKeyEvent* event,
-                                          const KeyMappingManager::KeyMappingAction& action ) {
-            return false;
-        }
-
-        /// @return true if the event has been taken into account, false otherwise
-        virtual bool handleKeyReleaseEvent( QKeyEvent* event ) { return false; }
-    */
     static inline KeyMappingManager::Context getContext() { return m_keyMappingContext; }
 
+    /// KeyManageable class should implement configureKeyMapping_impl to get their
+    /// keyMappingAction constants.
+    static inline void configureKeyMapping() { T::configureKeyMapping_impl(); }
+
   protected:
+    T& self() { return static_cast<T&>( *this ); }
     static KeyMappingManager::Context m_keyMappingContext;
 };
 
@@ -198,7 +179,7 @@ class KeyMappingManageable
 template <typename T>
 KeyMappingManager::Context KeyMappingManageable<T>::m_keyMappingContext;
 
-}; // namespace Gui
+} // namespace Gui
 } // namespace Ra
 
 #endif // RADIUMENGINE_KEYMAPPINGMANAGER_HPP

--- a/src/GuiBase/Utils/KeyMappingManager.hpp
+++ b/src/GuiBase/Utils/KeyMappingManager.hpp
@@ -164,8 +164,6 @@ template <typename T>
 class KeyMappingManageable
 {
   public:
-    //    static virtual void registerKeyMapping() = 0;
-
     /*
         /// @return true if the event has been taken into account, false otherwise
         virtual bool handleMouseReleaseEvent( QMouseEvent* event ) { return false; }
@@ -190,7 +188,7 @@ class KeyMappingManageable
         /// @return true if the event has been taken into account, false otherwise
         virtual bool handleKeyReleaseEvent( QKeyEvent* event ) { return false; }
     */
-    static KeyMappingManager::Context getContext() { return m_keyMappingContext; }
+    static inline KeyMappingManager::Context getContext() { return m_keyMappingContext; }
 
   protected:
     static KeyMappingManager::Context m_keyMappingContext;

--- a/src/GuiBase/Viewer/CameraInterface.hpp
+++ b/src/GuiBase/Viewer/CameraInterface.hpp
@@ -25,7 +25,7 @@ namespace Ra {
 namespace Gui {
 
 /// The CameraInterface class is the generic class for camera manipulators.
-class RA_GUIBASE_API CameraInterface : public QObject, public KeyMappingManageable<CameraInterface>
+class RA_GUIBASE_API CameraInterface : public QObject
 {
     Q_OBJECT
 

--- a/src/GuiBase/Viewer/Gizmo/GizmoManager.cpp
+++ b/src/GuiBase/Viewer/Gizmo/GizmoManager.cpp
@@ -17,7 +17,7 @@ namespace Gui {
 KeyMappingGizmo;
 #undef KMA_VALUE
 
-void GizmoManager::configureKeyMapping() {
+void GizmoManager::configureKeyMapping_impl() {
     m_keyMappingContext = Gui::KeyMappingManager::getInstance()->getContext( "GizmoContext" );
     if ( m_keyMappingContext.isInvalid() )
     {

--- a/src/GuiBase/Viewer/Gizmo/GizmoManager.cpp
+++ b/src/GuiBase/Viewer/Gizmo/GizmoManager.cpp
@@ -17,7 +17,7 @@ namespace Gui {
 KeyMappingGizmo;
 #undef KMA_VALUE
 
-void GizmoManager::registerKeyMapping() {
+void GizmoManager::configureKeyMapping() {
     m_keyMappingContext = Gui::KeyMappingManager::getInstance()->getContext( "GizmoContext" );
     if ( m_keyMappingContext.isInvalid() )
     {

--- a/src/GuiBase/Viewer/Gizmo/GizmoManager.hpp
+++ b/src/GuiBase/Viewer/Gizmo/GizmoManager.hpp
@@ -24,6 +24,7 @@ class RA_GUIBASE_API GizmoManager : public QObject,
                                     public KeyMappingManageable<GizmoManager>
 {
     Q_OBJECT
+    friend class KeyMappingManageable<GizmoManager>;
 
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
@@ -31,19 +32,6 @@ class RA_GUIBASE_API GizmoManager : public QObject,
 
     explicit GizmoManager( QObject* parent = nullptr );
     ~GizmoManager() = default;
-
-#define KeyMappingGizmo                    \
-    KMA_VALUE( GIZMOMANAGER_MANIPULATION ) \
-    KMA_VALUE( GIZMOMANAGER_STEP )         \
-    KMA_VALUE( GIZMOMANAGER_WHOLE )        \
-    KMA_VALUE( GIZMOMANAGER_STEP_WHOLE )
-
-#define KMA_VALUE( XX ) static KeyMappingManager::KeyMappingAction XX;
-    KeyMappingGizmo
-#undef KMA_VALUE
-
-        static void
-        registerKeyMapping();
 
   public:
     /// Receive mouse events and transmit them to the gizmos.
@@ -89,6 +77,18 @@ class RA_GUIBASE_API GizmoManager : public QObject,
     std::array<std::unique_ptr<Gizmo>, 3> m_gizmos; //! Owning pointers to the gizmos
     GizmoType m_currentGizmoType;                   //! Type of the gizmo
     Gizmo::Mode m_mode;                             //! Local/global axis mode.
+
+    static void configureKeyMapping_impl();
+
+#define KeyMappingGizmo                    \
+    KMA_VALUE( GIZMOMANAGER_MANIPULATION ) \
+    KMA_VALUE( GIZMOMANAGER_STEP )         \
+    KMA_VALUE( GIZMOMANAGER_WHOLE )        \
+    KMA_VALUE( GIZMOMANAGER_STEP_WHOLE )
+
+#define KMA_VALUE( XX ) static KeyMappingManager::KeyMappingAction XX;
+    KeyMappingGizmo
+#undef KMA_VALUE
 };
 } // namespace Gui
 } // namespace Ra

--- a/src/GuiBase/Viewer/TrackballCamera.cpp
+++ b/src/GuiBase/Viewer/TrackballCamera.cpp
@@ -21,7 +21,7 @@ using Core::Math::Pi;
 KeyMappingCamera;
 #undef KMA_VALUE
 
-void Gui::TrackballCamera::configureKeyMapping() {
+void Gui::TrackballCamera::configureKeyMapping_impl() {
 
     m_keyMappingContext = Gui::KeyMappingManager::getInstance()->getContext( "CameraContext" );
     if ( m_keyMappingContext.isInvalid() )

--- a/src/GuiBase/Viewer/TrackballCamera.cpp
+++ b/src/GuiBase/Viewer/TrackballCamera.cpp
@@ -21,7 +21,7 @@ using Core::Math::Pi;
 KeyMappingCamera;
 #undef KMA_VALUE
 
-void Gui::TrackballCamera::registerKeyMapping() {
+void Gui::TrackballCamera::configureKeyMapping() {
 
     m_keyMappingContext = Gui::KeyMappingManager::getInstance()->getContext( "CameraContext" );
     if ( m_keyMappingContext.isInvalid() )

--- a/src/GuiBase/Viewer/TrackballCamera.hpp
+++ b/src/GuiBase/Viewer/TrackballCamera.hpp
@@ -16,7 +16,7 @@ class RA_GUIBASE_API TrackballCamera : public CameraInterface
     TrackballCamera( uint width, uint height );
     virtual ~TrackballCamera();
 
-    static void registerKeyMapping();
+    static void configureKeyMapping();
 
     bool handleMousePressEvent( QMouseEvent* event,
                                 const Qt::MouseButtons& buttons,

--- a/src/GuiBase/Viewer/TrackballCamera.hpp
+++ b/src/GuiBase/Viewer/TrackballCamera.hpp
@@ -8,15 +8,15 @@ namespace Ra {
 namespace Gui {
 
 /// A Trackball manipulator for Cameras.
-class RA_GUIBASE_API TrackballCamera : public CameraInterface
+class RA_GUIBASE_API TrackballCamera : public CameraInterface,
+                                       public KeyMappingManageable<TrackballCamera>
 {
     Q_OBJECT
+    friend class KeyMappingManageable<TrackballCamera>;
 
   public:
     TrackballCamera( uint width, uint height );
     virtual ~TrackballCamera();
-
-    static void configureKeyMapping();
 
     bool handleMousePressEvent( QMouseEvent* event,
                                 const Qt::MouseButtons& buttons,
@@ -94,9 +94,9 @@ class RA_GUIBASE_API TrackballCamera : public CameraInterface
     bool m_cameraRotateMode;
     bool m_cameraPanMode;
     bool m_cameraZoomMode;
-    // TODO(Charly): fps mode
 
-    // static KeyMappingManager::Context m_keyMappingContext;
+  private:
+    static void configureKeyMapping_impl();
 
 #define KeyMappingCamera                \
     KMA_VALUE( TRACKBALLCAMERA_ROTATE ) \

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -61,11 +61,17 @@ KeyMappingViewer;
 
 // Register all keymapings related to the viewer and its managed functionalities (Trackball camera,
 // Gizmo, ..)
-void Gui::Viewer::registerKeyMapping() {
+void Gui::Viewer::setupKeyMappingCallbacks() {
     auto keyMappingManager = Gui::KeyMappingManager::getInstance();
+
     keyMappingManager->addListener( Gui::TrackballCamera::registerKeyMapping );
     keyMappingManager->addListener( Gui::GizmoManager::registerKeyMapping );
-    m_keyMappingContext = keyMappingManager->getContext( "ViewerContext" );
+    keyMappingManager->addListener( registerKeyMapping );
+}
+
+void Gui::Viewer::registerKeyMapping() {
+    auto keyMappingManager = Gui::KeyMappingManager::getInstance();
+    m_keyMappingContext    = keyMappingManager->getContext( "ViewerContext" );
     if ( m_keyMappingContext.isInvalid() )
     {
         LOG( logINFO )

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -64,12 +64,12 @@ KeyMappingViewer;
 void Gui::Viewer::setupKeyMappingCallbacks() {
     auto keyMappingManager = Gui::KeyMappingManager::getInstance();
 
-    keyMappingManager->addListener( Gui::TrackballCamera::registerKeyMapping );
-    keyMappingManager->addListener( Gui::GizmoManager::registerKeyMapping );
-    keyMappingManager->addListener( registerKeyMapping );
+    keyMappingManager->addListener( Gui::TrackballCamera::configureKeyMapping );
+    keyMappingManager->addListener( Gui::GizmoManager::configureKeyMapping );
+    keyMappingManager->addListener( configureKeyMapping );
 }
 
-void Gui::Viewer::registerKeyMapping() {
+void Gui::Viewer::configureKeyMapping(){
     auto keyMappingManager = Gui::KeyMappingManager::getInstance();
     m_keyMappingContext    = keyMappingManager->getContext( "ViewerContext" );
     if ( m_keyMappingContext.isInvalid() )

--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -69,7 +69,7 @@ void Gui::Viewer::setupKeyMappingCallbacks() {
     keyMappingManager->addListener( configureKeyMapping );
 }
 
-void Gui::Viewer::configureKeyMapping(){
+void Gui::Viewer::configureKeyMapping_impl() {
     auto keyMappingManager = Gui::KeyMappingManager::getInstance();
     m_keyMappingContext    = keyMappingManager->getContext( "ViewerContext" );
     if ( m_keyMappingContext.isInvalid() )

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -68,7 +68,7 @@ class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewe
     /// update keymapping according to keymapping manager's config, should be
     /// called each time the configuration changes, or added to observer's list
     /// with KeyMappingManager::addListener
-    static void registerKeyMapping();
+    static void configureKeyMapping();
 
     //
     // Accessors

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -62,6 +62,7 @@ class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewe
     /// Destructor
     ~Viewer() override;
 
+    static void setupKeyMappingCallbacks();
     static void registerKeyMapping();
 
     //

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -54,6 +54,7 @@ namespace Gui {
 class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewer>
 {
     Q_OBJECT
+    friend class KeyMappingManageable<Viewer>;
 
   public:
     /// Constructor
@@ -64,11 +65,6 @@ class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewe
 
     /// add observers to keyMappingManager for gizmo, camera and viewer.
     static void setupKeyMappingCallbacks();
-
-    /// update keymapping according to keymapping manager's config, should be
-    /// called each time the configuration changes, or added to observer's list
-    /// with KeyMappingManager::addListener
-    static void configureKeyMapping();
 
     //
     // Accessors
@@ -211,6 +207,13 @@ class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewe
     void wheelEvent( QWheelEvent* event ) override;
     void showEvent( QShowEvent* ev ) override;
 
+  private:
+    /// update keymapping according to keymapping manager's config, should be
+    /// called each time the configuration changes, or added to observer's list
+    /// with KeyMappingManager::addListener
+    /// Called with KeyManageable::configureKeyMapping
+    static void configureKeyMapping_impl();
+
   public:
     Scalar m_dt{0.1_ra};
 
@@ -238,6 +241,7 @@ class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewe
 
     Core::Utils::Color m_backgroundColor{Core::Utils::Color::Grey( 0.0392_ra, 0_ra )};
 
+    KeyMappingManager::Context m_activeContext{-1};
 #define KeyMappingViewer                     \
     KMA_VALUE( VIEWER_PICKING )              \
     KMA_VALUE( VIEWER_PICKING_VERTEX )       \
@@ -251,8 +255,6 @@ class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewe
 #define KMA_VALUE( x ) static KeyMappingManager::KeyMappingAction x;
     KeyMappingViewer
 #undef KMA_VALUE
-
-        KeyMappingManager::Context m_activeContext{-1};
 };
 
 } // namespace Gui

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -62,7 +62,12 @@ class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewe
     /// Destructor
     ~Viewer() override;
 
+    /// add observers to keyMappingManager for gizmo, camera and viewer.
     static void setupKeyMappingCallbacks();
+
+    /// update keymapping according to keymapping manager's config, should be
+    /// called each time the configuration changes, or added to observer's list
+    /// with KeyMappingManager::addListener
     static void registerKeyMapping();
 
     //


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix #457


* **What is the current behavior?** (You can also link to an open issue here)
the Viewer::registerKeymapping, which should act as a call back called by keyMappingManager, add also callback's for camera and gizmo to the keyMappingManager
the PR also cleanup file management in keyMappingManager, I was not sure of the expected behavior, so I correct them to what I expect to be correct, but comment are welcoms.

* **What is the new behavior (if this is a feature change)?**
an helper function of the viewer is added to register all callback's to keyMappingManager.
I don't chech minimalapp, which register camera and viewer only, it's maybe a mistake ... or not.

