### PR TITLE
Fix use of transforms on aabb ;

### DIFF
--- a/src/Core/Geometry/Obb.hpp
+++ b/src/Core/Geometry/Obb.hpp
@@ -31,10 +31,11 @@ class Obb
 
     /// Return the AABB enclosing this
     inline Aabb toAabb() const {
+        if ( m_aabb.isEmpty() ) { return m_aabb; }
         Aabb tmp;
         for ( int i = 0; i < 8; ++i )
         {
-            tmp.extend( m_transform * m_aabb.corner( static_cast<Aabb::CornerType>( i ) ) );
+            tmp.extend( worldCorner( i ) );
         }
         return tmp;
     }

--- a/src/Engine/Renderer/RenderObject/RenderObject.cpp
+++ b/src/Engine/Renderer/RenderObject/RenderObject.cpp
@@ -168,8 +168,9 @@ Core::Matrix4 RenderObject::getTransformAsMatrix() const {
 
 Core::Aabb RenderObject::computeAabb() const {
     auto aabb = m_mesh->getGeometry().computeAabb();
-    Core::Aabb result;
+    if ( aabb.isEmpty() ) { return aabb; }
 
+    Core::Aabb result;
     for ( int i = 0; i < 8; ++i )
     {
         result.extend( getTransform() * aabb.corner( Core::Aabb::CornerType( i ) ) );

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(unittests
     Core/indexmap.cpp
     Core/mesh.cpp
     Core/observer.cpp
+    Core/obb.cpp
     Core/polyline.cpp
     Core/raycast.cpp
     Core/string.cpp

--- a/tests/unittest/Core/obb.cpp
+++ b/tests/unittest/Core/obb.cpp
@@ -1,0 +1,19 @@
+#include <Core/Geometry/Obb.hpp>
+#include <Core/Math/Math.hpp>
+#include <Core/Types.hpp>
+#include <catch2/catch.hpp>
+
+TEST_CASE( "Core/Geometry/Obb", "[Core][Core/Geometry][Obb]" ) {
+
+    using namespace Ra::Core;
+    SECTION( "Simple tests" ) {
+        // Check Obb and empty aabb
+        Aabb aabb;
+        Geometry::Obb obb( aabb, Transform::Identity() );
+        REQUIRE( obb.toAabb().isEmpty() );
+        REQUIRE( obb.toAabb().isApprox( aabb ) );
+        obb.transform().rotate( AngleAxis( Math::Pi, Vector3::UnitX() ) );
+        REQUIRE( obb.toAabb().isEmpty() );
+        REQUIRE( obb.toAabb().isApprox( aabb ) );
+    }
+}


### PR DESCRIPTION
UPDATE the form below to describe your PR.


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix on `Aabb` with `Transforms`.
Also add a test on `Obb` in `tests/CoreTests/src/geometry.cpp`.


* **What is the current behavior?** (You can also link to an open issue here)
When applying a `Transfom` T to an `Aabb` A (basically an `Obb` - or the use made in `RenderObject`), T is applied to all the corners of A to fill an empty `Aabb`.
This becomes bad as soon as A is empty, even if T is the Identity.


* **What is the new behavior (if this is a feature change)?**
A is tested before applying T. If A is empty, then it is returned as is.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:

Test code:
```
Aabb aabb;
Obb obb( aabb, Transform::Identity() );
std::cout << obb.toAabb().min().transpose() << "\t" << obb.toAabb().max().transpose() << std::endl;
obb.transform().rotate( AngleAxis( Ra::Core::Math::Pi, Vector3::UnitX() ) );
std::cout << obb.toAabb().min().transpose() << "\t" << obb.toAabb().max().transpose() << std::endl;
```
Test result before PR:
```
-3.40282e+38 -3.40282e+38 -3.40282e+38	3.40282e+38 3.40282e+38 3.40282e+38 // -> the whole space
-3.40282e+38         -inf         -inf	3.40282e+38         inf         inf // -> even worse
```
Test result after PR:
```
3.40282e+38 3.40282e+38 3.40282e+38	-3.40282e+38 -3.40282e+38 -3.40282e+38
3.40282e+38 3.40282e+38 3.40282e+38	-3.40282e+38 -3.40282e+38 -3.40282e+38
```
