### PR TITLE
Add missing definition for debug mode

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,16 +31,23 @@ set(ConfigPackageLocation lib/cmake/Radium)
 # multiple binaries.
 # Use with `configureTargetWithDefaultRaSettings(exampleApp)`
 macro(configureTargetWithDefaultRaSettings TARGET)
-  message( "Configure library ${TARGET} with default settings" )
+  message("Configure library ${TARGET} with default settings")
+
+  if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+      target_compile_definitions(${TARGET}
+              PUBLIC
+              _DEBUG
+              )
+  endif ()
 
   target_include_directories(${TARGET} PUBLIC
-      $<BUILD_INTERFACE:${RADIUM_SRC_DIR}>
-      $<INSTALL_INTERFACE:include>
-      )
+          $<BUILD_INTERFACE:${RADIUM_SRC_DIR}>
+          $<INSTALL_INTERFACE:include>
+          )
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
 
   # Create Exported target properties
-  set_target_properties( ${TARGET} PROPERTIES VERSION ${RADIUM_VERSION} )
+  set_target_properties(${TARGET} PROPERTIES VERSION ${RADIUM_VERSION})
 
   if(OPENMP_FOUND)
     target_link_libraries(${TARGET} PUBLIC OpenMP::OpenMP_CXX)


### PR DESCRIPTION
UPDATE the form below to describe your PR.
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature Fix ;)


* **What is the current behavior?** (You can also link to an open issue here)
The DEBUG definition is not exported when the lib is compiled in debug mode.
So MACROs such as GL_ASSERT are empty.


* **What is the new behavior (if this is a feature change)?**
The DEBUG definition is exported, and so the MACROs.
