### PR TITLE
Fix 454

### DIFF
--- a/src/Core/Geometry/CatmullClarkSubdivider.hpp
+++ b/src/Core/Geometry/CatmullClarkSubdivider.hpp
@@ -32,7 +32,7 @@ class RA_CORE_API CatmullClarkSubdivider
 
     explicit CatmullClarkSubdivider( TopologicalMesh& mesh ) : base() { attach( mesh ); }
 
-    ~CatmullClarkSubdivider() {}
+    ~CatmullClarkSubdivider() { detach(); }
 
   public:
     const char* name( void ) const override { return "CatmullClarkSubdivider"; }

--- a/src/Core/Geometry/LoopSubdivider.hpp
+++ b/src/Core/Geometry/LoopSubdivider.hpp
@@ -34,7 +34,7 @@ class RA_CORE_API LoopSubdivider
 
     explicit LoopSubdivider( TopologicalMesh& mesh ) : base() { attach( mesh ); }
 
-    ~LoopSubdivider() {}
+    ~LoopSubdivider() { detach(); }
 
   public:
     const char* name( void ) const override { return "LoopSubdivider"; }

--- a/src/Core/Geometry/TriangleMesh.hpp
+++ b/src/Core/Geometry/TriangleMesh.hpp
@@ -15,7 +15,7 @@ namespace Geometry {
 
 /// Attributes are unique per vertex, so that same position with different
 /// normals are two vertices.
-/// Points and Normals, defining the mesh geometry, are always present.
+/// Points and Normals, defining the geometry, are always present.
 /// They can be accessed through vertices() and normals().
 /// Other attribs could be added with addAttrib() and accesssed with getAttrib().
 /// \note Attribute names "in_position" "in_normal" are reserved and pre-allocated.
@@ -34,37 +34,38 @@ class RA_CORE_API AttribArrayGeometry : public AbstractGeometry
     using Vec3AttribHandle   = Utils::AttribHandle<Vector3>;
     using Vec4AttribHandle   = Utils::AttribHandle<Vector4>;
 
-    /// Create an empty mesh.
+    /// Create an empty geometry.
     inline AttribArrayGeometry() : AbstractGeometry() { initDefaultAttribs(); }
 
-    /// Copy constructor, copy all the mesh data (faces, geometry, attributes).
+    /// Copy constructor, copy all the data (geometry, attributes).
     /// \note Handles on \p other are not valid for *this.
     inline explicit AttribArrayGeometry( const AttribArrayGeometry& other );
 
-    /// Move constructor, copy all the mesh data (faces, geometry, attributes).
+    /// Move constructor, copy all the data (geometry, attributes).
     /// \note Handles on \p other are also valid for *this.
     inline explicit AttribArrayGeometry( AttribArrayGeometry&& other );
 
-    /// Assignment operator, copy all the mesh data (faces, geometry, attributes).
+    /// Assignment operator, copy all the data (geometry, attributes).
     /// \warning Handles on \p other are not valid for *this.
     inline AttribArrayGeometry& operator=( const AttribArrayGeometry& other );
 
-    /// Move assignment, copy all the mesh data (faces, geometry, attributes).
+    /// Move assignment, copy all the data (geometry, attributes).
     /// \note Handles on \p other are also valid for *this.
     inline AttribArrayGeometry& operator=( AttribArrayGeometry&& other );
 
     ~AttribArrayGeometry() = default;
 
-    /// Appends another mesh to this one, but only if they have the same attributes.
-    /// Return True if the mesh has been successfully appended.
+    /// Appends another AttribArrayGeometry to this one, but only if they have the same attributes.
+    /// Return True if \p other has been successfully appended.
     /// \warning There is no error check on the handles attribute type.
     bool append( const AttribArrayGeometry& other );
 
-    /// Erases all data, making the mesh empty.
+    /// Erases all data, making the AttribArrayGeometry empty.
     void clear() override;
 
     /// Set vertices
     inline void setVertices( PointAttribHandle::Container&& vertices );
+    /// Set vertices
     inline void setVertices( const PointAttribHandle::Container& vertices );
 
     /// Access the vertices positions.
@@ -72,7 +73,9 @@ class RA_CORE_API AttribArrayGeometry : public AbstractGeometry
 
     /// Set normals
     inline void setNormals( PointAttribHandle::Container&& normals );
+    /// Set normals
     inline void setNormals( const PointAttribHandle::Container& normals );
+
     /// Access the vertices normals.
     inline const NormalAttribHandle::Container& normals() const;
 
@@ -91,6 +94,8 @@ class RA_CORE_API AttribArrayGeometry : public AbstractGeometry
     template <typename T>
     inline Utils::Attrib<T>& getAttrib( const Utils::AttribHandle<T>& h );
 
+    /// Get attribute by handle.
+    /// \see AttribManager::getAttrib() for more info.
     template <typename T>
     inline Utils::Attrib<T>* getAttribPtr( const Utils::AttribHandle<T>& h );
 
@@ -99,6 +104,8 @@ class RA_CORE_API AttribArrayGeometry : public AbstractGeometry
     template <typename T>
     inline const Utils::Attrib<T>& getAttrib( const Utils::AttribHandle<T>& h ) const;
 
+    /// Get attribute by handle (const).
+    /// \see AttribManager::getAttrib() for more info.
     inline Utils::AttribBase* getAttribBase( const std::string& name );
 
     /// Check if an attribute exists with the given name.
@@ -134,10 +141,10 @@ class RA_CORE_API AttribArrayGeometry : public AbstractGeometry
     template <typename T>
     inline void removeAttrib( Utils::AttribHandle<T>& h );
 
-    /// Erases all attributes, leaving the mesh with faces and geometry only.
+    /// Erases all attributes, leaving the AttribArrayGeometry with geometry only.
     inline void clearAttributes();
 
-    /// Copy only the mesh faces and geometry.
+    /// Copy only the geometry.
     /// The needed attributes can be copied through copyAttributes().
     /// \warning Deletes all attributes of *this.
     inline virtual void copyBaseGeometry( const AttribArrayGeometry& other );
@@ -146,7 +153,7 @@ class RA_CORE_API AttribArrayGeometry : public AbstractGeometry
     /// kept untouched, except if overwritten by attributes copied from \p other.
     /// \return True if the attributes have been sucessfully copied, false otherwise.
     /// \note *this and \p input must have the same number of vertices.
-    /// \warning The original handles are not valid for the mesh copy.
+    /// \warning The original handles are not valid for the AttribArrayGeometry copy.
     template <typename... Handles>
     bool copyAttributes( const AttribArrayGeometry& input, Handles... attribs );
 
@@ -154,12 +161,13 @@ class RA_CORE_API AttribArrayGeometry : public AbstractGeometry
     /// kept untouched, except if overwritten by attributes copied from \p other.
     /// \return True if the attributes have been sucessfully copied, false otherwise.
     /// \note *this and \p input must have the same number of vertices.
-    /// \warning The original handles are not valid for the mesh copy.
+    /// \warning The original handles are not valid for the AttribArrayGeometry copy.
     inline bool copyAllAttributes( const AttribArrayGeometry& input );
 
     inline Aabb computeAabb() const override;
 
-    /// Utility function colorzing the mesh with a given color. Add the color attribute if needed.
+    /// Utility function colorzing the AttribArrayGeometry with a given color.
+    /// \note Add the color attribute if needed.
     void colorize( const Utils::Color& c );
 
     /// Return the vertexAttribs manager. In case you want to have direct access
@@ -224,13 +232,19 @@ class IndexedGeometry : public AttribArrayGeometry
     inline explicit IndexedGeometry( IndexedGeometry<IndexType>&& other );
     inline IndexedGeometry<IndexType>& operator=( const IndexedGeometry<IndexType>& other );
     inline IndexedGeometry<IndexType>& operator=( IndexedGeometry<IndexType>&& other );
+
     inline void clear() override;
+
+    /// Copy only the geometry and the indices from \p other, but not the attributes.
     inline void copy( const IndexedGeometry<IndexType>& other );
 
-    /// Check that the mesh is well built, asserting when it is not.
+    /// Check that the IndexedGeometry is well built, asserting when it is not.
     /// only compiles to something when in debug mode.
     inline void checkConsistency() const;
 
+    /// Appends another IndexedGeometry to this one, but only if they have the same attributes.
+    /// Return True if \p other has been successfully appended.
+    /// \warning There is no error check on the handles attribute type.
     inline bool append( const IndexedGeometry<IndexType>& other );
 
     ///\todo make it protected

--- a/src/Engine/Renderer/Mesh/Mesh.hpp
+++ b/src/Engine/Renderer/Mesh/Mesh.hpp
@@ -174,6 +174,10 @@ class RA_ENGINE_API AttribArrayDisplayable : public Displayable
 /// Concept class to ensure consistent naming of VaoIndices accross derived classes.
 class RA_ENGINE_API VaoIndices
 {
+  public:
+    /// Tag the indices as dirty, asking for a update to gpu.
+    inline void setIndicesDirty();
+
   protected:
     std::unique_ptr<globjects::Buffer> m_indices;
     bool m_indicesDirty{true};
@@ -231,8 +235,17 @@ class CoreGeometryDisplayable : public AttribArrayDisplayable
                                                        const typename Core::VectorArray<A>& data );
     inline size_t getNumVertices() const override;
 
-    /// Use the given geometry as base for a display mesh. Normals are optionnal.
+    /// Use the given geometry as base for a display mesh.
+    /// This will move \p mesh and *this will take the ownership
+    /// of the data.
+    /// The currently owned mesh is deleted, if any.
+    /// This method should be called to set or replace the CoreGeometry, if you
+    /// want to update attributes or indices, use getCoreGeometry and
+    /// Core::Geometry::AttribArrayGeometry setters instead.
+    /// \warning For indices, you must call setIndicesDirty after modification.
+    /// \todo add observer mecanism for indices.
     virtual void loadGeometry( CoreGeometry&& mesh );
+
     /// Update (i.e. send to GPU) the buffers marked as dirty
     void updateGL() override;
 

--- a/src/Engine/Renderer/Mesh/Mesh.inl
+++ b/src/Engine/Renderer/Mesh/Mesh.inl
@@ -387,13 +387,13 @@ IndexedGeometry<T>::IndexedGeometry( const std::string& name,
 
 template <typename T>
 void IndexedGeometry<T>::loadGeometry( T&& mesh ) {
+    if ( base::m_mesh.m_indices != mesh.m_indices ) { m_indicesDirty = true; }
     m_numElements = mesh.m_indices.size() * base::CoreGeometry::IndexType::RowsAtCompileTime;
     base::loadGeometry_common( std::move( mesh ) );
 }
 
 template <typename T>
 void IndexedGeometry<T>::updateGL_specific_impl() {
-
     if ( !m_indices )
     {
         m_indices      = globjects::Buffer::create();

--- a/src/Engine/Renderer/Mesh/Mesh.inl
+++ b/src/Engine/Renderer/Mesh/Mesh.inl
@@ -38,6 +38,11 @@ std::string AttribArrayDisplayable::getAttribName( MeshData type ) {
     if ( type == VERTEX_WEIGHT_IDX ) return {"in_weight_idx"};
     return {"invalid mesh data attr name"};
 }
+///////////////// VaoIndices  ///////////////////////
+
+void VaoIndices::setIndicesDirty() {
+    m_indicesDirty = true;
+}
 
 ///////////////// IndexedAttribArrayDisplayable ///////////////////////
 template <typename I>
@@ -387,7 +392,7 @@ IndexedGeometry<T>::IndexedGeometry( const std::string& name,
 
 template <typename T>
 void IndexedGeometry<T>::loadGeometry( T&& mesh ) {
-    if ( base::m_mesh.m_indices != mesh.m_indices ) { m_indicesDirty = true; }
+    setIndicesDirty();
     m_numElements = mesh.m_indices.size() * base::CoreGeometry::IndexType::RowsAtCompileTime;
     base::loadGeometry_common( std::move( mesh ) );
 }


### PR DESCRIPTION
UPDATE the form below to describe your PR.


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Fix bug on `IndexedGeometry<T>::loadGeometry`,
- Fix bug on Subdivider destructor.


* **What is the current behavior?** (You can also link to an open issue here)
- When replacing the `Ra::Core::Geometry::IndexedGeometry` of a `Ra::Engine::IndexedGeometry` with a new one by calling `Ra::Engine::IndexedGeometry<T>::loadGeometry()`, indices are not tagged as dirty, which is only done on the first call to `Ra::Engine::IndexedGeometry<T>::updateGL_specific_impl()`. Thus the new `Ra::Core::Geometry::IndexedGeometry` is not displayed correctly since indices are not send on OpenGL side.
- When calling the destructor of a `Ra::Core::Geometry::*Subdivider`, nothing specific is done. Thus when the destructor of `OpenMesh::Subdivider::Uniform::SubdividerT` (which it publicly inherits) is called, this one calls `OpenMesh::Subdivider::Uniform::SubdividerT::detach()`, which might call the `cleanup` method, which is pure virtual in `OpenMesh::Subdivider::Uniform::SubdividerT::detach()`.
This causes a crash.


* **What is the new behavior (if this is a feature change)?**
- When calling `Ra::Engine::IndexedGeometry<T>::loadGeometry()`, indices are checked and tagged as dirty if necessary. Doing so they will be updated on OpenGL side when calling `Ra::Engine::IndexedGeometry<T>::updateGL_specific_impl()`.
- The `Ra::Core::Geometry::*Subdivider`'s destructor now calls `detach`, which calls the overriden `cleanup` method and makes the last call to `detach` (in`OpenMesh::Subdivider::Uniform::SubdividerT`'s destructor) to do nothing.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
