### PR TITLE
Fix trackball when setting camera direction along Y axis ;

### DIFF
--- a/src/GuiBase/Viewer/TrackballCameraManipulator.cpp
+++ b/src/GuiBase/Viewer/TrackballCameraManipulator.cpp
@@ -376,10 +376,12 @@ void Gui::TrackballCameraManipulator::updatePhiTheta() {
     using Core::Math::areApproxEqual;
     const auto R = m_camera->getDirection().normalized();
 
-    m_theta = std::acos( R.y() );
-    m_phi   = ( areApproxEqual( R.z(), 0_ra ) && areApproxEqual( R.x(), 0_ra ) )
-                ? 0_ra
+    m_theta = std::acos( -R.y() );
+
+    m_phi = ( areApproxEqual( R.z(), 0_ra ) && areApproxEqual( R.x(), 0_ra ) )
+                ? std::acos( m_camera->getRightVector().dot( Ra::Core::Vector3::UnitZ() ) ) + Pi
                 : std::atan2( R.z(), R.x() );
+
     // Keep phi between 0 and 2pi
     // Keep theta between -pi and pi
     if ( m_phi < 0_ra )


### PR DESCRIPTION
UPDATE the form below to describe your PR.


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix trackball issue when updating `phi` / `theta` angles from Y-axis aligned direction.


* **What is the current behavior?** (You can also link to an open issue here)
- When such a case occurs, the `phi` angle is automatically set to `0`, whatever the orientation of the camera, which is not right.
- There is also an issue with the `theta` angle, which is set to `acos( Dir.y() )`, which makes it `-Pi` above, and `Pi` below, which is reversed from the computations made when rotating the camera.


* **What is the new behavior (if this is a feature change)?**
- the `phi` angle is set w.r.t. the camera orientation when the camera is along the Y axis.
- the `theta` angle is set to `acos( -Dir.y() )`.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
