### PR TITLE
Wedges

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -96,6 +96,7 @@ if(DOXYGEN_FOUND)
     set( DOXYGEN_DOT_IMAGE_FORMAT       "svg")
     set( DOXYGEN_INTERACTIVE_SVG        "YES")
     set( DOXYGEN_TOC_INCLUDE_HEADINGS   "2")
+    set( DOXYGEN_IMAGE_PATH             "${CMAKE_CURRENT_SOURCE_DIR}/images")
     
     doxygen_add_docs(RadiumDoc
         ${md_pages_order} ${md_files} ${RADIUM_SRC_DIR} ${CURRENT_SRC_DIR}

--- a/doc/developer/mesh.md
+++ b/doc/developer/mesh.md
@@ -161,3 +161,6 @@ TopologicalMesh methods and types related to wedges:
 \warning To delete face, one need to call `Ra::Core::Geometry::TopologicalMesh::delete_face`, not the `OpenMesh` vanilla `delete_face`
 
 \todo make OpenMesh inheritance private.
+
+Use `Ra::Core::Geometry::TopologicalMesh::collapseWedge` to perform halfedge collapse (works on triangle only ...). The following figure show the nasty updates:
+![Halfedge collapse and wedge.](wedge-collapse.svg)

--- a/doc/developer/mesh.md
+++ b/doc/developer/mesh.md
@@ -20,7 +20,7 @@ A converter allows to go back and forth to `TriangleMesh`
 without loss of data, but during the conversion, vertices with the same position represents the same topological point (and are hence merged). 
 **Soon deprecated:** The other vertex attributes are stored on half-edges (to manage multiple normals per 3D positions
 for instance).
-**New:** The other vertex attribuytes are store on wedges. Each half-edges as one wedge index. If multiple half-edge have the same set of attributes (including vertex position) they have the same wedge index at construction. See section [wedges](#wedges) below.
+**New:** The other vertex attributes are stored on wedges. Each half-edge has one wedge index. If multiple half-edge have the same set of attributes (including vertex position) they have the same wedge index at construction. See section [wedges](#wedges) below.
 
  3. Ra::Engine::*, which stores a Core Geometry to handle 3D data, and manages the rendering aspect of it (VAO, VBO, draw call).
 See inheritance digram of Ra::Engine::AttribArrayDisplayable
@@ -135,16 +135,16 @@ Other examples are provided in DrawPrimitives.cpp
 
 Wedge are built at construction by using CoreMesh vertex index (which are supposed to represent wedges). Vertices with same (exact) position are merged topologically.
 The figure above show the basic concept of wedges for the example of vertex with color attribute (same works for normals, texture coordinates or any other attributes).
-a) A colored mesh, each vertex can have a different color depending on which face is considered. b) for rendering, vertex are duplicated the needed number of time. Here the center vertex is duplicated three time, while the top right one is duplicated two times. c) But for topological computation, one need to know these vertex are actually the same position, and are modified the same way. d) So the attributes (here color only) are represented as wedges associated with each coherent set of position+attributes. Here the center vertex has three wedges, whil the top right vertex has two wedges. e) In the TopologicalMesh implementation, wedges are stored in an array, independently of the topology. Each hafledge has a wedge index. Halfedge that share the same wedge have the same index.
-During manipulation, if two wedges become the same (i.e. for example the example on the figure, if we recolor the whole mesh using a single color), **they are not merged**.
-To merge wedges an explicitCall to TopologicalMesh::mergeEqualWedges is needed.
+a) A colored mesh, each vertex can have a different color depending on which face is considered. b) for rendering, vertex are duplicated the needed number of time. Here the center vertex is duplicated three time, while the top right one is duplicated two times. c) But for topological computation, one need to know these vertex are actually the same position, and are modified the same way. d) So the attributes (here color only) are represented as wedges associated with each coherent set of position+attributes. Here the center vertex has three wedges, while the top right vertex has two wedges. e) In the TopologicalMesh implementation, wedges are stored in an array, independently of the topology. Each half-edge has a wedge index. Half-edges that share the same wedge have the same index.
+During manipulation, if two wedges become the same (i.e. for the example on the figure, if we recolor the whole mesh using a single color), **they are not merged**.
+To merge wedges an explicit call to TopologicalMesh::mergeEqualWedges is needed.
 When a wedge is not referenced anymore (because referencing halfedges have been deleted), it is marked for deletation. When one call Ra::Core::Geometry::TopologicalMesh::garbage_collection(), the marked wedges are eventually deleted and halfedges index are updated accordingly.
 
 \todo  TopologicalMesh::mergeEqualWedges
 
 TopologicalMesh methods and types related to wedges: 
 
-- Ra::Core::Geometry::TopologicalMesh::WedgeData the actual wedge data, with one vector array for each of the supported types (float, Vector2, Vector3, Vector4). The ordre in these arrays follow the names found in getXXXAttribNames referenced below.
+- Ra::Core::Geometry::TopologicalMesh::WedgeData the actual wedge data, with one vector array for each of the supported types (float, Vector2, Vector3, Vector4). The order in these arrays follow the names found in getXXXAttribNames referenced below.
 - Ra::Core::Geometry::TopologicalMesh::WedgeIndex
 - Ra::Core::Geometry::TopologicalMesh::vertex_wedges
 - Ra::Core::Geometry::TopologicalMesh::getWedgeData

--- a/doc/developer/mesh.md
+++ b/doc/developer/mesh.md
@@ -18,8 +18,9 @@ See inheritance diagram of Ra::Core::Geometry::AbstractGeometry :
  2. Ra::Core::Geometry::TopologicalMesh, which is an half-edge data structure. 
 A converter allows to go back and forth to `TriangleMesh`
 without loss of data, but during the conversion, vertices with the same position represents the same topological point (and are hence merged). 
-The other vertex attributes are stored on half-edges (to manage multiple normals per 3D positions
+**Soon deprecated:** The other vertex attributes are stored on half-edges (to manage multiple normals per 3D positions
 for instance).
+**New:** The other vertex attribuytes are store on wedges. Each half-edges as one wedge index. If multiple half-edge have the same set of attributes (including vertex position) they have the same wedge index at construction. See section [wedges](#wedges) below.
 
  3. Ra::Engine::*, which stores a Core Geometry to handle 3D data, and manages the rendering aspect of it (VAO, VBO, draw call).
 See inheritance digram of Ra::Engine::AttribArrayDisplayable
@@ -127,3 +128,36 @@ m2.copyAttributes( m, handle1 );
 
 
 Other examples are provided in DrawPrimitives.cpp
+
+## Wedges {#wedges}
+
+![Wedge concept in a nutshell.](wedges.svg)
+
+Wedge are built at construction by using CoreMesh vertex index (which are supposed to represent wedges). Vertices with same (exact) position are merged topologically.
+The figure above show the basic concept of wedges for the example of vertex with color attribute (same works for normals, texture coordinates or any other attributes).
+a) A colored mesh, each vertex can have a different color depending on which face is considered. b) for rendering, vertex are duplicated the needed number of time. Here the center vertex is duplicated three time, while the top right one is duplicated two times. c) But for topological computation, one need to know these vertex are actually the same position, and are modified the same way. d) So the attributes (here color only) are represented as wedges associated with each coherent set of position+attributes. Here the center vertex has three wedges, whil the top right vertex has two wedges. e) In the TopologicalMesh implementation, wedges are stored in an array, independently of the topology. Each hafledge has a wedge index. Halfedge that share the same wedge have the same index.
+During manipulation, if two wedges become the same (i.e. for example the example on the figure, if we recolor the whole mesh using a single color), **they are not merged**.
+To merge wedges an explicitCall to TopologicalMesh::mergeEqualWedges is needed.
+When a wedge is not referenced anymore (because referencing halfedges have been deleted), it is marked for deletation. When one call Ra::Core::Geometry::TopologicalMesh::garbage_collection(), the marked wedges are eventually deleted and halfedges index are updated accordingly.
+
+\todo  TopologicalMesh::mergeEqualWedges
+
+TopologicalMesh methods and types related to wedges: 
+
+- Ra::Core::Geometry::TopologicalMesh::WedgeData the actual wedge data, with one vector array for each of the supported types (float, Vector2, Vector3, Vector4). The ordre in these arrays follow the names found in getXXXAttribNames referenced below.
+- Ra::Core::Geometry::TopologicalMesh::WedgeIndex
+- Ra::Core::Geometry::TopologicalMesh::vertex_wedges
+- Ra::Core::Geometry::TopologicalMesh::getWedgeData
+- Ra::Core::Geometry::TopologicalMesh::setWedgeData
+- Ra::Core::Geometry::TopologicalMesh::getVec4AttribNames
+- Ra::Core::Geometry::TopologicalMesh::getVec3AttribNames
+- Ra::Core::Geometry::TopologicalMesh::getVec2AttribNames
+- Ra::Core::Geometry::TopologicalMesh::getFloatAttribNames
+- Ra::Core::Geometry::TopologicalMesh::isFeatureVertex
+- Ra::Core::Geometry::TopologicalMesh::isFeatureEdge
+- Ra::Core::Geometry::TopologicalMesh::getWedgeIndexPph
+
+
+\warning To delete face, one need to call `Ra::Core::Geometry::TopologicalMesh::delete_face`, not the `OpenMesh` vanilla `delete_face`
+
+\todo make OpenMesh inheritance private.

--- a/doc/images/wedge-collapse.svg
+++ b/doc/images/wedge-collapse.svg
@@ -7,18 +7,589 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="559.36481mm"
-   height="98.255623mm"
-   viewBox="0 0 559.36481 98.255623"
+   width="204.06343mm"
+   height="113.19799mm"
+   viewBox="0 0 204.06343 113.19799"
    version="1.1"
    id="svg8"
    inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
-   sodipodi:docname="collapse.svg">
+   sodipodi:docname="collapse-wedges.svg">
   <defs
      id="defs2">
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker13961"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path13959"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12251"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path12249" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8504"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8502" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8400"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8398" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8296"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path8294"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7270"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7268"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6173"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6171"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5460"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5458"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2819"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2817"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6107"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6105"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6088"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6086"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6069"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6067"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5646"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5644" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4350"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4348"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3920"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3918"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2519"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2517"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2502"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2500"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2481"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2479"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2464"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2462"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2456"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2454"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2408"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2406" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2391"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2389"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2358"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2356"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2341"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2339"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2337"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2335" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2333"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2331"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2329"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2327"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2325"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2323" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2321"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2319" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2317"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2315" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2313"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2311" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2309"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2307" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2305"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2303"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2301"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2299" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2297"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2295" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2293"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2291"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2289"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2287"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2285"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2283"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
     <marker
        inkscape:isstock="true"
        style="overflow:visible"
@@ -41,7 +612,8 @@
        refX="0"
        refY="0"
        orient="auto"
-       inkscape:stockid="Arrow1Lend">
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
       <path
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
@@ -86,7 +658,8 @@
        refX="0"
        refY="0"
        orient="auto"
-       inkscape:stockid="Arrow1Lend">
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
       <path
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
@@ -101,7 +674,8 @@
        refX="0"
        refY="0"
        orient="auto"
-       inkscape:stockid="Arrow1Lend">
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
       <path
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
@@ -146,7 +720,8 @@
        refX="0"
        refY="0"
        orient="auto"
-       inkscape:stockid="Arrow1Lend">
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
       <path
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
@@ -161,7 +736,8 @@
        refX="0"
        refY="0"
        orient="auto"
-       inkscape:stockid="Arrow1Lend">
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
       <path
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
@@ -251,7 +827,8 @@
        refX="0"
        refY="0"
        orient="auto"
-       inkscape:stockid="Arrow1Lend">
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
       <path
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
@@ -341,7 +918,8 @@
        refX="0"
        refY="0"
        orient="auto"
-       inkscape:stockid="Arrow1Lend">
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
       <path
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
@@ -2522,6 +3100,1081 @@
          style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)" />
     </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2341-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2339-6"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2341-5"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2339-3"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2426-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2424-1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2426-7"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2424-0"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2391-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2389-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2392-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2390-2"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2470-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2468-1"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2405-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2403-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2199-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2197-2"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2327-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2325-2"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2418-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2416-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2457-5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2455-9"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2353-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2351-2"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2574-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2572-9"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2561-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2559-3"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2431-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2429-1"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2509-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2507-9"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2340-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2338-1"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2496-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2494-4"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-78"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path2173-45"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2587-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2585-3"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2212-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2210-1"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2444-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2442-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2483-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2481-2"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2366-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2364-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2548-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2546-5"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2522-5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2520-4"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2535-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2533-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2379-5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2377-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1706-5"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1704-9"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1819-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1817-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2027-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2025-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1795-5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1793-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1791-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1789-9"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2967-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2965-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1807-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1805-3"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1811-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1809-8"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2014-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2012-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1803-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1801-8"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1799-5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1797-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2535-5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2533-9"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2053-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2051-4"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1706-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1704-3"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1819-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1817-8"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2027-4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2025-3"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1795-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1793-3"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1791-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1789-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2967-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2965-8"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1807-8"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1805-9"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1811-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1809-4"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2014-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2012-9"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1803-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1801-5"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1799-4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1797-0"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3647-5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3645-9"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2535-4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2533-69"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2053-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2051-2"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3647-1-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3645-1-2"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3647-1-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3645-1-0"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3647-1-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3645-1-3"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2535-7-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2533-6-9"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2391-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2389-0"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2481-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2479-6"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6173-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6171-3"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7270-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7268-6"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6173-1-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6171-3-6"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2391-1-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2389-0-0"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2481-0-5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2479-6-7"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker13961-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path13959-3"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2535-7-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2533-6-5"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12251-3"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path12249-7" />
+    </marker>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -2530,16 +4183,16 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.4939848"
-     inkscape:cx="1169.5541"
-     inkscape:cy="144.65779"
+     inkscape:zoom="0.98796959"
+     inkscape:cx="507.43813"
+     inkscape:cy="212.2644"
      inkscape:document-units="mm"
-     inkscape:current-layer="g853"
+     inkscape:current-layer="layer3"
      showgrid="false"
-     inkscape:window-width="1918"
-     inkscape:window-height="1158"
-     inkscape:window-x="0"
-     inkscape:window-y="18"
+     inkscape:window-width="1920"
+     inkscape:window-height="1153"
+     inkscape:window-x="1920"
+     inkscape:window-y="19"
      inkscape:window-maximized="1"
      inkscape:snap-global="true"
      fit-margin-top="0"
@@ -2559,48 +4212,35 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     style="display:none;opacity:1"
-     transform="translate(470.69208,-22.182517)">
-    <image
-       y="94.159073"
-       x="55.694801"
-       id="image823"
-       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAhsAAAIbCAYAAABCJ1y9AAAABHNCSVQICAgIfAhkiAAAABl0RVh0 U29mdHdhcmUAZ25vbWUtc2NyZWVuc2hvdO8Dvz4AAAAtdEVYdENyZWF0aW9uIFRpbWUAbWFyLiAx MSBm6XZyLiAyMDIwIDExOjUyOjA2IENFVLlZxpwAACAASURBVHic7d09byZX+cfxs5GVdqsIUZAi Uqy/opSxtoqU2BZNFFmi4AW4SMVr2CLahhIRItH4LVCsaBI7CdqO0BGEWCRIBQVKse3KJP9iOd7x eB7OzHm6Hr6fCkLYvWd8e+Y313WdOfcePHjwQ8h0fn4eLi4ucv+Yan8eAKA8KddqKZ8D8+6VCBsh vPhhhxCyf+B8aQBAj57X7FL3HdRXLGxEOV88ggYA6NPj2s39QpdXSv+BFxcXN2lzC744AIA15+fn 3C8UKl7ZiLZ8GfjiAIBuLa7j3Cv0qhY2Qkjrp/HlAQAbal7PuVfoVjVsRHNfEr48AGBLjdWJITAE ql2TsBHC3S8gQQMAbCp1fec+YUezsBFCuDU4yhcIAOzKXZkYAvcJS4qvRlnCFwcAsCSGFO4XtjQN G8Mv0Z7lsQAAHfZc52mb2NVtZmPunwEA7Ei5ztM2sa/rapT4v4XAlwwArFq7B3D9t69pG2UKbRUA sG3qGs+bQH2pXtngTaIAgBBeXuO51vtT/Q2iW79QtFUAwCau735Va6PsTa60VQDAHq7pvlWpbPD2 OABAxBukUTxs1HgvPl9KANBnqW3Ctd2XomGj1peHPh80ury8DP/973/DJ598Eh4/ftz74wBNpb5f g+u6D8XCRosvDV9MaHB2dhaOjo7C66+/Hr7//vtweXkZnj17RuCAG6xCxFiRAdFWXxYGRyHd2dlZ uH//fnj99dfD5eXlzT+/f/9++PDDDzt+MqA+3p2BOdmVjR5fLNoqkCgGjdPT05ugcXx8fCt0UOGA Vbm7vHI9ty2rstHrC8LyWEjz6NGjcP/+/dV/jwoHrClRzeB6bt/usCEhifIFhQSPHj0KT58+DSGE W1WNOQQOWFFyO3iu57btChsSgkbEFxQ9DYPGFgQOaFfjPsD13K7NMxuSgsYQcxxoKa44GQaNqarG eGZj7PDwMDx8+LDa5wRKa3GtlXqfwX6bKhuSvwDMcaCVOAi6FjRSPH36NHz88cclPx5QTcm2CXzp vsV8aQQO1BSDRkkEDkjXekkr13F7ksOG5KrGWPyi8mVFSXMrTvZWNYYIHJCqVzWDwGFLUtjQFDQi 2iooae8g6BYEDkjT+9rPNdyO1bDR+8uWiy8rci0FjRJVjSECBySQ9CZQruE2LIYNKV+2XHxZscfZ 2VmTisZYDBwsjUUPEodAuYbrdzD3P1gJGtHwy2rpuFDH1IqTsdJVjaGnT5/evIuD15ujBa6PqGny PRvWgsaY9eNDnpQVJ6lBY+09GynYTwW1abkmavmcuOtOG8XDD5OSHOak7nHSEm8bRU2arvlcu/W6 VdnQ9KUrgbIhhlLnM7a0T0pUNiIqHChJ8/XP273KgpvKhscfHstjEfUYBN2KCgdKkTgEugXXbX1e CcFn0Bjii+vX1hUnNYdCUxA4kEPSktZcXLd1ecXKFy8XX1x/UlacDPUOGhGBA3tor2ZAt1f44r3E a879qLHHSUv379/n5V9IZvWhkodEPcxtxJaLOQ779qw4kVLVGOJto1hjqW0yh+u1DoSNGXyBbdIw CLoFgQNzPLVNuF7LN/lSL7ykeXkYXjo7OwtHR0e7gkZOVaPk0tclh4eH4eHDh9X/Hsjn+ZplvYqj GWEjEV9ivXLmM3LbJ63CRggEDnCdCoFzIBVtlESU6XTSPgi6BS0V37jJQjLCxgYEDl1yg4bEodA1 7Bjrj4ch0C24TstE2NiI5bE6SNzjpJXhjrGwzdMQ6BYEDnmY2cjA04RMJVaclKpqtJzZmMJ+KjZ5 HgLdgmu0HFQ2MpCeZdn66nEPqHDYQzUjHddoOQgbmWiryLD11eNLNM5qLCFw2MGT+nYEDhkOen8A C+IvPxeCPkquOLEWNKIYOGip6ETbBNpR2SiIBN2ep6Wtuahw6ETbJB/X5v4IG4XxpW6n9IoTq1WN ITZw04MlrWVxbe6LsFEBcxz1MQi6Hy//ko9qRh0Ejn4IG5Wwe2wdtVaceKhqDBE45KKaURfX5T4I G5XxxS6n5IqTIW9BIyJwyELbpB2uy+0RNhqgrZKPQdA6CBwy0DaBdbxBtDGeXLarGTRqVzV6v0E0 FTvG9sGS1r64HrdDZaMxynfbeN7jpCU2cGuPakZ/XI/bIWx0wBc8Te0VJ15nNeawgVs7PFHLwfW4 DdooHVFCnXZ2dhaOjo5MBA0tbZQxNnCrg995uQiAdVHZ6IjlsXfVWnGCbahwlEfbRDauxXURNgTg S/5CqxUntE/SEDjKYEkrQNgQw/vyWJa2ykTgyEM1Qxce/OohbAjita3ScsUJVY3tCBz7UM3QyeM1 uAXChkCevuzscaIDG7ilo22in6drcCuEDaGsf9lr7XGyhKpGHt42uo62iR3Wr8GtsfRVOItL5XrM Z/QKGlqXvi7hbaN3Wfw9xQtUqcqgsiGctTkOBkH1o8JxG9UMYB1hQwkLgaPXq8dpn5RH4HiBp177 LFx7JSBsKKJ5eSyDoPZ4DhwMgfpC4MjHzIZSmi50PYNG76qGxZmNscPDw/D111+7eb25pt89lMXP fj/ChmLSv/gt9jhZ0jtohOAjbETW91NhCBQhyL/uSkUbRTHJpT32OPHH8su/GAJFJPm6KxlhQzmJ cxwSVpxIqGp4ZDFw8CQL5CNsGCBpeWyvFSeQw0rgYAgUc6RcbzUhbBjS+xdAyooTqhr9aQ8ctE2w pvf1VhsGRA3qMchG0JjmaUB0irahUYZAsRXVrzRUNgxq2VbpsccJ9NBU4aCagT2ocKQhbBhW+5dA 2ooTaVUNvKBhx1ieTpGDwLGOsGFcrV8CCStONLh3717vjyCC1LeNMgSKUggcywgbDpReHitxxQlV DfmkBQ7aJkA7hA0nSs1xMJ+BHBICB9UM1EJ1Yx5hw5mcXwapQYOqhi49AwfVDNRG4JhG2HBoa1tF 8ooTgoZOPQIH1Qy0QuC4i7DhVGpbRdqKE9gRA0ftpbG0TdADgeM2woZzS78Q0lecUNXQ7+nTp1Xf xUHbBD0ROF4ibGDyF0LiihPYVTpwUM0AZOF15bgRA8cbb7whvm2ipapxcnISPv/8894fQ40Srzcn ZEAavpNUNjDw3XffhTfeeCP84x//6P1RFmkJGtgut8LBRR0S0U4hbOB/hoOg19fX4eDgoPdHglN7 AgdtE0jnPXAQNjA5CBoDh7TQQVXDhy2BgyFQaOE5cBA2nFtacXJ9fU2VA92sbeBGNQMaeQ0chA3H UlecSAkcVDX8mXv5F9UMQBfChlNb3wjaO3AQNPwaBg6qGbDAY3Wj/+Mqmjo7OwtHR0e7lrYOA8f1 9XXpjwbMevr0KSEDpsTA4eU7TWXDkRKvHu8xx0FVA6+++mp4/vx59x1jgZI8VTgIG06UfvV477YK fHj11VdvgkYIMraoB0ryEjgIGw7U2uOkxfJYqhp+xZARg0bUagM3oBUPgYOwYVztPU5YHovSxtWM KbU3cANQFmHDsK0rTnLUCBxUNfyZq2bMIXDACuvVDcKGQWdnZ02DRlQycBA0/FmrZswhcMAKy4GD sGFMiRUnOaS+5hxypbRN1hA4YIXVwEHYMKTWIOhWuXMcVDX82No2WULggBUWAwdhwwgpQWOIwVHM KVHNmELggBXWAgdhw4DaK05ybG2rUNWwr2Q1Y8raBm4A2iNsKNdjEHSr1LYKQcO+GtWMKbz8CxZY qm4QNpTqteIkB20Vv2q1TZYQOGCBlcBB2FCo94qTHHOBg6qGXbXbJksIHLDAQuAgbCgjcRB0K5bH +tCjmjGFwAELtAcOwoYikgdBtxrOcVDVsKdnNWMKgQMWaA4chA0ltM1npLq+vg5fffVV74+BgiRU M6awgRvQD2FDAatBI4QXsxq0VWyQ0jZZwgZu0E5rdYOwIZjGFSdbDNsn7B6rm7S2yRoCBzTTGDgI G0JpXnGSg8Chi4ZqxhwCBzTTFjgIGwJZWHGyZmkolMChg7ZqxhQCBzTTFDgIG8JYWnGSgzkO2bRW M6YQOKCZlsBB2BDE8nzGUOpSV+Y45NHcNllC4ADqImwIQdCYR+CQwULbZAmBA1ppqG4QNjqzvuKk FNoq/VitZkxhx1hoJT1wEDY68rbiJPdNobRV2rNezZjC20ahleTAQdjoxMOKk1oIHG14qWZMIXBA K6mBg7DRweXlpbugUXr/EwJHPZ7aJksIHNBKYuAgbDR2eXkZ/vWvf/X+GE3V2miNOY7yPLZNlhA4 gDIIGw09evTIXdCojTmOMqhmzCNwQCNp1Q3CRgNxxcnrr78eQgiutlNvtX08gWM/qhnr2DEWGkkK HFydKxuuOIlhA3UMA8f19XXnT6MD1Yx1JycnN//5pz/9aQghhMePH/f6OMAmMXBcXFx0/RyEjYqG K07iE/7p6WnnT9VOq6rGUAwZBwcHBI4Fr776agghEDQmDMNFCCFcXV3d+u/x5V8EDmghIXAQNioZ vqirx03Xu1jlIHDcRTXjtrVwMYXAAW16Bw7CRgW8EVRGwCJw3EY144U94WL4756cnISrqysCB7AB YaOgs7OzcHR0dCtoSLjptibpmJnjeMFzNSMnXKwhcECTntUNwkYh3l49ron3OQ5PQWMcLEIoGy6m EDigSa/AQdgoYO7V45Ke8FuRfMze2ioe2iY1qxZbxA3cHj582OXvB7boETgIG5m2BA3JN2IvvLRV rFYzpISLKfFdHAQOaNA6cBA2MjAIepuWMGW5rWKtmiE5XEwhcECTloGDsLHTUtDQctMtSeMxW2ur WKhmaAsXUwgcwF2EjY2mVpxALyuBQ2vQsBAuphA4oEWr6sa9Bw8e/FD1bzBkbj5jaOkJX+PTfwoL x1VrjuPk5CR8/vnnRf/MIW1tEyvhIr5rY83h4SGBAyrUDhxUNhKlBA3opXGOQ0M1w0q42CtWOL7+ +muWxkK02hUOwkaC1KBh4Ql/K2vHrKGtIrma4T1cTHn69Cnv4oAKNQMHYWNF6ooTazfdFFaPWfLy WGnVDMJFOgIHNKgVOAgbC0oubbV6Y7ZKYltFQtAgXOQhcMArwsaErStOPAYJL8csoa3Ss21CuCiP wAHpalQ3CBsj7HGCsZ6Bo3U1g3DRBoED0pUOHISNgT0rTrw84Q95PObWcxytqhmEi34IHJCuZOAg bPwPQQNrWs1x1KxmEC7KuLq6Sn7XxhI2cIN0pQIHYSOwx8kWBKy6bZXSQYNwIR9vG4V0JQKH+7Cx N2h4vOl6POY5pQNHqbYJ4UInAgescxs22OMEuUrNceRUMwgXdhA4IFludcNl2MhdceLxCd/jMafI mePYWs0YB4sQCBfWEDggWU7gcBc2cvc42XPT5UZt39a2Sko1g6qFTwQOSLY3cLgKGwyC7kNYSpPa VpkLGoQLRGzgBsn2BA43YaNE0PB40/V4zDmW2irjtgnhAkvYwA2SbQ0cLsIGFQ20NqxyhPAiaLz7 7ru3/h3ChW6l3rWxhsABC0yHjZIrTjw+4Xs85pKur6/DH/7wh5ugQbjAXgQOSLSluvFKg8/TBXuc oLeDg4Pw0UcfhefPn4cnT570/jhQLgYOQJIYONaYDBu5K07GPD7hezzmkk5PT8N7770X/va3v4UQ XsxpxJkNYC8CByRaChzn5+fh/PzcXth49OgRQSOTx2Mu5eDgYPb8PX/+fPJdGcAWBA5INA4cMWRc XFyEi4sLW2FD4iAoN24/Tk9Pw/X1dbi8vJz9ucehQqocyEHggEQxcAxDRmQmbNQIGh6DgsdjzrVU zZhydXVFWwXZ4o6xgBRLw6Lqw8bZ2ZnIigZ8iO/TGAaN1OBBWwW54su/gJ6G1Yw5qsNGzRUnHp/w PR5zjtg2Gf+zLecwtlWgk4SfH4EDvcy1TKYGRtWGjdIrToa46WLJlrbJ1dVVOD09Xf13mONADgIH WpoLGUPjwKEybJRecQICVqrhEOjU/7b3HDLHgVwEDtSWEjKGhoFD3RtEa89neLzpejzmrQ4ODsJ7 771X/TzFOQ7eNoo92DEWNcTAsGdr+Rg4VIUNBkHRw9QQ6FjJwBbbKk+ePFndhh4YY8dYlJITMoYu Li50hI2Se5wsKf2Er6FioOEz9pRyfmqcw1jZmNuOHljCjrHItXUL+TXiZzbY4wQ9bH13Ri0sj0UO Xv6FrVKWse4hOmzUXHEyJuHG0prHY06xNAQ69e/WPocSlldCLwIHUmwd/txKbNhoueLE403X4zGv kVLNmMLyWLk0hEECB+bUDhmRyJkNBkHRWsoQ6FjrYMIcB3Iww4GhUsOfqUSFjVaDoENSn2Rr8njM S/acj57nkOWx2IvAgdYhIxITNhgERWut3p1RA8tjsVfcwI13cfjSK2REIsJGy0HQIY9P+B6PeUo8 D3vOhZRzSFsFe/HyLz96h4yo+4Co1aAh5YY0JPEztSZ5CHQvlsdiD15vbl+Lwc9UXcMGe5ygpT1D oGNSg4qGFRGQh8BhU613ZeToFjZ6rjiResOoyeMxD01tB28Ny2P70Rz2CBx2tFrGukfzmY0eK07g V8khUA2BjTkO7MEMh25S5jKWNA0bElacaLhhlObxmEPIGwKd+7O0YHkstmIDN300hIyoWdjoNQg6 pO2GgX00L2ktieWx2IoN3HTQFDKiJmFDQtDwylvAKjEEOqb5HNJWwR4EDpk0hoyo+oColBUnmm8Y e3k65rik1foQ6F4sj8VW7Kcih+TBz1RVw4bXPU483eQlqFHNiCz9LDWvmEAfBI7+tIeMqErYODs7 ExU0LN0wUnk55prVDIvnkOWx2IrA0YfEd2XkKD6zIWHFCexjCHQ/5jjqiEHO4gogZjja0TyXsaRo 2JA4CGrx6XSN9WOu2TaJrJ/DEFgei23YwK0uqyEjKtZGIWjIYPmYGQItj7YKtuBto+VZGP5MUaSy IWk+Aza1qGZElgPbFNoq2IK3jZZhvZIxll3ZkBo0vN0wQrB7zC2rGVbPYQqWxyIVFY79vFQyxnaH DWkrTmCPxe3gpWN5LFIROLbzGDKiXWFD+oqTnjeoXn+3tZtyy7ZJZO0c7sUcB1IRONJYW8a6x+aZ DYmDoEPcMHRjSasMzHEgFRu4zfM2l7FkU2VDyqvHcZuVgNWjmhFZOYelMcexjdc21HADN/idy1iS HDY0zGd4vGFYOWaWtMpFWwWpvAcOQsa8pDaKhqABnSS0TawEtppoqyCVx7eN0i5Ztxg2zs7OwtHR kYqg4fGGof2Ye7ZNIu3nsDXeOooUXgIHISPdbBtF+ooT6MWbQHXzOpeAbSy3VGiXbDcZNqSvOBnz +HSq9ZglVDMiredQAuY4kMJi4CBk7HMnbGhbcSLphtHqs0g65i2oZthydXUVnj9/TuDAIiuBg3dl 5Lk1s8EgKGqQMAQ6pjWwScQcB9Zo3jGWuYwybiobGoOGxxuGtmOW1DaJtJ1DDWirvMRMyzRtbxtl LqOsA00rTqCHxGoG6mJ5LNZo2DGWSkYdB1pXnHh8OtVyzBKrGZGWc6gZbRUskRo4CBl1ZW8x34PH G4aWY2YIFCHQSsAySS0V2iVtbN6IDZiioW2iJbBZEQPHkydPaKvgjt4VDioZbakLGx5vGNKPWXLb JJJ+Dq1ijgNLeu0YyxLW9lS2USTyeDPjTaBIxe6xmNNyx1jeldGPqsqGxxu61GPWUM2IpJ5Db2ir YEnN/VRomfSnprLBDUMOqhnYy8tbRxmQ3ad0hYPhTzlUVTa8kRawNAyBjkk7h3iB5bGY87Of/Sy8 9dZb4Ze//OXuP4NKhjwHBwcv8obkJ1WPNwxpx6ypbRJJO4e4LT79EzgQxe/Ds2fPdv3/CRlyHcSQ oSF0oD2N1QzowRwHQgg3LacYPI+OjjbNbhAy5LtpowxDh6TA4fHpVMoxa6xmRFLOIdaxPNa33OoW q0t0uDMgen19HQ4ODm4qHfCJIVC0xvJYX05OTmaDxtOnT1cHRVnGqstkopDSWvH4dNr7mC20TXqf Q+xHW8WHnGoGLROdFssXPUOHphtGqc/a+5g1t01gB20Vu8azGVsQMnRLes/G9fX1TXsF9lh6E2jv wIZytLdVeNfGbbGakRo0jo6OQgi8K8OKTelhGDhq3pg83jB6HbOlaobH7411LI/Vb28149tvv2Um w5DNbxAdVjmodOhmpZoB22LgsP7WUYu2VjNCeNE+iy20//znPxU/HVranRZqzXN4fDptfcwWhkDH PH5vPGGOQ5c91YwYJvn52pRdmij5fg6PN4weQcNK2wT+8Jpz+fb8fAiR9hXbiI3WimyWhkDHPIZU z2iryLT03ow5w5bJlDgkCv2KJoOc1orHG0arY7ZczfD4vQFtFWn2hIwQaJl4UmWLeU9LZaXf7KxW M4AQ9C+P1W5rNWNYyUgJGilvEoUOVcJGlNpakX7DrqH2Mce2ieXzav34kEby+ywkf7ZcW1aabA0Z sKdq2AiBpbI9WG6bAFOY42hnSzWjRMhgbsOGZnf/uXkOj0+ntY7Z4pLWOR6/N1jGHEd9W0JGCMxk 4KXmpYZh6PByYxyqGTS8VDMIGljC8tjyUt+bQcjAnOptlDnX19fhq6++orVSAEOgwG20VcpJnc2o NZPBkKgN3e70w6fT3lvZt1L6idxjdYiqBlLRVslDNQMldatsDDFEul2sZnDjBZaxPHa7lGpGyxUm DInq1+XOPvd0WvLV5y1secou9UTusZoRUdXAXuwemyalmkElA3s0DxspN4xWW9m3UjJoUM0A9omB 48mTJ01vlBqCDiEDtYloo0yhtXKb9yFQqhoo4erqKjx//pzB0YG1lomEF3IxJKpf07v4nhtGra3s W8m9SXpum0QEDZTG8tj1agaVDJQktrIx5mm/lYghUKAez8tjU6oZ0l4tzpCobs3u3KWeTjXNc+w9 ZqoZL1HVQE3elsdSzUAvTcJG6RuGhtZKTtCgmgG05aGtsnR8hAzUpqaNMsXaEKn3IdAxqhpoyeoO rUsbp0kY/kzFkKhu1e/QLW4YPd7PsXRcW4+ZtsldBA300Gt5bC1LISMEKhloR3VlY0xjlYMhUECW GstjW1dN5qoZmioZUxgS1avqXbnH02nveY7UY6aaMY+qBiTQOscxFzJCoJKBfvSUADaS/OpzhkAB HTS1VaZWmhAyIEW1NoqUp9OWrZWUY2YIdJmU7w0QaXjr6NR7MzS3S+YwJKpXlTuwtBtGi9bK2jHT Nlkn7XsDDElsq1DNgBamBkTX9FoqyxCob/fu3ev9EVCIpOWx42qG9uHPVAyJ6lT8jqvh6bT0PMfc MVPNSKfhewOE0H+OY1zNoJIBDcwOiKbY++rzlBsjQ6CAXXtec15iq/nh/5+QAU2KtlE0Pp3mtlam jpkh0G00fm+AEF7OcdQ2fG+Gl3bJHIZEdSpW2dB+w9gzRDo+Ztom22n/3gC12ypTIQPQxtWAaIq9 W9kzBAr4VWN5bKxmPHnyxHUlYwpDovoUCRsWn07XWivxmA8ODkwefwucN1hTqq0SqxmxWkLIgHau B0TXrLVWGAIFMJYzCBqDyrCaAViQXdnw8HQ6HiI9PDy8+efYx8P3Bn7FwLGlrRJbJlQz1jEkqg8z GxsMwwU3SgBLUuc4YighZMCyrLDh7en09PQ0fPTRR+HTTz/t/VFU8/a9gW/DOY7xG0gJGfsxJKrL 7rDh6YYRh0BDeFG+w36evjdANG6reH9XBvyhjbKCIVAAJcS2CpUMeLQrbHh5Oh2+CdTLMdfEOYRn 8b0Z7777rpjN3DRjSFQXKhsTeHcGgJLGO7RK2j0WaGFz2LB+E556E6j1Y26BcwiPhnuajO1ZHovb GBLVY9NLvSzfMOb2NbF8zK1wDuFRyou99uweC2hEGyUwBAqgnKVqxpxWu8daw9yGHslhw+rT6dJ2 8ONjtnoOauKcwYthyFgKGnPzGrRVYJnbvVHYDh5AKXv3QhmjrQKrkiob1p5OU7aDt3bMPXAOYd2e lkkK2irpGBLVYbWyYemGkVrNsHTMvXAOYV2NkDGUs3ssII2bAVGGQAGUUKuaMYU5jnUMieqwWNmw 8nS65TisHHNPnENY1aPSwBwHLDA9IMoQKIAShru29hLnOGirQKPZNor2p9OUIdCp/4/mY5aAcwhr UpaztkJbZRpDovKZq2zsrWas3SS5iQK+1Kxm5Ax/0laBRpOVDa03VoZA+9L6vQHGJFUz5rA89iWG ROW7EzY03jDiLq1zbwJdo/GYpeEcwoKWK01KYPdYaKG+jUI1A0AJmkLGUAwcT548oa0CsW5VNrQ9 neZUM4Z/hqZjlohzCM20VTOmXF1dhefPn7seHGVIVDaVlQ2WtAIoQXvIGGN5LKS6qWxoeTot2TbR csyScQ6hkYVqxhyvy2MZEpXtIAQdN4zS1QwNxywd5xAaWQ0ZQyyPhTQq9kbpPQTKTRXQT1o1o8VK EpbHQopXpN9ISwyBTv2Zko9ZA84hNNHw3oxaPC2PZUhULrEDogyBAsglYU8TCVgei95ekXgzr9k2 4Yk8H+cQGniuZkzxsDyWIVG5RM1s5L4JdA03yXycQ0gnbTZDGuY40IOYNkrvIVAA+hEy0tBWQWsi Khs1qxnDv4Mgk4dzCKmoZmxnta3CkKhMXSsbDIECyEXIyMNbR9FCt8pGy7YJT+T5OIeQxkI1Q8qy VCmfowSGRGVqHjZqD4GWxk0WkIeVJuV5fc052mjaRukxBEpYyMc5hBS8N6MuXnOOWppVNnpUM7hJ 5uMcQgqqGe1oXx7LkKg81SsbDIECyEE1ow+Wx6KkqmGj57szeCLPxzlET4SM/rS2VeKQ6OPHj3t/ FPxPlTaKtiFQALLQMpFFe1sF/RUPGxLeBMoTeT7OIXqwsJzVKkvLY9HW+fl52bAhoZrBTTIf5xA9 eK1maLqJa1oey5Bof+fn5+H8/DxcXFyUmdmwOgTKTReoj9kMXbTOcaCd8/PzEEIIFxcXN/8sO2xI aJtEhIN8nEO0RMtEL+mvOWdItK0YhIT2owAAFeZJREFUMEK4HTKi3WHDajUDQH1UM2xgeSymqhhT doUNSdWMiCfyfJxDtCD5aRjbSW6rHB0dUdmoJDVkRJvDhsQbksTPpA3nELVRzbBNelsF+dZaJUuS wwZtEwB7cRPyIbZV+FnbsrWKMSUpbEhsm0Q8kefjHKIWqhn+SJrjYEg0T4mQES2GDaoZAPbiCTed tYqA5DkOLMtplSyZDRuSqxlRzSdyL0/7Xo4T7VDNQCRhjoMh0TQlqxhTJsMGNyAf+DmjtN43Fsgj qa2Cu2qHjOhW2NDUNuFGCchBNQNLaKvIUqtVsuQmbGhom0QEjXycQ5RCNQOperRVGBJ9qVUVY8qB pmoGADmoZmAPa8OwGvQMGdGBlmpGxBN5Ps4hcnGzQI7Wcxweh0R7tEqWFNn1FYAPVDPq8fbEzxxH HRKqGFNUhQ2eyPNxDrGXpxsh2pGwPNYCqSEjUhM2Wt4krd6QrR4X6qKagdpqt1WsDolKa5UsURM2 ALTHEydaoa2STnoVY4qKsMETeT7OIbagmoFearVVLAyJagwZkYqwAaAdqhnozduw7BJNrZIl4sMG T+T5OIdIQTUDknh/zbnmKsYU0WGDm2Q+ziFS8BQJiUrOcWgZErUWMiLRYQNAXVQzZKF9MM368lgr rZIlYsMGT+T5OIdYYvniDXtKtFWkDYlarWJMERs2euEGDeuoZkArK8tjPYWMSGTY4Iafj3OIMUIG rNDYVvHQKlkiMmwgD0EDY9ouzMCaPfMtPYZEPVYxpogLG9wogXKoZsAyyctjCRm3iQobBI18nENE VDPgwdY5jppDot5bJUtEhQ0A+ahmwKOecxxUMdaJCRs8kefjHIJqhn68a2O/1m0VQkY6MWEDwH5U M4AX1toquUOitEr2ERE2pDyRS/kce2j+7NZdXV1V/fnwFAzcVbqtQhUjT/ewwU0yH+fQJ6oZwLK5 ltSWIVFCRhndwwaA7ahmAGn2zHHQKimva9jgiTwf59AXqhnAdqnLY6li1ENlA1CCagaQZzjHMRwS JWTU1y1s8ESej3PoA9UMoJxhW4WQ0c4rPf5SbpL5OIc+xKcwgoYv8YaIOq6ursLPf/7zEAJBo5Uu YQPAspOTE9omQCUnJyfhj3/8Y7i4uLg1DIp6mrdRpD6RS/1cUzR9VmxHyADqGf5+ffjhhzeBgwpH XQyIAkIwmwHUNRfkhxUOQkcdTcMGT+T5OIc2Uc0A6lr7HYshgypHHcxsKELQsIfZDKCfo6OjO/+M OY46mlU2uFECtxEygDa2/q7RVimvSWWDoJGPc2gH1QygnaXftbgD7JSLiwuqHAXRRgEa4r0ZSMW7 NvKVCPUEjjKqhw2eyPNxDvX7v//7P6oZQEMlf98IHPmobARu5qjn+Pg4vPfee+Evf/lL+OGHH3p/ HAAjU0OiU2LgIHTsU3VAlJt4Ps6hTsfHx+H7778Pn3322a1/fnJyEu7duxe++OKLTp8MsK9WFZHl sftVq2xwk8zHOdQnVjI+++yzyZ/d1dVVuLy8DMfHxx0+HWDf1qCxNCQ6h7bKdrxBFChgrpIx5/Ly kioHUFjLuSiWx25TJWzwRJ6Pc6jD1pAxFC+KhA5AJ9oq6RgQBXY6Pj6ebZdsEVsr77//Pu0VYKec qkbqkOgc2irriocNnsjzcQ5lG85llDQMHUAIvGsjlYRl5QSOZUXbKNwk83EO5cppmWwRbzC0VoB1 JYJGHBJ9/Phx1p/DHMc89wOi3NyxplXIGGKeA1gnoaIxxhzHtGJhg5t2Ps6hLD1CxhihA9ApVjkI HC+4r2wAYxJCxtgwdHz55ZedPw3QX+mqxtHRUXYbZYy2yktFwgZP5Pk4h/1JDBljzHMAMtsnc2ir vEBlQwCCRl8aQsYQrRV4VitolBoSneO9rZIdNrhRQittIWOM0AFvNFU0pngOHFlhg6CRj3PYnvaQ MUbosC22zjTfZPGS1zkO2ihww1rIGIs3o9PTUwIHzGkRuGoMiU7xOMexO2zwRJ6Pc9iG9ZAxxiZv sMZqZcdTW8V1ZaPnzZ6gUZ+3kDFEawVWtAwatYdEp3hpq+wKG9woIZnnkDFG6ADk89BW2bwRG0Ej H+ewnlI7sVoTN3ljV1loYrV9MsfyZm5sMQ8Tau3Eag1b2UOLXkEjd7v5XFYDx6Y2Ck/k+TiHZdEy 2Y7WCqTzVtEYszjH4XpAFHoRMvIROvTw9K6N3sfZY0h0irU5juSwwRN5Ps5hPkJGeWzyBshlZXks lY1GCBp5CBn1sckbeutd1YhavdwrlYW2SlLYsHijtHhMFhEy2qK1gl6kBA2ptLdVVsMGN+V8nMPt CBl9ETrQEkEjnda2CktfIcpwCSsBrb/4fo7333+/90eBURKDRhwSlUrj8tjFygZP5Pk4h2moZMjG PAcgi7Y5DgZEKyJorCNk6EFrpS+Ly18lH4+0IdEpmuY4ZsMGN0rURMjQi9CBEiQHDW00zHFMhg2C Rj7O4TRChh2EDuxF0ChPeluFNgqaIGTYFW8ap6enBA6YIeVNoltIbqvcWY3i4Ym89jF6OIdbsLrE BzZ5QwqqGvVJXK3C0tfCCBovxWWsnA8/hktlCR0Y0xY0eu8Am0Na4LjVRuFGiRJomYB5DoxpCxoW SJrjuAkbBI183s8hIQNjzHMgBIJGT1LmOGijIBtv/cQaWitlxHdtoA3pbxLdondb5SAEnshL8HgO qWRgC1orPlHVkKNnW4Wlr9iMkIEchA4/LAQNDW8S3aJXW+XA4xN5aV7OISEDJQ1Dx5dfftn506A0 C0HDstZvHXVX2SgdDDwEDUIGamKTN3sIGjq0DBwH1m+U2I+QgVZorUAqjW8S3aLVHIe7ykZJVqsa hAz0QujQj6qGPjXnOGKQIWzgBiEDUjDPoZPVoGFtSHROqbbKcIlt/LMIGztZqmoQMiAV8xx3xXMi 7aYu8TNhu71tlamAMUTY2MFK0CBkQANaK0BbW9oqqcGEsOFUfOMnoAWhQy7rVQ3rQ6Jz5toqa1WM KYSNjbRXNWI1Q/MxwDdChyzWg4Z3U6853zPT4SpsaA8KOWiZwBo2eevPU9DwMiQ6NLWXyt7hUVdh I5fGsELIgHWXl5dUOTrwFDQ8WWuR7F2tQthIpC1oEDLgCa0VIE/qoOfe5bGEDWMIGfCM0NGGx6qG xSHRPYOe8d/dujyWsJFAQ1WDkAG8ZH2eo+e7NjwGDUv2BoyxrW8dJWwoR8gA5jHPUZb3oKF1SLRU wJiS2lYhbKyQWtUgZABpaK2U4T1oaFMzYIylBA7CxgKJQYOQAexD6IAHLXZwnbI2x+EmbEgMDlsQ MoAyrM9z1EBV4wWpQ6ItqxhLluY43ISNraSEE0IGUAfzHGkIGjJJCRhTptoqhA2hCBlAfbRWlhE0 7uo5JCo5YIyN2yqEjQk9qxqEDKA9Qgek0hQwxoZtFcKGIOzECvQ1DB1ffvll50+zrPa7NqhqTGs1 t9Fr0LMGKhsTelQ12IkVkCXeyL1WOQgafWiuYqwhbAy0Dhq0TAC5vLZWCBptWQ4YQ4SNDggZgB6e QgdBI03ukKiXgDHkImykVCxaVDUIGYBemuY5II/HgDHkImz0RsgA7LA6z0FVI92WIVFLg545CBuh XlWDkAHYZK21QtAoy3sVY4r7sFEjaBAyAB8shA6CRhkEjGXuw0ZJhAzAp16hI/ddGwSN/Y6OjsJr r712898JGMtch41SVQ1CBoAQ2OTNGwJGOtdhIxchA8AUDZu8UdXII3UHWKncho2cqgYhA8AayfMc BA20Zj5sTIWKvUGDkAFgK2mhg6CBHsyHjRIIGQBySZjnIGiU1XO7eW3chY2tVQ12YgVQkoZ5DqA0 d2EjFTuxAqilR2uFqkZ5DImmcxU2UqoatEwAtFIidKS8a4Oggd5chY0lhAwAvdTc5I2gAQnchI25 qgYhA4AUVjd5s4wh0TQuwsZU0CBkAJCo5DwHVQ1IYTpsxJBxenp6888IGQA0yA0dBI02GBJNYzps hPAycBAyAGi0Z56DoAFpzIeNw8PDcH19TcgAoFrqPAdBAxKZDRvHx8fh8PAwhBDCW2+9Fb7//vvO n8gXhtuA8qS9+hwvMCS6zlzYGLZLhtWM4+PjEAI3wVbi+YY9/A71Nw4dseox/N8ASe795je/+aH3 hygh9Y2fw5sgF01gO4KkPG+//XYIIYRPPvmk8yfx69mzZ1Q3FqivbGwd/BwGDKodwHb8vsgRr2Hf fPNN+OKLL7pu8gYsURs2Sqwuib+UVDsAaLF0vWKTN0ilLmzUWMJKtQOAdKnXJoZI+2BIdJmqsHF8 fFx9CSvVDgBS5FyHCB2QRMWAaO/t3ql2AGil1oMO8xz1MSQ6T3RlQ8pbP6l2AKit9kMN8xzoSWTY kBIyxpjtAFBS6wcYWivoRVTYkBoyplDtALCHhGsGoaMOhkTniQgbmkLGGNUOACkkXh/2bPIG7NF1 QLT34GctEp5cAPSn6VpAlaMMhkSndalsaK5kpKDaAfilKWAM0VpBTU3DhvWQMYXZDsAHKw8WhI48 zG1MaxI2PIaMMaodgD2WHyKY50BJVcMGIWMa1Q5AL2+/t3H7eqocyFFlQNTq4GdNVDsAubwFjDmE jjQMid5VtLJBJWM/qh2APDwE3MY8B/YqEjYIGeUw2wH0ReBfR+hYxpDoXdlho8VOrF5R7QDa4Hds nxg62OQNa3aHDaoZ7VDtAOrg96kMNnnDms0Dogx/ysCTGLAPvzt1ETpeYEj0tuTKBpUMWah2AOkI GO0wz4Epq2GDkCEfsx3ANIJ4P97nORgSvW02bBAy9KHaARC6pWGew7fz8/MQwkTYIGTYQLUDnvA9 l43Wii8xYIQQwsXFRQhhMCDK4Kd9VDtgDd9pnbyEDi9DosNwEcLLgDF0769//esPhAxfeAqEZnx/ 7bC+yZvlsDFVvVhy71e/+lXxvVGgB0+G0ICAYZflKsfh4WF4+PBh749RzNaAMdRki3nIxWwHpOI7 6QPzHLLlBIwhwgZCCKxkgRx8/3widMiQMn+xB20UzOLJEq3wXcOYlXkODXMbpaoXS6hsYBbVDtRE wMCSq6srqhwVtQgYQ4QNJGG2A6UQXJHKQmtF0ptEWweMIcIGNqHagT0IqchhIXT0UGv+Yg/CBnaj 2oElfC9QGqFjXc/qxRIGRFEU1Q7wHUArWjZ5qz0kKjVgDFHZQFFUO3zi540evG7yJqk9koqwgSqY 7bCPgAEJNLRWSgyJaqheLCFsoDqqHXbwM4RUGkLHVtoDxhBhA81Q7dCLnxe0iKFDyzzHmKWAMcSA KLriSVkufjbQTlKVY25IVOP8xR5UNtAV1Q5ZCBiwRGprxWr1YgmVDYjDDa89gh486Bk6Dg8Pw7ff fhtC8BMwhqhsQByqHW0Q6uDNsNLRY5M3jyEjImxANFaylMV5BNjkrQfaKFCHasd2nDNgWsvQoWG7 +VqobEAdqh1pOD/AOqlDpNYQNqAWsx13ETCAfVrMc0jabr41wgZM8F7tIGwBZTDPUQczGzDL+g3Y a7ACWqkROrzObVDZgFkWqx2WjgWQjnmOcggbME/7bAcBA+iL0JGPsAFXNFU7NAYjwLISm7x5HRIl bMAlqdUODSEI8O7y8pIqx0YMiAL/0+tGT8AA9NoTOjwOiVLZAP6ndbVDUkUFwD575jlee+212h9L HCobwILSVQeqGIBtKfMcz549uwkcXjZnI2wAifZWIggYgC9rVY7Dw8Pw8OHDEEII5+fnIQT7oePe n//85+phgwssLEkND7RJAN/mQscwbETn5+emA0eTysbw4gys0XRzHgcKqhgAxqZCx9SQqOUqB20U iKMtnL799tu3/vs333zT6ZP4RKiDFsNN3pZWpFgMHYQNYKe5Ngntk7a0hVP01fv3MlY5fve7360u f7UUOggbwAZb2iS0VAB5eofTH//4xyGEEP75z3+GX/ziF0n/HwvzHIQNYEWJ0EC1A/DrzTffDH/6 059CCCH8/ve/3/VnaK9yEDaACbWqElQ7APvefPPNEELIDhhTtIYOwgYw0LICQbUDsKNE9WILba0V wgbc611t6P33A9iuZvUilaYqB2EDLkm9wVPtAORqXb1IpSF0EDbgipabudQwBHgioXqxheTQQdiA edpv3FoCEmDBMGBIDxdzJM5zEDZgkvaAMcXiMQG9aatepJJW5SBswBQvVQAvxwnUYKF6kUpK6CBs QD3PT/yejx1IZbV6sUXv0EHYgErcZO+i2gG85Kl6sUWreY4YbiLCBtQgYKThPMEjqhfpalQ5xuFi /GcTNiAeT+z7ce5gGdWLPLmhYxgw1v4MwgZE4um8LM4nrJD6Yi3NUkPHWvViyb2PP/74h3feeSeE EMLf//73jR8RKIcbYhtUO6AJ7ZF2xvMcOeFi7N6DBw9uKhsffPBBCCGEd955h+CBZrj59UG4g1RU L/ooGS7GboWNoWHwCIGqB8riRicLgQ89Ub3oZ27uovQQ6WzYGPvggw8IHshCwJCPnxFaoXrRx9bq RamlsslhY4jggS14ataJnxtKonrRR4nWSIkqx66wMcScB6bwhGwHP0vsxdLU9mrOXeSEjuywMcSc h2/clOyj2oElVC/62PK+i5J/36alryXDxhjtFh+4AflDsERE9aK9mtWLrZ8j9e+uFjbGSYvgYQs3 G0SETV+oXrQnJVxMSa1yFA8bKX8xcx46ETCwhO+HXVQv2pIcLuas3fuLhI2cfhHBQzZuINiDaod+ LE1tq/XcRS1zoSMrbJR+6QcDpnJws0AJhFU9aI+0pbF6scV4nmNX2KixPe0U5jza4saAmgiw8gyr Fz/60Y9u/rm1G58E1sPFlGFWSA4bvUs8tFvqIGCgNb5z/aRWL1o9UFrX+74pxfn5+XrYkPilI3jk 4ykTEvA9rC9n9kLi9V8yj9WLVLNhQ8uXjDmPdDxRQiq+m+XUmL3Qcj9ojXCR7lbYsFDyYc7jNi7i 0IZqx3atVo54Dx2Ei/3uPXjw4AerXyDP7RYu2NCOoDyv98oRCw+mqTwda033fvvb3/7g4QR6CB5c nGEV4Vnui7WsPaxSvaij6t4oUlma8yBgwBNP3/fe1YuttIYOwkUbLsPGmMY5D5704J3F3wGp1Yst pIcOwkUfhI0RycHD01MdkErz74W26sUWkkIHcxf9ETYWSJjz0HwhBVrTUO2wUL3YokfooHohD2Ej Ucs5DwIGkEfa7xCbmtWtLhAu5CNs7FSj3aLhqQzQpsfvleX2SAm51Q7ChT6EjQJygoe0JzDAqtq/ a1QvttsSOpi70I2wUVjKnAcBA+irRLWD6kU5U6GD6oUthI2KxnMeP/nJT0IIBAxAiq3Bn+pFPYQL 29y8QVSCX//61+GNN94IIYTw73//u/OngXWE2m2mqh1UL+pZChe0TOy5tTdKCPxgW5H8Pg/YMHxq R7q33347fPfdd+HTTz8lXBS2514j6X0d2O9OG4VSVnsS3ucBeEX1op6S9xNCh27/DwyZOBFKLgsz AAAAAElFTkSuQmCC "
-       preserveAspectRatio="none"
-       height="142.61041"
-       width="142.61041" />
-  </g>
-  <g
-     inkscape:groupmode="layer"
-     id="layer2"
-     inkscape:label="Calque 2"
-     style="display:none;opacity:0.57599996"
-     transform="translate(470.69208,-22.182517)">
-    <image
-       y="118.73846"
-       x="57.565689"
-       id="image834"
-       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAegAAAG0CAYAAAD5HLSAAAAABHNCSVQICAgIfAhkiAAAABl0RVh0 U29mdHdhcmUAZ25vbWUtc2NyZWVuc2hvdO8Dvz4AAAAtdEVYdENyZWF0aW9uIFRpbWUAbWFyLiAx MSBm6XZyLiAyMDIwIDExOjUyOjMyIENFVMpNEvIAACAASURBVHic7d27bxzX+cbxl9SKspzClfFD mnRWkMBlBFcBDPFOLknd7QCpWLjy36DCcJMygB0gDfsESBxEvkgkde/idDEQQyniKr2a6EaJv0I5 1OxwZnYu5/Kec74fIEAsrshditxnnvecmZl57733DgXJ29rakrfeeqvxMaPRSA4ODjw9o2YLCwuy v78f+mm0Nj8/L3t7e6GfRrTOnDkj165dq/zY9va2iIjs7Oz4fErAYNvb24N+bmctPhco9emnn04N ZxGRg4MDGY1GHp5Rs9jCGcM9fPhQPvnkk2N/bt7gCGfkiIBO3KeffioPHz5s/fjQIU0456sY0tvb 24PbBxDazs7O0QSoj/B1CU5sbW3J2bNnO4WzUQxpLSNv5OHhw4cEM5JiQrrPzzQNOkFmvblPOBsH Bwfe2zTtGXNzc/Ls2bPKcTcQq75NmoBOTJvNYF2EHnkjD3Nzc0fhLFK/Jg3Eqk9IE9AJsR3Ohglp l0FNe86XCWYTzoYJ6Y2NjUDPDLCra0gT0Ilou1O7rxAjb6St3JqrPHz4UN566y1CGlkioBPQdaf2 EC5Cmvacn7rWXIeQRiq6tGgCOmJbW1tew9mwGdKEc36mteY6hDRS0TakCehI2dipPYSPdWmkpc1I expCGqloE9IEdIRcbQbraui6NO05H11H2k0IaaRiWkgT0JHREs5FbB5DHRutuQohjVQ0hTQBHRHX O7WH6Drypj2nz2ZrrvLWW29xrjSSRkBHIsRmsK7ajrwJ5/S5aM1VuKAJUlDXoglo5ULt1B6CkXe+ XI20mxDSSEFVSBPQioXeqT1EXUjTntPleqTdhJBGCsohTUArpXEzWFecipWHEK25CiGNFBRDmoBW SPNmsK6K69K05/SEbM1VCGmkwIQ0Aa1MbOvNbR0cHMjdu3dDPw1YpKE1V+EmG0gFAa1IquEs8mrt mZF3GrSMtJtwkw3Ebmdnh4DWIMad2l0UR9vcFStu2kba0xDSiBkBHVjMO7WHIKTjEkNrrkNII1YE dEAp7NSepmljGCEdh9hacxVCGjEioANJaaf2EKxL6xZra65CSCM2BHQAKa83F7U9rYp1aX1iHmk3 IaQREwLaM8K5HiGtQwoj7SaENGJBQHuS+k5tWxh5h5Nqa67CnbAQAwLag9x2ag+9Yhgjb/9Sb81V uOoYtCOgHcthp7YrhLQfubTmKoQ0NCOgHdrf388unG1fb5uQdienkXYTQhpaEdCO7O/vy3/+85/Q T8MrVzfDYF3avhxH2k0IaWhEQDvw6aefZhfOrrEubQetuR4hDW14t7Noa2tLzp49Kz/5yU9ERLK6 taKvW0makD44OHD+tVJDME9nQvrbb7+V69evh346yBwBbUlxp7YJaLhRbNIEdTuE83Tz8/NH/39p aUlEhJBGUAS0BcWd2qZJLiwsBH5W/vhqz0UmmGnTzebm5kRECOcKxUAWEbl169bRn3/22WdHFzQh pBEKAT1Q8eIjIYIqd4y869GaJ9UFchNCGiER0ANwZTAdByWE9CRa8yt9Anl+fv7Y4whphEJA92A2 gxXDWUNQ+abpNbMu/UrOrblPILdFSCMEArqj3C7bGZPc16VzCudyGIsMD+Sq9lxESMM3ArqDust2 amqSvmh+zbmNvHMYabtsx12Ym2xcu3YtyNdHXgjolrqEs+bwykUuI+9UW7PvQJ7WnovMudKENFwj oFtgM9ikWA5AUh55p9aatTTktghp+EBAT9EUzrEElU0xvubURt4ptGZNgdylPRcR0nCNgK5RtVMb 8UolpGMNZ02BbBMhDZcI6AptdmrH2CSHiv01x7wuHdtIO5ZA7tueiwhpuEJAl9RtBkMaYlyXjqE1 xxLIrnCTDbhAQBe0DefYm2Qfqb3mGEbemltzCoFsoz0XPXz4kHOlYRUB/T9td2qnFlRtpPqaNY+8 tbXmFALZF0IathDQYvc0qlTDLFUaR94awjn1QLbdnssIadiQdUB33amdY/jm8po1jLxDjrRTD+Qi 1+FsENIYKtuA5praKAsZ0r5bc06BHBIhjSGyDOg+O7VzaZJFOb5m3+vSvlozgfyKr/ZcREijr+wC mnDGNL7WpV22ZgJZF26ygT6yCmiuqd0eByVuR962w5lAni5Eey7igiboKpuA7hvOOQZVjq+5ju2Q tjXSJpDjREiji+QDmmtqYyhb69JDWjOBPEzo9lxESKOtpAN66E7tHJtkjq+5jSHr0l1bczmMRQjk 1BDSaCPZgB56Te0+QUW4pa/ryLtNa6Ydu6WpPRcR0pgmyYBmM1g/HGC003bkXRfOBDIMbrKBJskF tI1wzjGocnzNQzSNvMsjbQI5HK3tuYibbKBOUgFNc4ZvxTYt8iqcf/nLX048RntAQAdCGmVJBLTN ndo5NskcX7NNBwcHcu/evaNwJpB1iKE9lxHSKJoN/QSG4praCG00GslHH30kz549kwcPHoR+Ooic CWkg6oAeulO7LMcmmeNrtmlhYUHef/99+f7770Xk1bqzWYNGODG25yJCGiIRB/Snn35KOA+U42u2 ZTQaHX3/Dg8PJz4W+l7OSAMhjSgDWuNmMMIuHwsLC3JwcCD7+/tH/+4zMzOVj6VN+xd7ey4ipPMW XUC7COccwzXH1zxUsTUb5fZcxsgbQ5k7YSE/0QT01taWyuaMPJjznYvh3PYgh5G3Pym15yJzQRPk JYqAdrlTO8cmmeNrHsKMtMt/tre3JyIiMzMztSNu+JNqOBuEdH7UB7TtndpFBBWaVI20i4rBvL+/ L4uLi60+LyNv9EVI50V1QNveqQ0OStoqbgSr+tiQ7yHr0val3p6LCOl8qA1o1+vNOQZVjq+5q2mt WUSOjbP7jLhZl8YQhHQeVAY0m8EQQtVGsLLFxcWjtWeR42HdB216mJzac5EJaU7DSpeqgPa1U9t2 k4yhmcbwHEOq2ghWVgznqtbcN6wZeaOv4p2wkB41Ac01tRFCm5F2WVUQD23SjLz7ybU9lxHSaVIR 0C53apfl2CRzfM1tNG0EKzPt2cb6M+ACIZ2e4AHtc6d2jkGV42uepm9rtjXSboOR93S05+MI6bQE DWg2g8G3NhvBysobw0Sqd3LbxLo0+iKk0xEkoENctjPHJpnja27SZiNY2eLi4sT30GeTZl26Hu25 GSGdBu8BzWYw+NZnpG0Uw3fa+jMjb2jCTTbi5zWgfW4GK8qxSeb4mqt02QhWVtwY5nP9uQoj79do z+1xQZO4eQvoVMNZYxBqfE6+DWnNxuzsbOtTqnwENiNv9EFIx8tLQHNNbfjUZyNY2dLSUuXGME6z Cov23A8hHSfnAR1yp3aOTTLH11zUZyNYlTYj7dDBzMgbXRDS8XEW0CF2aiNfNkbaxvLy8tRLempo 0rmtS9OehyOk4+IkoDXs1M6xSeb4mkWGbQQrK462Na0/12FdGl1xk414WA/oUJvBinINqtzYbM2G 2RimtTU3SblN057t4iYbcRjZ/GQawjlXuR2U2NgIVla1MUxEX2uuY0beqbVqwtkdE9LXr18P/VRQ sL29LSIWA1rLenNuQSWS12sejUby/vvvO3m9s7OTA6UYRtxlqYUz3COk9TDBvLOzIyKWAlpLOPuW UzBq4KI1GysrKxPtOcZwThHt2Q9COrzt7e2jYDYGBfTW1pacPXtWTTjnGJi5vGaXr7M82u57ipXG sE5x5A03COkwyq25qHdAa9ipjfS5HGkbJ06cEJFhQawxnEXiXpemPftHSPvTFMxGr4DWuBkslyZZ lPprdjnSNpaXl2V3dzfJcDZiDGeEY26yce3atdBPJUltgtnoHNCEsw4pv2Yfrdmout52KsFcJZY2 TXsOy5wrTUjb0yWYjU4BnetmMPjjozUbxSuGGSmHs0jcI2/4RUjb0SeYjdYBrTWcU26SdVJ9zT5f 1/Ly8kRDGxrM2i5a0kR7ONOe9SCk+xsSzMbUgNa2Uxvp8TnSNszGMJE0N4cBthDS3VWdMtXHzHvv vXdY90GN681FIZtkqK+dWns2I22fTHu20ZqL3n//ffn666/tPEmPNI28ac96nTlzhpCewkZrLqpt 0IQzXArRmo0TJ07QmgtYl0Ybpkl/++23nIZVYjuYjcqA1rrenLtUDkp8bgQrG7IxrOtjY6IhnGnP +hVvskFIuwtm41hAxxDOqQRVF6m85tCvYzSa/JG3PeZOAW0a0+Qe0q6D2Zh4t4ohnBGnkCNtY319 XXZ3d0XETWtOJaxDjLxpz/HJMaR9BbMxEolrp3boBhZC7K855EjbWFlZ6RzOuY25i2jQaCOXkPYd zMaIa2rDFQ2t2ajbGCbCmDs02nPcUg7pUMFsjDTv1C6LvUn2Eetr1tCajfKtJA1ac3usS6NJiiFt 61zmIWanP0QHTUHl67loes1dLCwseD+3uUl5Y5hIt9aceziLvF6Xto32nA4T0rHb3t5WEc4iA+8H DRRpGmkb4/H4aO1ZhNY8BA0a08R8J6zQ4+wqUQR0rE1yiNhes6aRtlHcGCbibq3Z/HlO4W1j5E17 TlNslwbVGMxGFAENvTS2ZsOMtl225pxCuWjoqViEc9piCGnNwWyoD+jYmqQNsbxmja3ZWF1dld3d XeetOWeMvNFEa0jHEMyG6oCOJahsiuU1a3+eo9HoWIjSmnWgPedDU0jHFMyG6oCGPppH2oZpz0Wu WzOhzalYqBY6pGMMZkNtQGtvaC5of82aR9rG6uqq3L59++i/Xbdmgvm1NuvStOc8hboTlpbTpfqK 5jxoLbSHqAuj0Ujduc11iuc82zivue7xTX8nZzRo1CneCcs1TecyD6GyQecYglpfcwyt2SiOtm3c 4IJgHqbcpmnPEHF71bGYx9lV1AW01qDKUWz/FidPngy61kxwTwpxVyzEwXZIpxbMhrqAzpG2IIxh I1hZ1cYwET+tmWCuZ8KZ9oyyixcvys9//nP5zW9+0/tzpBrMhqqA1hZUPmh7zTGNtI3V1VW5c+fO xJ/RmgG9zAHbo0ePev391IPZUBXQCCfG1mycPHly4r9pzboU2zMj77zNz8+LiBz9PJw9e7bTmDuX YDbUBLS2JumDltccY2s21tbWGjeG9fnzIR9DM9al8zV0mSOFXdldjcybM/Kk5SChL9Oeac06Vb0p E855KbfmoocPH07dLJZbay4aHRwcHJ07GiqoYw+JPkK/5phH2oZpzzZ2bvf9O20+jnq06bQNac05 B7MxEnkdzCGCOnRQdWHruYZ+zTGPtIvKa88i/lsz4VyvzZszI+80NbXmaQjm1ybWoItBzdg7PSm0 ZmNra6vV9bab/rzv36n7OGHdD+Gclq6t2WwUI5iPq9wk5mvsHbpJhhDqNafSmkUmN4YZPm98QRBP x3nP+enbmn/44YcsN4C1UbuLO+TYG3aldiA0Nzd39P8J5vQw8o5PnwMy83v87Nmz3udDp27qaVau gjq10GjD92tOaaRtrK2tyc2bN0WEcNZqaHtmXToefVpzMZjRrPV50DbXpwln91IaaRfNzc2pDGYC /BVbo23evPXr25r5t22v8+0mzfp08bZ+0COmW0N2tb6+Xnm9bZFw4dx0O0rYUVzSQHjz8/Odw3lu bq4xnM+ePWvr6SWlV8oOGXvTnt1JtTWLvArn8vW2RcIGMya52hjGyFuPPsEswkSkr84Nuujg4GBi x3fKtB9YpNqajaoWRTjngzf4sLq25mJjbvNvZ64ohklWkrXtaVnaQ84F1685xY1gZevr60cbw0QI Zo04rSpdXYNZhAMqW6xVX07L8i/lkXbRkNOqhnysz+PgByNv97rs0LYRzF3vbJUD67PpuqCmPduT Q2s2THumNesVoj2zLu1W239TGrNbzhaPi0GdS5gUuQznHFqzyOuNYbG0ZsLcL0LBvratmWD2Y9Am sTYODg7k7t27WWwkcy31jWBlp06dqr3mdVNoDw3nPqdO5RrOWtaeORVrOPNv2Sac227+6oKNYsc5 T81ik8xlfdp2e85xClHeGGbQmlGFkXd/tGa9nDfoouJpWTTqdkxrzimcRV615yJasz5a2rNBcHTX pjV3PWVqCC5YMslpStY1ydhua9mlEdtqzzm2ZmM8Hrc6rWrIx7o8xsbfATRp05ppzOE5C+g2QeXr tpa+2AznHFuzYdqzth3aBPNr2tpzFUbexxHMcfE64q7C2HtSbhvByi5duiQ3btwY1JrbhDfhnD6z Lo1Xpo2zfY6y67BRbJKTROzTJGO/0MnQ9pzzSNswo+0+p1W1+Xjbxwx5fA5iaM8GLXB6a6Yx6xW8 QZfldH1vI9eNYGXljWFFtGYMlWObbtOaQzbmKmwUe816Ctpah41pfbrva6Y1v1beGGbQmnWJqT2X 5XQqFq05DVYD2vb5vzGMvYeEM635tTfeeGPiv0NdppNwTlsOgdR0EEUwx0XdiLtKahvJct8IVnb5 8mW5cePG0X+Has2Ec7OY23MOmm4JqWEDWFtsFHvNWtr5uBlGiPOnm15X19fMSPu48Xh8FM6Ms/VK NZxTGXk3BbMIjTlWUTToshjbNBvBqpnR9tBNYNM+h43HIz2xn4pV15pjasxV2Cj2ipWEC3ErydDr 021fM6253rTTqkRozRqk2p6NGANMpPrfhcaclngqaA3Nlw1lI1iz8sawIjaBIYQYRt5VO7QJ5jQN HnGHaM9VfI6927xmNoI129jYqDytSoRNYJqk3p7LtI+8q85rjnmUXYeNYq8MSjMt4Wz4GHtPe82M tKfb2NiQu3fvHvtzWjM00Bh0tOY8RblJbJpQp2WxEaydqtF2Cq35Rz/6kbev5UNu7VmrcmuOfQNY W2wUG9CgtbXnKrbXp+teM625vY2NjU7nPLd9zJDHA01CrUuXWzONOT/RbxJro+9lQ9schLARrJti eyac9aI9vxbiEqHF7z/BnK9eI+4Y2nPZ0LF31WtmI1g3pj27uLkFm8Dgkq9wLJ7XnMsouw4bxXo0 6BjDuajPRrLya2ak3Z3ZGEZr1o/23MxVm64KZuQtyU1ibfS9rSUbwfo5ffo0rRlJsH0qlmnNDx48 yLoxV8l9o1indIq9PVeZtj5tXjOtub/yxrAyTp3Sg/bcjq0ALbZmQhllWWwSm2ba2JuNYMOcPn26 9mOMs5Ejs0O72JqBstYj7hTbc1l5I9mZM2eO/hz91LVnxtn60J776zLyNuPsBw8eMM6eIveNYtmu QTcpBnLqByWuVbVnWjNS02Zden5+Xubm5ghmtNYqoHNoz0ULCwvy0Ucfye9+97vQTyVqV69ePXZR kpRb8+HhYein0BvtebimwCWY+8t5o9jUNeicwtlsBBN5NVpBf5ubm52vGFYUUzADZWZdmYuMYAhG 3P/DRjC7zGg79dacAtqzfcWrjxHO6KsxoHNpz8UrguXyml3a3NyUb775htaMLJnzmglmO3LeKJb1 aVac2+xGm4uSFKUQzLGuP9Oe7eL7CZtqG3TqTbLqimCpv2YfymvPTVIZZxPOKF5Du47Nq4/lJteN YpUNOuWgqmvNKb9mXzY3N+XevXutHkswIxVtD3RC3BULcctqkxgbwdxqumKYkUJrPjw8jD6cac/D tWnNZYRzP7muQx9r0Kk2yabXVf5Yqt8Dl9qMtmMPZpHm1hx7aKMdc5nOoQc4tGlMk/wmMTaC+WHz etsapRS+tOf+bH7vGHljmokRd2rNsc2tIVN7zSE0tefYwzmFcTaG6zPOboNwbi/HjWJHDTqloGrb mlN6zaHUbQyLPZhF0mrNBu25O75nCCW5TWJsBPPrzTffnPhvNoEhFa5acxNOxaqX40axWZF0mmTx imBtHpvCaw7JXDHMyDmYYwh0mmB75nvl+/vV5q5YyEcSm8TYCBaGac+xB7NI/4CNIZjRnq0d2kOw Lg1jNvYm2WYjWNXfifk1a9D3etva2GzNmsOa9jxdqNbchDY9KbeNYtE26L6teVo4E97tvPnmm1GH 85Aw1RzE6E5Da67DqVh5m40xjNgIFtaHH37Y+nrbGg1pzDGGM+25nsbWXEY4v5bbRrGoGvTQtWba 8XBbW1vRhjOtGYbm1gwY0QQ0rVmHNtfb1ibnYKY9Hxf794SRdz6iOA+6y+lTTZ+DcB8mxvbsa5wd 6/g7JyHOa3Yh91OxctooprpBc/qULjG1Z1+tWXMopxBGtqT2vaBB50Ftg7Y50qY9DxfTxjAfrZnG HIdUWnOT3Np0ThvF1DVo262ZcB4ultG2r4uNxBDMqYdSG7l8DzgVK12qAjr0RjDCvFr5etvaMM6e lEsw1clxhzbhnCY1I24bG8GqPieBO8zW1tbE9ba10TTOjiXAUxbDec0YLpeNYsEbNBvBdNPanrWN s7WEc67tOcfW3ISRdxqCNmiXI23a83Aa27OvO051ac1awjlXtObjUj8VK5eNYkEatOvWTDgPt7W1 Jffu3Qv9NCb4CmaXz8Wl3NozrbkZDTp+3gM69EYwtKNptB3LOFtjaKcqt4ORoRh5x8nriNvFRrCq r0H4D6NltM04u71cAiuH85pdSHHkncNGMS8Nmo1gcdHQnhlno4xgHoYGHR/nDdrnSJv2PFzo9ty3 pfa5dratx4Vu1qkHF60ZVXLYKOasQcfWmgn3V0K1Z20XG+G8Zx0IZndYl9bPSUCH2AhGwA73q1/9 Kkh7jnGcXfW4EIGdaoCxQ9s9LhGqn/URt4+NYFVfk3AeJsRo28c42/YGsNDj7BxwXrM/sYdz6hvF rDXo2EbamORztM04247U2jOtOSzatD5WAjrkuc205+F8tufYxtmxhndMCGYdYhx5m41i169fD/1U nBgU0LTmNPhoz7EFc9vHFR/jM6hTac+pvI5UxBTOOegd0BquCEZ7Hs7HxrC+68wuHk9r1oHWDEzX a5NYiI1gVc+BcB7G9Wh7yCYw21+jzeNsPca12Fsnm8DiEcPVx1LeKNapQac60s417F2NtmMbZ9OY /aA1xyfGdemUtG7QGkbaRq6BapOr9qzlKmBdmrXPrzdUrO2Z1hwv7eGc8hXFpjboVFtz7my351xb M826Ga05LbRpvxobtKbWbNCeh7PZnmO72EjMa9GxtWdac3q03hUr1XXo2gatMQg1PqfYbG1tyb17 96x8Lh8bwHw+TvPdrWIKZ1pz2mjQ/hwLaEbaabMx2mac3f9zpC6mAwlAu4kRt8aRtkF7Hm7oaJtx dvNjXIkh9LglZL40jLxT3Sg2EqE152JIe45pnK3tMakjmPPGqVjuzGpuzYbL9pxLM+/bnn1dbMTW 87C1uUvLJjHN4UdrhqEhnFPcKDYKfUUwuNdnYxjrzN0/nlObJphRhzZtj7XbTbqSS8N1qetoW0Nj bvs4bY+xSWMIskMb0zDytqfXtbh9IZyH6zLajmmcrekxGq7P7QPnNaOtEOGc4kYx9Q0aw7Rpz6mN s32dF13+uM2Q1tSeac1AGGobNO15uDbtOcXTpoZ+rdCnVWlCa4YNvk7FSm2jGA06YadPn679mJbW rOkxWtahNbRnWjNsYl26H5UBTXse7sMPP5QbN25UfkzLOrONz6UpvFOh4QAB6SGcu1M34vYZzqke CGxtbVWGc5/NTK7G2UM/l6YNYOYxNkI8ZDhyXjN8cTXyTm2jmMoGjWHKo23X4+wYT5uiVU8imOET I+92VAV0qo3Wp3J7jmWcTTCHCUnWmhGKq3A+e/asXL9+3cnn9mV7e1tElAU0hjPtWUMwt31cLOvM KTVmEVozoIkJZRGRnZ0dEVEU0LTn4TY3N3vfrUrjOFtLMLf9HEMC3GdY0pqhUa4jbxPMJpSLVAQ0 4Tzc5uZm5+tti+Q9ztY87naF1gytbK1Lm41i2sfcTcFsqAhoDOfyetuaQrfNY7SEe1s+QpPWjBik 3qCrxthNggc07Xm4rqPtVMfZWj5HF77CmWBGbIa0aW0bxdq05SrBAzqUlA4M2rZnja1Zy9dJcdxN a0bMUjgVq28wG0EDOqWQDKVNe9YYzLYeoyV4+4Szq2ZLMCMVMYZz1zF2k2wbdArabAzzPc4mmMNi nA2E2Sg2tC1XCRbQtOfhbN0MQ0uoavkcPoLZdpDSmpEDjSNvF8FsBAlownm4zc3N2utttxVTMNv4 Oq6/Rqg2TWtGLrqsS7vcKGZzjN2EEXekqtoz4+xwz6ELW4FKa0aOQjZol225iveApj0PV27PuZ42 peE5tH2MbbRmwN/I23cwGzToCPW53raWtmvjc8TyPKsMDVZaM/Ba08h76EYxX2PsJl4DWkt71vI8 +vjggw/kxo0bXttwm8fE8jlcfj/29vZkaWlJdnd3p/79PmjNwHG2G3SotlzFW0DHHIpadLlimKZ1 Zg3B6/Pc7Tp9A5bWDPTTZaOYpmA2GHFHpOm0qqKUWrOG52DzMV3RmoFuuqxLaxhjN/ES0LTn4Wxd MUxLoOUWzF2DltYM9NPmVCyNbbkKDToSb7zxRu3HYhpnx/AcbD6mD1ozMIwJ5/JGsViC2XAe0LTn 4a5evVp5URIRPU0yl6/R9jFFbQOX1gzYNT8/Lw8ePIgumA2nAU04D7exsdH7imFaAiv0x319jiFo zciVOTB14datW/LrX/9a/vjHP0YXziKMuNUrbwwjmNt/3NfnKD6u/NhpwUtrRixcBanLn/35+Xn5 29/+Jjs7O7K9vR1dSDsLaK3tWevzqlJuz1oCKfTHNX2OLo8rozXDNtdtNCbF36+NjY0oQ5oGrViX K4YRvPa+hq3H1AUwrTlvhKh7db97JqTN/9fOSUDH1FK12tjYaHVRkljaZuiP+35MUzjzJqofIRqv ab9jJphjaNM0aIU2Njbk7t27Ux+nIdS0f9z3Y+rQmt2IcV0U/lVdUSyGkbf1gKY9D9d0zrMIwevz c7R9TPFx5SP43FszbRS+dP1d0z7ythrQhPNwdadVieQRvDEHc1lMrZkQReyawrnpzlaaR96MuJWp as8aQiuG4NUQzD/96U/ls88+c9KaNEyjvQAAFXtJREFUCVGgmo3fN40jb2sBTXserqo9awgt7R/3 9TnaPu7jjz+Wf/7zn9YDlRAFjrN5MKwtpLNq0NoPIortWUNoaf+4r8/R5nELCwtHH//+++8JU0CZ tree1LQubSWgtQdfDK5cuSI3btwgeFt8XNNjTDDv7e2JiBz9HiwsLEz8NwD7XG3A1LIuPfP555/3 P3dE4gpnrc/VnFYVOthiCF5NwSwiR8FcZ35+XuXPHBC7PuH86NGjVi26KGRIZzXi1urUqVNOg3Po 5yCYX1tcXJxozNPcunXr6O8Q1IAdPk9dDDnyHhTQWhtpTMbjce1pVSLhW632j/t6zOLiooi8bswz MzNTP59h3kiWlpY6hTsAHUKNvGe9fSVUqrsoyeHh8Tsj8fEwj1lcXJS9vb3Bwbq/vy+3bt2SpaWl o8AH0M2Q9nz27NlBX7vYpn3oHdC05+EuX75ceVqV5mD0FbzTPu4rmJeWlmR/f19mZmas/e/WrVty +/ZtWV5ebnx+ACZpuCqfz5DutUks1nDW9LzH4/HE9bZT3wAW0zr00tKSiEzfAGbDwsKCvHz5krE3 MIWtcO6zUayKj3XpbDaJaQpnkVcbw4yQ4ZhTME973NLSkszMzPRaZ+7LvOGsrKzIy5cvZXd31/nX BGKjoTmX+ViX7hzQ2oIuRuPxWG7evBk8HF0Gu42vb+tzTHtcOZhDML9TBDUQF5dXH8umQWvi+rSq 2D/u6zFLS0syOzvrtTFPe04mqFdXV1vdDxxIne323PaKYl24OhWrU0DTnodrOq0q9XVmLcG8vLws s7OzwVpqmwOB/f19WV1dlRcvXtCmkS2No+06LkbeNGiPxuOx3Llzp/JjKa8zawvmPo257SjdJnMw vLa2Ji9evJCbN296fw5AKK7CuenWkzbYHHm3Dmja83DFjWGG5nVkLWvINoL5xIkTg5qor/F3FYIa uYmpOVexFdKtAppwHm59fX1itE0wuw/mlZWVoKNs28zv4Pr6uhwcHBDUgGI21qUZcXti2nPu68y+ grnYmEO2XxeKO76bLhMLxMhHe3axUazK0HXpqQFNex5ufX198GlVoYMzxmBO3Z07d2Q8HsvBwQFB jSTEPtqu03fkPfVKYikEdMjXsL6+XrsxzMg5uG08ZnV1NatgrrK4uCjPnz8nqBEt3+Fs64piXXQd eTc26BTCObSqjWFGzOvMGtahV1dXZTQasRYrry9LurGxIQcHB5xDDSjUdeRdG9CE83DljWFFrsI1 h2AWeRXOt2/fFpH01pjbqvoemaDmQieISaqj7TptR97cbtKhubm5Y392eFh/B6Wmj7X9+JC/O+Tj XR4zzbTWvLm5eRTOOWu6Y9bdu3dlc3NTVldXQz9NoFGocB5668mh2twVq7JB056HMxvDDK2tWEsj nvaYtbU1GY1GUe3MDnFxkyLTpre2tuTZs2c0aqiTW3Mum3YqFqdZOWLas9Zg9vFxG49ZW1uTkydP RrnOrOUgohjUz58/l6+//jrwMwLCh7PrK4q11bQufSygac/DXbhwYeppVSkHt43HmGC21ZhDt1kN TFCfP39e/vKXvwR+NgCKqtaladCWNW0MEyGYpz1mbW1N5ubmrDdmLW1Wg729PTl//rw8e/aMNo0g Qrdnw9cFS9oqj7wnAjrF9uz7NZ08ebLyz3M/pWraY9bX16MdZcfItOkLFy7I06dPCWp4oyWctSqO vI8COsVw9m1tba0yYGIddfv4HOvr6xONmabbX58xvllCuHDhgjx79ky++uor208LOEI4t3esQWOY 8mlVWndmawxmDDfk4MY06osXL8qf//xnW08JOKIxnLVsFKszEqE923D+/PmjsNHcikO37vX1dTl1 6pS1xszmL7t2d3fl4sWL8vTpU9o0EBgN2gIz2iaY6x8zHo/Z/BUJ06YvXbokT548IagxmMb2bGjb KFY0oj0Pd/LkyWjXmV2Pu8fjsZw6dYqbOETIrE9funRJnj59Kl9++WXgZ4QYaQ5n7UaE8zB1G8NE CGabo2xfGJkfZ4L68uXL8uTJE4IarRHOwzDiHqjqtKrUg7npMePxWN54441oG3MsBxIhmKAej8eE NJKheaNY0gHtenxf1Z5jHXXbeMzly5ejDWa0d//+fbly5Yo8fvyYoEYt2vNwSQe0S2traxN3VNJ6 SpWNrz/tMRsbG0fj7BANlLG0f+bAlKBGldjCWetGMQK6p9Ho1bdO87jaRzBrGGczlg5nd3dXDg8P 5cqVK/LkyROVb3LwK7Zw1oyA7mF1dXXq6UIxB/e0x2gJZugwMzNztD6tdS0PfhDOdhHQPdRdb1uE YEbe7t+/L1evXpXHjx8T1IiG1o1iBHRHde1Z8wYwG8F8+vTpo2C2PVJmDTkt5veDoM4L7dk+Aroj s/ZsaA7moZ+jHMyusIbsh+8DIRPUH3zwgfz3v/8lqBOWQjhr3ChGQHewsbFxtNZGMCM2oQ6EikH9 hz/8IchzgDsphLNWyQa07XOgV1dXW4VzzHeh2tzcZI0Zzty8eZM2nRjC2a1kA9q20Wikeh2ZYEYM GHtDK40bxQjoFppOq9IcvNM+TjAjlGJQP378WP76178GfkboivbsHgHdwokTJyr/XHOjbnoMwQwt WJ+OU6rhrG2jGAE9xXg8Plp7NghmwC6zPk2b1i/VcNaIgG6wsrIyEc4EM+AOY29gEgHdoM31tqd9 PPQpVVevXiWYERWCWq/U27O2jWIEdI2VlRXV19ue9hhaM2JHUOuSejhrlGRA2zgHum5jmIju20Ny kRGkxgT15uYmIR1ITuGsaaNYkgE9VHnt2Qi9zkwwI2f379/n/OkAcgpnbQjokpWVlWM/jAQzoAMX OkFOCOiS4mhbezCzxqwXNwBxi6D2I8f2rGmjGAFdUBxtaz2limCOA7fQ9MP8Hmh5Q01JjuGsDQFd MDs7SzADEbp//z73n7Yo93DWslGMgP6f5eXlyo1hImFPmRqPxxPBzOgUqGbG3gT1MLmHsyYEtLwK 57ofyFC3hywHc5fPibRwUNYNQY1UJBfQfc6BrjrnOWQwnzp1aupFUpAPDsr6MQe34/FYvvzyy8DP Jg6051e0bBRLLqC7Ko+2Q60zm2DWsMZMY0NK7t+/L1euXJHHjx8T1A0IZ32yD+jZ2VkRCRfM6+vr 6hozjS19uR2Emd+vy5cvy5MnTwjqEsL5uJAbxba3t0Uk84Bu2hhm5BTMyEeuB2EENbQyoSwisrOz IyKZB7Rpz1VcNuoLFy4QzInJrZHGzvz+Xbp0Sf70pz8FfjZh0Z6r+VqHNsFsQrko24BeXV31fr3t 9fV1mZubI5wTlGsjjd3Nmzfl0qVL8uTJE/nqq69CPx3vCOcwqtpylSwDumq07TKY19bWCGZPaLLo yvxeXrx4UZ4+fZpNUBPOfrUN5aIsA7r4Jk4wp4Ummx5fB13moD2HoCac2xm6UaxPKBclFdBtzoFe WlqSvb0958F88uRJglkZ2nWcfB90md/bCxcuyBdffOH1ayN+Q0O5KKmAbsPl9bZXV1ePgpkw0Id2 nRbXv2O7u7ty4cIFefr0qXz99ddOv5ZPtOf2umwUa9rs1VdWAb20tNT7ettNj1ldXZXRaNTpgieI HwdhYfn4HTNt+vz58/Ls2bPog5pwtstmW66STUAvLS3Vjr/7tmYTzNpG2QSHHxyEpWPa74w5+N7a 2pJnz57JN9984+NpWUU42+E6lIuyCeiqX8C+wbyysnKsMWtCcKSNAzD72v7OmN/5zc1Nef78eTRB TTj3d/bsWXn77beP/tt1KBdlEdBmY5gxJJhPnDihNpi1I1js4AAsPPMesLq6Gk1Ioz+foVyURUCb YOgbzMvLyxPBTND0Q7CkKeffhzt37sjGxoY8f/5cxY1uqtCehwl5Z6vkA7ppY5jRNpinPR7pyDl0 usr998G8P4zHYzk4OFAV1IRz3JIJ6KpzoMuj7bKmYJ6dnU16lE0ANcs9dFLj4+fdvNeMx2N5/vx5 8M2jhHP8kgnoLurefJeWlmR2drYx1FNBAKWLg6/jfP68mwP75eXlYCFNONsV6taTyQb04uLisaBt +iVdXl7OIphTQxgdx8GXDrdv35a1tTV58eJF8DaNOCUb0G2vt724uBjVOJtAmkQYpSmVn3Nz0L+6 uiovXrzw8j5De7Yv1EaxJAPatOdpwTwzMxNdayaQ0pZKMA2V2s+5r6AmnNOSZEDPzMzU/oIvLi6K iEQXzDkgnNILptyVf6bN+87Kyor13d6Ec3qSC+jFxcXKo9OFhQUREXWjbELpNcIpTTn/jNf9TO/t 7cny8rK8fPmSshCJEBvFkgroqo1hCwsLcnh4qPaXgFBKX84BJcLPeB3znrS0tDT4PYr2nKYkAtqc A23G1yKvfmBF9DXm3OQeTiIEVGps/0yb6zcsLi7K4eHh1HvalxHOfoTYKJZEQIu8bs/z8/NyeHgY NJgJpdcIp3Tl+nPu6me6GNRt2zThnLZkAvqdd96Rg4MDFY2ZUMpDrgFl8HPuxt7e3tGemaY2TTin L/qAPnfunJw5c0ZERH72s5/JixcvAj+jvNy5cyf0UwiGgEqPloMuE8xmqY4g1sH3RrFoA/rcuXPy 8uVL2d3dnWjN586dE5FXV/GBe+b7jfTkePCl7aCrGNQzMzNHQU17zsPM559/rusncgoTzNM2UhSD g7AGuuPgS593331XREQ+++yzwM8kX48ePfLWoqNp0MXG3EYxlGnVQHf8vuhh3sO+++47uX37tiws LPDvkwH1Ad01mKuYH2RaNYBYNL1f7e/vH429eS9Ll9qAthHMZbRqANq1fW8qrkcT1P743CimMqDP nTvn/HQpWjUALYa8DxHU6VK1SaztBjCXX1+EoAbgnqtywPq0e742iqlo0C7G2X3QqgG45roIsD6d jqABrSWYy1irBmCT74N+xt5pCBLQWoO5Cq0aQB8a3jMIajd8bRTzGtAxBXMZrRpAGxrfH4pBneMV 4mLlZZNY6M1frmg4QgYQXkzvBbRpO3xsFHPaoGNuzG3QqoF8xRTKRYy94+EkoFMP5iqsVQN5SOVg nKAexsc6tNWAzjGYy2jVQHpSPvBmfVovKwFNMFejVQPxyu339tatW7RpZQZtEkt185dLtGpAr9xC uQ5B3Y7rjWK9GjSNuT9aNaAPB86TWJ/WoVNAE8z2sFYNhMVB8nQEdTPXG8VaB7SPO0zlilYN+MHv WD8mqLkRh19TA5rW7A+tGnCD3yc7uBGHX7WbxNgApgNH/EA//O64RVC/4nKj2LEGTWPWhVYNtEco +8P6tHtHAU0w68daNVCNg9dwcl+fdrlRbEQwx4dWDXCgqg3r0/aNCOa40aqRE37OdWPsbdfMb3/7 W+e3m4RftGqkhp/pOOUS1K42ijm93STCoFUjBfz8xo8bcQxDQCeMtWrEhlBOU+o34nC1UYyAzgSt GlrxM5kH1qe7I6AzQ6uGFvz85Ymgbo9NYqDBwBt+1lCWyvq0i41iNGjQquEUoYwmqa9PD0FAYwJr 1bCFgz20lcLY28VGMQIalWjV6IMDOwyRQlDbREBjKlo1mvBzAdsI6lfYJIZeaNXgZwC+xHIjDtsb xWjQ6IVWnSf+vRFCrjfiIKAxCGvV6SOUoUEMY28bG8W2t7eP/j8BDWto1eng3xBaxRDUXRVDeWdn 5+j/E9CwjlYdL/69EAsT1LGsT5fVhXIRm8TgBY1ML/5tEDtNbbpuo1gxkEXqQ7mIBg0vaNW6EMpI idaxd5uW3IQGjWAICf84OEIOQgb1mTNn5IcffhCRfqFcRINGMLRqPzgQQm6KjTrEjTiGBrNBQEMF doDbxfcRiP9GHIy4oRatuju+Z0A1n0Ft64piNGioRatuh+8PMJ3WjWRNCGiox1r1cYQy0I+P9Wlb t54koBGV3Fs1ByiAHTGsT7MGjeilHlq5HowAvrgIahvr0DRoRC/FVp3SawG007o+TUAjGbGvVRPK QFjagpqARpJiatUxHkwAKbNxIw4bG8UIaCRNa6uO4cAByN3+/n7QNs0mMWQnVDgSykC8+gT10I1i NGhkx3er1tTcAfTTZ3367bffHvQ1adCA2G+3tGUgbW3Wpx89enQU0txuErCgb+MllIG8TGvTZ86c kWvXronI63tDdwnqmX/84x/WApo3JaSkbeAywgbyVhfUxYA2tre3W4e01QZdfEMDpokp0MohTFsG UFYV1FUbxdq2aUbcCCa2A7p333134r+/++67QM8kTxwIIRbFG3E07eSeFtQENDBF3Qib0bZfsR3Q IazQv5emTX/xxRdTT7WqC2oCGqjQZYTNuBvQJ/QB3Y9//GMREfn3v/8tH3/8cau/U16fJqCB/7ER tLRqIF/vvPOO/P3vfxcRka+++qrX5yi2aQIaWXPVfmnVQPreeecdEZHBoVxle3ubgEaefDZdWjWQ DhstuS0CGtkI3WpDf30A3blsydMQ0Eia1lCkVQN6+WzJTQhoJCmWANR6AAHkJGRLbkJAIxmxh10s BxVACoqhrCWQywhoRC32UK6S4msCQtPakpsQ0IhSLm0zl9cJuBBDS25CQCMaOTfLnF870FaMLbkJ AQ3VCKbjaNXAa7G35CYENNQhlNvh+4QcpdaSmxDQUINm2B/fO6Qs5ZbchIBGULRAu/h+IhVaLhYS EgEN7wgRP2jViElOo+u2CGh4Q2CEwQERtKIlN5v55JNPDkVEfvGLX4iIyL/+9a+gTwhpIRx04SAJ IdGSu5l57733Jhr0+vo6YY1BCGX9+DeCL7Tk/o4FdBFhjS5oZ3Hi3w020ZLtaQzoovX1dRF5NQon rGHQxNLBvyX6yvU0KNdaB3RRMaxFaNe54Y08fbRqNKEl+9EroMsYheeBN+38cDAGg5bs3+CA3t7e Pvr/Ozs7hHVieIOGwQFaXmjJ/hXzVGRAQJtPtLOzU/sY1q3jRCijCT8f6aIl+1UO5HKedgroclvu grDWjTdd9EGrjh+nQfnVJUdbBXSbttwFm8z04A0WNnCAFw9G135Na8lNGgPadjDXYd3aL95M4RIH ffoUW/L//d//Hf256/f2HA0J5LJjAT1kjG0Do3A3CGX4xs9cOG1bsq8SljpXuXkU0Br/oQjr4Wgz 0ICfQ/eGrCVrfP/XzGZLbjLz+9///tDlF7CFdev2aC7Qip9Ne1ysJRPU1XwFcpmVC5WEwLr1JN74 EBtadXe+dlznHtShArks2oAuynkUzpscYsfBZb3QO65D70nySeNrTSKgi3IIa97QkCoOOPVeLCS1 Vq2lJTdJLqCLUlq3JpSRk5x+3kO35K5iDeoYArks6YAui3HdmkaB3KX4O6C1JXehPahjDOSy/wf7 N0ZJzex1OAAAAABJRU5ErkJggg== "
-       preserveAspectRatio="none"
-       height="115.35833"
-       width="129.11667"
-       style="opacity:1" />
-  </g>
-  <g
      inkscape:groupmode="layer"
      id="layer3"
      inkscape:label="Calque 3"
      style="display:inline"
-     transform="translate(470.69208,-22.182517)">
+     transform="translate(531.29058,-276.27503)">
+    <rect
+       y="276.28369"
+       x="-531.28192"
+       height="113.18067"
+       width="204.04611"
+       id="rect2815"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.01731572;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+    <text
+       id="text1487"
+       y="19.553877"
+       x="-332.88181"
+       style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.26458332"
+         y="23.299385"
+         x="-332.88181"
+         id="tspan1485"
+         sodipodi:role="line" /></text>
     <g
-       id="g853"
-       transform="translate(-146.80274,-10.712205)">
+       id="g3681"
+       transform="matrix(0.34710464,0,0,0.34710464,-360.39374,273.11944)">
       <g
          id="g3352"
-         transform="translate(117.57435)">
+         transform="translate(-29.22839,-10.712205)">
         <path
            style="fill:#ffaaee;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            d="m -167.2354,43.514868 0.58657,39.268632 -3.79886,7.709069 -1.19355,-50.252777 z"
@@ -2826,7 +4466,7 @@
       </g>
       <g
          id="g2172"
-         transform="translate(3.8707961)">
+         transform="translate(-142.93194,-10.712205)">
         <g
            id="g3220">
           <path
@@ -3057,26 +4697,26 @@
       <text
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         x="-210.347"
-         y="119.61711"
+         x="-357.14975"
+         y="108.90491"
          id="text1483"><tspan
            sodipodi:role="line"
            id="tspan1481"
-           x="-210.347"
-           y="119.61711"
+           x="-357.14975"
+           y="108.90491"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1">Make incident halfedge to <tspan
    style="font-weight:bold"
    id="tspan2266">vo</tspan> point to <tspan
    style="font-weight:bold"
    id="tspan2264">vh</tspan> (in blue)</tspan><tspan
            sodipodi:role="line"
-           x="-210.347"
-           y="124.92691"
+           x="-357.14975"
+           y="114.21471"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="tspan2029">update their wedge to widx</tspan><tspan
            sodipodi:role="line"
-           x="-210.347"
-           y="130.21858"
+           x="-357.14975"
+           y="119.50637"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="tspan1857">delete <tspan
    style="font-weight:bold"
@@ -3084,30 +4724,19 @@
       <text
          xml:space="preserve"
          style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-         x="-186.07906"
-         y="30.266083"
-         id="text1487"><tspan
-           sodipodi:role="line"
-           id="tspan1485"
-           x="-186.07906"
-           y="34.011589"
-           style="stroke-width:0.26458332" /></text>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-         x="-324.05057"
-         y="119.61711"
+         x="-470.8533"
+         y="108.90491"
          id="text1491"><tspan
            sodipodi:role="line"
            id="tspan1489"
-           x="-324.05057"
-           y="119.61711"
+           x="-470.8533"
+           y="108.90491"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';stroke-width:0.26458332">collapse(<tspan
    style="font-weight:bold"
    id="tspan2262">h</tspan>) with wedge widx</tspan></text>
       <g
          id="g2232"
-         transform="translate(-4.9307811e-6)">
+         transform="translate(-146.80274,-10.712205)">
         <g
            transform="translate(-394.26174,-95.062148)"
            id="g2628">
@@ -3431,37 +5060,37 @@
       <text
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         x="-96.639313"
-         y="119.61711"
+         x="-243.44205"
+         y="108.90491"
          id="text1546"><tspan
            sodipodi:role="line"
            id="tspan1544"
-           x="-96.639313"
-           y="119.61711"
+           x="-243.44205"
+           y="108.90491"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1">After this, some faces are two sided </tspan><tspan
            sodipodi:role="line"
-           x="-96.639313"
-           y="124.90878"
+           x="-243.44205"
+           y="114.19657"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="tspan1853">(in pink, for real they have no surface)</tspan></text>
       <text
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         x="16.909206"
-         y="119.61711"
+         x="-129.89354"
+         y="108.90491"
          id="text1550"><tspan
            sodipodi:role="line"
            id="tspan1548"
-           x="16.909206"
-           y="119.61711"
+           x="-129.89354"
+           y="108.90491"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1">Remove loops, i.e. halfedges <tspan
    style="font-weight:bold"
    id="tspan2298">hn</tspan> and <tspan
    style="font-weight:bold"
    id="tspan2300">op</tspan> (in red, and the pink faces)</tspan><tspan
            sodipodi:role="line"
-           x="16.909206"
-           y="124.92691"
+           x="-129.89354"
+           y="114.21471"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="tspan1552"><tspan
    style="font-weight:bold"
@@ -3469,8 +5098,8 @@
    style="font-weight:bold"
    id="tspan2272">on</tspan> remains (corresponding to the purple edges/halfedges)</tspan><tspan
            sodipodi:role="line"
-           x="16.909206"
-           y="130.23671"
+           x="-129.89354"
+           y="119.52451"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="tspan2045"><tspan
    style="font-weight:bold"
@@ -3482,18 +5111,18 @@
    style="font-weight:normal"
    id="tspan2304">(resp. </tspan>b</tspan>)</tspan><tspan
            sodipodi:role="line"
-           x="16.909206"
-           y="135.54651"
+           x="-129.89354"
+           y="124.8343"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="tspan2043" /><tspan
            sodipodi:role="line"
-           x="16.909206"
-           y="140.83817"
+           x="-129.89354"
+           y="130.12596"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="tspan2031" /></text>
       <g
          id="g2129"
-         transform="translate(-31.056147)">
+         transform="translate(-177.85889,-10.712205)">
         <path
            id="path1558"
            d="m 235.13236,33.023512 -30.736,7.21628"
@@ -3673,7 +5302,7 @@
       </g>
       <g
          id="g2096"
-         transform="translate(-12.463958)">
+         transform="translate(-159.2667,-10.712205)">
         <path
            inkscape:connector-curvature="0"
            style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -3908,23 +5537,2540 @@
              id="tspan2039"
              sodipodi:role="line">b</tspan></text>
       </g>
-      <flowRoot
-         xml:space="preserve"
-         id="flowRoot2308"
-         style="font-style:normal;font-weight:normal;font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-         transform="matrix(0.26458333,0,0,0.26458333,146.80274,10.712205)"><flowRegion
-           id="flowRegion2310"><rect
-             id="rect2312"
-             width="1417.0476"
-             height="769.25446"
-             x="-2526.3936"
-             y="-845.15222" /></flowRegion><flowPara
-           id="flowPara2314"></flowPara></flowRoot>    </g>
+    </g>
+    <flowRoot
+       style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="flowRoot2308"
+       xml:space="preserve"><flowRegion
+         id="flowRegion2310"
+         style="stroke-width:0.26458332"><rect
+           y="-223.61319"
+           x="-668.44159"
+           height="203.53191"
+           width="374.92719"
+           id="rect2312"
+           style="stroke-width:0.07000434" /></flowRegion><flowPara
+         id="flowPara2314"
+         style="stroke-width:0.26458332" /></flowRoot>    <g
+       id="g3873"
+       transform="matrix(0.34710464,0,0,0.34710464,-360.41558,273.11944)">
+      <g
+         transform="translate(-29.22839,99.623515)"
+         id="g1481">
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -140.90524,33.023512 -30.736,7.21628"
+           id="path1402" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -117.38553,55.206882 -18.97613,12.56167"
+           id="path1404" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -109.63471,87.813762 -21.38156,25.390598"
+           id="path1406" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -136.36166,67.768552 -34.2105,22.7179"
+           id="path1408" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -170.66072,90.539913 9.86961,1.238409 30.15724,17.165808 -0.3824,4.26023"
+           id="path1414" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -109.63471,87.813762 -52.13623,-1.291759 -8.20333,3.970568"
+           id="path1416" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -213.86983,112.9371 43.29767,-22.450648"
+           id="path1422" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path1424"
+           d="m -131.01627,113.20436 0.3824,-4.26023 -30.15724,-17.16581 -9.65658,-1.285749 z"
+           style="fill:#ffaaee;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -170.57216,90.486452 39.55589,22.717908"
+           id="path1426" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -131.01627,113.20436 -82.85356,-0.53453"
+           id="path1428" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -140.90524,33.023512 23.51971,22.18337"
+           id="path1430" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -117.38553,55.206882 7.75082,32.60688"
+           id="path1432" />
+        <path
+           id="path1434"
+           d="m -119.04836,54.790612 -48.17022,32.30545"
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3380)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path1436"
+           d="m -111.71195,88.052502 -18.17264,22.086028"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2470)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           id="path1442"
+           d="m -161.52854,92.599725 29.85461,18.120865"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3396)"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1444"
+           d="m -169.82027,90.568465 9.67923,-2.994938 47.22396,1.416293"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3400)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccc" />
+        <path
+           id="path1450"
+           d="m -171.98686,89.706812 -38.9679,20.205588"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2967)"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1452"
+           d="M -132.95216,111.47806 -166.20605,91.646793"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3416)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path1454"
+           d="m -117.93909,56.770752 6.73912,28.12548"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2999)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3372)"
+           d="m -169.23066,40.611462 25.79467,-5.861954"
+           id="path1456"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3404)"
+           d="m -159.97747,84.429268 42.03838,-27.658516"
+           id="path1459"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3412)"
+           d="m -129.45851,108.57625 -31.82638,-18.010641 -5.72346,-0.05993"
+           id="path1465"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3408)"
+           d="m -111.5787,85.843066 -48.69796,-0.455101"
+           id="path1468"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3420)"
+           d="m -209.05735,111.6245 38.98463,-20.088428"
+           id="path1473"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2971)"
+           d="m -170.4835,91.662882 35.16304,20.470218"
+           id="path1475"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2535)"
+           d="m -135.32046,112.1331 -73.73689,-0.5086"
+           id="path1477"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3392)"
+           d="m -139.31956,36.017462 20.19695,18.79338"
+           id="path1479"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1818-4"
+           d="m -167.21858,87.096067 26.36223,-51.802025"
+           style="display:inline;opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.238125px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker7270-0)" />
+        <path
+           inkscape:connector-curvature="0"
+           style="display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m -170.57216,90.486462 -1.06908,-50.24667"
+           id="path1697-4-2" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1719-4-0"
+           d="m -168.80639,84.416396 -0.75903,-42.800664"
+           style="display:inline;opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.238125px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2391-1-1)" />
+        <path
+           style="display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.238125px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2481-0-5)"
+           d="m -173.59675,42.686302 0.87999,47.046212"
+           id="path1738-3-0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="display:inline;fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -170.44855,90.274046 29.54331,-57.250534"
+           id="path1701-3-3" />
+        <path
+           id="path1726-1-3"
+           d="m -142.93386,34.983842 -25.87253,49.432554"
+           style="display:inline;opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.238125px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker6173-1-3)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc"
+           inkscape:transform-center-x="9.8585882"
+           inkscape:transform-center-y="-0.71567592" />
+      </g>
+      <g
+         transform="translate(-142.93194,99.623515)"
+         id="g1567">
+        <g
+           id="g1563">
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -140.90524,33.023512 -30.736,7.21628"
+             id="path1483" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -117.38553,55.206882 -18.97613,12.56167"
+             id="path1485" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -109.63471,87.813762 -21.38156,25.390598"
+             id="path1487" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#ff0000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -136.36166,67.768552 -34.2105,22.7179"
+             id="path1489" />
+          <path
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -171.64124,40.239792 35.27958,27.52876"
+             id="path1493"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -136.36166,67.768552 5.34539,45.435808"
+             id="path1495" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -109.63471,87.813762 -26.72695,-20.04521"
+             id="path1497" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -136.36166,67.768552 -4.54358,-34.74504"
+             id="path1499" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -213.86983,112.9371 43.29767,-22.450648"
+             id="path1503" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -170.57216,90.486452 39.55589,22.717908"
+             id="path1505" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -131.01627,113.20436 -82.85356,-0.53453"
+             id="path1507" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -140.90524,33.023512 23.51971,22.18337"
+             id="path1509" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -117.38553,55.206882 7.75082,32.60688"
+             id="path1511" />
+          <path
+             id="path1513"
+             d="m -119.80583,54.222512 -46.27655,29.938364"
+             style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2979)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path1515"
+             d="m -111.71195,88.052502 -18.17264,22.086028"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2470)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path1517"
+             d="m -167.91035,90.510592 30.78945,-20.44611"
+             style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2983)"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path1521"
+             d="m -137.47904,65.387352 -31.75162,-24.77589"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3003)" />
+          <path
+             id="path1523"
+             d="m -137.47896,70.065072 4.81085,40.892228"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2418)"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1525"
+             d="m -134.61817,70.662762 22.90622,17.38974"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3498)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path1528"
+             d="m -142.06349,34.414752 -26.00724,51.97119"
+             style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3268)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc"
+             inkscape:transform-center-x="9.8585882"
+             inkscape:transform-center-y="-0.71567592" />
+          <path
+             id="path1532"
+             d="m -171.98686,89.706812 -38.9679,20.205588"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2967)"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1534"
+             d="M -132.66811,110.9573 -167.91035,90.510592"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2431)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path1536"
+             d="m -117.93909,56.770752 6.73912,28.12548"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2999)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2340)"
+             d="m -169.23066,40.611462 27.16717,-6.19671"
+             id="path1538"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2496)"
+             d="m -134.40208,67.423642 16.46299,-10.65289"
+             id="path1540"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:none;stroke:#ff0000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker2995)"
+             d="m -138.93794,67.515232 -30.42667,20.29945"
+             id="path1542"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2309)"
+             d="m -169.40916,43.075282 0.50392,43.09258"
+             id="path1546"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2987)"
+             d="m -129.88459,110.13853 -37.4467,-20.491738"
+             id="path1548"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2991)"
+             d="m -111.19997,84.896232 -54.9684,3.9732"
+             id="path1550"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2366)"
+             d="m -135.29617,65.698972 -4.08922,-29.66371"
+             id="path1552"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2548)"
+             d="m -209.05735,111.6245 38.98463,-20.088428"
+             id="path1555"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2971)"
+             d="m -170.4835,91.662882 35.16304,20.470218"
+             id="path1557"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2535)"
+             d="m -135.32046,112.1331 -73.73689,-0.5086"
+             id="path1559"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3011)"
+             d="m -139.31956,36.017462 20.19695,18.79338"
+             id="path1561"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+        </g>
+        <circle
+           r="1.0888592"
+           cy="67.848015"
+           cx="-136.33174"
+           id="circle1565"
+           style="opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      </g>
+      <g
+         transform="translate(-146.80274,99.623515)"
+         id="g1687">
+        <g
+           id="g1649"
+           transform="translate(-394.26174,-95.062148)">
+          <path
+             id="path1569"
+             d="m 143.52374,128.08566 -30.736,7.21628"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1571"
+             d="M 167.04345,150.26903 148.06732,162.8307"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1573"
+             d="m 174.79427,182.87591 -21.38156,25.3906"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1575"
+             d="m 148.06732,162.8307 -34.2105,22.7179"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path1579"
+             d="m 112.78774,135.30194 35.27958,27.52876"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             id="path1581"
+             d="m 148.06732,162.8307 5.34539,45.43581"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1583"
+             d="M 174.79427,182.87591 148.06732,162.8307"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1585"
+             d="m 148.06732,162.8307 -4.54358,-34.74504"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1589"
+             d="M 70.559154,207.99925 113.85682,185.5486"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1591"
+             d="m 113.85682,185.5486 39.55589,22.71791"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1593"
+             d="M 153.41271,208.26651 70.559155,207.73198"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1595"
+             d="m 143.52374,128.08566 23.51971,22.18337"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1599"
+             d="m 167.04345,150.26903 7.75082,32.60688"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2392)"
+             d="m 165.38062,149.85276 -16.2751,10.9038"
+             id="path1601" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2470)"
+             d="m 172.71703,183.11465 -18.17264,22.08603"
+             id="path1603" />
+          <path
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2405)"
+             d="m 116.32154,185.57566 30.78945,-20.44611"
+             id="path1605" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2327)"
+             d="M 146.94994,160.4495 115.19832,135.67361"
+             id="path1609"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2418)"
+             d="m 146.95002,165.12722 4.81085,40.89223"
+             id="path1611" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2457)"
+             d="m 149.81081,165.72491 22.90622,17.38974"
+             id="path1613" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2353)"
+             d="m 142.36549,129.4769 4.58445,30.9726"
+             id="path1615" />
+          <path
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2561)"
+             d="M 112.44212,184.76896 73.474222,204.97455"
+             id="path1619" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2431)"
+             d="M 151.76087,206.01945 116.51863,185.57274"
+             id="path1621" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2509)"
+             d="m 166.48989,151.8329 6.73912,28.12548"
+             id="path1623" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path1625"
+             d="m 115.19832,135.67361 27.16717,-6.19671"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2340)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path1627"
+             d="M 150.0269,162.48579 166.48989,151.8329"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2496)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path1629"
+             d="m 145.49104,162.57738 -30.42667,20.29945"
+             style="fill:#008000;stroke:#008000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker2175)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path1633"
+             d="m 114.19134,138.01908 31.2997,24.5583"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2212)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path1635"
+             d="m 154.54439,205.20068 -4.73358,-39.47577"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2444)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path1637"
+             d="M 173.22901,179.95838 150.0269,162.48579"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2483)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path1639"
+             d="m 149.13281,160.76112 -4.08922,-29.66371"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2366)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path1641"
+             d="M 75.371629,206.68665 114.35626,186.59822"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2548)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path1643"
+             d="m 113.94548,186.72503 35.16304,20.47022"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2522)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path1645"
+             d="m 149.10852,207.19525 -73.736891,-0.5086"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2535)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path1647"
+             d="m 145.10942,131.07961 20.19695,18.79338"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2379)" />
+        </g>
+        <circle
+           style="opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;stroke:#333333;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="circle1651"
+           cx="-279.41464"
+           cy="90.082382"
+           r="2.9351857" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="-267.224"
+           y="77.265884"
+           id="text1655"><tspan
+             sodipodi:role="line"
+             id="tspan1653"
+             x="-267.224"
+             y="77.265884"
+             style="font-weight:bold;stroke-width:0.26458332">h</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="-262.0018"
+           y="83.559303"
+           id="text1659"><tspan
+             sodipodi:role="line"
+             id="tspan1657"
+             x="-262.0018"
+             y="83.559303"
+             style="stroke-width:0.26458332">o</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="-300.69968"
+           y="96.280052"
+           id="text1663"><tspan
+             sodipodi:role="line"
+             id="tspan1661"
+             x="-300.69968"
+             y="96.280052"
+             style="stroke-width:0.26458332">hn</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="-266.55447"
+           y="58.251717"
+           id="text1667"><tspan
+             sodipodi:role="line"
+             id="tspan1665"
+             x="-266.55447"
+             y="58.251717"
+             style="stroke-width:0.26458332">hp</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="-251.82521"
+           y="91.057846"
+           id="text1671"><tspan
+             sodipodi:role="line"
+             id="tspan1669"
+             x="-251.82521"
+             y="91.057846"
+             style="stroke-width:0.26458332">on</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="-261.33228"
+           y="97.886887"
+           id="text1675"><tspan
+             sodipodi:role="line"
+             id="tspan1673"
+             x="-261.33228"
+             y="97.886887"
+             style="stroke-width:0.26458332">op</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="-282.04126"
+           y="91.415672"
+           id="text1679"><tspan
+             sodipodi:role="line"
+             id="tspan1677"
+             x="-282.04126"
+             y="91.415672"
+             style="stroke-width:0.26458332">vh</tspan></text>
+        <circle
+           style="display:inline;opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;stroke:#333333;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="circle1681"
+           cx="-246.51216"
+           cy="68.115822"
+           r="2.9351857" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="-248.96942"
+           y="69.476562"
+           id="text1685"><tspan
+             sodipodi:role="line"
+             id="tspan1683"
+             x="-248.96942"
+             y="69.476562"
+             style="stroke-width:0.26458332">vo</tspan></text>
+      </g>
+      <g
+         transform="translate(-177.85889,99.623515)"
+         id="g1752">
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 235.13236,33.023512 -30.736,7.21628"
+           id="path1689" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 258.65207,55.206882 -18.97613,12.56167"
+           id="path1691" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 266.40289,87.813762 245.02133,113.20436"
+           id="path1693" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 239.67594,67.768552 -34.2105,22.7179"
+           id="path1695" />
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 205.46544,90.486452 -1.06908,-50.24666"
+           id="path1697" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 266.40289,87.813762 205.9647,90.271275"
+           id="path1699" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 205.58905,90.274037 235.13236,33.023512"
+           id="path1701" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 162.16777,112.9371 205.46544,90.486452"
+           id="path1705" />
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 205.46544,90.486452 39.55589,22.717908"
+           id="path1707" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 245.02133,113.20436 -82.85356,-0.53453"
+           id="path1709" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 235.13236,33.023512 23.51971,22.18337"
+           id="path1711" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 258.65207,55.206882 7.75082,32.60688"
+           id="path1713" />
+        <path
+           id="path1715"
+           d="m 256.98924,54.790612 -48.17022,32.30545"
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1706)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path1717"
+           d="M 263.09477,89.141361 244.81398,110.13853"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1819)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1719"
+           d="M 207.82791,82.459929 206.47218,41.615731"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2391)" />
+        <path
+           sodipodi:nodetypes="cc"
+           id="path1721"
+           d="m 205.57912,91.394602 34.4073,20.665018"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.23800001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2027)"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1724"
+           d="M 213.08461,90.787189 263.12052,88.98982"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1795)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path1726"
+           d="M 233.10374,34.983838 207.23121,84.416384"
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker6173)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc"
+           inkscape:transform-center-x="9.8585882"
+           inkscape:transform-center-y="-0.71567592" />
+        <path
+           id="path1730"
+           d="M 204.05074,89.706812 165.08284,109.9124"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2967)"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1732"
+           d="m 258.09851,56.770752 6.20351,28.928895"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1807)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2341)"
+           d="m 206.53913,41.950488 26.46419,-6.531467"
+           id="path1734"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1811)"
+           d="M 211.64135,88.245491 258.09851,56.770752"
+           id="path1736"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2481)"
+           d="m 202.44085,42.686301 0.87999,47.046204"
+           id="path1738"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.23800001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2014)"
+           d="M 244.97226,110.18308 211.75812,90.919975"
+           id="path1740"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1803)"
+           d="M 264.4589,85.843066 211.34216,88.26687"
+           id="path1742"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1799)"
+           d="M 209.00651,86.788626 235.18125,35.29404"
+           id="path1744"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3647)"
+           d="M 166.98025,111.6245 205.96488,91.536072"
+           id="path1746"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2535)"
+           d="m 240.71714,112.1331 -73.73689,-0.5086"
+           id="path1748"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2053)"
+           d="m 236.71804,36.017462 20.19695,18.79338"
+           id="path1750"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+      </g>
+      <g
+         transform="translate(-159.2667,99.623515)"
+         id="g1836">
+        <path
+           id="path1754"
+           d="m 102.83662,33.023512 -30.736,7.21628"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1756"
+           d="M 126.35633,55.206882 107.3802,67.768552"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1758"
+           d="M 134.10715,87.813762 112.72559,113.20436"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1760"
+           d="m 107.3802,67.768552 -34.2105,22.7179"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1766"
+           d="m 73.08114,90.539913 9.86961,1.238409 30.15724,17.165808 -0.3824,4.26023"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.565;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccc" />
+        <path
+           id="path1768"
+           d="M 134.10715,87.813762 81.97092,86.522003 73.76759,90.492571"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccc" />
+        <path
+           id="path1774"
+           d="M 29.87203,112.9371 73.1697,90.486452"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1776"
+           d="m 73.1697,90.486452 39.55589,22.717908"
+           style="fill:none;stroke:#ff0000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1778"
+           d="M 112.72559,113.20436 29.87203,112.66983"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1780"
+           d="m 102.83662,33.023512 23.51971,22.18337"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1782"
+           d="m 126.35633,55.206882 7.75082,32.60688"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3380)"
+           d="M 124.6935,54.790612 76.52328,87.096062"
+           id="path1784" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3691)"
+           d="M 132.02991,88.052502 113.85727,110.13853"
+           id="path1786" />
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.23800001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1975)"
+           d="m 82.21332,92.599725 29.85461,18.120865"
+           id="path1792"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3400)"
+           d="m 73.92159,90.568465 9.67923,-2.994938 47.22396,1.416293"
+           id="path1794" />
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2967)"
+           d="M 71.755,89.706812 32.7871,109.9124"
+           id="path1800" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:#ff0000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3594)"
+           d="M 110.7897,111.47806 77.53581,91.646793"
+           id="path1802" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2999)"
+           d="m 125.80277,56.770752 6.73912,28.12548"
+           id="path1804" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1806"
+           d="m 74.5112,40.611462 25.79467,-5.861954"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3372)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1808"
+           d="M 83.76439,84.429268 125.80277,56.770752"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3404)" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           id="path1814"
+           d="M 114.28335,108.57625 82.45697,90.565609 76.73351,90.505679"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.23800001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1962)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1816"
+           d="M 132.16316,85.843066 83.4652,85.387965"
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3408)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1818"
+           d="M 76.52328,87.096062 102.88551,35.29404"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker7270)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1820"
+           d="M 34.68451,111.6245 73.66914,91.536072"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3647)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1822"
+           d="M 73.25836,91.662882 108.4214,112.1331"
+           style="opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:#ff0000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3643)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1824"
+           d="M 108.4214,112.1331 34.68451,111.6245"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2535)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1826"
+           d="m 104.4223,36.017462 20.19695,18.79338"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1556)" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="80.134407"
+           y="95.33429"
+           id="text1834"><tspan
+             sodipodi:role="line"
+             id="tspan1832"
+             x="80.134407"
+             y="95.33429"
+             style="stroke-width:0.26458332">b</tspan></text>
+        <path
+           inkscape:connector-curvature="0"
+           style="display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="M 73.1697,90.486456 72.10062,40.239792"
+           id="path1697-4" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1719-4"
+           d="M 74.93547,84.41639 74.17644,41.615732"
+           style="display:inline;opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.238125px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2391-1)" />
+        <path
+           style="display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.238125px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2481-0)"
+           d="M 70.14511,42.686302 71.0251,89.732508"
+           id="path1738-3"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="display:inline;fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 73.29331,90.27404 102.83662,33.023512"
+           id="path1701-3" />
+        <path
+           id="path1726-1"
+           d="M 100.808,34.983842 74.93547,84.41639"
+           style="display:inline;opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.238125px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker6173-1)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc"
+           inkscape:transform-center-x="9.8585882"
+           inkscape:transform-center-y="-0.71567592" />
+      </g>
+    </g>
+    <flowRoot
+       transform="matrix(0.26458333,0,0,0.26458333,-479.56252,229.66774)"
+       style="font-style:normal;font-weight:normal;font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot2807"
+       xml:space="preserve"><flowRegion
+         id="flowRegion2809"><rect
+           y="310.50851"
+           x="-133.12338"
+           height="505.2963"
+           width="1022.0441"
+           id="rect2811" /></flowRegion><flowPara
+         id="flowPara2813" /></flowRoot>    <g
+       id="g1853"
+       transform="translate(-108.21956)">
+      <g
+         id="g1789"
+         transform="matrix(0.34710464,0,0,0.34710464,-242.12998,221.83039)">
+        <path
+           d="m -476.84706,440.9689 a 7.0563884,7.0563884 0 0 1 2.76896,-9.17702 7.0563884,7.0563884 0 0 1 9.36366,2.05108 l -5.78999,4.03344 z"
+           sodipodi:end="5.6747281"
+           sodipodi:start="2.6879363"
+           sodipodi:ry="7.0563884"
+           sodipodi:rx="7.0563884"
+           sodipodi:cy="437.8764"
+           sodipodi:cx="-470.50443"
+           sodipodi:type="arc"
+           id="path1650"
+           style="display:inline;opacity:1;vector-effect:none;fill:#2c5aa0;fill-opacity:1;stroke:#000000;stroke-width:0.05;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+        <path
+           style="display:inline;opacity:1;vector-effect:none;fill:#44aa00;fill-opacity:1;stroke:#000000;stroke-width:0.05000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="path1652"
+           sodipodi:type="arc"
+           sodipodi:cx="-470.50443"
+           sodipodi:cy="437.8764"
+           sodipodi:rx="7.0563884"
+           sodipodi:ry="7.0563884"
+           sodipodi:start="5.6896692"
+           sodipodi:end="0.49907344"
+           d="m -464.65482,433.92991 a 7.0563884,7.0563884 0 0 1 0.34609,7.32377 l -6.1957,-3.37728 z" />
+        <path
+           d="m -464.28472,441.23494 a 7.0563884,7.0563884 0 0 1 -6.35308,3.58433 7.0563884,7.0563884 0 0 1 -6.13053,-3.95294 l 6.3388,-3.10037 z"
+           sodipodi:end="2.6866945"
+           sodipodi:start="0.51393615"
+           sodipodi:ry="7.0563884"
+           sodipodi:rx="7.0563884"
+           sodipodi:cy="437.76596"
+           sodipodi:cx="-470.42953"
+           sodipodi:type="arc"
+           id="path1654"
+           style="display:inline;opacity:1;vector-effect:none;fill:#00d4aa;fill-opacity:1;stroke:#000000;stroke-width:0.05;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+        <path
+           d="m -430.46411,410.96016 a 7.0563884,7.0563884 0 0 1 0.60921,7.06475 7.0563884,7.0563884 0 0 1 -5.83655,4.02698 7.0563884,7.0563884 0 0 1 -6.38842,-3.07735 l 5.84192,-3.95785 z"
+           sodipodi:end="2.5461338"
+           sodipodi:start="5.670735"
+           sodipodi:ry="7.0563884"
+           sodipodi:rx="7.0563884"
+           sodipodi:cy="415.01669"
+           sodipodi:cx="-436.23795"
+           sodipodi:type="arc"
+           id="path1656"
+           style="opacity:1;vector-effect:none;fill:#00ffff;fill-opacity:1;stroke:#000000;stroke-width:0.05;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+        <path
+           d="m -442.17058,418.83906 a 7.0563884,7.0563884 0 0 1 2.08727,-9.69523 7.0563884,7.0563884 0 0 1 9.72029,1.96726 l -5.856,3.93698 z"
+           sodipodi:end="5.6912951"
+           sodipodi:start="2.5744274"
+           sodipodi:ry="7.0563884"
+           sodipodi:rx="7.0563884"
+           sodipodi:cy="415.04807"
+           sodipodi:cx="-436.21902"
+           sodipodi:type="arc"
+           id="path1658"
+           style="opacity:1;vector-effect:none;fill:#aa4400;fill-opacity:1;stroke:#000000;stroke-width:0.05;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -440.7626,380.30302 -30.736,7.21628"
+           id="path1660" />
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.84124488;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m -417.24289,402.48639 -18.97613,12.56167"
+           id="path1662" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -409.49207,435.09327 -21.38156,25.3906"
+           id="path1664" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.84124488;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -436.21902,415.04806 -34.2105,22.7179"
+           id="path1666" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M -470.42952,437.76596 -471.4986,387.5193"
+           id="path1668" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -471.4986,387.5193 35.27958,27.52876"
+           id="path1670"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -436.21902,415.04806 5.34539,45.43581"
+           id="path1672" />
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m -409.49207,435.09327 -26.72695,-20.04521"
+           id="path1674" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -436.21902,415.04806 -4.54358,-34.74504"
+           id="path1676" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -471.4986,387.5193 -42.22859,72.69731"
+           id="path1678" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -513.72719,460.21661 43.29767,-22.45065"
+           id="path1681" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -470.42952,437.76596 39.55589,22.71791"
+           id="path1683" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -430.87363,460.48387 -82.85355,-0.53453"
+           id="path1685" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -440.7626,380.30302 23.51971,22.18337"
+           id="path1687" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -417.24289,402.48639 7.75082,32.60688"
+           id="path1690" />
+        <path
+           id="path1694"
+           d="m -418.90572,402.07012 -16.2751,10.9038"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2392-6)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path1698"
+           d="m -411.56931,435.33201 -18.17264,22.08603"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2470-6)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path1702"
+           d="m -467.9648,437.79302 30.78945,-20.44611"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2405-8)"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1706"
+           d="m -469.22197,435.09419 -0.96217,-45.22199"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2199-9)"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1708"
+           d="m -437.3364,412.66686 -31.75162,-24.77589"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2327-0)" />
+        <path
+           id="path1710"
+           d="m -437.33632,417.34458 4.81085,40.89223"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2418-3)"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1712"
+           d="m -434.47553,417.94227 22.90622,17.38974"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2457-5)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path1714"
+           d="m -441.92085,381.69426 4.58445,30.9726"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2353-2)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path1716"
+           d="m -510.81212,457.19191 38.04616,-65.62145"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2574-8)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path1718"
+           d="m -471.84422,436.98632 -38.9679,20.20559"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2561-7)"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1720"
+           d="M -432.52547,458.23681 -467.76771,437.7901"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2431-6)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path1722"
+           d="m -417.79645,404.05026 6.73912,28.12548"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2509-2)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2340-3)"
+           d="m -469.08802,387.89097 27.16717,-6.19671"
+           id="path1725"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2496-9)"
+           d="m -434.25944,414.70315 16.46299,-10.65289"
+           id="path1727"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2587-0)"
+           d="m -472.61147,391.32727 0.96217,45.22199"
+           id="path1729"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2212-6)"
+           d="m -470.095,390.23644 31.2997,24.5583"
+           id="path1731"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2444-0)"
+           d="m -429.74195,457.41804 -4.73358,-39.47577"
+           id="path1733"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2483-3)"
+           d="m -411.05733,432.17574 -23.20211,-17.47259"
+           id="path1735"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2366-0)"
+           d="m -435.15353,412.97848 -4.08922,-29.66371"
+           id="path1737"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2548-1)"
+           d="m -508.91471,458.90401 38.98463,-20.08843"
+           id="path1739"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2522-5)"
+           d="m -470.34086,438.94239 35.16304,20.47022"
+           id="path1741"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2535-7)"
+           d="m -435.17782,459.41261 -73.73689,-0.5086"
+           id="path1743"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2379-5)"
+           d="m -439.17692,383.29697 20.19695,18.79338"
+           id="path1745"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="-457.2486"
+           y="424.54538"
+           id="text1749"><tspan
+             sodipodi:role="line"
+             id="tspan1747"
+             x="-457.2486"
+             y="424.54538"
+             style="font-weight:bold;stroke-width:0.26458332">h</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="-452.0264"
+           y="430.83881"
+           id="text1753"><tspan
+             sodipodi:role="line"
+             id="tspan1751"
+             x="-452.0264"
+             y="430.83881"
+             style="stroke-width:0.26458332">o</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="-469.03204"
+           y="415.70782"
+           id="text1757"><tspan
+             sodipodi:role="line"
+             id="tspan1755"
+             x="-469.03204"
+             y="415.70782"
+             style="stroke-width:0.26458332">hn</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="-456.57907"
+           y="405.53122"
+           id="text1761"><tspan
+             sodipodi:role="line"
+             id="tspan1759"
+             x="-456.57907"
+             y="405.53122"
+             style="stroke-width:0.26458332">hp</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="-441.84982"
+           y="438.33734"
+           id="text1765"><tspan
+             sodipodi:role="line"
+             id="tspan1763"
+             x="-441.84982"
+             y="438.33734"
+             style="stroke-width:0.26458332">on</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="-451.35687"
+           y="445.16638"
+           id="text1769"><tspan
+             sodipodi:role="line"
+             id="tspan1767"
+             x="-451.35687"
+             y="445.16638"
+             style="stroke-width:0.26458332">op</tspan></text>
+        <g
+           id="g1777">
+          <circle
+             r="2.9351857"
+             cy="415.39532"
+             cx="-436.53677"
+             id="circle1771"
+             style="display:inline;opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;stroke:#333333;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <text
+             id="text1775"
+             y="416.75607"
+             x="-438.99402"
+             style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+             xml:space="preserve"><tspan
+               style="stroke-width:0.26458332"
+               y="416.75607"
+               x="-438.99402"
+               id="tspan1773"
+               sodipodi:role="line">vo</tspan></text>
+        </g>
+        <path
+           style="display:inline;fill:#ff0000;stroke:#ff0000;stroke-width:0.565;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2175-78)"
+           d="m -438.7953,414.79473 -30.42667,20.29945"
+           id="path1779"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <g
+           id="g1787"
+           transform="translate(-0.60276563,0.09644282)">
+          <circle
+             r="2.9351857"
+             cy="437.36188"
+             cx="-469.43924"
+             id="circle1781"
+             style="opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;stroke:#333333;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <text
+             id="text1785"
+             y="438.69519"
+             x="-472.06586"
+             style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+             xml:space="preserve"><tspan
+               style="stroke-width:0.26458332"
+               y="438.69519"
+               x="-472.06586"
+               id="tspan1783"
+               sodipodi:role="line">vh</tspan></text>
+        </g>
+      </g>
+      <g
+         id="g1851">
+        <path
+           d="m -363.94681,372.44946 a 2.4493055,2.4493055 0 0 1 0.12013,2.54211 l -2.15055,-1.17226 z"
+           sodipodi:end="0.49907344"
+           sodipodi:start="5.6896692"
+           sodipodi:ry="2.4493055"
+           sodipodi:rx="2.4493055"
+           sodipodi:cy="373.81931"
+           sodipodi:cx="-365.97723"
+           sodipodi:type="arc"
+           id="path1791"
+           style="display:inline;opacity:1;vector-effect:none;fill:#44aa00;fill-opacity:1;stroke:#000000;stroke-width:0.01735524;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+        <path
+           style="display:inline;opacity:1;vector-effect:none;fill:#2c5aa0;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="path1795"
+           sodipodi:type="arc"
+           sodipodi:cx="-365.97723"
+           sodipodi:cy="373.81931"
+           sodipodi:rx="2.4493055"
+           sodipodi:ry="2.4493055"
+           sodipodi:start="2.6879363"
+           sodipodi:end="5.6747281"
+           d="m -368.17879,374.89273 a 2.4493055,2.4493055 0 0 1 0.96112,-3.18539 2.4493055,2.4493055 0 0 1 3.25017,0.71194 l -2.00973,1.40003 z" />
+        <path
+           style="display:inline;opacity:1;vector-effect:none;fill:#00d4aa;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="path1798"
+           sodipodi:type="arc"
+           sodipodi:cx="-365.95123"
+           sodipodi:cy="373.78098"
+           sodipodi:rx="2.4493055"
+           sodipodi:ry="2.4493055"
+           sodipodi:start="0.51393615"
+           sodipodi:end="2.6866945"
+           d="m -363.81834,374.98508 a 2.4493055,2.4493055 0 0 1 -2.20518,1.24413 2.4493055,2.4493055 0 0 1 -2.12794,-1.37208 l 2.20023,-1.07615 z" />
+        <g
+           id="g1841"
+           transform="matrix(0.34710464,0,0,0.34710464,-437.29524,342.41104)"
+           style="display:inline">
+          <path
+             id="path1803"
+             d="m 235.13236,33.023512 -30.736,7.21628"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1807"
+             d="m 258.65207,55.206882 -18.97613,12.56167"
+             style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.84124488;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1810"
+             d="M 266.40289,87.813762 245.02133,113.20436"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1812"
+             d="m 239.67594,67.768552 -34.2105,22.7179"
+             style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.84124488;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1815"
+             d="m 205.46544,90.486452 -1.06908,-50.24666"
+             style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1819"
+             d="M 266.40289,87.813762 205.9647,90.271275"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path1827"
+             d="M 205.58905,90.274037 235.13236,33.023512"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path1829"
+             d="M 204.39636,40.239792 162.16777,112.9371"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1831"
+             d="M 162.16777,112.9371 205.46544,90.486452"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1833"
+             d="m 205.46544,90.486452 39.55589,22.717908"
+             style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1835"
+             d="m 245.02133,113.20436 -82.85356,-0.53453"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1837"
+             d="m 235.13236,33.023512 23.51971,22.18337"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path1839"
+             d="m 258.65207,55.206882 7.75082,32.60688"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g1849"
+           style="display:inline"
+           transform="matrix(0.34710464,0,0,0.34710464,-214.48335,229.67193)">
+          <circle
+             style="display:inline;opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;stroke:#333333;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="circle1843"
+             cx="-436.53677"
+             cy="415.39532"
+             r="2.9351857" />
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+             x="-438.99402"
+             y="416.75607"
+             id="text1847"><tspan
+               sodipodi:role="line"
+               id="tspan1845"
+               x="-438.99402"
+               y="416.75607"
+               style="stroke-width:0.26458332">vo</tspan></text>
+        </g>
+      </g>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+       x="-523.36707"
+       y="349.75623"
+       id="text1491-9"><tspan
+         sodipodi:role="line"
+         id="tspan1489-1"
+         x="-523.36707"
+         y="349.75623"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1.46940958px;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';stroke-width:0.0918381">collapse(<tspan
+   style="font-weight:bold;stroke-width:0.0918381"
+   id="tspan2262-2">h</tspan>) a boundary halfedge</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="-510.24719"
+       y="384.68835"
+       id="text12116"><tspan
+         sodipodi:role="line"
+         id="tspan12114"
+         x="-510.24719"
+         y="394.05212"
+         style="stroke-width:0.26458332"></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+       x="-528.1283"
+       y="384.24289"
+       id="text1491-7"><tspan
+         sodipodi:role="line"
+         id="tspan1489-0"
+         x="-528.1283"
+         y="384.24289"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1.46940958px;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';stroke-width:0.0918381">Wedges updates work has follow: if multiple wedges are around vo and vh, we try to identify</tspan><tspan
+         sodipodi:role="line"
+         x="-528.1283"
+         y="386.08383"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1.46940958px;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';stroke-width:0.0918381"
+         id="tspan13861">a feature loop, to update wedges respecting the loop.      </tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+       x="-446.21594"
+       y="382.23294"
+       id="text1491-7-6"><tspan
+         sodipodi:role="line"
+         x="-446.21594"
+         y="382.23294"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1.46940958px;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';stroke-width:0.0918381"
+         id="tspan13861-8">In the general case, if vh as two different wedges on both side of h, the first one will be set to all halfedges pointing to vo that have the</tspan><tspan
+         sodipodi:role="line"
+         x="-446.21594"
+         y="384.07388"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1.46940958px;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';stroke-width:0.0918381"
+         id="tspan13957">same wedge has hp, the second one will be set to the remaining halfedges</tspan></text>
+    <g
+       id="g65794"
+       transform="translate(-3.9767034,5.6810049)">
+      <g
+         transform="translate(-10.054167)"
+         id="g65599">
+        <g
+           id="g8381"
+           transform="matrix(0.70158983,0,0,0.70158983,-136.72946,106.42568)">
+          <path
+             style="display:inline;opacity:1;vector-effect:none;fill:#c83737;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path1855"
+             sodipodi:type="arc"
+             sodipodi:cx="-405.44424"
+             sodipodi:cy="373.81934"
+             sodipodi:rx="2.4493051"
+             sodipodi:ry="2.4493051"
+             sodipodi:start="2.6879363"
+             sodipodi:end="4.7019997"
+             d="m -407.6458,374.89276 a 2.4493051,2.4493051 0 0 1 0.1178,-2.36069 2.4493051,2.4493051 0 0 1 2.05831,-1.16191 l 0.0255,2.44918 z" />
+          <path
+             d="m -405.44439,371.37003 a 2.4493051,2.4493051 0 0 1 2.00988,1.04928 l -2.00973,1.40003 z"
+             sodipodi:end="5.6747281"
+             sodipodi:start="4.7123279"
+             sodipodi:ry="2.4493051"
+             sodipodi:rx="2.4493051"
+             sodipodi:cy="373.81934"
+             sodipodi:cx="-405.44424"
+             sodipodi:type="arc"
+             id="path4344-1"
+             style="display:inline;opacity:1;vector-effect:none;fill:#2c5aa0;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <path
+             style="display:inline;opacity:1;vector-effect:none;fill:#44aa00;fill-opacity:1;stroke:#000000;stroke-width:0.01735524;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path4557"
+             sodipodi:type="arc"
+             sodipodi:cx="-405.44424"
+             sodipodi:cy="373.81934"
+             sodipodi:rx="2.4493051"
+             sodipodi:ry="2.4493051"
+             sodipodi:start="5.6896692"
+             sodipodi:end="0.49907344"
+             d="m -403.41382,372.44949 a 2.4493051,2.4493051 0 0 1 0.12013,2.54211 l -2.15055,-1.17226 z" />
+          <path
+             d="m -403.28535,374.98508 a 2.4493051,2.4493051 0 0 1 -2.181,1.24473 2.4493051,2.4493051 0 0 1 -2.13043,-1.32943 l 2.17854,-1.1194 z"
+             sodipodi:end="2.6669389"
+             sodipodi:start="0.51393615"
+             sodipodi:ry="2.4493051"
+             sodipodi:rx="2.4493051"
+             sodipodi:cy="373.78098"
+             sodipodi:cx="-405.41824"
+             sodipodi:type="arc"
+             id="path4559"
+             style="display:inline;opacity:1;vector-effect:none;fill:#00d4aa;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <path
+             d="m -393.26401,368.3288 a 2.4493051,2.4493051 0 0 1 -2.31738,-1.07436 l 2.03775,-1.35893 z"
+             sodipodi:end="2.5534438"
+             sodipodi:start="1.4563784"
+             sodipodi:ry="2.4493051"
+             sodipodi:rx="2.4493051"
+             sodipodi:cy="365.89551"
+             sodipodi:cx="-393.54364"
+             sodipodi:type="arc"
+             id="path8054"
+             style="opacity:1;vector-effect:none;fill:#88aa00;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#aa0044;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path8056"
+             sodipodi:type="arc"
+             sodipodi:cx="-393.54364"
+             sodipodi:cy="365.89551"
+             sodipodi:rx="2.4493051"
+             sodipodi:ry="2.4493051"
+             sodipodi:start="0.64251217"
+             sodipodi:end="1.4493741"
+             d="m -391.58274,367.36315 a 2.4493051,2.4493051 0 0 1 -1.66423,0.96363 l -0.29667,-2.43127 z" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008080;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path8044"
+             sodipodi:type="arc"
+             sodipodi:cx="-393.54364"
+             sodipodi:cy="365.89551"
+             sodipodi:rx="2.4493051"
+             sodipodi:ry="2.4493051"
+             sodipodi:start="5.6888999"
+             sodipodi:end="0.63806861"
+             d="m -391.51427,364.5241 a 2.4493051,2.4493051 0 0 1 -0.062,2.83032 l -1.9674,-1.45891 z" />
+          <path
+             d="m -393.8742,363.46861 a 2.4493051,2.4493051 0 0 1 2.34928,1.03987 l -2.01872,1.38703 z"
+             sodipodi:end="5.6811825"
+             sodipodi:start="4.5770143"
+             sodipodi:ry="2.4493051"
+             sodipodi:rx="2.4493051"
+             sodipodi:cy="365.89551"
+             sodipodi:cx="-393.54364"
+             sodipodi:type="arc"
+             id="path8046"
+             style="opacity:1;vector-effect:none;fill:#800080;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <path
+             d="m -395.60945,367.21138 a 2.4493051,2.4493051 0 0 1 0.11204,-2.79299 l 1.95377,1.47712 z"
+             sodipodi:end="3.7889428"
+             sodipodi:start="2.5744274"
+             sodipodi:ry="2.4493051"
+             sodipodi:rx="2.4493051"
+             sodipodi:cy="365.89551"
+             sodipodi:cx="-393.54364"
+             sodipodi:type="arc"
+             id="path4344"
+             style="opacity:1;vector-effect:none;fill:#d4aa00;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -395.12072,353.83533 -10.66861,2.50481"
+             id="path840-7" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -386.95692,361.53528 -6.58671,4.36022"
+             id="path842-4" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -384.26658,372.85328 -7.42164,8.8132"
+             id="path844-5" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -393.54363,365.8955 -11.87462,7.88549"
+             id="path846-2" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -405.41825,373.78099 -0.37108,-17.44085"
+             id="path2016-5" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#ff6600;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path8048"
+             sodipodi:type="arc"
+             sodipodi:cx="-393.54364"
+             sodipodi:cy="365.89551"
+             sodipodi:rx="2.4493051"
+             sodipodi:ry="2.4493051"
+             sodipodi:start="3.8103025"
+             sodipodi:end="4.5858825"
+             d="m -395.46542,364.377 a 2.4493051,2.4493051 0 0 1 1.61275,-0.91122 l 0.30903,2.42973 z" />
+          <path
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -405.78933,356.34014 12.2457,9.55536"
+             id="path2014-4"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -393.54363,365.8955 1.85541,15.77098"
+             id="path848-7" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -384.26658,372.85328 -9.27705,-6.95778"
+             id="path2010-4" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -393.54363,365.8955 -1.57709,-12.06017"
+             id="path850-4" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -405.78933,356.34014 -14.65774,25.23357"
+             id="path2006-3" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -420.44707,381.57371 15.02882,-7.79272"
+             id="path2004-0" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -405.41825,373.78099 13.73003,7.88549"
+             id="path2002-7" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -391.68822,381.66648 -28.75885,-0.18554"
+             id="path852-8" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -395.12072,353.83533 8.1638,7.69995"
+             id="path2028-6" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -386.95692,361.53528 2.69034,11.318"
+             id="path854-8" />
+          <path
+             id="path2084-8"
+             d="m -387.5341,361.39079 -5.64916,3.78476"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2392-6)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path2086-4"
+             d="m -384.9876,372.93615 -6.3078,7.66616"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2470-6)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path2088-3"
+             d="m -404.56273,373.79038 10.68716,-7.09694"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker13961)"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2090-1"
+             d="m -404.9991,372.8536 -0.33398,-15.69676"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2199-9)"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path2092-4"
+             d="m -393.93147,365.06897 -11.02114,-8.59982"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2327-0)" />
+          <path
+             id="path2094-9"
+             d="m -393.93145,366.69263 1.66987,14.19388"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2418-3)"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2096-2"
+             d="m -392.93845,366.90009 7.95085,6.03606"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2457-5)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path2098-0"
+             d="m -395.52276,354.31824 1.59129,10.75073"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2353-2)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path2100-6"
+             d="m -419.43524,380.52382 13.206,-22.77751"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2574-8)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path2102-8"
+             d="m -405.9093,373.51037 -13.52594,7.01345"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2561-7)"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2104-9"
+             d="m -392.26158,380.88651 -12.23274,-7.09714"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2431-6)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path2110-2"
+             d="m -387.14907,362.07811 2.33918,9.76248"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2509-2)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2340-3)"
+             d="m -404.95261,356.46915 9.42985,-2.15091"
+             id="path2112-6"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2496-9)"
+             d="m -392.86345,365.77578 5.71438,-3.69767"
+             id="path2114-6"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2587-0)"
+             d="m -406.17561,357.6619 0.33397,15.69676"
+             id="path2120-9"
+             inkscape:connector-curvature="0" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2212-6)"
+             d="m -405.30214,357.28327 10.86428,8.5243"
+             id="path2122-5"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2444-0)"
+             d="m -391.2954,380.60231 -1.64305,-13.70222"
+             id="path2124-0"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2483-3)"
+             d="m -384.80989,371.84059 -8.05356,-6.06481"
+             id="path2126-4"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2366-0)"
+             d="m -393.17379,365.17714 -1.41939,-10.29641"
+             id="path2128-8"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2548-1)"
+             d="m -418.77664,381.1181 13.53175,-6.97279"
+             id="path2132-7"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2522-5)"
+             d="m -405.38747,374.18933 12.20525,7.10531"
+             id="path2134-1"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2535-7)"
+             d="m -393.18222,381.29464 -25.59442,-0.17654"
+             id="path2136-7"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2379-5)"
+             d="m -394.57033,354.87455 7.01046,6.52327"
+             id="path2138-2"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+             x="-400.84308"
+             y="369.19205"
+             id="text1495-2"><tspan
+               sodipodi:role="line"
+               id="tspan1493-2"
+               x="-400.84308"
+               y="369.19205"
+               style="font-weight:bold;stroke-width:0.0918381">h</tspan></text>
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+             x="-399.03043"
+             y="371.37653"
+             id="text1499-6"><tspan
+               sodipodi:role="line"
+               id="tspan1497-1"
+               x="-399.03043"
+               y="371.37653"
+               style="stroke-width:0.0918381">o</tspan></text>
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+             x="-404.93317"
+             y="366.12451"
+             id="text1511-0"><tspan
+               sodipodi:role="line"
+               id="tspan1509-6"
+               x="-404.93317"
+               y="366.12451"
+               style="stroke-width:0.0918381">hn</tspan></text>
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+             x="-400.61069"
+             y="362.59216"
+             id="text1515-1"><tspan
+               sodipodi:role="line"
+               id="tspan1513-5"
+               x="-400.61069"
+               y="362.59216"
+               style="stroke-width:0.0918381">hp</tspan></text>
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+             x="-395.49811"
+             y="373.97931"
+             id="text1519-9"><tspan
+               sodipodi:role="line"
+               id="tspan1517-4"
+               x="-395.49811"
+               y="373.97931"
+               style="stroke-width:0.0918381">on</tspan></text>
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+             x="-398.79803"
+             y="376.3497"
+             id="text1523-9"><tspan
+               sodipodi:role="line"
+               id="tspan1521-0"
+               x="-398.79803"
+               y="376.3497"
+               style="stroke-width:0.0918381">op</tspan></text>
+          <circle
+             style="display:inline;opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;stroke:#333333;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path1527-3-7"
+             cx="-393.65393"
+             cy="366.01602"
+             r="1.0188166" />
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+             x="-394.50684"
+             y="366.48834"
+             id="text1507-7"><tspan
+               sodipodi:role="line"
+               id="tspan1505-1"
+               x="-394.50684"
+               y="366.48834"
+               style="stroke-width:0.0918381">vo</tspan></text>
+          <path
+             style="display:inline;fill:#ff0000;stroke:#ff0000;stroke-width:0.19611412;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker12251)"
+             d="m -394.43786,365.80757 -10.56124,7.04603"
+             id="path2118-4"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <circle
+             style="opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;stroke:#333333;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path1527-7"
+             cx="-405.28375"
+             cy="373.67419"
+             r="1.0188166" />
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+             x="-406.19543"
+             y="374.13699"
+             id="text1503-9"><tspan
+               sodipodi:role="line"
+               id="tspan1501-1"
+               x="-406.19543"
+               y="374.13699"
+               style="stroke-width:0.0918381">vh</tspan></text>
+        </g>
+        <g
+           id="g8312"
+           transform="matrix(0.70158983,0,0,0.70158983,-139.71588,106.42568)">
+          <path
+             d="m -368.17879,374.89273 a 2.4493053,2.4493053 0 0 1 0.1178,-2.36069 2.4493053,2.4493053 0 0 1 2.05831,-1.16191 l 0.0254,2.44918 z"
+             sodipodi:end="4.7019997"
+             sodipodi:start="2.6879363"
+             sodipodi:ry="2.4493053"
+             sodipodi:rx="2.4493053"
+             sodipodi:cy="373.81931"
+             sodipodi:cx="-365.97723"
+             sodipodi:type="arc"
+             id="path8060"
+             style="display:inline;opacity:1;vector-effect:none;fill:#c83737;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <path
+             style="display:inline;opacity:1;vector-effect:none;fill:#2c5aa0;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path8062"
+             sodipodi:type="arc"
+             sodipodi:cx="-365.97723"
+             sodipodi:cy="373.81931"
+             sodipodi:rx="2.4493053"
+             sodipodi:ry="2.4493053"
+             sodipodi:start="4.7123279"
+             sodipodi:end="5.1983904"
+             d="m -365.97738,371.37 a 2.4493053,2.4493053 0 0 1 1.1442,0.28361 l -1.14405,2.1657 z" />
+          <path
+             d="m -364.82637,371.65722 a 2.4493053,2.4493053 0 0 1 1.19526,1.45868 2.4493053,2.4493053 0 0 1 -0.19557,1.87567 l -2.15055,-1.17226 z"
+             sodipodi:end="0.49907344"
+             sodipodi:start="5.2015367"
+             sodipodi:ry="2.4493053"
+             sodipodi:rx="2.4493053"
+             sodipodi:cy="373.81931"
+             sodipodi:cx="-365.97723"
+             sodipodi:type="arc"
+             id="path8064"
+             style="display:inline;opacity:1;vector-effect:none;fill:#44aa00;fill-opacity:1;stroke:#000000;stroke-width:0.01735524;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -355.6537,353.83533 -10.66861,2.50481"
+             id="path2133-1" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -347.4899,361.53528 -6.5867,4.36022"
+             id="path2135-0" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -344.79955,372.85328 -7.42164,8.8132"
+             id="path2137-3" />
+          <path
+             style="display:inline;opacity:1;vector-effect:none;fill:#00d4aa;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path8066"
+             sodipodi:type="arc"
+             sodipodi:cx="-365.95123"
+             sodipodi:cy="373.78098"
+             sodipodi:rx="2.4493053"
+             sodipodi:ry="2.4493053"
+             sodipodi:start="0.51393615"
+             sodipodi:end="2.6579534"
+             d="m -363.81834,374.98508 a 2.4493053,2.4493053 0 0 1 -2.16999,1.24492 2.4493053,2.4493053 0 0 1 -2.13129,-1.31009 l 2.16839,-1.13893 z" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -354.0766,365.8955 -11.87462,7.88549"
+             id="path2139-0" />
+          <path
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m -365.95122,373.78099 -0.37109,-17.44085"
+             id="path2141-4" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -344.79955,372.85328 -20.97838,0.85302"
+             id="path2143-4" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -365.90832,373.70726 10.25462,-19.87193"
+             id="path2145-4" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -366.32231,356.34014 -14.65773,25.23357"
+             id="path2147-4" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -380.98004,381.57371 15.02882,-7.79272"
+             id="path2149-7" />
+          <path
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m -365.95122,373.78099 13.73003,7.88549"
+             id="path2151-6" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -352.22119,381.66648 -28.75885,-0.18554"
+             id="path2153-3" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -355.6537,353.83533 8.1638,7.69995"
+             id="path2155-1" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -347.4899,361.53528 2.69035,11.318"
+             id="path2157-7" />
+          <circle
+             r="1.0188166"
+             cy="373.85757"
+             cx="-366.00729"
+             id="path1527-3-7-5"
+             style="display:inline;opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;stroke:#333333;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <text
+             id="text1507-7-6"
+             y="374.3299"
+             x="-366.8602"
+             style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+             xml:space="preserve"><tspan
+               style="stroke-width:0.0918381"
+               y="374.3299"
+               x="-366.8602"
+               id="tspan1505-1-9"
+               sodipodi:role="line">vo</tspan></text>
+        </g>
+      </g>
+      <g
+         id="g65651">
+        <g
+           id="g65319"
+           transform="matrix(0.70158988,0,0,0.70158983,-79.701334,71.985499)">
+          <path
+             style="display:inline;opacity:1;vector-effect:none;fill:#c83737;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path1855-2"
+             sodipodi:type="arc"
+             sodipodi:cx="-416.30759"
+             sodipodi:cy="423.09366"
+             sodipodi:rx="2.4493051"
+             sodipodi:ry="2.4493051"
+             sodipodi:start="2.6879363"
+             sodipodi:end="4.7019997"
+             d="m -418.50915,424.16708 a 2.4493051,2.4493051 0 0 1 0.1178,-2.36068 2.4493051,2.4493051 0 0 1 2.05832,-1.16191 l 0.0254,2.44917 z" />
+          <path
+             d="m -416.30774,420.64435 a 2.4493051,2.4493051 0 0 1 2.00988,1.04928 l -2.00973,1.40003 z"
+             sodipodi:end="5.6747281"
+             sodipodi:start="4.7123279"
+             sodipodi:ry="2.4493051"
+             sodipodi:rx="2.4493051"
+             sodipodi:cy="423.09366"
+             sodipodi:cx="-416.30759"
+             sodipodi:type="arc"
+             id="path4344-1-5"
+             style="display:inline;opacity:1;vector-effect:none;fill:#2c5aa0;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <path
+             style="display:inline;opacity:1;vector-effect:none;fill:#44aa00;fill-opacity:1;stroke:#000000;stroke-width:0.01735524;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path4557-4"
+             sodipodi:type="arc"
+             sodipodi:cx="-416.30759"
+             sodipodi:cy="423.09366"
+             sodipodi:rx="2.4493051"
+             sodipodi:ry="2.4493051"
+             sodipodi:start="5.6896692"
+             sodipodi:end="0.49907344"
+             d="m -414.27716,421.72381 a 2.4493051,2.4493051 0 0 1 0.12013,2.54212 l -2.15056,-1.17227 z" />
+          <path
+             d="m -414.14869,424.2594 a 2.4493051,2.4493051 0 0 1 -2.181,1.24473 2.4493051,2.4493051 0 0 1 -2.13043,-1.32943 l 2.17853,-1.1194 z"
+             sodipodi:end="2.6669389"
+             sodipodi:start="0.51393615"
+             sodipodi:ry="2.4493051"
+             sodipodi:rx="2.4493051"
+             sodipodi:cy="423.0553"
+             sodipodi:cx="-416.28159"
+             sodipodi:type="arc"
+             id="path4559-7"
+             style="display:inline;opacity:1;vector-effect:none;fill:#00d4aa;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <circle
+             r="2.4493051"
+             cy="415.16983"
+             cx="-404.40698"
+             id="path4344-7"
+             style="opacity:1;vector-effect:none;fill:#d4aa00;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -405.98406,403.10964 -10.66861,2.50481"
+             id="path840-7-8" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -397.82026,410.80959 -6.58671,4.36022"
+             id="path842-4-6" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -395.12992,422.12759 -7.42164,8.8132"
+             id="path844-5-8" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -404.40697,415.16981 -11.87462,7.88549"
+             id="path846-2-8" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -416.28159,423.0553 -0.37108,-17.44085"
+             id="path2016-5-4" />
+          <path
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -416.65267,405.61445 12.2457,9.55536"
+             id="path2014-4-1"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -404.40697,415.16981 1.85541,15.77098"
+             id="path848-7-4" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -395.12992,422.12759 -9.27705,-6.95778"
+             id="path2010-4-9" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -404.40697,415.16981 -1.57709,-12.06017"
+             id="path850-4-2" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -416.65267,405.61445 -14.65774,25.23357"
+             id="path2006-3-0" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -431.31041,430.84802 15.02882,-7.79272"
+             id="path2004-0-6" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -416.28159,423.0553 13.73003,7.88549"
+             id="path2002-7-8" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -402.55156,430.94079 -28.75885,-0.18554"
+             id="path852-8-9" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -405.98406,403.10964 8.1638,7.69995"
+             id="path2028-6-2" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -397.82026,410.80959 2.69034,11.318"
+             id="path854-8-6" />
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+             x="-411.70642"
+             y="418.46637"
+             id="text1495-2-0"><tspan
+               sodipodi:role="line"
+               id="tspan1493-2-9"
+               x="-411.70642"
+               y="418.46637"
+               style="font-weight:bold;stroke-width:0.0918381">h</tspan></text>
+          <circle
+             style="display:inline;opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;stroke:#333333;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path1527-3-7-7"
+             cx="-404.51727"
+             cy="415.29034"
+             r="1.0188166" />
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+             x="-405.37018"
+             y="415.76266"
+             id="text1507-7-3"><tspan
+               sodipodi:role="line"
+               id="tspan1505-1-6"
+               x="-405.37018"
+               y="415.76266"
+               style="stroke-width:0.0918381">vo</tspan></text>
+          <path
+             style="display:inline;fill:#ff0000;stroke:#ff0000;stroke-width:0.19611412;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker12251-3)"
+             d="m -405.3012,415.08188 -10.56124,7.04603"
+             id="path2118-4-5"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <circle
+             style="opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;stroke:#333333;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path1527-7-6"
+             cx="-416.14709"
+             cy="422.94852"
+             r="1.0188166" />
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+             x="-417.05878"
+             y="423.41132"
+             id="text1503-9-3"><tspan
+               sodipodi:role="line"
+               id="tspan1501-1-9"
+               x="-417.05878"
+               y="423.41132"
+               style="stroke-width:0.0918381">vh</tspan></text>
+        </g>
+        <g
+           id="g65340"
+           transform="matrix(0.70158988,0,0,0.70158983,-82.687743,71.985499)">
+          <path
+             d="m -379.04214,424.16705 a 2.4493053,2.4493053 0 0 1 0.1178,-2.36068 2.4493053,2.4493053 0 0 1 2.05832,-1.16192 l 0.0254,2.44918 z"
+             sodipodi:end="4.7019997"
+             sodipodi:start="2.6879363"
+             sodipodi:ry="2.4493053"
+             sodipodi:rx="2.4493053"
+             sodipodi:cy="423.09363"
+             sodipodi:cx="-376.84058"
+             sodipodi:type="arc"
+             id="path8060-8"
+             style="display:inline;opacity:1;vector-effect:none;fill:#c83737;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <path
+             style="display:inline;opacity:1;vector-effect:none;fill:#2c5aa0;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path8062-1"
+             sodipodi:type="arc"
+             sodipodi:cx="-376.84058"
+             sodipodi:cy="423.09363"
+             sodipodi:rx="2.4493053"
+             sodipodi:ry="2.4493053"
+             sodipodi:start="4.7123279"
+             sodipodi:end="0.49662559"
+             d="m -376.84073,420.64432 a 2.4493053,2.4493053 0 0 1 2.10457,1.1961 2.4493053,2.4493053 0 0 1 0.049,2.42021 l -2.15342,-1.167 z" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -366.51704,403.10964 -10.66861,2.50481"
+             id="path2133-1-9" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -358.35324,410.80959 -6.5867,4.36022"
+             id="path2135-0-3" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -355.66289,422.12759 -7.42164,8.8132"
+             id="path2137-3-9" />
+          <path
+             style="display:inline;opacity:1;vector-effect:none;fill:#00d4aa;fill-opacity:1;stroke:#000000;stroke-width:0.01735523;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path8066-0"
+             sodipodi:type="arc"
+             sodipodi:cx="-376.81458"
+             sodipodi:cy="423.0553"
+             sodipodi:rx="2.4493053"
+             sodipodi:ry="2.4493053"
+             sodipodi:start="0.51393615"
+             sodipodi:end="2.6579534"
+             d="m -374.68168,424.2594 a 2.4493053,2.4493053 0 0 1 -2.17,1.24492 2.4493053,2.4493053 0 0 1 -2.13129,-1.31009 l 2.16839,-1.13893 z" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -364.93994,415.16981 -11.87462,7.88549"
+             id="path2139-0-8" />
+          <path
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m -376.81456,423.0553 -0.37109,-17.44085"
+             id="path2141-4-8" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -355.66289,422.12759 -20.97838,0.85302"
+             id="path2143-4-5" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -376.77166,422.98157 10.25462,-19.87193"
+             id="path2145-4-0" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -377.18565,405.61445 -14.65773,25.23357"
+             id="path2147-4-9" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -391.84338,430.84802 15.02882,-7.79272"
+             id="path2149-7-6" />
+          <path
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m -376.81456,423.0553 13.73003,7.88549"
+             id="path2151-6-3" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -363.08453,430.94079 -28.75885,-0.18554"
+             id="path2153-3-8" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -366.51704,403.10964 8.1638,7.69995"
+             id="path2155-1-5" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.0918381px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m -358.35324,410.80959 2.69035,11.318"
+             id="path2157-7-6" />
+          <circle
+             r="1.0188166"
+             cy="423.1319"
+             cx="-376.87064"
+             id="path1527-3-7-5-1"
+             style="display:inline;opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;stroke:#333333;stroke-width:0.08265428px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+          <text
+             id="text1507-7-6-1"
+             y="423.60422"
+             x="-377.72354"
+             style="font-style:normal;font-weight:normal;font-size:1.46940958px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0918381"
+             xml:space="preserve"><tspan
+               style="stroke-width:0.0918381"
+               y="423.60422"
+               x="-377.72354"
+               id="tspan1505-1-9-5"
+               sodipodi:role="line">vo</tspan></text>
+        </g>
+      </g>
+    </g>
   </g>
-  <g
-     inkscape:groupmode="layer"
-     id="layer4"
-     inkscape:label="Calque 4"
-     style="display:inline"
-     transform="translate(470.69208,-22.182517)" />
 </svg>

--- a/doc/images/wedge-collapse.svg
+++ b/doc/images/wedge-collapse.svg
@@ -1,0 +1,3930 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="559.36481mm"
+   height="98.255623mm"
+   viewBox="0 0 559.36481 98.255623"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="collapse.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2053"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2051"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2049"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2047"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2027"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2025"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2014"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2012"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2001"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1999"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1988"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1986"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1975"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1973"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1962"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1960"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1949"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1947"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1925"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1923"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1921"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1919"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1908"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1906"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1895"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1893"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1827"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1825"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1819"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1817"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1815"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1813"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1811"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1809"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1807"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1805"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1803"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1801"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1799"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1797"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1795"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1793"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1791"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1789"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1787"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1785"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1759"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1757"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1706"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1704"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1702"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1700"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1698"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1696"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1694"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1692"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1690"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1688"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1686"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1684"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1682"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1680"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1634"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1632"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1556"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path1554"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3731"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3729"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path3689"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3647"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3645"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3643"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path3641"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3630"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3628"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3606"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3604"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3594"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3592"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3590"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3588"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3586"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path3584"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#aa00d4;fill-opacity:1;fill-rule:evenodd;stroke:#aa00d4;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3582"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3580"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3578"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3576"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3498"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3496"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3420"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path3418"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3416"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path3414"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3412"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3410"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3408"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3406"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3404"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path3402"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3400"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path3398"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3396"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path3394"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3392"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3390"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3388"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path3386"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3384"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path3382"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3380"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3378"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3376"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path3374"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3372"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path3370"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3368"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3366"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3364"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3362"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3360"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3358"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3356"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3354"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3272"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3270"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3268"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3266"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3264"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3262"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3260"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3258"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3256"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3254"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3252"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3250"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3248"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3246"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3244"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3242"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3240"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3238"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3236"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3234"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3232"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3230"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3228"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3226"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3224"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3222"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3179"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3177"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3097"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3095"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3093"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3091"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3011"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path3009"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3007"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3005"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3003"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path3001"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2999"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path2997"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2995"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2993"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2991"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path2989"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2987"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path2985"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2983"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path2981"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2979"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path2977"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2971"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path2969"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2967"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2965"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2963"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path2961"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2959"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path2957"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2955"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path2953"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2587"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2585"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2574"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2572"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2561"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2559"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2548"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2546"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2535"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2533"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2522"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2520"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2509"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2507"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2496"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2494"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2483"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2481"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2470"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2468"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2457"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2455"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2444"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2442"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2431"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2429"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2418"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2416"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2405"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2403"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2392"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2390"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2379"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2377"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2366"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2364"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2353"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2351"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2340"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2338"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2327"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2325"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2212"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2210"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2199"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2197"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path2173"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutL"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1597"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.8)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2150"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2148"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Sstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1467"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2144"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2142"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1996"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#00ff00;fill-opacity:1;fill-rule:evenodd;stroke:#00ff00;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1994"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1981"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#00ff00;fill-opacity:1;fill-rule:evenodd;stroke:#00ff00;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1979"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1966"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#00ff00;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1964"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1931"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1929"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1916"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1914"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1893"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1891"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1725"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1723"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1464"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#00ff00;fill-opacity:1;fill-rule:evenodd;stroke:#00ff00;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Send"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1470"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#00ff00;fill-opacity:1;fill-rule:evenodd;stroke:#00ff00;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1458"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#00ff00;fill-opacity:1;fill-rule:evenodd;stroke:#00ff00;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1867-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1865-6"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1867-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1865-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1867-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1865-8"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1867-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1865-20"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1867-37"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1865-5"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1867-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1865-28"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-7"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-3"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-76"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-5"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-37"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-5"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-25"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-74"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-4"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-7"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-8"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-4"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-31"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-92"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-0"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-9"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-66"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-49"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-04"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-87"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-72"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-72"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-61"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-06"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-59"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-490"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-17"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-71"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-597"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-76"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-6"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-63"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-94"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-12"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-93"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-08"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-85"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2175-96"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2173-38"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3582-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3580-1" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3582-5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3580-9" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3647-0"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3645-3" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691-4"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3689-4"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#008000;fill-opacity:1;fill-rule:evenodd;stroke:#008000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.4939848"
+     inkscape:cx="1169.5541"
+     inkscape:cy="144.65779"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g853"
+     showgrid="false"
+     inkscape:window-width="1918"
+     inkscape:window-height="1158"
+     inkscape:window-x="0"
+     inkscape:window-y="18"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:none;opacity:1"
+     transform="translate(470.69208,-22.182517)">
+    <image
+       y="94.159073"
+       x="55.694801"
+       id="image823"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAhsAAAIbCAYAAABCJ1y9AAAABHNCSVQICAgIfAhkiAAAABl0RVh0 U29mdHdhcmUAZ25vbWUtc2NyZWVuc2hvdO8Dvz4AAAAtdEVYdENyZWF0aW9uIFRpbWUAbWFyLiAx MSBm6XZyLiAyMDIwIDExOjUyOjA2IENFVLlZxpwAACAASURBVHic7d09byZX+cfxs5GVdqsIUZAi Uqy/opSxtoqU2BZNFFmi4AW4SMVr2CLahhIRItH4LVCsaBI7CdqO0BGEWCRIBQVKse3KJP9iOd7x eB7OzHm6Hr6fCkLYvWd8e+Y313WdOfcePHjwQ8h0fn4eLi4ucv+Yan8eAKA8KddqKZ8D8+6VCBsh vPhhhxCyf+B8aQBAj57X7FL3HdRXLGxEOV88ggYA6NPj2s39QpdXSv+BFxcXN2lzC744AIA15+fn 3C8UKl7ZiLZ8GfjiAIBuLa7j3Cv0qhY2Qkjrp/HlAQAbal7PuVfoVjVsRHNfEr48AGBLjdWJITAE ql2TsBHC3S8gQQMAbCp1fec+YUezsBFCuDU4yhcIAOzKXZkYAvcJS4qvRlnCFwcAsCSGFO4XtjQN G8Mv0Z7lsQAAHfZc52mb2NVtZmPunwEA7Ei5ztM2sa/rapT4v4XAlwwArFq7B3D9t69pG2UKbRUA sG3qGs+bQH2pXtngTaIAgBBeXuO51vtT/Q2iW79QtFUAwCau735Va6PsTa60VQDAHq7pvlWpbPD2 OABAxBukUTxs1HgvPl9KANBnqW3Ctd2XomGj1peHPh80ury8DP/973/DJ598Eh4/ftz74wBNpb5f g+u6D8XCRosvDV9MaHB2dhaOjo7C66+/Hr7//vtweXkZnj17RuCAG6xCxFiRAdFWXxYGRyHd2dlZ uH//fnj99dfD5eXlzT+/f/9++PDDDzt+MqA+3p2BOdmVjR5fLNoqkCgGjdPT05ugcXx8fCt0UOGA Vbm7vHI9ty2rstHrC8LyWEjz6NGjcP/+/dV/jwoHrClRzeB6bt/usCEhifIFhQSPHj0KT58+DSGE W1WNOQQOWFFyO3iu57btChsSgkbEFxQ9DYPGFgQOaFfjPsD13K7NMxuSgsYQcxxoKa44GQaNqarG eGZj7PDwMDx8+LDa5wRKa3GtlXqfwX6bKhuSvwDMcaCVOAi6FjRSPH36NHz88cclPx5QTcm2CXzp vsV8aQQO1BSDRkkEDkjXekkr13F7ksOG5KrGWPyi8mVFSXMrTvZWNYYIHJCqVzWDwGFLUtjQFDQi 2iooae8g6BYEDkjT+9rPNdyO1bDR+8uWiy8rci0FjRJVjSECBySQ9CZQruE2LIYNKV+2XHxZscfZ 2VmTisZYDBwsjUUPEodAuYbrdzD3P1gJGtHwy2rpuFDH1IqTsdJVjaGnT5/evIuD15ujBa6PqGny PRvWgsaY9eNDnpQVJ6lBY+09GynYTwW1abkmavmcuOtOG8XDD5OSHOak7nHSEm8bRU2arvlcu/W6 VdnQ9KUrgbIhhlLnM7a0T0pUNiIqHChJ8/XP273KgpvKhscfHstjEfUYBN2KCgdKkTgEugXXbX1e CcFn0Bjii+vX1hUnNYdCUxA4kEPSktZcXLd1ecXKFy8XX1x/UlacDPUOGhGBA3tor2ZAt1f44r3E a879qLHHSUv379/n5V9IZvWhkodEPcxtxJaLOQ779qw4kVLVGOJto1hjqW0yh+u1DoSNGXyBbdIw CLoFgQNzPLVNuF7LN/lSL7ykeXkYXjo7OwtHR0e7gkZOVaPk0tclh4eH4eHDh9X/Hsjn+ZplvYqj GWEjEV9ivXLmM3LbJ63CRggEDnCdCoFzIBVtlESU6XTSPgi6BS0V37jJQjLCxgYEDl1yg4bEodA1 7Bjrj4ch0C24TstE2NiI5bE6SNzjpJXhjrGwzdMQ6BYEDnmY2cjA04RMJVaclKpqtJzZmMJ+KjZ5 HgLdgmu0HFQ2MpCeZdn66nEPqHDYQzUjHddoOQgbmWiryLD11eNLNM5qLCFw2MGT+nYEDhkOen8A C+IvPxeCPkquOLEWNKIYOGip6ETbBNpR2SiIBN2ep6Wtuahw6ETbJB/X5v4IG4XxpW6n9IoTq1WN ITZw04MlrWVxbe6LsFEBcxz1MQi6Hy//ko9qRh0Ejn4IG5Wwe2wdtVaceKhqDBE45KKaURfX5T4I G5XxxS6n5IqTIW9BIyJwyELbpB2uy+0RNhqgrZKPQdA6CBwy0DaBdbxBtDGeXLarGTRqVzV6v0E0 FTvG9sGS1r64HrdDZaMxynfbeN7jpCU2cGuPakZ/XI/bIWx0wBc8Te0VJ15nNeawgVs7PFHLwfW4 DdooHVFCnXZ2dhaOjo5MBA0tbZQxNnCrg995uQiAdVHZ6IjlsXfVWnGCbahwlEfbRDauxXURNgTg S/5CqxUntE/SEDjKYEkrQNgQw/vyWJa2ykTgyEM1Qxce/OohbAjita3ScsUJVY3tCBz7UM3QyeM1 uAXChkCevuzscaIDG7ilo22in6drcCuEDaGsf9lr7XGyhKpGHt42uo62iR3Wr8GtsfRVOItL5XrM Z/QKGlqXvi7hbaN3Wfw9xQtUqcqgsiGctTkOBkH1o8JxG9UMYB1hQwkLgaPXq8dpn5RH4HiBp177 LFx7JSBsKKJ5eSyDoPZ4DhwMgfpC4MjHzIZSmi50PYNG76qGxZmNscPDw/D111+7eb25pt89lMXP fj/ChmLSv/gt9jhZ0jtohOAjbETW91NhCBQhyL/uSkUbRTHJpT32OPHH8su/GAJFJPm6KxlhQzmJ cxwSVpxIqGp4ZDFw8CQL5CNsGCBpeWyvFSeQw0rgYAgUc6RcbzUhbBjS+xdAyooTqhr9aQ8ctE2w pvf1VhsGRA3qMchG0JjmaUB0irahUYZAsRXVrzRUNgxq2VbpsccJ9NBU4aCagT2ocKQhbBhW+5dA 2ooTaVUNvKBhx1ieTpGDwLGOsGFcrV8CCStONLh3717vjyCC1LeNMgSKUggcywgbDpReHitxxQlV DfmkBQ7aJkA7hA0nSs1xMJ+BHBICB9UM1EJ1Yx5hw5mcXwapQYOqhi49AwfVDNRG4JhG2HBoa1tF 8ooTgoZOPQIH1Qy0QuC4i7DhVGpbRdqKE9gRA0ftpbG0TdADgeM2woZzS78Q0lecUNXQ7+nTp1Xf xUHbBD0ROF4ibGDyF0LiihPYVTpwUM0AZOF15bgRA8cbb7whvm2ipapxcnISPv/8894fQ40Srzcn ZEAavpNUNjDw3XffhTfeeCP84x//6P1RFmkJGtgut8LBRR0S0U4hbOB/hoOg19fX4eDgoPdHglN7 AgdtE0jnPXAQNjA5CBoDh7TQQVXDhy2BgyFQaOE5cBA2nFtacXJ9fU2VA92sbeBGNQMaeQ0chA3H UlecSAkcVDX8mXv5F9UMQBfChlNb3wjaO3AQNPwaBg6qGbDAY3Wj/+Mqmjo7OwtHR0e7lrYOA8f1 9XXpjwbMevr0KSEDpsTA4eU7TWXDkRKvHu8xx0FVA6+++mp4/vx59x1jgZI8VTgIG06UfvV477YK fHj11VdvgkYIMraoB0ryEjgIGw7U2uOkxfJYqhp+xZARg0bUagM3oBUPgYOwYVztPU5YHovSxtWM KbU3cANQFmHDsK0rTnLUCBxUNfyZq2bMIXDACuvVDcKGQWdnZ02DRlQycBA0/FmrZswhcMAKy4GD sGFMiRUnOaS+5hxypbRN1hA4YIXVwEHYMKTWIOhWuXMcVDX82No2WULggBUWAwdhwwgpQWOIwVHM KVHNmELggBXWAgdhw4DaK05ybG2rUNWwr2Q1Y8raBm4A2iNsKNdjEHSr1LYKQcO+GtWMKbz8CxZY qm4QNpTqteIkB20Vv2q1TZYQOGCBlcBB2FCo94qTHHOBg6qGXbXbJksIHLDAQuAgbCgjcRB0K5bH +tCjmjGFwAELtAcOwoYikgdBtxrOcVDVsKdnNWMKgQMWaA4chA0ltM1npLq+vg5fffVV74+BgiRU M6awgRvQD2FDAatBI4QXsxq0VWyQ0jZZwgZu0E5rdYOwIZjGFSdbDNsn7B6rm7S2yRoCBzTTGDgI G0JpXnGSg8Chi4ZqxhwCBzTTFjgIGwJZWHGyZmkolMChg7ZqxhQCBzTTFDgIG8JYWnGSgzkO2bRW M6YQOKCZlsBB2BDE8nzGUOpSV+Y45NHcNllC4ADqImwIQdCYR+CQwULbZAmBA1ppqG4QNjqzvuKk FNoq/VitZkxhx1hoJT1wEDY68rbiJPdNobRV2rNezZjC20ahleTAQdjoxMOKk1oIHG14qWZMIXBA K6mBg7DRweXlpbugUXr/EwJHPZ7aJksIHNBKYuAgbDR2eXkZ/vWvf/X+GE3V2miNOY7yPLZNlhA4 gDIIGw09evTIXdCojTmOMqhmzCNwQCNp1Q3CRgNxxcnrr78eQgiutlNvtX08gWM/qhnr2DEWGkkK HFydKxuuOIlhA3UMA8f19XXnT6MD1Yx1JycnN//5pz/9aQghhMePH/f6OMAmMXBcXFx0/RyEjYqG K07iE/7p6WnnT9VOq6rGUAwZBwcHBI4Fr776agghEDQmDMNFCCFcXV3d+u/x5V8EDmghIXAQNioZ vqirx03Xu1jlIHDcRTXjtrVwMYXAAW16Bw7CRgW8EVRGwCJw3EY144U94WL4756cnISrqysCB7AB YaOgs7OzcHR0dCtoSLjptibpmJnjeMFzNSMnXKwhcECTntUNwkYh3l49ron3OQ5PQWMcLEIoGy6m EDigSa/AQdgoYO7V45Ke8FuRfMze2ioe2iY1qxZbxA3cHj582OXvB7boETgIG5m2BA3JN2IvvLRV rFYzpISLKfFdHAQOaNA6cBA2MjAIepuWMGW5rWKtmiE5XEwhcECTloGDsLHTUtDQctMtSeMxW2ur WKhmaAsXUwgcwF2EjY2mVpxALyuBQ2vQsBAuphA4oEWr6sa9Bw8e/FD1bzBkbj5jaOkJX+PTfwoL x1VrjuPk5CR8/vnnRf/MIW1tEyvhIr5rY83h4SGBAyrUDhxUNhKlBA3opXGOQ0M1w0q42CtWOL7+ +muWxkK02hUOwkaC1KBh4Ql/K2vHrKGtIrma4T1cTHn69Cnv4oAKNQMHYWNF6ooTazfdFFaPWfLy WGnVDMJFOgIHNKgVOAgbC0oubbV6Y7ZKYltFQtAgXOQhcMArwsaErStOPAYJL8csoa3Ss21CuCiP wAHpalQ3CBsj7HGCsZ6Bo3U1g3DRBoED0pUOHISNgT0rTrw84Q95PObWcxytqhmEi34IHJCuZOAg bPwPQQNrWs1x1KxmEC7KuLq6Sn7XxhI2cIN0pQIHYSOwx8kWBKy6bZXSQYNwIR9vG4V0JQKH+7Cx N2h4vOl6POY5pQNHqbYJ4UInAgescxs22OMEuUrNceRUMwgXdhA4IFludcNl2MhdceLxCd/jMafI mePYWs0YB4sQCBfWEDggWU7gcBc2cvc42XPT5UZt39a2Sko1g6qFTwQOSLY3cLgKGwyC7kNYSpPa VpkLGoQLRGzgBsn2BA43YaNE0PB40/V4zDmW2irjtgnhAkvYwA2SbQ0cLsIGFQ20NqxyhPAiaLz7 7ru3/h3ChW6l3rWxhsABC0yHjZIrTjw+4Xs85pKur6/DH/7wh5ugQbjAXgQOSLSluvFKg8/TBXuc oLeDg4Pw0UcfhefPn4cnT570/jhQLgYOQJIYONaYDBu5K07GPD7hezzmkk5PT8N7770X/va3v4UQ XsxpxJkNYC8CByRaChzn5+fh/PzcXth49OgRQSOTx2Mu5eDgYPb8PX/+fPJdGcAWBA5INA4cMWRc XFyEi4sLW2FD4iAoN24/Tk9Pw/X1dbi8vJz9ucehQqocyEHggEQxcAxDRmQmbNQIGh6DgsdjzrVU zZhydXVFWwXZ4o6xgBRLw6Lqw8bZ2ZnIigZ8iO/TGAaN1OBBWwW54su/gJ6G1Yw5qsNGzRUnHp/w PR5zjtg2Gf+zLecwtlWgk4SfH4EDvcy1TKYGRtWGjdIrToa46WLJlrbJ1dVVOD09Xf13mONADgIH WpoLGUPjwKEybJRecQICVqrhEOjU/7b3HDLHgVwEDtSWEjKGhoFD3RtEa89neLzpejzmrQ4ODsJ7 771X/TzFOQ7eNoo92DEWNcTAsGdr+Rg4VIUNBkHRw9QQ6FjJwBbbKk+ePFndhh4YY8dYlJITMoYu Li50hI2Se5wsKf2Er6FioOEz9pRyfmqcw1jZmNuOHljCjrHItXUL+TXiZzbY4wQ9bH13Ri0sj0UO Xv6FrVKWse4hOmzUXHEyJuHG0prHY06xNAQ69e/WPocSlldCLwIHUmwd/txKbNhoueLE403X4zGv kVLNmMLyWLk0hEECB+bUDhmRyJkNBkHRWsoQ6FjrYMIcB3Iww4GhUsOfqUSFjVaDoENSn2Rr8njM S/acj57nkOWx2IvAgdYhIxITNhgERWut3p1RA8tjsVfcwI13cfjSK2REIsJGy0HQIY9P+B6PeUo8 D3vOhZRzSFsFe/HyLz96h4yo+4Co1aAh5YY0JPEztSZ5CHQvlsdiD15vbl+Lwc9UXcMGe5ygpT1D oGNSg4qGFRGQh8BhU613ZeToFjZ6rjiResOoyeMxD01tB28Ny2P70Rz2CBx2tFrGukfzmY0eK07g V8khUA2BjTkO7MEMh25S5jKWNA0bElacaLhhlObxmEPIGwKd+7O0YHkstmIDN300hIyoWdjoNQg6 pO2GgX00L2ktieWx2IoN3HTQFDKiJmFDQtDwylvAKjEEOqb5HNJWwR4EDpk0hoyo+oColBUnmm8Y e3k65rik1foQ6F4sj8VW7Kcih+TBz1RVw4bXPU483eQlqFHNiCz9LDWvmEAfBI7+tIeMqErYODs7 ExU0LN0wUnk55prVDIvnkOWx2IrA0YfEd2XkKD6zIWHFCexjCHQ/5jjqiEHO4gogZjja0TyXsaRo 2JA4CGrx6XSN9WOu2TaJrJ/DEFgei23YwK0uqyEjKtZGIWjIYPmYGQItj7YKtuBto+VZGP5MUaSy IWk+Aza1qGZElgPbFNoq2IK3jZZhvZIxll3ZkBo0vN0wQrB7zC2rGVbPYQqWxyIVFY79vFQyxnaH DWkrTmCPxe3gpWN5LFIROLbzGDKiXWFD+oqTnjeoXn+3tZtyy7ZJZO0c7sUcB1IRONJYW8a6x+aZ DYmDoEPcMHRjSasMzHEgFRu4zfM2l7FkU2VDyqvHcZuVgNWjmhFZOYelMcexjdc21HADN/idy1iS HDY0zGd4vGFYOWaWtMpFWwWpvAcOQsa8pDaKhqABnSS0TawEtppoqyCVx7eN0i5Ztxg2zs7OwtHR kYqg4fGGof2Ye7ZNIu3nsDXeOooUXgIHISPdbBtF+ooT6MWbQHXzOpeAbSy3VGiXbDcZNqSvOBnz +HSq9ZglVDMiredQAuY4kMJi4CBk7HMnbGhbcSLphtHqs0g65i2oZthydXUVnj9/TuDAIiuBg3dl 5Lk1s8EgKGqQMAQ6pjWwScQcB9Zo3jGWuYwybiobGoOGxxuGtmOW1DaJtJ1DDWirvMRMyzRtbxtl LqOsA00rTqCHxGoG6mJ5LNZo2DGWSkYdB1pXnHh8OtVyzBKrGZGWc6gZbRUskRo4CBl1ZW8x34PH G4aWY2YIFCHQSsAySS0V2iVtbN6IDZiioW2iJbBZEQPHkydPaKvgjt4VDioZbakLGx5vGNKPWXLb JJJ+Dq1ijgNLeu0YyxLW9lS2USTyeDPjTaBIxe6xmNNyx1jeldGPqsqGxxu61GPWUM2IpJ5Db2ir YEnN/VRomfSnprLBDUMOqhnYy8tbRxmQ3ad0hYPhTzlUVTa8kRawNAyBjkk7h3iB5bGY87Of/Sy8 9dZb4Ze//OXuP4NKhjwHBwcv8obkJ1WPNwxpx6ypbRJJO4e4LT79EzgQxe/Ds2fPdv3/CRlyHcSQ oSF0oD2N1QzowRwHQgg3LacYPI+OjjbNbhAy5LtpowxDh6TA4fHpVMoxa6xmRFLOIdaxPNa33OoW q0t0uDMgen19HQ4ODm4qHfCJIVC0xvJYX05OTmaDxtOnT1cHRVnGqstkopDSWvH4dNr7mC20TXqf Q+xHW8WHnGoGLROdFssXPUOHphtGqc/a+5g1t01gB20Vu8azGVsQMnRLes/G9fX1TXsF9lh6E2jv wIZytLdVeNfGbbGakRo0jo6OQgi8K8OKTelhGDhq3pg83jB6HbOlaobH7411LI/Vb28149tvv2Um w5DNbxAdVjmodOhmpZoB22LgsP7WUYu2VjNCeNE+iy20//znPxU/HVranRZqzXN4fDptfcwWhkDH PH5vPGGOQ5c91YwYJvn52pRdmij5fg6PN4weQcNK2wT+8Jpz+fb8fAiR9hXbiI3WimyWhkDHPIZU z2iryLT03ow5w5bJlDgkCv2KJoOc1orHG0arY7ZczfD4vQFtFWn2hIwQaJl4UmWLeU9LZaXf7KxW M4AQ9C+P1W5rNWNYyUgJGilvEoUOVcJGlNpakX7DrqH2Mce2ieXzav34kEby+ywkf7ZcW1aabA0Z sKdq2AiBpbI9WG6bAFOY42hnSzWjRMhgbsOGZnf/uXkOj0+ntY7Z4pLWOR6/N1jGHEd9W0JGCMxk 4KXmpYZh6PByYxyqGTS8VDMIGljC8tjyUt+bQcjAnOptlDnX19fhq6++orVSAEOgwG20VcpJnc2o NZPBkKgN3e70w6fT3lvZt1L6idxjdYiqBlLRVslDNQMldatsDDFEul2sZnDjBZaxPHa7lGpGyxUm DInq1+XOPvd0WvLV5y1secou9UTusZoRUdXAXuwemyalmkElA3s0DxspN4xWW9m3UjJoUM0A9omB 48mTJ01vlBqCDiEDtYloo0yhtXKb9yFQqhoo4erqKjx//pzB0YG1lomEF3IxJKpf07v4nhtGra3s W8m9SXpum0QEDZTG8tj1agaVDJQktrIx5mm/lYghUKAez8tjU6oZ0l4tzpCobs3u3KWeTjXNc+w9 ZqoZL1HVQE3elsdSzUAvTcJG6RuGhtZKTtCgmgG05aGtsnR8hAzUpqaNMsXaEKn3IdAxqhpoyeoO rUsbp0kY/kzFkKhu1e/QLW4YPd7PsXRcW4+ZtsldBA300Gt5bC1LISMEKhloR3VlY0xjlYMhUECW GstjW1dN5qoZmioZUxgS1avqXbnH02nveY7UY6aaMY+qBiTQOscxFzJCoJKBfvSUADaS/OpzhkAB HTS1VaZWmhAyIEW1NoqUp9OWrZWUY2YIdJmU7w0QaXjr6NR7MzS3S+YwJKpXlTuwtBtGi9bK2jHT Nlkn7XsDDElsq1DNgBamBkTX9FoqyxCob/fu3ev9EVCIpOWx42qG9uHPVAyJ6lT8jqvh6bT0PMfc MVPNSKfhewOE0H+OY1zNoJIBDcwOiKbY++rzlBsjQ6CAXXtec15iq/nh/5+QAU2KtlE0Pp3mtlam jpkh0G00fm+AEF7OcdQ2fG+Gl3bJHIZEdSpW2dB+w9gzRDo+Ztom22n/3gC12ypTIQPQxtWAaIq9 W9kzBAr4VWN5bKxmPHnyxHUlYwpDovoUCRsWn07XWivxmA8ODkwefwucN1hTqq0SqxmxWkLIgHau B0TXrLVWGAIFMJYzCBqDyrCaAViQXdnw8HQ6HiI9PDy8+efYx8P3Bn7FwLGlrRJbJlQz1jEkqg8z GxsMwwU3SgBLUuc4YighZMCyrLDh7en09PQ0fPTRR+HTTz/t/VFU8/a9gW/DOY7xG0gJGfsxJKrL 7rDh6YYRh0BDeFG+w36evjdANG6reH9XBvyhjbKCIVAAJcS2CpUMeLQrbHh5Oh2+CdTLMdfEOYRn 8b0Z7777rpjN3DRjSFQXKhsTeHcGgJLGO7RK2j0WaGFz2LB+E556E6j1Y26BcwiPhnuajO1ZHovb GBLVY9NLvSzfMOb2NbF8zK1wDuFRyou99uweC2hEGyUwBAqgnKVqxpxWu8daw9yGHslhw+rT6dJ2 8ONjtnoOauKcwYthyFgKGnPzGrRVYJnbvVHYDh5AKXv3QhmjrQKrkiob1p5OU7aDt3bMPXAOYd2e lkkK2irpGBLVYbWyYemGkVrNsHTMvXAOYV2NkDGUs3ssII2bAVGGQAGUUKuaMYU5jnUMieqwWNmw 8nS65TisHHNPnENY1aPSwBwHLDA9IMoQKIAShru29hLnOGirQKPZNor2p9OUIdCp/4/mY5aAcwhr UpaztkJbZRpDovKZq2zsrWas3SS5iQK+1Kxm5Ax/0laBRpOVDa03VoZA+9L6vQHGJFUz5rA89iWG ROW7EzY03jDiLq1zbwJdo/GYpeEcwoKWK01KYPdYaKG+jUI1A0AJmkLGUAwcT548oa0CsW5VNrQ9 neZUM4Z/hqZjlohzCM20VTOmXF1dhefPn7seHGVIVDaVlQ2WtAIoQXvIGGN5LKS6qWxoeTot2TbR csyScQ6hkYVqxhyvy2MZEpXtIAQdN4zS1QwNxywd5xAaWQ0ZQyyPhTQq9kbpPQTKTRXQT1o1o8VK EpbHQopXpN9ISwyBTv2Zko9ZA84hNNHw3oxaPC2PZUhULrEDogyBAsglYU8TCVgei95ekXgzr9k2 4Yk8H+cQGniuZkzxsDyWIVG5RM1s5L4JdA03yXycQ0gnbTZDGuY40IOYNkrvIVAA+hEy0tBWQWsi Khs1qxnDv4Mgk4dzCKmoZmxnta3CkKhMXSsbDIECyEXIyMNbR9FCt8pGy7YJT+T5OIeQxkI1Q8qy VCmfowSGRGVqHjZqD4GWxk0WkIeVJuV5fc052mjaRukxBEpYyMc5hBS8N6MuXnOOWppVNnpUM7hJ 5uMcQgqqGe1oXx7LkKg81SsbDIECyEE1ow+Wx6KkqmGj57szeCLPxzlET4SM/rS2VeKQ6OPHj3t/ FPxPlTaKtiFQALLQMpFFe1sF/RUPGxLeBMoTeT7OIXqwsJzVKkvLY9HW+fl52bAhoZrBTTIf5xA9 eK1maLqJa1oey5Bof+fn5+H8/DxcXFyUmdmwOgTKTReoj9kMXbTOcaCd8/PzEEIIFxcXN/8sO2xI aJtEhIN8nEO0RMtEL+mvOWdItK0YhIT2owAAFeZJREFUMEK4HTKi3WHDajUDQH1UM2xgeSymqhhT doUNSdWMiCfyfJxDtCD5aRjbSW6rHB0dUdmoJDVkRJvDhsQbksTPpA3nELVRzbBNelsF+dZaJUuS wwZtEwB7cRPyIbZV+FnbsrWKMSUpbEhsm0Q8kefjHKIWqhn+SJrjYEg0T4mQES2GDaoZAPbiCTed tYqA5DkOLMtplSyZDRuSqxlRzSdyL0/7Xo4T7VDNQCRhjoMh0TQlqxhTJsMGNyAf+DmjtN43Fsgj qa2Cu2qHjOhW2NDUNuFGCchBNQNLaKvIUqtVsuQmbGhom0QEjXycQ5RCNQOperRVGBJ9qVUVY8qB pmoGADmoZmAPa8OwGvQMGdGBlmpGxBN5Ps4hcnGzQI7Wcxweh0R7tEqWFNn1FYAPVDPq8fbEzxxH HRKqGFNUhQ2eyPNxDrGXpxsh2pGwPNYCqSEjUhM2Wt4krd6QrR4X6qKagdpqt1WsDolKa5UsURM2 ALTHEydaoa2STnoVY4qKsMETeT7OIbagmoFearVVLAyJagwZkYqwAaAdqhnozduw7BJNrZIl4sMG T+T5OIdIQTUDknh/zbnmKsYU0WGDm2Q+ziFS8BQJiUrOcWgZErUWMiLRYQNAXVQzZKF9MM368lgr rZIlYsMGT+T5OIdYYvniDXtKtFWkDYlarWJMERs2euEGDeuoZkArK8tjPYWMSGTY4Iafj3OIMUIG rNDYVvHQKlkiMmwgD0EDY9ouzMCaPfMtPYZEPVYxpogLG9wogXKoZsAyyctjCRm3iQobBI18nENE VDPgwdY5jppDot5bJUtEhQ0A+ahmwKOecxxUMdaJCRs8kefjHIJqhn68a2O/1m0VQkY6MWEDwH5U M4AX1toquUOitEr2ERE2pDyRS/kce2j+7NZdXV1V/fnwFAzcVbqtQhUjT/ewwU0yH+fQJ6oZwLK5 ltSWIVFCRhndwwaA7ahmAGn2zHHQKimva9jgiTwf59AXqhnAdqnLY6li1ENlA1CCagaQZzjHMRwS JWTU1y1s8ESej3PoA9UMoJxhW4WQ0c4rPf5SbpL5OIc+xKcwgoYv8YaIOq6ursLPf/7zEAJBo5Uu YQPAspOTE9omQCUnJyfhj3/8Y7i4uLg1DIp6mrdRpD6RS/1cUzR9VmxHyADqGf5+ffjhhzeBgwpH XQyIAkIwmwHUNRfkhxUOQkcdTcMGT+T5OIc2Uc0A6lr7HYshgypHHcxsKELQsIfZDKCfo6OjO/+M OY46mlU2uFECtxEygDa2/q7RVimvSWWDoJGPc2gH1QygnaXftbgD7JSLiwuqHAXRRgEa4r0ZSMW7 NvKVCPUEjjKqhw2eyPNxDvX7v//7P6oZQEMlf98IHPmobARu5qjn+Pg4vPfee+Evf/lL+OGHH3p/ HAAjU0OiU2LgIHTsU3VAlJt4Ps6hTsfHx+H7778Pn3322a1/fnJyEu7duxe++OKLTp8MsK9WFZHl sftVq2xwk8zHOdQnVjI+++yzyZ/d1dVVuLy8DMfHxx0+HWDf1qCxNCQ6h7bKdrxBFChgrpIx5/Ly kioHUFjLuSiWx25TJWzwRJ6Pc6jD1pAxFC+KhA5AJ9oq6RgQBXY6Pj6ebZdsEVsr77//Pu0VYKec qkbqkOgc2irriocNnsjzcQ5lG85llDQMHUAIvGsjlYRl5QSOZUXbKNwk83EO5cppmWwRbzC0VoB1 JYJGHBJ9/Phx1p/DHMc89wOi3NyxplXIGGKeA1gnoaIxxhzHtGJhg5t2Ps6hLD1CxhihA9ApVjkI HC+4r2wAYxJCxtgwdHz55ZedPw3QX+mqxtHRUXYbZYy2yktFwgZP5Pk4h/1JDBljzHMAMtsnc2ir vEBlQwCCRl8aQsYQrRV4VitolBoSneO9rZIdNrhRQittIWOM0AFvNFU0pngOHFlhg6CRj3PYnvaQ MUbosC22zjTfZPGS1zkO2ihww1rIGIs3o9PTUwIHzGkRuGoMiU7xOMexO2zwRJ6Pc9iG9ZAxxiZv sMZqZcdTW8V1ZaPnzZ6gUZ+3kDFEawVWtAwatYdEp3hpq+wKG9woIZnnkDFG6ADk89BW2bwRG0Ej H+ewnlI7sVoTN3ljV1loYrV9MsfyZm5sMQ8Tau3Eag1b2UOLXkEjd7v5XFYDx6Y2Ck/k+TiHZdEy 2Y7WCqTzVtEYszjH4XpAFHoRMvIROvTw9K6N3sfZY0h0irU5juSwwRN5Ps5hPkJGeWzyBshlZXks lY1GCBp5CBn1sckbeutd1YhavdwrlYW2SlLYsHijtHhMFhEy2qK1gl6kBA2ptLdVVsMGN+V8nMPt CBl9ETrQEkEjnda2CktfIcpwCSsBrb/4fo7333+/90eBURKDRhwSlUrj8tjFygZP5Pk4h2moZMjG PAcgi7Y5DgZEKyJorCNk6EFrpS+Ly18lH4+0IdEpmuY4ZsMGN0rURMjQi9CBEiQHDW00zHFMhg2C Rj7O4TRChh2EDuxF0ChPeluFNgqaIGTYFW8ap6enBA6YIeVNoltIbqvcWY3i4Ym89jF6OIdbsLrE BzZ5QwqqGvVJXK3C0tfCCBovxWWsnA8/hktlCR0Y0xY0eu8Am0Na4LjVRuFGiRJomYB5DoxpCxoW SJrjuAkbBI183s8hIQNjzHMgBIJGT1LmOGijIBtv/cQaWitlxHdtoA3pbxLdondb5SAEnshL8HgO qWRgC1orPlHVkKNnW4Wlr9iMkIEchA4/LAQNDW8S3aJXW+XA4xN5aV7OISEDJQ1Dx5dfftn506A0 C0HDstZvHXVX2SgdDDwEDUIGamKTN3sIGjq0DBwH1m+U2I+QgVZorUAqjW8S3aLVHIe7ykZJVqsa hAz0QujQj6qGPjXnOGKQIWzgBiEDUjDPoZPVoGFtSHROqbbKcIlt/LMIGztZqmoQMiAV8xx3xXMi 7aYu8TNhu71tlamAMUTY2MFK0CBkQANaK0BbW9oqqcGEsOFUfOMnoAWhQy7rVQ3rQ6Jz5toqa1WM KYSNjbRXNWI1Q/MxwDdChyzWg4Z3U6853zPT4SpsaA8KOWiZwBo2eevPU9DwMiQ6NLWXyt7hUVdh I5fGsELIgHWXl5dUOTrwFDQ8WWuR7F2tQthIpC1oEDLgCa0VIE/qoOfe5bGEDWMIGfCM0NGGx6qG xSHRPYOe8d/dujyWsJFAQ1WDkAG8ZH2eo+e7NjwGDUv2BoyxrW8dJWwoR8gA5jHPUZb3oKF1SLRU wJiS2lYhbKyQWtUgZABpaK2U4T1oaFMzYIylBA7CxgKJQYOQAexD6IAHLXZwnbI2x+EmbEgMDlsQ MoAyrM9z1EBV4wWpQ6ItqxhLluY43ISNraSEE0IGUAfzHGkIGjJJCRhTptoqhA2hCBlAfbRWlhE0 7uo5JCo5YIyN2yqEjQk9qxqEDKA9Qgek0hQwxoZtFcKGIOzECvQ1DB1ffvll50+zrPa7NqhqTGs1 t9Fr0LMGKhsTelQ12IkVkCXeyL1WOQgafWiuYqwhbAy0Dhq0TAC5vLZWCBptWQ4YQ4SNDggZgB6e QgdBI03ukKiXgDHkImykVCxaVDUIGYBemuY5II/HgDHkImz0RsgA7LA6z0FVI92WIVFLg545CBuh XlWDkAHYZK21QtAoy3sVY4r7sFEjaBAyAB8shA6CRhkEjGXuw0ZJhAzAp16hI/ddGwSN/Y6OjsJr r712898JGMtch41SVQ1CBoAQ2OTNGwJGOtdhIxchA8AUDZu8UdXII3UHWKncho2cqgYhA8AayfMc BA20Zj5sTIWKvUGDkAFgK2mhg6CBHsyHjRIIGQBySZjnIGiU1XO7eW3chY2tVQ12YgVQkoZ5DqA0 d2EjFTuxAqilR2uFqkZ5DImmcxU2UqoatEwAtFIidKS8a4Oggd5chY0lhAwAvdTc5I2gAQnchI25 qgYhA4AUVjd5s4wh0TQuwsZU0CBkAJCo5DwHVQ1IYTpsxJBxenp6888IGQA0yA0dBI02GBJNYzps hPAycBAyAGi0Z56DoAFpzIeNw8PDcH19TcgAoFrqPAdBAxKZDRvHx8fh8PAwhBDCW2+9Fb7//vvO n8gXhtuA8qS9+hwvMCS6zlzYGLZLhtWM4+PjEAI3wVbi+YY9/A71Nw4dseox/N8ASe795je/+aH3 hygh9Y2fw5sgF01gO4KkPG+//XYIIYRPPvmk8yfx69mzZ1Q3FqivbGwd/BwGDKodwHb8vsgRr2Hf fPNN+OKLL7pu8gYsURs2Sqwuib+UVDsAaLF0vWKTN0ilLmzUWMJKtQOAdKnXJoZI+2BIdJmqsHF8 fFx9CSvVDgBS5FyHCB2QRMWAaO/t3ql2AGil1oMO8xz1MSQ6T3RlQ8pbP6l2AKit9kMN8xzoSWTY kBIyxpjtAFBS6wcYWivoRVTYkBoyplDtALCHhGsGoaMOhkTniQgbmkLGGNUOACkkXh/2bPIG7NF1 QLT34GctEp5cAPSn6VpAlaMMhkSndalsaK5kpKDaAfilKWAM0VpBTU3DhvWQMYXZDsAHKw8WhI48 zG1MaxI2PIaMMaodgD2WHyKY50BJVcMGIWMa1Q5AL2+/t3H7eqocyFFlQNTq4GdNVDsAubwFjDmE jjQMid5VtLJBJWM/qh2APDwE3MY8B/YqEjYIGeUw2wH0ReBfR+hYxpDoXdlho8VOrF5R7QDa4Hds nxg62OQNa3aHDaoZ7VDtAOrg96kMNnnDms0Dogx/ysCTGLAPvzt1ETpeYEj0tuTKBpUMWah2AOkI GO0wz4Epq2GDkCEfsx3ANIJ4P97nORgSvW02bBAy9KHaARC6pWGew7fz8/MQwkTYIGTYQLUDnvA9 l43Wii8xYIQQwsXFRQhhMCDK4Kd9VDtgDd9pnbyEDi9DosNwEcLLgDF0769//esPhAxfeAqEZnx/ 7bC+yZvlsDFVvVhy71e/+lXxvVGgB0+G0ICAYZflKsfh4WF4+PBh749RzNaAMdRki3nIxWwHpOI7 6QPzHLLlBIwhwgZCCKxkgRx8/3widMiQMn+xB20UzOLJEq3wXcOYlXkODXMbpaoXS6hsYBbVDtRE wMCSq6srqhwVtQgYQ4QNJGG2A6UQXJHKQmtF0ptEWweMIcIGNqHagT0IqchhIXT0UGv+Yg/CBnaj 2oElfC9QGqFjXc/qxRIGRFEU1Q7wHUArWjZ5qz0kKjVgDFHZQFFUO3zi540evG7yJqk9koqwgSqY 7bCPgAEJNLRWSgyJaqheLCFsoDqqHXbwM4RUGkLHVtoDxhBhA81Q7dCLnxe0iKFDyzzHmKWAMcSA KLriSVkufjbQTlKVY25IVOP8xR5UNtAV1Q5ZCBiwRGprxWr1YgmVDYjDDa89gh486Bk6Dg8Pw7ff fhtC8BMwhqhsQByqHW0Q6uDNsNLRY5M3jyEjImxANFaylMV5BNjkrQfaKFCHasd2nDNgWsvQoWG7 +VqobEAdqh1pOD/AOqlDpNYQNqAWsx13ETCAfVrMc0jabr41wgZM8F7tIGwBZTDPUQczGzDL+g3Y a7ACWqkROrzObVDZgFkWqx2WjgWQjnmOcggbME/7bAcBA+iL0JGPsAFXNFU7NAYjwLISm7x5HRIl bMAlqdUODSEI8O7y8pIqx0YMiAL/0+tGT8AA9NoTOjwOiVLZAP6ndbVDUkUFwD575jlee+212h9L HCobwILSVQeqGIBtKfMcz549uwkcXjZnI2wAifZWIggYgC9rVY7Dw8Pw8OHDEEII5+fnIQT7oePe n//85+phgwssLEkND7RJAN/mQscwbETn5+emA0eTysbw4gys0XRzHgcKqhgAxqZCx9SQqOUqB20U iKMtnL799tu3/vs333zT6ZP4RKiDFsNN3pZWpFgMHYQNYKe5Ngntk7a0hVP01fv3MlY5fve7360u f7UUOggbwAZb2iS0VAB5eofTH//4xyGEEP75z3+GX/ziF0n/HwvzHIQNYEWJ0EC1A/DrzTffDH/6 059CCCH8/ve/3/VnaK9yEDaACbWqElQ7APvefPPNEELIDhhTtIYOwgYw0LICQbUDsKNE9WILba0V wgbc611t6P33A9iuZvUilaYqB2EDLkm9wVPtAORqXb1IpSF0EDbgipabudQwBHgioXqxheTQQdiA edpv3FoCEmDBMGBIDxdzJM5zEDZgkvaAMcXiMQG9aatepJJW5SBswBQvVQAvxwnUYKF6kUpK6CBs QD3PT/yejx1IZbV6sUXv0EHYgErcZO+i2gG85Kl6sUWreY4YbiLCBtQgYKThPMEjqhfpalQ5xuFi /GcTNiAeT+z7ce5gGdWLPLmhYxgw1v4MwgZE4um8LM4nrJD6Yi3NUkPHWvViyb2PP/74h3feeSeE EMLf//73jR8RKIcbYhtUO6AJ7ZF2xvMcOeFi7N6DBw9uKhsffPBBCCGEd955h+CBZrj59UG4g1RU L/ooGS7GboWNoWHwCIGqB8riRicLgQ89Ub3oZ27uovQQ6WzYGPvggw8IHshCwJCPnxFaoXrRx9bq RamlsslhY4jggS14ataJnxtKonrRR4nWSIkqx66wMcScB6bwhGwHP0vsxdLU9mrOXeSEjuywMcSc h2/clOyj2oElVC/62PK+i5J/36alryXDxhjtFh+4AflDsERE9aK9mtWLrZ8j9e+uFjbGSYvgYQs3 G0SETV+oXrQnJVxMSa1yFA8bKX8xcx46ETCwhO+HXVQv2pIcLuas3fuLhI2cfhHBQzZuINiDaod+ LE1tq/XcRS1zoSMrbJR+6QcDpnJws0AJhFU9aI+0pbF6scV4nmNX2KixPe0U5jza4saAmgiw8gyr Fz/60Y9u/rm1G58E1sPFlGFWSA4bvUs8tFvqIGCgNb5z/aRWL1o9UFrX+74pxfn5+XrYkPilI3jk 4ykTEvA9rC9n9kLi9V8yj9WLVLNhQ8uXjDmPdDxRQiq+m+XUmL3Qcj9ojXCR7lbYsFDyYc7jNi7i 0IZqx3atVo54Dx2Ei/3uPXjw4AerXyDP7RYu2NCOoDyv98oRCw+mqTwda033fvvb3/7g4QR6CB5c nGEV4Vnui7WsPaxSvaij6t4oUlma8yBgwBNP3/fe1YuttIYOwkUbLsPGmMY5D5704J3F3wGp1Yst pIcOwkUfhI0RycHD01MdkErz74W26sUWkkIHcxf9ETYWSJjz0HwhBVrTUO2wUL3YokfooHohD2Ej Ucs5DwIGkEfa7xCbmtWtLhAu5CNs7FSj3aLhqQzQpsfvleX2SAm51Q7ChT6EjQJygoe0JzDAqtq/ a1QvttsSOpi70I2wUVjKnAcBA+irRLWD6kU5U6GD6oUthI2KxnMeP/nJT0IIBAxAiq3Bn+pFPYQL 29y8QVSCX//61+GNN94IIYTw73//u/OngXWE2m2mqh1UL+pZChe0TOy5tTdKCPxgW5H8Pg/YMHxq R7q33347fPfdd+HTTz8lXBS2514j6X0d2O9OG4VSVnsS3ucBeEX1op6S9xNCh27/DwyZOBFKLgsz AAAAAElFTkSuQmCC "
+       preserveAspectRatio="none"
+       height="142.61041"
+       width="142.61041" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Calque 2"
+     style="display:none;opacity:0.57599996"
+     transform="translate(470.69208,-22.182517)">
+    <image
+       y="118.73846"
+       x="57.565689"
+       id="image834"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAegAAAG0CAYAAAD5HLSAAAAABHNCSVQICAgIfAhkiAAAABl0RVh0 U29mdHdhcmUAZ25vbWUtc2NyZWVuc2hvdO8Dvz4AAAAtdEVYdENyZWF0aW9uIFRpbWUAbWFyLiAx MSBm6XZyLiAyMDIwIDExOjUyOjMyIENFVMpNEvIAACAASURBVHic7d27bxzX+cbxl9SKspzClfFD mnRWkMBlBFcBDPFOLknd7QCpWLjy36DCcJMygB0gDfsESBxEvkgkde/idDEQQyniKr2a6EaJv0I5 1OxwZnYu5/Kec74fIEAsrshditxnnvecmZl57733DgXJ29rakrfeeqvxMaPRSA4ODjw9o2YLCwuy v78f+mm0Nj8/L3t7e6GfRrTOnDkj165dq/zY9va2iIjs7Oz4fErAYNvb24N+bmctPhco9emnn04N ZxGRg4MDGY1GHp5Rs9jCGcM9fPhQPvnkk2N/bt7gCGfkiIBO3KeffioPHz5s/fjQIU0456sY0tvb 24PbBxDazs7O0QSoj/B1CU5sbW3J2bNnO4WzUQxpLSNv5OHhw4cEM5JiQrrPzzQNOkFmvblPOBsH Bwfe2zTtGXNzc/Ls2bPKcTcQq75NmoBOTJvNYF2EHnkjD3Nzc0fhLFK/Jg3Eqk9IE9AJsR3Ohglp l0FNe86XCWYTzoYJ6Y2NjUDPDLCra0gT0Ilou1O7rxAjb6St3JqrPHz4UN566y1CGlkioBPQdaf2 EC5Cmvacn7rWXIeQRiq6tGgCOmJbW1tew9mwGdKEc36mteY6hDRS0TakCehI2dipPYSPdWmkpc1I expCGqloE9IEdIRcbQbraui6NO05H11H2k0IaaRiWkgT0JHREs5FbB5DHRutuQohjVQ0hTQBHRHX O7WH6Drypj2nz2ZrrvLWW29xrjSSRkBHIsRmsK7ajrwJ5/S5aM1VuKAJUlDXoglo5ULt1B6CkXe+ XI20mxDSSEFVSBPQioXeqT1EXUjTntPleqTdhJBGCsohTUArpXEzWFecipWHEK25CiGNFBRDmoBW SPNmsK6K69K05/SEbM1VCGmkwIQ0Aa1MbOvNbR0cHMjdu3dDPw1YpKE1V+EmG0gFAa1IquEs8mrt mZF3GrSMtJtwkw3Ebmdnh4DWIMad2l0UR9vcFStu2kba0xDSiBkBHVjMO7WHIKTjEkNrrkNII1YE dEAp7NSepmljGCEdh9hacxVCGjEioANJaaf2EKxL6xZra65CSCM2BHQAKa83F7U9rYp1aX1iHmk3 IaQREwLaM8K5HiGtQwoj7SaENGJBQHuS+k5tWxh5h5Nqa67CnbAQAwLag9x2ag+9Yhgjb/9Sb81V uOoYtCOgHcthp7YrhLQfubTmKoQ0NCOgHdrf388unG1fb5uQdienkXYTQhpaEdCO7O/vy3/+85/Q T8MrVzfDYF3avhxH2k0IaWhEQDvw6aefZhfOrrEubQetuR4hDW14t7Noa2tLzp49Kz/5yU9ERLK6 taKvW0makD44OHD+tVJDME9nQvrbb7+V69evh346yBwBbUlxp7YJaLhRbNIEdTuE83Tz8/NH/39p aUlEhJBGUAS0BcWd2qZJLiwsBH5W/vhqz0UmmGnTzebm5kRECOcKxUAWEbl169bRn3/22WdHFzQh pBEKAT1Q8eIjIYIqd4y869GaJ9UFchNCGiER0ANwZTAdByWE9CRa8yt9Anl+fv7Y4whphEJA92A2 gxXDWUNQ+abpNbMu/UrOrblPILdFSCMEArqj3C7bGZPc16VzCudyGIsMD+Sq9lxESMM3ArqDust2 amqSvmh+zbmNvHMYabtsx12Ym2xcu3YtyNdHXgjolrqEs+bwykUuI+9UW7PvQJ7WnovMudKENFwj oFtgM9ikWA5AUh55p9aatTTktghp+EBAT9EUzrEElU0xvubURt4ptGZNgdylPRcR0nCNgK5RtVMb 8UolpGMNZ02BbBMhDZcI6AptdmrH2CSHiv01x7wuHdtIO5ZA7tueiwhpuEJAl9RtBkMaYlyXjqE1 xxLIrnCTDbhAQBe0DefYm2Qfqb3mGEbemltzCoFsoz0XPXz4kHOlYRUB/T9td2qnFlRtpPqaNY+8 tbXmFALZF0IathDQYvc0qlTDLFUaR94awjn1QLbdnssIadiQdUB33amdY/jm8po1jLxDjrRTD+Qi 1+FsENIYKtuA5praKAsZ0r5bc06BHBIhjSGyDOg+O7VzaZJFOb5m3+vSvlozgfyKr/ZcREijr+wC mnDGNL7WpV22ZgJZF26ygT6yCmiuqd0eByVuR962w5lAni5Eey7igiboKpuA7hvOOQZVjq+5ju2Q tjXSJpDjREiji+QDmmtqYyhb69JDWjOBPEzo9lxESKOtpAN66E7tHJtkjq+5jSHr0l1bczmMRQjk 1BDSaCPZgB56Te0+QUW4pa/ryLtNa6Ydu6WpPRcR0pgmyYBmM1g/HGC003bkXRfOBDIMbrKBJskF tI1wzjGocnzNQzSNvMsjbQI5HK3tuYibbKBOUgFNc4ZvxTYt8iqcf/nLX048RntAQAdCGmVJBLTN ndo5NskcX7NNBwcHcu/evaNwJpB1iKE9lxHSKJoN/QSG4praCG00GslHH30kz549kwcPHoR+Ooic CWkg6oAeulO7LMcmmeNrtmlhYUHef/99+f7770Xk1bqzWYNGODG25yJCGiIRB/Snn35KOA+U42u2 ZTQaHX3/Dg8PJz4W+l7OSAMhjSgDWuNmMMIuHwsLC3JwcCD7+/tH/+4zMzOVj6VN+xd7ey4ipPMW XUC7COccwzXH1zxUsTUb5fZcxsgbQ5k7YSE/0QT01taWyuaMPJjznYvh3PYgh5G3Pym15yJzQRPk JYqAdrlTO8cmmeNrHsKMtMt/tre3JyIiMzMztSNu+JNqOBuEdH7UB7TtndpFBBWaVI20i4rBvL+/ L4uLi60+LyNv9EVI50V1QNveqQ0OStoqbgSr+tiQ7yHr0val3p6LCOl8qA1o1+vNOQZVjq+5q2mt WUSOjbP7jLhZl8YQhHQeVAY0m8EQQtVGsLLFxcWjtWeR42HdB216mJzac5EJaU7DSpeqgPa1U9t2 k4yhmcbwHEOq2ghWVgznqtbcN6wZeaOv4p2wkB41Ac01tRFCm5F2WVUQD23SjLz7ybU9lxHSaVIR 0C53apfl2CRzfM1tNG0EKzPt2cb6M+ACIZ2e4AHtc6d2jkGV42uepm9rtjXSboOR93S05+MI6bQE DWg2g8G3NhvBysobw0Sqd3LbxLo0+iKk0xEkoENctjPHJpnja27SZiNY2eLi4sT30GeTZl26Hu25 GSGdBu8BzWYw+NZnpG0Uw3fa+jMjb2jCTTbi5zWgfW4GK8qxSeb4mqt02QhWVtwY5nP9uQoj79do z+1xQZO4eQvoVMNZYxBqfE6+DWnNxuzsbOtTqnwENiNv9EFIx8tLQHNNbfjUZyNY2dLSUuXGME6z Cov23A8hHSfnAR1yp3aOTTLH11zUZyNYlTYj7dDBzMgbXRDS8XEW0CF2aiNfNkbaxvLy8tRLempo 0rmtS9OehyOk4+IkoDXs1M6xSeb4mkWGbQQrK462Na0/12FdGl1xk414WA/oUJvBinINqtzYbM2G 2RimtTU3SblN057t4iYbcRjZ/GQawjlXuR2U2NgIVla1MUxEX2uuY0beqbVqwtkdE9LXr18P/VRQ sL29LSIWA1rLenNuQSWS12sejUby/vvvO3m9s7OTA6UYRtxlqYUz3COk9TDBvLOzIyKWAlpLOPuW UzBq4KI1GysrKxPtOcZwThHt2Q9COrzt7e2jYDYGBfTW1pacPXtWTTjnGJi5vGaXr7M82u57ipXG sE5x5A03COkwyq25qHdAa9ipjfS5HGkbJ06cEJFhQawxnEXiXpemPftHSPvTFMxGr4DWuBkslyZZ lPprdjnSNpaXl2V3dzfJcDZiDGeEY26yce3atdBPJUltgtnoHNCEsw4pv2Yfrdmout52KsFcJZY2 TXsOy5wrTUjb0yWYjU4BnetmMPjjozUbxSuGGSmHs0jcI2/4RUjb0SeYjdYBrTWcU26SdVJ9zT5f 1/Ly8kRDGxrM2i5a0kR7ONOe9SCk+xsSzMbUgNa2Uxvp8TnSNszGMJE0N4cBthDS3VWdMtXHzHvv vXdY90GN681FIZtkqK+dWns2I22fTHu20ZqL3n//ffn666/tPEmPNI28ac96nTlzhpCewkZrLqpt 0IQzXArRmo0TJ07QmgtYl0Ybpkl/++23nIZVYjuYjcqA1rrenLtUDkp8bgQrG7IxrOtjY6IhnGnP +hVvskFIuwtm41hAxxDOqQRVF6m85tCvYzSa/JG3PeZOAW0a0+Qe0q6D2Zh4t4ohnBGnkCNtY319 XXZ3d0XETWtOJaxDjLxpz/HJMaR9BbMxEolrp3boBhZC7K855EjbWFlZ6RzOuY25i2jQaCOXkPYd zMaIa2rDFQ2t2ajbGCbCmDs02nPcUg7pUMFsjDTv1C6LvUn2Eetr1tCajfKtJA1ac3usS6NJiiFt 61zmIWanP0QHTUHl67loes1dLCwseD+3uUl5Y5hIt9aceziLvF6Xto32nA4T0rHb3t5WEc4iA+8H DRRpGmkb4/H4aO1ZhNY8BA0a08R8J6zQ4+wqUQR0rE1yiNhes6aRtlHcGCbibq3Z/HlO4W1j5E17 TlNslwbVGMxGFAENvTS2ZsOMtl225pxCuWjoqViEc9piCGnNwWyoD+jYmqQNsbxmja3ZWF1dld3d XeetOWeMvNFEa0jHEMyG6oCOJahsiuU1a3+eo9HoWIjSmnWgPedDU0jHFMyG6oCGPppH2oZpz0Wu WzOhzalYqBY6pGMMZkNtQGtvaC5of82aR9rG6uqq3L59++i/Xbdmgvm1NuvStOc8hboTlpbTpfqK 5jxoLbSHqAuj0Ujduc11iuc82zivue7xTX8nZzRo1CneCcs1TecyD6GyQecYglpfcwyt2SiOtm3c 4IJgHqbcpmnPEHF71bGYx9lV1AW01qDKUWz/FidPngy61kxwTwpxVyzEwXZIpxbMhrqAzpG2IIxh I1hZ1cYwET+tmWCuZ8KZ9oyyixcvys9//nP5zW9+0/tzpBrMhqqA1hZUPmh7zTGNtI3V1VW5c+fO xJ/RmgG9zAHbo0ePev391IPZUBXQCCfG1mycPHly4r9pzboU2zMj77zNz8+LiBz9PJw9e7bTmDuX YDbUBLS2JumDltccY2s21tbWGjeG9fnzIR9DM9al8zV0mSOFXdldjcybM/Kk5SChL9Oeac06Vb0p E855KbfmoocPH07dLJZbay4aHRwcHJ07GiqoYw+JPkK/5phH2oZpzzZ2bvf9O20+jnq06bQNac05 B7MxEnkdzCGCOnRQdWHruYZ+zTGPtIvKa88i/lsz4VyvzZszI+80NbXmaQjm1ybWoItBzdg7PSm0 ZmNra6vV9bab/rzv36n7OGHdD+Gclq6t2WwUI5iPq9wk5mvsHbpJhhDqNafSmkUmN4YZPm98QRBP x3nP+enbmn/44YcsN4C1UbuLO+TYG3aldiA0Nzd39P8J5vQw8o5PnwMy83v87Nmz3udDp27qaVau gjq10GjD92tOaaRtrK2tyc2bN0WEcNZqaHtmXToefVpzMZjRrPV50DbXpwln91IaaRfNzc2pDGYC /BVbo23evPXr25r5t22v8+0mzfp08bZ+0COmW0N2tb6+Xnm9bZFw4dx0O0rYUVzSQHjz8/Odw3lu bq4xnM+ePWvr6SWlV8oOGXvTnt1JtTWLvArn8vW2RcIGMya52hjGyFuPPsEswkSkr84Nuujg4GBi x3fKtB9YpNqajaoWRTjngzf4sLq25mJjbvNvZ64ohklWkrXtaVnaQ84F1685xY1gZevr60cbw0QI Zo04rSpdXYNZhAMqW6xVX07L8i/lkXbRkNOqhnysz+PgByNv97rs0LYRzF3vbJUD67PpuqCmPduT Q2s2THumNesVoj2zLu1W239TGrNbzhaPi0GdS5gUuQznHFqzyOuNYbG0ZsLcL0LBvratmWD2Y9Am sTYODg7k7t27WWwkcy31jWBlp06dqr3mdVNoDw3nPqdO5RrOWtaeORVrOPNv2Sac227+6oKNYsc5 T81ik8xlfdp2e85xClHeGGbQmlGFkXd/tGa9nDfoouJpWTTqdkxrzimcRV615yJasz5a2rNBcHTX pjV3PWVqCC5YMslpStY1ydhua9mlEdtqzzm2ZmM8Hrc6rWrIx7o8xsbfATRp05ppzOE5C+g2QeXr tpa+2AznHFuzYdqzth3aBPNr2tpzFUbexxHMcfE64q7C2HtSbhvByi5duiQ3btwY1JrbhDfhnD6z Lo1Xpo2zfY6y67BRbJKTROzTJGO/0MnQ9pzzSNswo+0+p1W1+Xjbxwx5fA5iaM8GLXB6a6Yx6xW8 QZfldH1vI9eNYGXljWFFtGYMlWObbtOaQzbmKmwUe816Ctpah41pfbrva6Y1v1beGGbQmnWJqT2X 5XQqFq05DVYD2vb5vzGMvYeEM635tTfeeGPiv0NdppNwTlsOgdR0EEUwx0XdiLtKahvJct8IVnb5 8mW5cePG0X+Has2Ec7OY23MOmm4JqWEDWFtsFHvNWtr5uBlGiPOnm15X19fMSPu48Xh8FM6Ms/VK NZxTGXk3BbMIjTlWUTToshjbNBvBqpnR9tBNYNM+h43HIz2xn4pV15pjasxV2Cj2ipWEC3ErydDr 021fM6253rTTqkRozRqk2p6NGANMpPrfhcaclngqaA3Nlw1lI1iz8sawIjaBIYQYRt5VO7QJ5jQN HnGHaM9VfI6927xmNoI129jYqDytSoRNYJqk3p7LtI+8q85rjnmUXYeNYq8MSjMt4Wz4GHtPe82M tKfb2NiQu3fvHvtzWjM00Bh0tOY8RblJbJpQp2WxEaydqtF2Cq35Rz/6kbev5UNu7VmrcmuOfQNY W2wUG9CgtbXnKrbXp+teM625vY2NjU7nPLd9zJDHA01CrUuXWzONOT/RbxJro+9lQ9schLARrJti eyac9aI9vxbiEqHF7z/BnK9eI+4Y2nPZ0LF31WtmI1g3pj27uLkFm8Dgkq9wLJ7XnMsouw4bxXo0 6BjDuajPRrLya2ak3Z3ZGEZr1o/23MxVm64KZuQtyU1ibfS9rSUbwfo5ffo0rRlJsH0qlmnNDx48 yLoxV8l9o1indIq9PVeZtj5tXjOtub/yxrAyTp3Sg/bcjq0ALbZmQhllWWwSm2ba2JuNYMOcPn26 9mOMs5Ejs0O72JqBstYj7hTbc1l5I9mZM2eO/hz91LVnxtn60J776zLyNuPsBw8eMM6eIveNYtmu QTcpBnLqByWuVbVnWjNS02Zden5+Xubm5ghmtNYqoHNoz0ULCwvy0Ucfye9+97vQTyVqV69ePXZR kpRb8+HhYein0BvtebimwCWY+8t5o9jUNeicwtlsBBN5NVpBf5ubm52vGFYUUzADZWZdmYuMYAhG 3P/DRjC7zGg79dacAtqzfcWrjxHO6KsxoHNpz8UrguXyml3a3NyUb775htaMLJnzmglmO3LeKJb1 aVac2+xGm4uSFKUQzLGuP9Oe7eL7CZtqG3TqTbLqimCpv2YfymvPTVIZZxPOKF5Du47Nq4/lJteN YpUNOuWgqmvNKb9mXzY3N+XevXutHkswIxVtD3RC3BULcctqkxgbwdxqumKYkUJrPjw8jD6cac/D tWnNZYRzP7muQx9r0Kk2yabXVf5Yqt8Dl9qMtmMPZpHm1hx7aKMdc5nOoQc4tGlMk/wmMTaC+WHz etsapRS+tOf+bH7vGHljmokRd2rNsc2tIVN7zSE0tefYwzmFcTaG6zPOboNwbi/HjWJHDTqloGrb mlN6zaHUbQyLPZhF0mrNBu25O75nCCW5TWJsBPPrzTffnPhvNoEhFa5acxNOxaqX40axWZF0mmTx imBtHpvCaw7JXDHMyDmYYwh0mmB75nvl+/vV5q5YyEcSm8TYCBaGac+xB7NI/4CNIZjRnq0d2kOw Lg1jNvYm2WYjWNXfifk1a9D3etva2GzNmsOa9jxdqNbchDY9KbeNYtE26L6teVo4E97tvPnmm1GH 85Aw1RzE6E5Da67DqVh5m40xjNgIFtaHH37Y+nrbGg1pzDGGM+25nsbWXEY4v5bbRrGoGvTQtWba 8XBbW1vRhjOtGYbm1gwY0QQ0rVmHNtfb1ibnYKY9Hxf794SRdz6iOA+6y+lTTZ+DcB8mxvbsa5wd 6/g7JyHOa3Yh91OxctooprpBc/qULjG1Z1+tWXMopxBGtqT2vaBB50Ftg7Y50qY9DxfTxjAfrZnG HIdUWnOT3Np0ThvF1DVo262ZcB4ultG2r4uNxBDMqYdSG7l8DzgVK12qAjr0RjDCvFr5etvaMM6e lEsw1clxhzbhnCY1I24bG8GqPieBO8zW1tbE9ba10TTOjiXAUxbDec0YLpeNYsEbNBvBdNPanrWN s7WEc67tOcfW3ISRdxqCNmiXI23a83Aa27OvO051ac1awjlXtObjUj8VK5eNYkEatOvWTDgPt7W1 Jffu3Qv9NCb4CmaXz8Wl3NozrbkZDTp+3gM69EYwtKNptB3LOFtjaKcqt4ORoRh5x8nriNvFRrCq r0H4D6NltM04u71cAiuH85pdSHHkncNGMS8Nmo1gcdHQnhlno4xgHoYGHR/nDdrnSJv2PFzo9ty3 pfa5dratx4Vu1qkHF60ZVXLYKOasQcfWmgn3V0K1Z20XG+G8Zx0IZndYl9bPSUCH2AhGwA73q1/9 Kkh7jnGcXfW4EIGdaoCxQ9s9LhGqn/URt4+NYFVfk3AeJsRo28c42/YGsNDj7BxwXrM/sYdz6hvF rDXo2EbamORztM04247U2jOtOSzatD5WAjrkuc205+F8tufYxtmxhndMCGYdYhx5m41i169fD/1U nBgU0LTmNPhoz7EFc9vHFR/jM6hTac+pvI5UxBTOOegd0BquCEZ7Hs7HxrC+68wuHk9r1oHWDEzX a5NYiI1gVc+BcB7G9Wh7yCYw21+jzeNsPca12Fsnm8DiEcPVx1LeKNapQac60s417F2NtmMbZ9OY /aA1xyfGdemUtG7QGkbaRq6BapOr9qzlKmBdmrXPrzdUrO2Z1hwv7eGc8hXFpjboVFtz7my351xb M826Ga05LbRpvxobtKbWbNCeh7PZnmO72EjMa9GxtWdac3q03hUr1XXo2gatMQg1PqfYbG1tyb17 96x8Lh8bwHw+TvPdrWIKZ1pz2mjQ/hwLaEbaabMx2mac3f9zpC6mAwlAu4kRt8aRtkF7Hm7oaJtx dvNjXIkh9LglZL40jLxT3Sg2EqE152JIe45pnK3tMakjmPPGqVjuzGpuzYbL9pxLM+/bnn1dbMTW 87C1uUvLJjHN4UdrhqEhnFPcKDYKfUUwuNdnYxjrzN0/nlObJphRhzZtj7XbTbqSS8N1qetoW0Nj bvs4bY+xSWMIskMb0zDytqfXtbh9IZyH6zLajmmcrekxGq7P7QPnNaOtEOGc4kYx9Q0aw7Rpz6mN s32dF13+uM2Q1tSeac1AGGobNO15uDbtOcXTpoZ+rdCnVWlCa4YNvk7FSm2jGA06YadPn679mJbW rOkxWtahNbRnWjNsYl26H5UBTXse7sMPP5QbN25UfkzLOrONz6UpvFOh4QAB6SGcu1M34vYZzqke CGxtbVWGc5/NTK7G2UM/l6YNYOYxNkI8ZDhyXjN8cTXyTm2jmMoGjWHKo23X4+wYT5uiVU8imOET I+92VAV0qo3Wp3J7jmWcTTCHCUnWmhGKq3A+e/asXL9+3cnn9mV7e1tElAU0hjPtWUMwt31cLOvM KTVmEVozoIkJZRGRnZ0dEVEU0LTn4TY3N3vfrUrjOFtLMLf9HEMC3GdY0pqhUa4jbxPMJpSLVAQ0 4Tzc5uZm5+tti+Q9ztY87naF1gytbK1Lm41i2sfcTcFsqAhoDOfyetuaQrfNY7SEe1s+QpPWjBik 3qCrxthNggc07Xm4rqPtVMfZWj5HF77CmWBGbIa0aW0bxdq05SrBAzqUlA4M2rZnja1Zy9dJcdxN a0bMUjgVq28wG0EDOqWQDKVNe9YYzLYeoyV4+4Szq2ZLMCMVMYZz1zF2k2wbdArabAzzPc4mmMNi nA2E2Sg2tC1XCRbQtOfhbN0MQ0uoavkcPoLZdpDSmpEDjSNvF8FsBAlownm4zc3N2utttxVTMNv4 Oq6/Rqg2TWtGLrqsS7vcKGZzjN2EEXekqtoz4+xwz6ELW4FKa0aOQjZol225iveApj0PV27PuZ42 peE5tH2MbbRmwN/I23cwGzToCPW53raWtmvjc8TyPKsMDVZaM/Ba08h76EYxX2PsJl4DWkt71vI8 +vjggw/kxo0bXttwm8fE8jlcfj/29vZkaWlJdnd3p/79PmjNwHG2G3SotlzFW0DHHIpadLlimKZ1 Zg3B6/Pc7Tp9A5bWDPTTZaOYpmA2GHFHpOm0qqKUWrOG52DzMV3RmoFuuqxLaxhjN/ES0LTn4Wxd MUxLoOUWzF2DltYM9NPmVCyNbbkKDToSb7zxRu3HYhpnx/AcbD6mD1ozMIwJ5/JGsViC2XAe0LTn 4a5evVp5URIRPU0yl6/R9jFFbQOX1gzYNT8/Lw8ePIgumA2nAU04D7exsdH7imFaAiv0x319jiFo zciVOTB14datW/LrX/9a/vjHP0YXziKMuNUrbwwjmNt/3NfnKD6u/NhpwUtrRixcBanLn/35+Xn5 29/+Jjs7O7K9vR1dSDsLaK3tWevzqlJuz1oCKfTHNX2OLo8rozXDNtdtNCbF36+NjY0oQ5oGrViX K4YRvPa+hq3H1AUwrTlvhKh7db97JqTN/9fOSUDH1FK12tjYaHVRkljaZuiP+35MUzjzJqofIRqv ab9jJphjaNM0aIU2Njbk7t27Ux+nIdS0f9z3Y+rQmt2IcV0U/lVdUSyGkbf1gKY9D9d0zrMIwevz c7R9TPFx5SP43FszbRS+dP1d0z7ythrQhPNwdadVieQRvDEHc1lMrZkQReyawrnpzlaaR96MuJWp as8aQiuG4NUQzD/96U/ls88+c9KaNEyjvQAAFXtJREFUCVGgmo3fN40jb2sBTXserqo9awgt7R/3 9TnaPu7jjz+Wf/7zn9YDlRAFjrN5MKwtpLNq0NoPIortWUNoaf+4r8/R5nELCwtHH//+++8JU0CZ tree1LQubSWgtQdfDK5cuSI3btwgeFt8XNNjTDDv7e2JiBz9HiwsLEz8NwD7XG3A1LIuPfP555/3 P3dE4gpnrc/VnFYVOthiCF5NwSwiR8FcZ35+XuXPHBC7PuH86NGjVi26KGRIZzXi1urUqVNOg3Po 5yCYX1tcXJxozNPcunXr6O8Q1IAdPk9dDDnyHhTQWhtpTMbjce1pVSLhW632j/t6zOLiooi8bswz MzNTP59h3kiWlpY6hTsAHUKNvGe9fSVUqrsoyeHh8Tsj8fEwj1lcXJS9vb3Bwbq/vy+3bt2SpaWl o8AH0M2Q9nz27NlBX7vYpn3oHdC05+EuX75ceVqV5mD0FbzTPu4rmJeWlmR/f19mZmas/e/WrVty +/ZtWV5ebnx+ACZpuCqfz5DutUks1nDW9LzH4/HE9bZT3wAW0zr00tKSiEzfAGbDwsKCvHz5krE3 MIWtcO6zUayKj3XpbDaJaQpnkVcbw4yQ4ZhTME973NLSkszMzPRaZ+7LvOGsrKzIy5cvZXd31/nX BGKjoTmX+ViX7hzQ2oIuRuPxWG7evBk8HF0Gu42vb+tzTHtcOZhDML9TBDUQF5dXH8umQWvi+rSq 2D/u6zFLS0syOzvrtTFPe04mqFdXV1vdDxxIne323PaKYl24OhWrU0DTnodrOq0q9XVmLcG8vLws s7OzwVpqmwOB/f19WV1dlRcvXtCmkS2No+06LkbeNGiPxuOx3Llzp/JjKa8zawvmPo257SjdJnMw vLa2Ji9evJCbN296fw5AKK7CuenWkzbYHHm3Dmja83DFjWGG5nVkLWvINoL5xIkTg5qor/F3FYIa uYmpOVexFdKtAppwHm59fX1itE0wuw/mlZWVoKNs28zv4Pr6uhwcHBDUgGI21qUZcXti2nPu68y+ grnYmEO2XxeKO76bLhMLxMhHe3axUazK0HXpqQFNex5ufX198GlVoYMzxmBO3Z07d2Q8HsvBwQFB jSTEPtqu03fkPfVKYikEdMjXsL6+XrsxzMg5uG08ZnV1NatgrrK4uCjPnz8nqBEt3+Fs64piXXQd eTc26BTCObSqjWFGzOvMGtahV1dXZTQasRYrry9LurGxIQcHB5xDDSjUdeRdG9CE83DljWFFrsI1 h2AWeRXOt2/fFpH01pjbqvoemaDmQieISaqj7TptR97cbtKhubm5Y392eFh/B6Wmj7X9+JC/O+Tj XR4zzbTWvLm5eRTOOWu6Y9bdu3dlc3NTVldXQz9NoFGocB5668mh2twVq7JB056HMxvDDK2tWEsj nvaYtbU1GY1GUe3MDnFxkyLTpre2tuTZs2c0aqiTW3Mum3YqFqdZOWLas9Zg9vFxG49ZW1uTkydP RrnOrOUgohjUz58/l6+//jrwMwLCh7PrK4q11bQufSygac/DXbhwYeppVSkHt43HmGC21ZhDt1kN TFCfP39e/vKXvwR+NgCKqtaladCWNW0MEyGYpz1mbW1N5ubmrDdmLW1Wg729PTl//rw8e/aMNo0g Qrdnw9cFS9oqj7wnAjrF9uz7NZ08ebLyz3M/pWraY9bX16MdZcfItOkLFy7I06dPCWp4oyWctSqO vI8COsVw9m1tba0yYGIddfv4HOvr6xONmabbX58xvllCuHDhgjx79ky++uor208LOEI4t3esQWOY 8mlVWndmawxmDDfk4MY06osXL8qf//xnW08JOKIxnLVsFKszEqE923D+/PmjsNHcikO37vX1dTl1 6pS1xszmL7t2d3fl4sWL8vTpU9o0EBgN2gIz2iaY6x8zHo/Z/BUJ06YvXbokT548IagxmMb2bGjb KFY0oj0Pd/LkyWjXmV2Pu8fjsZw6dYqbOETIrE9funRJnj59Kl9++WXgZ4QYaQ5n7UaE8zB1G8NE CGabo2xfGJkfZ4L68uXL8uTJE4IarRHOwzDiHqjqtKrUg7npMePxWN54441oG3MsBxIhmKAej8eE NJKheaNY0gHtenxf1Z5jHXXbeMzly5ejDWa0d//+fbly5Yo8fvyYoEYt2vNwSQe0S2traxN3VNJ6 SpWNrz/tMRsbG0fj7BANlLG0f+bAlKBGldjCWetGMQK6p9Ho1bdO87jaRzBrGGczlg5nd3dXDg8P 5cqVK/LkyROVb3LwK7Zw1oyA7mF1dXXq6UIxB/e0x2gJZugwMzNztD6tdS0PfhDOdhHQPdRdb1uE YEbe7t+/L1evXpXHjx8T1IiG1o1iBHRHde1Z8wYwG8F8+vTpo2C2PVJmDTkt5veDoM4L7dk+Aroj s/ZsaA7moZ+jHMyusIbsh+8DIRPUH3zwgfz3v/8lqBOWQjhr3ChGQHewsbFxtNZGMCM2oQ6EikH9 hz/8IchzgDsphLNWyQa07XOgV1dXW4VzzHeh2tzcZI0Zzty8eZM2nRjC2a1kA9q20Wikeh2ZYEYM GHtDK40bxQjoFppOq9IcvNM+TjAjlGJQP378WP76178GfkboivbsHgHdwokTJyr/XHOjbnoMwQwt WJ+OU6rhrG2jGAE9xXg8Plp7NghmwC6zPk2b1i/VcNaIgG6wsrIyEc4EM+AOY29gEgHdoM31tqd9 PPQpVVevXiWYERWCWq/U27O2jWIEdI2VlRXV19ue9hhaM2JHUOuSejhrlGRA2zgHum5jmIju20Ny kRGkxgT15uYmIR1ITuGsaaNYkgE9VHnt2Qi9zkwwI2f379/n/OkAcgpnbQjokpWVlWM/jAQzoAMX OkFOCOiS4mhbezCzxqwXNwBxi6D2I8f2rGmjGAFdUBxtaz2limCOA7fQ9MP8Hmh5Q01JjuGsDQFd MDs7SzADEbp//z73n7Yo93DWslGMgP6f5eXlyo1hImFPmRqPxxPBzOgUqGbG3gT1MLmHsyYEtLwK 57ofyFC3hywHc5fPibRwUNYNQY1UJBfQfc6BrjrnOWQwnzp1aupFUpAPDsr6MQe34/FYvvzyy8DP Jg6051e0bBRLLqC7Ko+2Q60zm2DWsMZMY0NK7t+/L1euXJHHjx8T1A0IZ32yD+jZ2VkRCRfM6+vr 6hozjS19uR2Emd+vy5cvy5MnTwjqEsL5uJAbxba3t0Uk84Bu2hhm5BTMyEeuB2EENbQyoSwisrOz IyKZB7Rpz1VcNuoLFy4QzInJrZHGzvz+Xbp0Sf70pz8FfjZh0Z6r+VqHNsFsQrko24BeXV31fr3t 9fV1mZubI5wTlGsjjd3Nmzfl0qVL8uTJE/nqq69CPx3vCOcwqtpylSwDumq07TKY19bWCGZPaLLo yvxeXrx4UZ4+fZpNUBPOfrUN5aIsA7r4Jk4wp4Ummx5fB13moD2HoCac2xm6UaxPKBclFdBtzoFe WlqSvb0958F88uRJglkZ2nWcfB90md/bCxcuyBdffOH1ayN+Q0O5KKmAbsPl9bZXV1ePgpkw0Id2 nRbXv2O7u7ty4cIFefr0qXz99ddOv5ZPtOf2umwUa9rs1VdWAb20tNT7ettNj1ldXZXRaNTpgieI HwdhYfn4HTNt+vz58/Ls2bPog5pwtstmW66STUAvLS3Vjr/7tmYTzNpG2QSHHxyEpWPa74w5+N7a 2pJnz57JN9984+NpWUU42+E6lIuyCeiqX8C+wbyysnKsMWtCcKSNAzD72v7OmN/5zc1Nef78eTRB TTj3d/bsWXn77beP/tt1KBdlEdBmY5gxJJhPnDihNpi1I1js4AAsPPMesLq6Gk1Ioz+foVyURUCb YOgbzMvLyxPBTND0Q7CkKeffhzt37sjGxoY8f/5cxY1uqtCehwl5Z6vkA7ppY5jRNpinPR7pyDl0 usr998G8P4zHYzk4OFAV1IRz3JIJ6KpzoMuj7bKmYJ6dnU16lE0ANcs9dFLj4+fdvNeMx2N5/vx5 8M2jhHP8kgnoLurefJeWlmR2drYx1FNBAKWLg6/jfP68mwP75eXlYCFNONsV6taTyQb04uLisaBt +iVdXl7OIphTQxgdx8GXDrdv35a1tTV58eJF8DaNOCUb0G2vt724uBjVOJtAmkQYpSmVn3Nz0L+6 uiovXrzw8j5De7Yv1EaxJAPatOdpwTwzMxNdayaQ0pZKMA2V2s+5r6AmnNOSZEDPzMzU/oIvLi6K iEQXzDkgnNILptyVf6bN+87Kyor13d6Ec3qSC+jFxcXKo9OFhQUREXWjbELpNcIpTTn/jNf9TO/t 7cny8rK8fPmSshCJEBvFkgroqo1hCwsLcnh4qPaXgFBKX84BJcLPeB3znrS0tDT4PYr2nKYkAtqc A23G1yKvfmBF9DXm3OQeTiIEVGps/0yb6zcsLi7K4eHh1HvalxHOfoTYKJZEQIu8bs/z8/NyeHgY NJgJpdcIp3Tl+nPu6me6GNRt2zThnLZkAvqdd96Rg4MDFY2ZUMpDrgFl8HPuxt7e3tGemaY2TTin L/qAPnfunJw5c0ZERH72s5/JixcvAj+jvNy5cyf0UwiGgEqPloMuE8xmqY4g1sH3RrFoA/rcuXPy 8uVL2d3dnWjN586dE5FXV/GBe+b7jfTkePCl7aCrGNQzMzNHQU17zsPM559/rusncgoTzNM2UhSD g7AGuuPgS593331XREQ+++yzwM8kX48ePfLWoqNp0MXG3EYxlGnVQHf8vuhh3sO+++47uX37tiws LPDvkwH1Ad01mKuYH2RaNYBYNL1f7e/vH429eS9Ll9qAthHMZbRqANq1fW8qrkcT1P743CimMqDP nTvn/HQpWjUALYa8DxHU6VK1SaztBjCXX1+EoAbgnqtywPq0e742iqlo0C7G2X3QqgG45roIsD6d jqABrSWYy1irBmCT74N+xt5pCBLQWoO5Cq0aQB8a3jMIajd8bRTzGtAxBXMZrRpAGxrfH4pBneMV 4mLlZZNY6M1frmg4QgYQXkzvBbRpO3xsFHPaoGNuzG3QqoF8xRTKRYy94+EkoFMP5iqsVQN5SOVg nKAexsc6tNWAzjGYy2jVQHpSPvBmfVovKwFNMFejVQPxyu339tatW7RpZQZtEkt185dLtGpAr9xC uQ5B3Y7rjWK9GjSNuT9aNaAPB86TWJ/WoVNAE8z2sFYNhMVB8nQEdTPXG8VaB7SPO0zlilYN+MHv WD8mqLkRh19TA5rW7A+tGnCD3yc7uBGHX7WbxNgApgNH/EA//O64RVC/4nKj2LEGTWPWhVYNtEco +8P6tHtHAU0w68daNVCNg9dwcl+fdrlRbEQwx4dWDXCgqg3r0/aNCOa40aqRE37OdWPsbdfMb3/7 W+e3m4RftGqkhp/pOOUS1K42ijm93STCoFUjBfz8xo8bcQxDQCeMtWrEhlBOU+o34nC1UYyAzgSt GlrxM5kH1qe7I6AzQ6uGFvz85Ymgbo9NYqDBwBt+1lCWyvq0i41iNGjQquEUoYwmqa9PD0FAYwJr 1bCFgz20lcLY28VGMQIalWjV6IMDOwyRQlDbREBjKlo1mvBzAdsI6lfYJIZeaNXgZwC+xHIjDtsb xWjQ6IVWnSf+vRFCrjfiIKAxCGvV6SOUoUEMY28bG8W2t7eP/j8BDWto1eng3xBaxRDUXRVDeWdn 5+j/E9CwjlYdL/69EAsT1LGsT5fVhXIRm8TgBY1ML/5tEDtNbbpuo1gxkEXqQ7mIBg0vaNW6EMpI idaxd5uW3IQGjWAICf84OEIOQgb1mTNn5IcffhCRfqFcRINGMLRqPzgQQm6KjTrEjTiGBrNBQEMF doDbxfcRiP9GHIy4oRatuju+Z0A1n0Ft64piNGioRatuh+8PMJ3WjWRNCGiox1r1cYQy0I+P9Wlb t54koBGV3Fs1ByiAHTGsT7MGjeilHlq5HowAvrgIahvr0DRoRC/FVp3SawG007o+TUAjGbGvVRPK QFjagpqARpJiatUxHkwAKbNxIw4bG8UIaCRNa6uO4cAByN3+/n7QNs0mMWQnVDgSykC8+gT10I1i NGhkx3er1tTcAfTTZ3367bffHvQ1adCA2G+3tGUgbW3Wpx89enQU0txuErCgb+MllIG8TGvTZ86c kWvXronI63tDdwnqmX/84x/WApo3JaSkbeAywgbyVhfUxYA2tre3W4e01QZdfEMDpokp0MohTFsG UFYV1FUbxdq2aUbcCCa2A7p333134r+/++67QM8kTxwIIRbFG3E07eSeFtQENDBF3Qib0bZfsR3Q IazQv5emTX/xxRdTT7WqC2oCGqjQZYTNuBvQJ/QB3Y9//GMREfn3v/8tH3/8cau/U16fJqCB/7ER tLRqIF/vvPOO/P3vfxcRka+++qrX5yi2aQIaWXPVfmnVQPreeecdEZHBoVxle3ubgEaefDZdWjWQ DhstuS0CGtkI3WpDf30A3blsydMQ0Eia1lCkVQN6+WzJTQhoJCmWANR6AAHkJGRLbkJAIxmxh10s BxVACoqhrCWQywhoRC32UK6S4msCQtPakpsQ0IhSLm0zl9cJuBBDS25CQCMaOTfLnF870FaMLbkJ AQ3VCKbjaNXAa7G35CYENNQhlNvh+4QcpdaSmxDQUINm2B/fO6Qs5ZbchIBGULRAu/h+IhVaLhYS EgEN7wgRP2jViElOo+u2CGh4Q2CEwQERtKIlN5v55JNPDkVEfvGLX4iIyL/+9a+gTwhpIRx04SAJ IdGSu5l57733Jhr0+vo6YY1BCGX9+DeCL7Tk/o4FdBFhjS5oZ3Hi3w020ZLtaQzoovX1dRF5NQon rGHQxNLBvyX6yvU0KNdaB3RRMaxFaNe54Y08fbRqNKEl+9EroMsYheeBN+38cDAGg5bs3+CA3t7e Pvr/Ozs7hHVieIOGwQFaXmjJ/hXzVGRAQJtPtLOzU/sY1q3jRCijCT8f6aIl+1UO5HKedgroclvu grDWjTdd9EGrjh+nQfnVJUdbBXSbttwFm8z04A0WNnCAFw9G135Na8lNGgPadjDXYd3aL95M4RIH ffoUW/L//d//Hf256/f2HA0J5LJjAT1kjG0Do3A3CGX4xs9cOG1bsq8SljpXuXkU0Br/oQjr4Wgz 0ICfQ/eGrCVrfP/XzGZLbjLz+9///tDlF7CFdev2aC7Qip9Ne1ysJRPU1XwFcpmVC5WEwLr1JN74 EBtadXe+dlznHtShArks2oAuynkUzpscYsfBZb3QO65D70nySeNrTSKgi3IIa97QkCoOOPVeLCS1 Vq2lJTdJLqCLUlq3JpSRk5x+3kO35K5iDeoYArks6YAui3HdmkaB3KX4O6C1JXehPahjDOSy/wf7 N0ZJzex1OAAAAABJRU5ErkJggg== "
+       preserveAspectRatio="none"
+       height="115.35833"
+       width="129.11667"
+       style="opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Calque 3"
+     style="display:inline"
+     transform="translate(470.69208,-22.182517)">
+    <g
+       id="g853"
+       transform="translate(-146.80274,-10.712205)">
+      <g
+         id="g3352"
+         transform="translate(117.57435)">
+        <path
+           style="fill:#ffaaee;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -167.2354,43.514868 0.58657,39.268632 -3.79886,7.709069 -1.19355,-50.252777 z"
+           id="path1821"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path3274"
+           d="m -140.90524,33.023512 -30.736,7.21628"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path3276"
+           d="m -117.38553,55.206882 -18.97613,12.56167"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path3278"
+           d="m -109.63471,87.813762 -21.38156,25.390598"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path3280"
+           d="m -136.36166,67.768552 -34.2105,22.7179"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path3282"
+           d="m -170.57216,90.486452 -1.06908,-50.24666"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path3284"
+           d="m -171.64124,40.239792 4.40584,3.275076 0.58657,39.268633 -3.79886,7.70907"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3286"
+           d="m -170.66072,90.539913 9.86961,1.238409 30.15724,17.165808 -0.3824,4.26023"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccc" />
+        <path
+           id="path3288"
+           d="m -109.63471,87.813762 -52.13623,-1.291759 -8.20333,3.970568"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccc" />
+        <path
+           id="path3290"
+           d="m -170.03816,90.197232 5.34742,-7.020031 23.7855,-50.153689"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccc" />
+        <path
+           id="path3292"
+           d="M -171.64124,40.239792 -213.86983,112.9371"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path3294"
+           d="m -213.86983,112.9371 43.29767,-22.450648"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:#ffaaee;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -131.01627,113.20436 0.3824,-4.26023 -30.15724,-17.16581 -9.65658,-1.285749 z"
+           id="path1823"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           id="path3296"
+           d="m -170.57216,90.486452 39.55589,22.717908"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path3298"
+           d="m -131.01627,113.20436 -82.85356,-0.53453"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path3300"
+           d="m -140.90524,33.023512 23.51971,22.18337"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path3302"
+           d="m -117.38553,55.206882 7.75082,32.60688"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3380)"
+           d="m -119.04836,54.790612 -48.17022,32.30545"
+           id="path3304" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2470)"
+           d="m -111.71195,88.052502 -18.17264,22.086028"
+           id="path3306" />
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3376)"
+           d="m -169.96717,87.346023 -0.89522,-44.887234"
+           id="path3310"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3368)"
+           d="m -165.79944,80.183585 -0.15061,-35.889803"
+           id="path3312"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3396)"
+           d="m -161.52854,92.599725 29.85461,18.120865"
+           id="path3314"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3400)"
+           d="m -169.82027,90.568465 9.67923,-2.994938 47.22396,1.416293"
+           id="path3316" />
+        <path
+           inkscape:transform-center-y="-0.71567592"
+           inkscape:transform-center-x="9.8585882"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3388)"
+           d="M -142.93386,34.983838 -164.92321,81.60443"
+           id="path3318" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2959)"
+           d="M -210.95476,109.9124 -172.9086,44.290952"
+           id="path3320" />
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2967)"
+           d="m -171.98686,89.706812 -38.9679,20.205588"
+           id="path3322" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3416)"
+           d="M -132.95216,111.47806 -166.20605,91.646793"
+           id="path3324" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2999)"
+           d="m -117.93909,56.770752 6.73912,28.12548"
+           id="path3326" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path3328"
+           d="m -169.23066,40.611462 25.79467,-5.861954"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3372)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path3330"
+           d="m -159.97747,84.429268 42.03838,-27.658516"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3404)" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path3334"
+           d="m -172.75411,44.047762 0.96217,45.22199"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2963)" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           id="path3336"
+           d="m -168.47857,43.393794 0.58253,36.850183 -1.45111,6.409775"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3356)" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           id="path3338"
+           d="m -129.45851,108.57625 -31.82638,-18.010641 -5.72346,-0.05993"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3412)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path3340"
+           d="m -111.5787,85.843066 -48.69796,-0.455101"
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3408)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path3342"
+           d="M -163.61657,82.704598 -140.85635,35.29404"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3384)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path3344"
+           d="m -209.05735,111.6245 38.98463,-20.088428"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3420)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path3346"
+           d="m -170.4835,91.662882 35.16304,20.470218"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2971)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path3348"
+           d="m -135.32046,112.1331 -73.73689,-0.5086"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2535)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path3350"
+           d="m -139.31956,36.017462 20.19695,18.79338"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3392)" />
+      </g>
+      <g
+         id="g2172"
+         transform="translate(3.8707961)">
+        <g
+           id="g3220">
+          <path
+             id="path2710"
+             d="m -140.90524,33.023512 -30.736,7.21628"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2712"
+             d="m -117.38553,55.206882 -18.97613,12.56167"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2714"
+             d="m -109.63471,87.813762 -21.38156,25.390598"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2716"
+             d="m -136.36166,67.768552 -34.2105,22.7179"
+             style="fill:none;stroke:#ff0000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2718"
+             d="m -170.57216,90.486452 -1.06908,-50.24666"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path2720"
+             d="m -171.64124,40.239792 35.27958,27.52876"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             id="path2722"
+             d="m -136.36166,67.768552 5.34539,45.435808"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2724"
+             d="m -109.63471,87.813762 -26.72695,-20.04521"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2726"
+             d="m -136.36166,67.768552 -4.54358,-34.74504"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2728"
+             d="M -171.64124,40.239792 -213.86983,112.9371"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2730"
+             d="m -213.86983,112.9371 43.29767,-22.450648"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2732"
+             d="m -170.57216,90.486452 39.55589,22.717908"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2734"
+             d="m -131.01627,113.20436 -82.85356,-0.53453"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2736"
+             d="m -140.90524,33.023512 23.51971,22.18337"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2738"
+             d="m -117.38553,55.206882 7.75082,32.60688"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2979)"
+             d="m -119.80583,54.222512 -46.27655,29.938364"
+             id="path2740" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2470)"
+             d="m -111.71195,88.052502 -18.17264,22.086028"
+             id="path2742" />
+          <path
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2983)"
+             d="m -167.91035,90.510592 30.78945,-20.44611"
+             id="path2744" />
+          <path
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2199)"
+             d="m -169.36461,87.814682 -0.96217,-45.22199"
+             id="path2746" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3003)"
+             d="m -137.47904,65.387352 -31.75162,-24.77589"
+             id="path2748"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2418)"
+             d="m -137.47896,70.065072 4.81085,40.892228"
+             id="path2750" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3498)"
+             d="m -134.61817,70.662762 22.90622,17.38974"
+             id="path2752" />
+          <path
+             inkscape:transform-center-y="-0.71567592"
+             inkscape:transform-center-x="9.8585882"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3268)"
+             d="m -142.06349,34.414752 -26.00724,51.97119"
+             id="path2754" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2959)"
+             d="M -210.95476,109.9124 -172.9086,44.290952"
+             id="path2756" />
+          <path
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2967)"
+             d="m -171.98686,89.706812 -38.9679,20.205588"
+             id="path2758" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2431)"
+             d="M -132.66811,110.9573 -167.91035,90.510592"
+             id="path2760" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2999)"
+             d="m -117.93909,56.770752 6.73912,28.12548"
+             id="path2762" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path2764"
+             d="m -169.23066,40.611462 27.16717,-6.19671"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2340)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path2766"
+             d="m -134.40208,67.423642 16.46299,-10.65289"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2496)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path2768"
+             d="m -138.93794,67.515232 -30.42667,20.29945"
+             style="fill:none;stroke:#ff0000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker2995)" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path2770"
+             d="m -172.75411,44.047762 0.96217,45.22199"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2963)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path2772"
+             d="m -169.40916,43.075282 0.50392,43.09258"
+             style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2955)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path2774"
+             d="m -129.88459,110.13853 -37.4467,-20.491738"
+             style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2987)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path2776"
+             d="m -111.19997,84.896232 -54.9684,3.9732"
+             style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2991)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path2778"
+             d="m -135.29617,65.698972 -4.08922,-29.66371"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2366)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path2780"
+             d="m -209.05735,111.6245 38.98463,-20.088428"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2548)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path2782"
+             d="m -170.4835,91.662882 35.16304,20.470218"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2971)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path2784"
+             d="m -135.32046,112.1331 -73.73689,-0.5086"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2535)" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path2786"
+             d="m -139.31956,36.017462 20.19695,18.79338"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3011)" />
+        </g>
+        <circle
+           style="opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="path3727"
+           cx="-136.33174"
+           cy="67.848015"
+           r="1.0888592" />
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         x="-210.347"
+         y="119.61711"
+         id="text1483"><tspan
+           sodipodi:role="line"
+           id="tspan1481"
+           x="-210.347"
+           y="119.61711"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1">Make incident halfedge to <tspan
+   style="font-weight:bold"
+   id="tspan2266">vo</tspan> point to <tspan
+   style="font-weight:bold"
+   id="tspan2264">vh</tspan> (in blue)</tspan><tspan
+           sodipodi:role="line"
+           x="-210.347"
+           y="124.92691"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="tspan2029">update their wedge to widx</tspan><tspan
+           sodipodi:role="line"
+           x="-210.347"
+           y="130.21858"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="tspan1857">delete <tspan
+   style="font-weight:bold"
+   id="tspan2268">vo, h, o</tspan> (in red)</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-186.07906"
+         y="30.266083"
+         id="text1487"><tspan
+           sodipodi:role="line"
+           id="tspan1485"
+           x="-186.07906"
+           y="34.011589"
+           style="stroke-width:0.26458332" /></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="-324.05057"
+         y="119.61711"
+         id="text1491"><tspan
+           sodipodi:role="line"
+           id="tspan1489"
+           x="-324.05057"
+           y="119.61711"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';stroke-width:0.26458332">collapse(<tspan
+   style="font-weight:bold"
+   id="tspan2262">h</tspan>) with wedge widx</tspan></text>
+      <g
+         id="g2232"
+         transform="translate(-4.9307811e-6)">
+        <g
+           transform="translate(-394.26174,-95.062148)"
+           id="g2628">
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 143.52374,128.08566 -30.736,7.21628"
+             id="path840" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="M 167.04345,150.26903 148.06732,162.8307"
+             id="path842" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 174.79427,182.87591 -21.38156,25.3906"
+             id="path844" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 148.06732,162.8307 -34.2105,22.7179"
+             id="path846" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 113.85682,185.5486 -1.06908,-50.24666"
+             id="path2016" />
+          <path
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 112.78774,135.30194 35.27958,27.52876"
+             id="path2014"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 148.06732,162.8307 5.34539,45.43581"
+             id="path848" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="M 174.79427,182.87591 148.06732,162.8307"
+             id="path2010" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 148.06732,162.8307 -4.54358,-34.74504"
+             id="path850" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="M 112.78774,135.30194 70.559154,207.99925"
+             id="path2006" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="M 70.559154,207.99925 113.85682,185.5486"
+             id="path2004" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 113.85682,185.5486 39.55589,22.71791"
+             id="path2002" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="M 153.41271,208.26651 70.559155,207.73198"
+             id="path852" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 143.52374,128.08566 23.51971,22.18337"
+             id="path2028" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 167.04345,150.26903 7.75082,32.60688"
+             id="path854" />
+          <path
+             id="path2084"
+             d="m 165.38062,149.85276 -16.2751,10.9038"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2392)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path2086"
+             d="m 172.71703,183.11465 -18.17264,22.08603"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2470)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path2088"
+             d="m 116.32154,185.57566 30.78945,-20.44611"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2405)"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2090"
+             d="M 115.06437,182.87683 114.1022,137.65484"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2199)"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path2092"
+             d="M 146.94994,160.4495 115.19832,135.67361"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2327)" />
+          <path
+             id="path2094"
+             d="m 146.95002,165.12722 4.81085,40.89223"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2418)"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2096"
+             d="m 149.81081,165.72491 22.90622,17.38974"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2457)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path2098"
+             d="m 142.36549,129.4769 4.58445,30.9726"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2353)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path2100"
+             d="M 73.474222,204.97455 111.52038,139.3531"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2574)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path2102"
+             d="M 112.44212,184.76896 73.474222,204.97455"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2561)"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path2104"
+             d="M 151.76087,206.01945 116.51863,185.57274"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2431)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="path2110"
+             d="m 166.48989,151.8329 6.73912,28.12548"
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2509)"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2340)"
+             d="m 115.19832,135.67361 27.16717,-6.19671"
+             id="path2112"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2496)"
+             d="M 150.0269,162.48579 166.48989,151.8329"
+             id="path2114"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:#008000;stroke:#008000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker2175)"
+             d="m 145.49104,162.57738 -30.42667,20.29945"
+             id="path2118"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2587)"
+             d="m 111.67487,139.10991 0.96217,45.22199"
+             id="path2120"
+             inkscape:connector-curvature="0" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2212)"
+             d="m 114.19134,138.01908 31.2997,24.5583"
+             id="path2122"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2444)"
+             d="m 154.54439,205.20068 -4.73358,-39.47577"
+             id="path2124"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2483)"
+             d="M 173.22901,179.95838 150.0269,162.48579"
+             id="path2126"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2366)"
+             d="m 149.13281,160.76112 -4.08922,-29.66371"
+             id="path2128"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2548)"
+             d="M 75.371629,206.68665 114.35626,186.59822"
+             id="path2132"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2522)"
+             d="m 113.94548,186.72503 35.16304,20.47022"
+             id="path2134"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2535)"
+             d="m 149.10852,207.19525 -73.736891,-0.5086"
+             id="path2136"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2379)"
+             d="m 145.10942,131.07961 20.19695,18.79338"
+             id="path2138"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+        </g>
+        <circle
+           r="2.9351857"
+           cy="90.082382"
+           cx="-279.41464"
+           id="path1527"
+           style="opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;stroke:#333333;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+        <text
+           id="text1495"
+           y="77.265884"
+           x="-267.224"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="font-weight:bold;stroke-width:0.26458332"
+             y="77.265884"
+             x="-267.224"
+             id="tspan1493"
+             sodipodi:role="line">h</tspan></text>
+        <text
+           id="text1499"
+           y="83.559303"
+           x="-262.0018"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.26458332"
+             y="83.559303"
+             x="-262.0018"
+             id="tspan1497"
+             sodipodi:role="line">o</tspan></text>
+        <text
+           id="text1511"
+           y="68.428314"
+           x="-279.00745"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.26458332"
+             y="68.428314"
+             x="-279.00745"
+             id="tspan1509"
+             sodipodi:role="line">hn</tspan></text>
+        <text
+           id="text1515"
+           y="58.251717"
+           x="-266.55447"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.26458332"
+             y="58.251717"
+             x="-266.55447"
+             id="tspan1513"
+             sodipodi:role="line">hp</tspan></text>
+        <text
+           id="text1519"
+           y="91.057846"
+           x="-251.82521"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.26458332"
+             y="91.057846"
+             x="-251.82521"
+             id="tspan1517"
+             sodipodi:role="line">on</tspan></text>
+        <text
+           id="text1523"
+           y="97.886887"
+           x="-261.33228"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.26458332"
+             y="97.886887"
+             x="-261.33228"
+             id="tspan1521"
+             sodipodi:role="line">op</tspan></text>
+        <text
+           id="text1503"
+           y="91.415672"
+           x="-282.04126"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.26458332"
+             y="91.415672"
+             x="-282.04126"
+             id="tspan1501"
+             sodipodi:role="line">vh</tspan></text>
+        <circle
+           r="2.9351857"
+           cy="68.115822"
+           cx="-246.51216"
+           id="path1527-3"
+           style="display:inline;opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;stroke:#333333;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+        <text
+           id="text1507"
+           y="69.476562"
+           x="-248.96942"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.26458332"
+             y="69.476562"
+             x="-248.96942"
+             id="tspan1505"
+             sodipodi:role="line">vo</tspan></text>
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         x="-96.639313"
+         y="119.61711"
+         id="text1546"><tspan
+           sodipodi:role="line"
+           id="tspan1544"
+           x="-96.639313"
+           y="119.61711"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1">After this, some faces are two sided </tspan><tspan
+           sodipodi:role="line"
+           x="-96.639313"
+           y="124.90878"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="tspan1853">(in pink, for real they have no surface)</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         x="16.909206"
+         y="119.61711"
+         id="text1550"><tspan
+           sodipodi:role="line"
+           id="tspan1548"
+           x="16.909206"
+           y="119.61711"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1">Remove loops, i.e. halfedges <tspan
+   style="font-weight:bold"
+   id="tspan2298">hn</tspan> and <tspan
+   style="font-weight:bold"
+   id="tspan2300">op</tspan> (in red, and the pink faces)</tspan><tspan
+           sodipodi:role="line"
+           x="16.909206"
+           y="124.92691"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="tspan1552"><tspan
+   style="font-weight:bold"
+   id="tspan2270">hp</tspan> and <tspan
+   style="font-weight:bold"
+   id="tspan2272">on</tspan> remains (corresponding to the purple edges/halfedges)</tspan><tspan
+           sodipodi:role="line"
+           x="16.909206"
+           y="130.23671"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="tspan2045"><tspan
+   style="font-weight:bold"
+   id="tspan2292">hp</tspan> (resp. <tspan
+   style="font-weight:bold"
+   id="tspan2302">on</tspan>) is modified to have the wedge of halfedge <tspan
+   style="font-weight:bold"
+   id="tspan2294">a <tspan
+   style="font-weight:normal"
+   id="tspan2304">(resp. </tspan>b</tspan>)</tspan><tspan
+           sodipodi:role="line"
+           x="16.909206"
+           y="135.54651"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="tspan2043" /><tspan
+           sodipodi:role="line"
+           x="16.909206"
+           y="140.83817"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="tspan2031" /></text>
+      <g
+         id="g2129"
+         transform="translate(-31.056147)">
+        <path
+           id="path1558"
+           d="m 235.13236,33.023512 -30.736,7.21628"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1560"
+           d="m 258.65207,55.206882 -18.97613,12.56167"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1562"
+           d="M 266.40289,87.813762 245.02133,113.20436"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1564"
+           d="m 239.67594,67.768552 -34.2105,22.7179"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1566"
+           d="m 205.46544,90.486452 -1.06908,-50.24666"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1572"
+           d="M 266.40289,87.813762 205.9647,90.271275"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path1574"
+           d="M 205.58905,90.274037 235.13236,33.023512"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path1576"
+           d="M 204.39636,40.239792 162.16777,112.9371"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1578"
+           d="M 162.16777,112.9371 205.46544,90.486452"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1580"
+           d="m 205.46544,90.486452 39.55589,22.717908"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1582"
+           d="m 245.02133,113.20436 -82.85356,-0.53453"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1584"
+           d="m 235.13236,33.023512 23.51971,22.18337"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path1586"
+           d="m 258.65207,55.206882 7.75082,32.60688"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1706)"
+           d="m 256.98924,54.790612 -48.17022,32.30545"
+           id="path1588" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1819)"
+           d="M 263.09477,89.141361 244.81398,110.13853"
+           id="path1590" />
+        <path
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.23800001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2001)"
+           d="M 207.82791,82.459929 206.47218,41.615731"
+           id="path1594"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.23800001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2027)"
+           d="m 205.57912,91.394602 34.4073,20.665018"
+           id="path1596"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1795)"
+           d="M 213.08461,90.787189 263.12052,88.98982"
+           id="path1598" />
+        <path
+           inkscape:transform-center-y="-0.71567592"
+           inkscape:transform-center-x="9.8585882"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1791)"
+           d="M 233.10374,34.983838 207.23121,84.416384"
+           id="path1600" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2959)"
+           d="M 165.08284,109.9124 203.129,44.290952"
+           id="path1602" />
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2967)"
+           d="M 204.05074,89.706812 165.08284,109.9124"
+           id="path1604" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1807)"
+           d="m 258.09851,56.770752 6.20351,28.928895"
+           id="path1608" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1610"
+           d="m 206.53913,41.950488 26.46419,-6.531467"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1815)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1612"
+           d="M 211.64135,88.245491 258.09851,56.770752"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1811)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1616"
+           d="m 202.73018,45.290249 0.59066,44.442256"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.23800001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1988)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1618"
+           d="M 244.97226,110.18308 211.75812,90.919975"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.23800001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2014)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1620"
+           d="M 264.4589,85.843066 211.34216,88.26687"
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1803)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1622"
+           d="M 209.00651,86.788626 235.18125,35.29404"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1799)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1624"
+           d="M 166.98025,111.6245 205.96488,91.536072"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3647)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1628"
+           d="m 240.71714,112.1331 -73.73689,-0.5086"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2535)" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1630"
+           d="m 236.71804,36.017462 20.19695,18.79338"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2053)" />
+      </g>
+      <g
+         id="g2096"
+         transform="translate(-12.463958)">
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 102.83662,33.023512 -30.736,7.21628"
+           id="path3500" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 126.35633,55.206882 107.3802,67.768552"
+           id="path3502" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 134.10715,87.813762 112.72559,113.20436"
+           id="path3504" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 107.3802,67.768552 -34.2105,22.7179"
+           id="path3506" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#ff0000;stroke:#ff0000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 73.1697,90.486452 72.10062,40.239792"
+           id="path3508" />
+        <path
+           style="fill:none;stroke:#aa00d4;stroke-width:0.565;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 72.10062,40.239792 4.40584,3.275076 0.58657,39.268633 -3.79886,7.70907"
+           id="path3510"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccc" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.565;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 73.08114,90.539913 9.86961,1.238409 30.15724,17.165808 -0.3824,4.26023"
+           id="path3512" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 134.10715,87.813762 81.97092,86.522003 73.76759,90.492571"
+           id="path3514" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 73.7037,90.197232 5.34742,-7.020031 23.7855,-50.153689"
+           id="path3516" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 72.10062,40.239792 29.87203,112.9371"
+           id="path3518" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 29.87203,112.9371 73.1697,90.486452"
+           id="path3520" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#ff0000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 73.1697,90.486452 39.55589,22.717908"
+           id="path3522" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 112.72559,113.20436 29.87203,112.66983"
+           id="path3524" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 102.83662,33.023512 23.51971,22.18337"
+           id="path3526" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 126.35633,55.206882 7.75082,32.60688"
+           id="path3528" />
+        <path
+           id="path3530"
+           d="M 124.6935,54.790612 76.52328,87.096062"
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3380)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path3532"
+           d="M 132.02991,88.052502 113.85727,110.13853"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3691)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           id="path3534"
+           d="M 73.77469,87.346023 72.87947,42.458789"
+           style="opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:#ff0000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3578)"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path3536"
+           d="M 77.94242,80.183585 77.79181,44.293782"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.23800001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1949)" />
+        <path
+           sodipodi:nodetypes="cc"
+           id="path3538"
+           d="m 82.21332,92.599725 29.85461,18.120865"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.23800001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1975)"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path3540"
+           d="m 73.92159,90.568465 9.67923,-2.994938 47.22396,1.416293"
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3400)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccc" />
+        <path
+           id="path3542"
+           d="M 100.808,34.983838 78.81865,81.60443"
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23800001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1925)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc"
+           inkscape:transform-center-x="9.8585882"
+           inkscape:transform-center-y="-0.71567592" />
+        <path
+           id="path3544"
+           d="M 32.7871,109.9124 70.83326,44.290952"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2959)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path3546"
+           d="M 71.755,89.706812 32.7871,109.9124"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2967)"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path3548"
+           d="M 110.7897,111.47806 77.53581,91.646793"
+           style="opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:#ff0000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3594)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path3550"
+           d="m 125.80277,56.770752 6.73912,28.12548"
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2999)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3372)"
+           d="m 74.5112,40.611462 25.79467,-5.861954"
+           id="path3552"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3404)"
+           d="M 83.76439,84.429268 125.80277,56.770752"
+           id="path3554"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:#ff0000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3582)"
+           d="m 70.98775,44.047762 0.96217,45.22199"
+           id="path3556"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.23800001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3586)"
+           d="m 75.26329,43.393794 0.58253,36.850183 -1.45111,6.409775"
+           id="path3558"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aa00d4;stroke-width:0.23800001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1962)"
+           d="M 114.28335,108.57625 82.45697,90.565609 76.73351,90.505679"
+           id="path3560"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3408)"
+           d="M 132.16316,85.843066 83.4652,85.387965"
+           id="path3562"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2049)"
+           d="M 80.12529,82.704598 102.88551,35.29404"
+           id="path3564"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3647)"
+           d="M 34.68451,111.6245 73.66914,91.536072"
+           id="path3566"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:#ff0000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3643)"
+           d="M 73.25836,91.662882 108.4214,112.1331"
+           id="path3568"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2535)"
+           d="M 108.4214,112.1331 34.68451,111.6245"
+           id="path3570"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#008000;fill-opacity:1;stroke:#008000;stroke-width:0.23812498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker1556)"
+           d="m 104.4223,36.017462 20.19695,18.79338"
+           id="path3572"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <text
+           id="text2037"
+           y="85.937538"
+           x="69.77906"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.26458332"
+             y="85.937538"
+             x="69.77906"
+             id="tspan2035"
+             sodipodi:role="line">a</tspan></text>
+        <text
+           id="text2041"
+           y="95.33429"
+           x="80.134407"
+           style="font-style:normal;font-weight:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.26458332"
+             y="95.33429"
+             x="80.134407"
+             id="tspan2039"
+             sodipodi:role="line">b</tspan></text>
+      </g>
+      <flowRoot
+         xml:space="preserve"
+         id="flowRoot2308"
+         style="font-style:normal;font-weight:normal;font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         transform="matrix(0.26458333,0,0,0.26458333,146.80274,10.712205)"><flowRegion
+           id="flowRegion2310"><rect
+             id="rect2312"
+             width="1417.0476"
+             height="769.25446"
+             x="-2526.3936"
+             y="-845.15222" /></flowRegion><flowPara
+           id="flowPara2314"></flowPara></flowRoot>    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="Calque 4"
+     style="display:inline"
+     transform="translate(470.69208,-22.182517)" />
+</svg>

--- a/doc/images/wedges.svg
+++ b/doc/images/wedges.svg
@@ -1,0 +1,576 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 181.78389 32.086823"
+   height="32.086823mm"
+   width="181.78389mm">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-4.7731,-3.87013)"
+     id="layer1">
+    <g
+       id="g4661"
+       transform="translate(-30.131033,-11.115366)">
+      <path
+         style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 35.036621,31.951577 44.131675,19.600909 50.591228,32.7784 Z"
+         id="path881" />
+      <path
+         style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 44.131675,19.600909 51.934814,17.688882 50.591228,32.7784 Z"
+         id="path883" />
+      <path
+         style="fill:#2c5aa0;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 51.934814,17.688882 50.591228,32.7784 c 0,0 9.146728,-8.681641 8.940022,-8.836671 -0.206706,-0.155029 -7.596436,-6.252847 -7.596436,-6.252847 z"
+         id="path885" />
+      <path
+         style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 59.541818,23.981406 -8.95059,8.796994 11.73055,0.465087 z"
+         id="path887" />
+      <path
+         style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 50.591228,32.7784 6.821289,8.52661 4.909261,-8.061523 z"
+         id="path889" />
+      <path
+         style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 50.591228,32.7784 45.010173,42.596921 35.036621,31.951577 Z"
+         id="path891" />
+      <path
+         style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 45.010173,42.596921 57.412517,41.30501 50.591228,32.7784 Z"
+         id="path893" />
+    </g>
+    <circle
+       r="0.44589564"
+       cy="22.003178"
+       cx="54.127045"
+       id="path4722-9-2-54"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.16500001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+    <circle
+       r="0.44589564"
+       cy="13.066231"
+       cx="63.824188"
+       id="path4722-9-2-7-7"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.16500001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+    <g
+       transform="translate(0.16535041)"
+       id="g5515">
+      <g
+         transform="translate(-29.363677,-5.2715408)"
+         id="g4940">
+        <path
+           style="opacity:0.5;fill:#2c5aa0;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 84.912172,11.497246 -1.343586,15.089518 c 0,0 9.146728,-8.681641 8.940022,-8.836671 -0.206706,-0.155029 -7.596436,-6.252847 -7.596436,-6.252847 z"
+           id="path4683" />
+        <circle
+           style="opacity:1;vector-effect:none;fill:#2c5aa0;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="path4722-2"
+           cx="83.663239"
+           cy="26.532301"
+           r="0.44589564" />
+        <circle
+           style="opacity:1;vector-effect:none;fill:#2c5aa0;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="path4722-2-4"
+           cx="92.652267"
+           cy="17.545971"
+           r="0.44589564" />
+      </g>
+      <g
+         transform="translate(-29.363677,-6.1458229)"
+         id="g4947">
+        <g
+           style="opacity:0.5"
+           id="g4886"
+           transform="translate(32.448191,-4.6041352)">
+          <path
+             id="path4685"
+             d="m 60.112093,24.419221 -8.991698,8.888346 11.73055,0.465087 z"
+             style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path4687"
+             d="m 51.120395,33.307567 6.821289,8.52661 4.909261,-8.061523 z"
+             style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path4691"
+             d="m 45.53934,43.126088 12.402344,-1.291911 -6.821289,-8.52661 z"
+             style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <circle
+           style="opacity:1;vector-effect:none;fill:#00d4aa;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="path4722-9"
+           cx="83.626701"
+           cy="28.797829"
+           r="0.44589564" />
+        <circle
+           style="opacity:1;vector-effect:none;fill:#00d4aa;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="path4722-9-9"
+           cx="92.652267"
+           cy="19.881884"
+           r="0.44589564" />
+      </g>
+      <g
+         transform="translate(-28.726235,-6.201308)"
+         id="g4954">
+        <g
+           style="opacity:0.5"
+           id="g4881"
+           transform="translate(32.448191,-4.6041352)">
+          <path
+             id="path4679"
+             d="M 33.978287,31.951577 43.073341,19.600909 49.532894,32.7784 Z"
+             style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path4681"
+             d="M 43.073341,19.600909 50.87648,17.688882 49.532894,32.7784 Z"
+             style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path4689"
+             d="M 49.532894,32.7784 43.951839,42.596921 33.978287,31.951577 Z"
+             style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <circle
+           style="opacity:1;vector-effect:none;fill:#44aa00;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="path4722-1"
+           cx="81.982368"
+           cy="28.140095"
+           r="0.44589564" />
+      </g>
+    </g>
+    <g
+       transform="translate(-14.799586)"
+       id="g5558">
+      <g
+         id="g5029"
+         transform="translate(84.899267,-11.115366)"
+         style="opacity:0.5">
+        <path
+           style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 35.036621,31.951577 44.131675,19.600909 50.591228,32.7784 Z"
+           id="path5015" />
+        <path
+           style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 44.131675,19.600909 51.934814,17.688882 50.591228,32.7784 Z"
+           id="path5017" />
+        <path
+           style="fill:#2c5aa0;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 51.934814,17.688882 50.591228,32.7784 c 0,0 9.146728,-8.681641 8.940022,-8.836671 -0.206706,-0.155029 -7.596436,-6.252847 -7.596436,-6.252847 z"
+           id="path5019" />
+        <path
+           style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 59.582926,23.890054 -8.991698,8.888346 11.73055,0.465087 z"
+           id="path5021" />
+        <path
+           style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 50.591228,32.7784 6.821289,8.52661 4.909261,-8.061523 z"
+           id="path5023" />
+        <path
+           style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 50.591228,32.7784 45.010173,42.596921 35.036621,31.951577 Z"
+           id="path5025" />
+        <path
+           style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 45.010173,42.596921 57.412517,41.30501 50.591228,32.7784 Z"
+           id="path5027" />
+      </g>
+      <path
+         d="m 135.63804,19.924702 a 1.5848118,1.5679156 0 0 1 1.05968,0.495417 l -1.15896,1.069419 z"
+         style="opacity:1;vector-effect:none;fill:#2c5aa0;fill-opacity:1;stroke:#000000;stroke-width:0.05;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle4958" />
+      <path
+         d="m 136.76963,20.522064 a 1.5444634,1.5665915 0 0 1 0.0272,1.97418 1.5444634,1.5665915 0 0 1 -1.89902,0.433323 l 0.68631,-1.403421 z"
+         style="opacity:1;vector-effect:none;fill:#00d4aa;fill-opacity:1;stroke:#000000;stroke-width:0.05;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle4970" />
+      <path
+         d="m 134.7903,22.91587 a 1.5584854,1.5380993 0 0 1 -0.82346,-1.754566 1.5584854,1.5380993 0 0 1 1.56553,-1.162665 l -0.0539,1.537177 z"
+         style="opacity:1;vector-effect:none;fill:#44aa00;fill-opacity:1;stroke:#000000;stroke-width:0.05000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle4982" />
+      <circle
+         r="0.44589564"
+         cy="21.592323"
+         cx="135.52966"
+         id="path4722-9-2"
+         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.16500001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <path
+         d="m 145.00207,14.346523 a 1.5444635,1.5665915 0 0 1 -1.61856,-0.419434 l 1.13085,-1.066999 z"
+         style="opacity:1;vector-effect:none;fill:#00d4aa;fill-opacity:1;stroke:#000000;stroke-width:0.05;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle4970-8" />
+      <path
+         d="m 143.30363,13.890001 a 1.5848118,1.5679156 0 0 1 -0.0616,-2.056365 l 1.22637,0.99311 z"
+         style="opacity:1;vector-effect:none;fill:#2c5aa0;fill-opacity:1;stroke:#000000;stroke-width:0.05;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle4958-4" />
+      <circle
+         r="0.44589564"
+         cy="12.824378"
+         cx="144.47772"
+         id="path4722-9-2-7"
+         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.16500001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+    </g>
+    <g
+       id="g5808">
+      <rect
+         style="opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.19607843;stroke:#000000;stroke-width:0.065;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="rect5595"
+         width="3.6767476"
+         height="3.576479"
+         x="168.1192"
+         y="24.186716" />
+      <use
+         x="0"
+         y="0"
+         xlink:href="#rect5595"
+         id="use5597"
+         transform="translate(3.6821331)"
+         width="100%"
+         height="100%" />
+      <use
+         x="0"
+         y="0"
+         xlink:href="#rect5595"
+         id="use5597-3"
+         transform="translate(7.3642495)"
+         width="100%"
+         height="100%" />
+      <use
+         x="0"
+         y="0"
+         xlink:href="#rect5595"
+         id="use5597-7"
+         transform="translate(11.046389)"
+         width="100%"
+         height="100%" />
+      <use
+         x="0"
+         y="0"
+         xlink:href="#rect5595"
+         id="use5597-4"
+         transform="translate(14.72854)"
+         width="100%"
+         height="100%" />
+      <g
+         id="g5142"
+         transform="translate(103.05968,-11.115366)"
+         style="opacity:0.5">
+        <path
+           style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 35.036621,31.951577 44.131675,19.600909 50.591228,32.7784 Z"
+           id="path5128" />
+        <path
+           style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 44.131675,19.600909 51.934814,17.688882 50.591228,32.7784 Z"
+           id="path5130" />
+        <path
+           style="fill:#2c5aa0;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 51.934814,17.688882 50.591228,32.7784 c 0,0 9.146728,-8.681641 8.940022,-8.836671 -0.206706,-0.155029 -7.596436,-6.252847 -7.596436,-6.252847 z"
+           id="path5132" />
+        <path
+           style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 59.582926,23.890054 -8.991698,8.888346 11.73055,0.465087 z"
+           id="path5134" />
+        <path
+           style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 50.591228,32.7784 6.821289,8.52661 4.909261,-8.061523 z"
+           id="path5136" />
+        <path
+           style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 50.591228,32.7784 45.010173,42.596921 35.036621,31.951577 Z"
+           id="path5138" />
+        <path
+           style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 45.010173,42.596921 57.412517,41.30501 50.591228,32.7784 Z"
+           id="path5140" />
+      </g>
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 149.37945,28.286094 2.67671,-4.564744 -1.81036,0.472003"
+         id="path5289" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 146.42414,20.979808 5.28486,0.268209 -1.25416,-1.388266"
+         id="path5289-3" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 150.37887,14.324402 2.34261,4.744876 0.60057,-1.771865"
+         id="path5289-6" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 154.74204,13.588475 -0.46728,5.270988 1.43457,-1.200921"
+         id="path5289-1" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 159.92343,15.920697 -3.75829,3.725174 1.87086,0.0083"
+         id="path5289-0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 160.85644,22.337213 -5.28843,-0.184834 1.27589,1.368315"
+         id="path5289-63" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 158.22535,27.886541 -3.2752,-4.156289 -0.22028,1.857868"
+         id="path5289-2" />
+      <path
+         id="path5342"
+         d="m 157.81863,17.131149 3.6955,-3.787472 -1.87074,0.02299"
+         style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path5344"
+         d="m 164.17084,19.431475 -1.52533,-5.067055 -0.88545,1.64808"
+         style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.2, 0.2;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 163.1946,15.82853 c 15.29622,-3.565673 14.4694,9.405111 14.4694,9.405111"
+         id="path5346" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.2, 0.2;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 160.61077,14.38159 c 17.7767,-3.203939 20.82561,5.632731 20.46387,11.110433"
+         id="path5348" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.2, 0.2;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 158.03896,17.915873 c 7.15743,9.890327 11.21892,9.182823 11.66472,8.19931"
+         id="path5350" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.2, 0.2;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 158.02695,22.391437 c 6.2345,7.532632 9.57074,5.642265 12.01553,4.296666"
+         id="path5360" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.2, 0.2;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 156.85694,26.160682 c 1.47025,0.287224 11.31575,4.581364 13.26802,0.07039"
+         id="path5362" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.2, 0.2;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 150.63722,25.750405 c 4.56804,5.741169 17.52839,10.521969 23.15937,0.771743"
+         id="path5364" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.2, 0.2;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 148.73165,21.177041 c -6.55896,18.38807 26.65492,15.542876 24.93624,4.903215"
+         id="path5366" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.2, 0.2;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 151.25734,16.396971 c -10.9554,4.237468 -12.67404,15.617318 -7.80314,17.001547 20.8118,5.914374 32.49819,0.519392 30.26904,-7.36394"
+         id="path5368" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.2, 0.2;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 154.56463,15.776854 c 13.75056,-17.059433 30.9158,4.742042 30.0757,10.180258"
+         id="path5370" />
+      <path
+         id="path5383"
+         style="opacity:1;vector-effect:none;fill:#2c5aa0;fill-opacity:1;stroke:#000000;stroke-width:0.075;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         d="m 184.1805,24.82756 a 2.3772178,2.3518734 0 0 1 1.58953,0.743125 l -1.73844,1.604129 z" />
+      <path
+         id="path5385"
+         style="opacity:1;vector-effect:none;fill:#00d4aa;fill-opacity:1;stroke:#000000;stroke-width:0.075;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         d="m 170.94424,24.073164 a 2.316695,2.3498874 0 0 1 0.0408,2.961269 2.316695,2.3498874 0 0 1 -2.84854,0.649986 l 1.02946,-2.105132 z" />
+      <path
+         id="path5387"
+         style="opacity:1;vector-effect:none;fill:#44aa00;fill-opacity:1;stroke:#000000;stroke-width:0.07500003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         d="m 173.85382,28.189808 a 2.337728,2.3071489 0 0 1 -1.23519,-2.631848 2.337728,2.3071489 0 0 1 2.34829,-1.743998 l -0.0809,2.305766 z" />
+      <path
+         d="m 178.60724,27.055868 a 2.3166952,2.3498871 0 0 1 -2.42784,-0.62915 l 1.69627,-1.600498 z"
+         style="opacity:1;vector-effect:none;fill:#00d4aa;fill-opacity:1;stroke:#000000;stroke-width:0.075;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle4970-8-1" />
+      <path
+         d="m 180.49048,27.543458 a 2.3772178,2.3518734 0 0 1 -0.0924,-3.084546 l 1.83956,1.489664 z"
+         style="opacity:1;vector-effect:none;fill:#2c5aa0;fill-opacity:1;stroke:#000000;stroke-width:0.075;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle4958-4-5" />
+      <circle
+         r="0.44589564"
+         cy="21.634163"
+         cx="153.63382"
+         id="path4722-9-2-5"
+         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.16500001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <circle
+         r="0.44589564"
+         cy="12.866216"
+         cx="162.58188"
+         id="path4722-9-2-7-2"
+         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.16500001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="7.1001844"
+       y="7.5417404"
+       id="text5664"><tspan
+         id="tspan5662"
+         x="7.1001844"
+         y="7.5417404"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.29166651px;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';stroke-width:0.26458332">a.</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="41.373974"
+       y="7.5417404"
+       id="text5664-4"><tspan
+         id="tspan5662-4"
+         x="41.373974"
+         y="7.5417404"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.29166651px;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';stroke-width:0.26458332">b.</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="75.745941"
+       y="7.5417404"
+       id="text5664-3"><tspan
+         id="tspan5662-0"
+         x="75.745941"
+         y="7.5417404"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.29166651px;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';stroke-width:0.26458332">c.</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="109.82852"
+       y="7.5417404"
+       id="text5664-7"><tspan
+         id="tspan5662-8"
+         x="109.82852"
+         y="7.5417404"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.29166651px;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';stroke-width:0.26458332">d.</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="144.19533"
+       y="7.5417404"
+       id="text5664-6"><tspan
+         id="tspan5662-88"
+         x="144.19533"
+         y="7.5417404"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.29166651px;font-family:'Liberation Serif';-inkscape-font-specification:'Liberation Serif';stroke-width:0.26458332">e.</tspan></text>
+    <g
+       transform="translate(-8.3642598)"
+       id="g5541">
+      <g
+         style="opacity:0.5"
+         transform="translate(45.289088,-11.089528)"
+         id="g5421">
+        <path
+           id="path5407"
+           d="M 35.036621,31.951577 44.131675,19.600909 50.591228,32.7784 Z"
+           style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path5409"
+           d="M 44.131675,19.600909 51.934814,17.688882 50.591228,32.7784 Z"
+           style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path5411"
+           d="M 51.934814,17.688882 50.591228,32.7784 c 0,0 9.146728,-8.681641 8.940022,-8.836671 -0.206706,-0.155029 -7.596436,-6.252847 -7.596436,-6.252847 z"
+           style="fill:#2c5aa0;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path5413"
+           d="m 59.582926,23.890054 -8.991698,8.888346 11.73055,0.465087 z"
+           style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path5415"
+           d="m 50.591228,32.7784 6.821289,8.52661 4.909261,-8.061523 z"
+           style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path5417"
+           d="M 50.591228,32.7784 45.010173,42.596921 35.036621,31.951577 Z"
+           style="fill:#44aa00;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path5419"
+           d="M 45.010173,42.596921 57.412517,41.30501 50.591228,32.7784 Z"
+           style="fill:#00d4aa;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         id="g5496"
+         transform="translate(45.289088,-11.115366)"
+         style="opacity:1;fill:none">
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 35.036621,31.951577 44.131675,19.600909 50.591228,32.7784 Z"
+           id="path5482" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 44.131675,19.600909 51.934814,17.688882 50.591228,32.7784 Z"
+           id="path5484" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 51.934814,17.688882 50.591228,32.7784 c 0,0 9.146728,-8.681641 8.940022,-8.836671 -0.206706,-0.155029 -7.596436,-6.252847 -7.596436,-6.252847 z"
+           id="path5486" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 59.582926,23.890054 -8.991698,8.888346 11.73055,0.465087 z"
+           id="path5488" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 50.591228,32.7784 6.821289,8.52661 4.909261,-8.061523 z"
+           id="path5490" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 50.591228,32.7784 45.010173,42.596921 35.036621,31.951577 Z"
+           id="path5492" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 45.010173,42.596921 57.412517,41.30501 50.591228,32.7784 Z"
+           id="path5494" />
+      </g>
+      <circle
+         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.16500001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle5429"
+         cx="95.919487"
+         cy="21.592323"
+         r="0.44589564" />
+      <circle
+         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.16500001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle5435"
+         cx="104.86755"
+         cy="12.824378"
+         r="0.44589564" />
+      <circle
+         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.16500001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle5435-4"
+         cx="102.60645"
+         cy="30.106319"
+         r="0.44589564" />
+      <circle
+         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.16500001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle5435-7"
+         cx="90.401833"
+         cy="31.494867"
+         r="0.44589564" />
+      <circle
+         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.16500001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle5435-6"
+         cx="80.535828"
+         cy="20.898048"
+         r="0.44589564" />
+      <circle
+         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.16500001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle5435-5"
+         cx="107.42982"
+         cy="22.213516"
+         r="0.44589564" />
+      <circle
+         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.16500001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle5435-56"
+         cx="89.451767"
+         cy="8.4011106"
+         r="0.44589564" />
+      <circle
+         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.16500001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="circle5435-9"
+         cx="97.19841"
+         cy="6.4279094"
+         r="0.44589564" />
+    </g>
+  </g>
+</svg>

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -737,6 +737,9 @@ void TopologicalMesh::collapseWedge( TopologicalMesh::HalfedgeHandle heh ) {
     auto position = m_wedges.getWedgeData( property( m_wedgeIndexPph, heh ) ).m_position;
     auto widx     = property( m_wedgeIndexPph, heh );
 
+    CORE_ASSERT( widx.isValid(), "try to collapse onto an invalid wedge" );
+    CORE_ASSERT( !isFeatureVertex( vo ), "try to collapse a feature vertex" );
+
     for ( VertexIHalfedgeIter vih_it( vih_iter( vo ) ); vih_it.is_valid(); ++vih_it )
     {
         // delete and set to new widx
@@ -745,14 +748,22 @@ void TopologicalMesh::collapseWedge( TopologicalMesh::HalfedgeHandle heh ) {
     }
     // but remove one ref for the deleted opposite he
     m_wedges.del( property( m_wedgeIndexPph, o ) );
+
     // and delete wedge of the remove he
-    property( m_wedgeIndexPph, hp ) =
-        m_wedges.newReference( property( m_wedgeIndexPph, opposite_halfedge_handle( hn ) ) );
+    // first if h is not boundary, copy the wedgeIndex of hn to hp to it
+    if ( !is_boundary( h ) )
+    {
+        property( m_wedgeIndexPph, hp ) =
+            m_wedges.newReference( property( m_wedgeIndexPph, opposite_halfedge_handle( hn ) ) );
+    }
     m_wedges.del( property( m_wedgeIndexPph, hn ) );
     m_wedges.del( property( m_wedgeIndexPph, opposite_halfedge_handle( hn ) ) );
 
-    property( m_wedgeIndexPph, on ) =
-        m_wedges.newReference( property( m_wedgeIndexPph, opposite_halfedge_handle( op ) ) );
+    if ( !is_boundary( o ) )
+    {
+        property( m_wedgeIndexPph, on ) =
+            m_wedges.newReference( property( m_wedgeIndexPph, opposite_halfedge_handle( op ) ) );
+    }
     m_wedges.del( property( m_wedgeIndexPph, op ) );
     m_wedges.del( property( m_wedgeIndexPph, opposite_halfedge_handle( op ) ) );
 

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -142,11 +142,11 @@ TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh ) {
             {
                 if ( attr->isFloat() )
                     addAttribPairToTopo( triMesh, this, attr, vprop_float, m_floatPph );
-                else if ( attr->isVec2() )
+                else if ( attr->isVector2() )
                     addAttribPairToTopo( triMesh, this, attr, vprop_vec2, m_vec2Pph );
-                else if ( attr->isVec3() )
+                else if ( attr->isVector3() )
                     addAttribPairToTopo( triMesh, this, attr, vprop_vec3, m_vec3Pph );
-                else if ( attr->isVec4() )
+                else if ( attr->isVector4() )
                     addAttribPairToTopo( triMesh, this, attr, vprop_vec4, m_vec4Pph );
                 else
                     LOG( logWARNING )
@@ -171,19 +171,19 @@ TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh ) {
                         triMesh.getAttribHandle<float>( attr->getName() ) );
                     m_wedges.addProp<float>( attr->getName() );
                 }
-                else if ( attr->isVec2() )
+                else if ( attr->isVector2() )
                 {
                     m_wedges.m_wedgeVector2AttribHandles.push_back(
                         triMesh.getAttribHandle<Vector2>( attr->getName() ) );
                     m_wedges.addProp<Vector2>( attr->getName() );
                 }
-                else if ( attr->isVec3() )
+                else if ( attr->isVector3() )
                 {
                     m_wedges.m_wedgeVector3AttribHandles.push_back(
                         triMesh.getAttribHandle<Vector3>( attr->getName() ) );
                     m_wedges.addProp<Vector3>( attr->getName() );
                 }
-                else if ( attr->isVec4() )
+                else if ( attr->isVector4() )
                 {
                     m_wedges.m_wedgeVector4AttribHandles.push_back(
                         triMesh.getAttribHandle<Vector4>( attr->getName() ) );

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -409,10 +409,14 @@ TriangleMesh TopologicalMesh::toTriangleMeshFromWedges() {
     std::vector<AttribHandle<Vector4>> wedgeVector4AttribHandles;
 
     TriangleMesh::PointAttribHandle::Container wedgePosition;
-    AlignedStdVector<Attrib<float>::Container> wedgeFloatAttribData(m_wedges.m_floatAttribNames.size());
-    AlignedStdVector<Attrib<Vector2>::Container> wedgeVector2AttribData(m_wedges.m_vector2AttribNames.size());
-    AlignedStdVector<Attrib<Vector3>::Container> wedgeVector3AttribData(m_wedges.m_vector3AttribNames.size());
-    AlignedStdVector<Attrib<Vector4>::Container> wedgeVector4AttribData(m_wedges.m_vector4AttribNames.size());
+    AlignedStdVector<Attrib<float>::Container> wedgeFloatAttribData(
+        m_wedges.m_floatAttribNames.size() );
+    AlignedStdVector<Attrib<Vector2>::Container> wedgeVector2AttribData(
+        m_wedges.m_vector2AttribNames.size() );
+    AlignedStdVector<Attrib<Vector3>::Container> wedgeVector3AttribData(
+        m_wedges.m_vector3AttribNames.size() );
+    AlignedStdVector<Attrib<Vector4>::Container> wedgeVector4AttribData(
+        m_wedges.m_vector4AttribNames.size() );
 
     /// Wedges are output vertices !
     for ( WedgeIndex widx{0}; widx < WedgeIndex( m_wedges.size() ); ++widx )

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -675,6 +675,79 @@ std::vector<int> TopologicalMesh::WedgeCollection::computeCleanupOffset() const 
     return ret;
 }
 
+///////////////// HELPERS ///////////////
+
+std::string wedgeInfo( const Ra::Core::Geometry::TopologicalMesh& topo,
+                       const Ra::Core::Geometry::TopologicalMesh::WedgeIndex& idx ) {
+
+    std::stringstream buffer;
+    if ( !idx.isValid() )
+    {
+        buffer << "wedge (invalid) ";
+        return buffer.str();
+    }
+
+    const Ra::Core::Geometry::TopologicalMesh::WedgeData& wd = topo.getWedgeData( idx );
+
+    buffer << "wedge (" << idx << "), ";
+    auto& floatAttrNames = topo.getFloatAttribNames();
+    for ( size_t i = 0; i < floatAttrNames.size(); ++i )
+    {
+        buffer << floatAttrNames[i];
+        buffer << "[";
+        buffer << wd.m_floatAttrib[i];
+        buffer << "], ";
+    }
+    auto vec2AttrNames = topo.getVec2AttribNames();
+    for ( size_t i = 0; i < vec2AttrNames.size(); ++i )
+    {
+        buffer << vec2AttrNames[i];
+        buffer << "[";
+        buffer << wd.m_vector2Attrib[i].transpose();
+        buffer << "], ";
+    }
+    auto vec3AttrNames = topo.getVec3AttribNames();
+    for ( size_t i = 0; i < vec3AttrNames.size(); ++i )
+    {
+        buffer << vec3AttrNames[i];
+        buffer << "[";
+        buffer << wd.m_vector3Attrib[i].transpose();
+        buffer << "], ";
+    }
+
+    auto vec4AttrNames = topo.getVec4AttribNames();
+    for ( size_t i = 0; i < vec4AttrNames.size(); ++i )
+    {
+        buffer << vec4AttrNames[i];
+        buffer << "[";
+        buffer << wd.m_vector4Attrib[i].transpose();
+        buffer << "], ";
+    }
+
+    return buffer.str();
+}
+
+void printWedgesInfo( const Ra::Core::Geometry::TopologicalMesh& topo ) {
+    using namespace Ra::Core;
+
+    for ( auto itr = topo.vertices_sbegin(); itr != topo.vertices_end(); ++itr )
+    {
+        LOG( Utils::logINFO ) << "vertex " << *itr;
+        auto wedges = topo.vertex_wedges( *itr );
+        for ( auto wedgeIndex : wedges )
+        {
+            LOG( Utils::logINFO ) << wedgeInfo( topo, wedgeIndex );
+        }
+    }
+
+    for ( auto itr = topo.halfedges_sbegin(); itr != topo.halfedges_end(); ++itr )
+    {
+        LOG( Utils::logINFO ) << "he " << *itr
+                              << ( topo.is_boundary( *itr ) ? " boundary " : " inner " );
+        LOG( Utils::logINFO ) << wedgeInfo( topo, topo.property( topo.getWedgeIndexPph(), *itr ) );
+    }
+}
+
 } // namespace Geometry
 } // namespace Core
 } // namespace Ra

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -419,7 +419,7 @@ TriangleMesh TopologicalMesh::toTriangleMeshFromWedges() {
         m_wedges.m_vector4AttribNames.size() );
 
     /// Wedges are output vertices !
-    for ( WedgeIndex widx{0}; widx < WedgeIndex( m_wedges.size() ); ++widx )
+    for ( WedgeIndex widx{0}; widx < WedgeIndex( m_wedges.getSize() ); ++widx )
     {
         const auto& wd = m_wedges.getWedgeData( widx );
         wedgePosition.push_back( wd.m_position );
@@ -792,12 +792,12 @@ void TopologicalMesh::garbage_collection() {
     for ( HalfedgeIter he_it = halfedges_begin(); he_it != halfedges_end(); ++he_it )
     {
         ON_ASSERT( auto idx = property( m_wedgeIndexPph, *he_it ); );
-        CORE_ASSERT( !idx.isValid() || !m_wedges.getWedge( idx ).deleted(),
+        CORE_ASSERT( !idx.isValid() || !m_wedges.getWedge( idx ).isDeleted(),
                      "references deleted wedge remains after garbage collection" );
     }
-    for ( size_t i = 0; i < m_wedges.size(); ++i )
+    for ( size_t i = 0; i < m_wedges.getSize(); ++i )
     {
-        CORE_ASSERT( !m_wedges.getWedge( WedgeIndex( i ) ).deleted(),
+        CORE_ASSERT( !m_wedges.getWedge( WedgeIndex( i ) ).isDeleted(),
                      "deleted wedge remains after garbage collection" );
     }
 }
@@ -838,7 +838,7 @@ std::vector<int> TopologicalMesh::WedgeCollection::computeCleanupOffset() const 
     int currentOffset = 0;
     for ( size_t i = 0; i < m_data.size(); ++i )
     {
-        if ( m_data[i].deleted() )
+        if ( m_data[i].isDeleted() )
         {
             ++currentOffset;
             ret[i] = -1;
@@ -902,7 +902,7 @@ std::string wedgeInfo( const Ra::Core::Geometry::TopologicalMesh& topo,
 }
 
 bool TopologicalMesh::checkIntegrity() const {
-    std::vector<unsigned int> count( m_wedges.size(), 0 );
+    std::vector<unsigned int> count( m_wedges.getSize(), 0 );
     bool ret = true;
     for ( auto he_itr{halfedges_begin()}; he_itr != halfedges_end(); ++he_itr )
     {
@@ -923,7 +923,7 @@ bool TopologicalMesh::checkIntegrity() const {
         }
     }
 
-    for ( int widx = 0; widx < int( m_wedges.size() ); ++widx )
+    for ( int widx = 0; widx < int( m_wedges.getSize() ); ++widx )
     {
         if ( m_wedges.getWedge( WedgeIndex{widx} ).getRefCount() != count[widx] )
         {
@@ -943,7 +943,7 @@ void printWedgesInfo( const Ra::Core::Geometry::TopologicalMesh& topo ) {
     for ( auto itr = topo.vertices_sbegin(); itr != topo.vertices_end(); ++itr )
     {
         LOG( Utils::logINFO ) << "vertex " << *itr;
-        auto wedges = topo.vertex_wedges( *itr );
+        auto wedges = topo.getVertexWedges( *itr );
         for ( auto wedgeIndex : wedges )
         {
             LOG( Utils::logINFO ) << wedgeInfo( topo, wedgeIndex );

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -388,7 +388,7 @@ void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh ) {
             face_vhandles[j]    = vh;
             face_normals[j]     = n;
             face_vertexIndex[j] = inMeshVertexIndex;
-            face_wedges[j]      = WedgeIndex{i};
+            face_wedges[j]      = WedgeIndex{int(i)};
         }
 
         // Add the face, then add attribs to vh

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -409,10 +409,10 @@ TriangleMesh TopologicalMesh::toTriangleMeshFromWedges() {
     std::vector<AttribHandle<Vector4>> wedgeVector4AttribHandles;
 
     TriangleMesh::PointAttribHandle::Container wedgePosition;
-    AlignedStdVector<Attrib<float>::Container> wedgeFloatAttribData;
-    AlignedStdVector<Attrib<Vector2>::Container> wedgeVector2AttribData;
-    AlignedStdVector<Attrib<Vector3>::Container> wedgeVector3AttribData;
-    AlignedStdVector<Attrib<Vector4>::Container> wedgeVector4AttribData;
+    AlignedStdVector<Attrib<float>::Container> wedgeFloatAttribData(m_wedges.m_floatAttribNames.size());
+    AlignedStdVector<Attrib<Vector2>::Container> wedgeVector2AttribData(m_wedges.m_vector2AttribNames.size());
+    AlignedStdVector<Attrib<Vector3>::Container> wedgeVector3AttribData(m_wedges.m_vector3AttribNames.size());
+    AlignedStdVector<Attrib<Vector4>::Container> wedgeVector4AttribData(m_wedges.m_vector4AttribNames.size());
 
     /// Wedges are output vertices !
     for ( WedgeIndex widx{0}; widx < WedgeIndex( m_wedges.size() ); ++widx )

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -274,9 +274,8 @@ TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh ) {
         face_normals.clear();
         face_vertexIndex.clear();
     }
-    LOG( logINFO ) << "TopologicalMesh: load end with  " << m_wedges.size() << " wedges ";
-
-    printWedgesInfo( *this );
+    //    LOG( logINFO ) << "TopologicalMesh: load end with  " << m_wedges.size() << " wedges ";
+    //    printWedgesInfo( *this );
 }
 
 void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh ) {

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -207,7 +207,6 @@ TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh ) {
 
     for ( unsigned int i = 0; i < num_triangles; i++ )
     {
-        if ( i % 10 == 0 ) LOG( logINFO ) << "Load " << i << "/" << num_triangles;
         std::vector<TopologicalMesh::VertexHandle> face_vhandles( 3 );
         std::vector<TopologicalMesh::Normal> face_normals( 3 );
         std::vector<unsigned int> face_vertexIndex( 3 );
@@ -226,13 +225,9 @@ TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh ) {
             {
                 vh = add_vertex( p );
                 vertexHandles.insert( vtr, VertexMap::value_type( p, vh ) );
-                LOG( logINFO ) << "New vert " << inMeshVertexIndex;
             }
             else
-            {
-                LOG( logINFO ) << "Old vert " << inMeshVertexIndex;
-                vh = vtr->second;
-            }
+            { vh = vtr->second; }
 
             face_vhandles[j]    = vh;
             face_normals[j]     = n;
@@ -249,10 +244,6 @@ TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh ) {
                                  &wd );
 
             face_wedges[j] = m_wedges.add( wd );
-            if ( face_wedges[j] != m_wedges.size() - 1 )
-            { LOG( logINFO ) << "New wedge " << face_wedges[j]; }
-            else
-            { LOG( logINFO ) << "Old wedge " << face_wedges[j]; }
         }
 
         // Add the face, then add attribs to vh
@@ -361,8 +352,6 @@ void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh ) {
 
     for ( unsigned int i = 0; i < num_triangles; i++ )
     {
-        if ( i % 10 == 0 ) LOG( logINFO ) << "Load " << i << "/" << num_triangles;
-
         std::vector<TopologicalMesh::VertexHandle> face_vhandles( 3 );
         std::vector<TopologicalMesh::Normal> face_normals( 3 );
         std::vector<unsigned int> face_vertexIndex( 3 );
@@ -388,7 +377,7 @@ void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh ) {
             face_vhandles[j]    = vh;
             face_normals[j]     = n;
             face_vertexIndex[j] = inMeshVertexIndex;
-            face_wedges[j]      = WedgeIndex{int(i)};
+            face_wedges[j]      = WedgeIndex{int( i )};
         }
 
         // Add the face, then add attribs to vh
@@ -830,6 +819,9 @@ bool TopologicalMesh::splitEdgeWedge( TopologicalMesh::EdgeHandle eh, Scalar f )
                                            HalfedgeHandle t2_,
                                            HalfedgeHandle a1_,
                                            HalfedgeHandle a2_ ) {
+        CORE_UNUSED( t2_ );
+        CORE_UNUSED( a2_ );
+
         if ( !is_boundary( t0_ ) )
         {
             CORE_ASSERT( t2_ == a2_, "TopologicalMesh: splitEdgeWedge inconsistency" );
@@ -849,6 +841,9 @@ bool TopologicalMesh::splitEdgeWedge( TopologicalMesh::EdgeHandle eh, Scalar f )
                                            HalfedgeHandle s2_,
                                            HalfedgeHandle b1_,
                                            TopologicalMesh::WedgeIndex v0widx_ ) {
+        CORE_UNUSED( s1_ );
+        CORE_UNUSED( b1_ );
+
         if ( !is_boundary( s0_ ) )
         {
             CORE_ASSERT( s1_ == b1_, "TopologicalMesh: splitEdgeWedge inconsistency" );
@@ -936,11 +931,7 @@ void TopologicalMesh::garbage_collection() {
         if ( !status( *he_it ).deleted() )
         {
             auto index = property( m_wedgeIndexPph, *he_it );
-            if ( index.isValid() )
-            {
-                auto newIndex                       = index - offset[index];
-                property( m_wedgeIndexPph, *he_it ) = newIndex;
-            }
+            if ( index.isValid() ) { property( m_wedgeIndexPph, *he_it ) = index - offset[index]; }
         }
     }
     m_wedges.garbageCollection();

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -18,6 +18,115 @@ using namespace Utils; // log, AttribXXX
 template <typename T>
 using PropPair = std::pair<AttribHandle<T>, OpenMesh::HPropHandleT<T>>;
 
+///////////////// HELPERS ///////////////
+
+std::string wedgeInfo( const Ra::Core::Geometry::TopologicalMesh& topo,
+                       const Ra::Core::Geometry::TopologicalMesh::WedgeIndex& idx ) {
+
+    std::stringstream buffer;
+    if ( !idx.isValid() )
+    {
+        buffer << "wedge (invalid) ";
+        return buffer.str();
+    }
+
+    const Ra::Core::Geometry::TopologicalMesh::WedgeData& wd = topo.getWedgeData( idx );
+
+    buffer << "wedge (" << idx << "," << topo.getWedgeRefCount( idx ) << "), ";
+    auto& floatAttrNames = topo.getFloatAttribNames();
+    for ( size_t i = 0; i < floatAttrNames.size(); ++i )
+    {
+        buffer << floatAttrNames[i];
+        buffer << "[";
+        buffer << wd.m_floatAttrib[i];
+        buffer << "], ";
+    }
+    auto vec2AttrNames = topo.getVec2AttribNames();
+    for ( size_t i = 0; i < vec2AttrNames.size(); ++i )
+    {
+        buffer << vec2AttrNames[i];
+        buffer << "[";
+        buffer << wd.m_vector2Attrib[i].transpose();
+        buffer << "], ";
+    }
+    auto vec3AttrNames = topo.getVec3AttribNames();
+    for ( size_t i = 0; i < vec3AttrNames.size(); ++i )
+    {
+        buffer << vec3AttrNames[i];
+        buffer << "[";
+        buffer << wd.m_vector3Attrib[i].transpose();
+        buffer << "], ";
+    }
+
+    auto vec4AttrNames = topo.getVec4AttribNames();
+    for ( size_t i = 0; i < vec4AttrNames.size(); ++i )
+    {
+        buffer << vec4AttrNames[i];
+        buffer << "[";
+        buffer << wd.m_vector4Attrib[i].transpose();
+        buffer << "], ";
+    }
+
+    return buffer.str();
+}
+
+bool TopologicalMesh::checkIntegrity() const {
+    std::vector<unsigned int> count( m_wedges.size(), 0 );
+    bool ret = true;
+    for ( auto he_itr{halfedges_begin()}; he_itr != halfedges_end(); ++he_itr )
+    {
+        auto widx = property( m_wedgeIndexPph, *he_itr );
+        if ( widx.isValid() )
+        {
+            count[widx]++;
+
+            if ( m_wedges.getWedgeData( widx ).m_position != point( to_vertex_handle( *he_itr ) ) )
+            {
+                LOG( logWARNING ) << "topological mesh wedge inconsistency, wedge and to position "
+                                     "differ for widx "
+                                  << widx << ", have "
+                                  << m_wedges.getWedgeData( widx ).m_position.transpose()
+                                  << "instead of "
+                                  << point( to_vertex_handle( *he_itr ) ).transpose();
+            }
+        }
+    }
+
+    for ( int widx = 0; widx < int( m_wedges.size() ); ++widx )
+    {
+        if ( m_wedges.getWedge( WedgeIndex{widx} ).getRefCount() != count[widx] )
+        {
+            LOG( logWARNING ) << "topological mesh wedge count inconsistency, have  " << count[widx]
+                              << " instead of "
+                              << m_wedges.getWedge( WedgeIndex{widx} ).getRefCount()
+                              << " for wedge id " << widx;
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+void printWedgesInfo( const Ra::Core::Geometry::TopologicalMesh& topo ) {
+    using namespace Ra::Core;
+
+    for ( auto itr = topo.vertices_sbegin(); itr != topo.vertices_end(); ++itr )
+    {
+        LOG( Utils::logINFO ) << "vertex " << *itr;
+        auto wedges = topo.getVertexWedges( *itr );
+        for ( auto wedgeIndex : wedges )
+        {
+            LOG( Utils::logINFO ) << wedgeInfo( topo, wedgeIndex );
+        }
+    }
+
+    for ( auto itr = topo.halfedges_sbegin(); itr != topo.halfedges_end(); ++itr )
+    {
+        LOG( Utils::logINFO ) << "he " << *itr
+                              << ( topo.is_boundary( *itr ) ? " boundary " : " inner " );
+        LOG( Utils::logINFO ) << wedgeInfo( topo, topo.property( topo.getWedgeIndexPph(), *itr ) );
+    }
+}
+
 template <typename T>
 void addAttribPairToTopo( const TriangleMesh& triMesh,
                           TopologicalMesh* topoMesh,
@@ -626,7 +735,9 @@ bool TopologicalMesh::splitEdge( TopologicalMesh::EdgeHandle eh, Scalar f ) {
     // not triangles or holes
     if ( ( !is_boundary( he0 ) && valence( F0 ) != 3 ) ||
          ( !is_boundary( he1 ) && valence( F1 ) != 3 ) )
-    { return false; } // add the new vertex
+    { return false; }
+
+    // add the new vertex
     const Point p  = Point( f * point( v0 ) + ( Scalar( 1. ) - f ) * point( v1 ) );
     VertexHandle v = add_vertex( p );
 
@@ -732,7 +843,7 @@ bool TopologicalMesh::splitEdge( TopologicalMesh::EdgeHandle eh, Scalar f ) {
 template <typename T>
 void interpolate( const VectorArray<T>& in1,
                   const VectorArray<T>& in2,
-                  VectorArray<T> out,
+                  VectorArray<T>& out,
                   const Scalar alpha ) {
     for ( size_t i = 0; i < in1.size(); ++i )
     {
@@ -752,6 +863,134 @@ TopologicalMesh::interpolateWedgeAttributes( const TopologicalMesh::WedgeData& w
     return ret;
 }
 
+//-----------------------------------------------------------------------------
+// from /OpenMesh/Core/Mesh/TriConnectivity.cc
+void TopologicalMesh::split( EdgeHandle _eh, VertexHandle _vh ) {
+    HalfedgeHandle h0 = halfedge_handle( _eh, 0 );
+    HalfedgeHandle o0 = halfedge_handle( _eh, 1 );
+
+    VertexHandle v2 = to_vertex_handle( o0 );
+
+    HalfedgeHandle e1 = new_edge( _vh, v2 );
+    HalfedgeHandle t1 = opposite_halfedge_handle( e1 );
+
+    FaceHandle f0 = face_handle( h0 );
+    FaceHandle f3 = face_handle( o0 );
+
+    set_halfedge_handle( _vh, h0 );
+    set_vertex_handle( o0, _vh );
+
+    if ( !is_boundary( h0 ) )
+    {
+        HalfedgeHandle h1 = next_halfedge_handle( h0 );
+        HalfedgeHandle h2 = next_halfedge_handle( h1 );
+
+        VertexHandle v1 = to_vertex_handle( h1 );
+
+        HalfedgeHandle e0 = new_edge( _vh, v1 );
+        HalfedgeHandle t0 = opposite_halfedge_handle( e0 );
+
+        FaceHandle f1 = new_face();
+        set_halfedge_handle( f0, h0 );
+        set_halfedge_handle( f1, h2 );
+
+        set_face_handle( h1, f0 );
+        set_face_handle( t0, f0 );
+        set_face_handle( h0, f0 );
+
+        set_face_handle( h2, f1 );
+        set_face_handle( t1, f1 );
+        set_face_handle( e0, f1 );
+
+        set_next_halfedge_handle( h0, h1 );
+        set_next_halfedge_handle( h1, t0 );
+        set_next_halfedge_handle( t0, h0 );
+
+        set_next_halfedge_handle( e0, h2 );
+        set_next_halfedge_handle( h2, t1 );
+        set_next_halfedge_handle( t1, e0 );
+    }
+    else
+    {
+        set_next_halfedge_handle( prev_halfedge_handle( h0 ), t1 );
+        set_next_halfedge_handle( t1, h0 );
+        // halfedge handle of _vh already is h0
+    }
+
+    if ( !is_boundary( o0 ) )
+    {
+        HalfedgeHandle o1 = next_halfedge_handle( o0 );
+        HalfedgeHandle o2 = next_halfedge_handle( o1 );
+
+        VertexHandle v3 = to_vertex_handle( o1 );
+
+        HalfedgeHandle e2 = new_edge( _vh, v3 );
+        HalfedgeHandle t2 = opposite_halfedge_handle( e2 );
+
+        FaceHandle f2 = new_face();
+        set_halfedge_handle( f2, o1 );
+        set_halfedge_handle( f3, o0 );
+
+        set_face_handle( o1, f2 );
+        set_face_handle( t2, f2 );
+        set_face_handle( e1, f2 );
+
+        set_face_handle( o2, f3 );
+        set_face_handle( o0, f3 );
+        set_face_handle( e2, f3 );
+
+        set_next_halfedge_handle( e1, o1 );
+        set_next_halfedge_handle( o1, t2 );
+        set_next_halfedge_handle( t2, e1 );
+
+        set_next_halfedge_handle( o0, e2 );
+        set_next_halfedge_handle( e2, o2 );
+        set_next_halfedge_handle( o2, o0 );
+    }
+    else
+    {
+        set_next_halfedge_handle( e1, next_halfedge_handle( o0 ) );
+        set_next_halfedge_handle( o0, e1 );
+        set_halfedge_handle( _vh, e1 );
+    }
+
+    if ( halfedge_handle( v2 ) == h0 ) set_halfedge_handle( v2, t1 );
+}
+
+//-----------------------------------------------------------------------------
+
+void TopologicalMesh::split_copy( EdgeHandle _eh, VertexHandle _vh ) {
+    const VertexHandle v0 = to_vertex_handle( halfedge_handle( _eh, 0 ) );
+    const VertexHandle v1 = to_vertex_handle( halfedge_handle( _eh, 1 ) );
+
+    const int nf = n_faces();
+
+    // Split the halfedge ( handle will be preserved)
+    split( _eh, _vh );
+
+    // Copy the properties of the original edge to all neighbor edges that
+    // have been created
+    for ( VEIter ve_it = ve_iter( _vh ); ve_it.is_valid(); ++ve_it )
+        copy_all_properties( _eh, *ve_it, true );
+
+    for ( auto vh : {v0, v1} )
+    {
+        // get the halfedge pointing from new vertex to old vertex
+        const HalfedgeHandle h = find_halfedge( _vh, vh );
+        if ( !is_boundary(
+                 h ) ) // for boundaries there are no faces whose properties need to be copied
+        {
+            FaceHandle fh0 = face_handle( h );
+            FaceHandle fh1 = face_handle( opposite_halfedge_handle( prev_halfedge_handle( h ) ) );
+            if ( fh0.idx() >= nf ) // is fh0 the new face?
+                std::swap( fh0, fh1 );
+
+            // copy properties from old face to new face
+            copy_all_properties( fh0, fh1, true );
+        }
+    }
+}
+
 bool TopologicalMesh::splitEdgeWedge( TopologicalMesh::EdgeHandle eh, Scalar f ) {
     // Global schema of operation
     /*
@@ -760,102 +999,140 @@ bool TopologicalMesh::splitEdgeWedge( TopologicalMesh::EdgeHandle eh, Scalar f )
 
             /    \                /    |    \
            /      \              /     |     \
-          /a2    a1\            /t2  t1|u2  u1\
-         /    a0 -->\          /  t0   |  u0   \
-        V0 -------- V1       V0 ------ V ------ V1
-         \<-- b0    /          \  s0   |  r0   /
-          \b1    b2/            \s1  s2|r1  r2/
+          /h2    h1\            /r2  r1|s2  s1\
+         /    h0 -->\          /  r0   | s0=h0 \
+        V0 -------- V1        V0-(1-f)-V---f---V1
+         \<-- o0    /          \  u0   | t0=o0 /
+          \o1    o2/            \u1  u2|t1  t2/
            \      /              \     |     /
             \    /                \    |    /
 
 
     */
 
+    //   LOG( logINFO ) << "* before ************************";
+    //   printWedgesInfo( *this );
+
     // incorrect factor
     if ( f < 0 || f > 1 ) { return false; }
 
-    // get existing topology data
-    auto a0 = halfedge_handle( eh, 0 );
-    auto b0 = halfedge_handle( eh, 1 );
-    auto v0 = to_vertex_handle( b0 );
-    auto v1 = to_vertex_handle( a0 );
+    if ( is_boundary( eh ) )
+    {
+        CORE_ASSERT( false, "ouch" );
+        return false;
+    }
 
-    auto a1 = next_halfedge_handle( a0 );
-    auto a2 = next_halfedge_handle( a1 );
+    const auto h0 = halfedge_handle( eh, 0 );
+    const auto o0 = halfedge_handle( eh, 1 );
 
-    auto b1 = next_halfedge_handle( b0 );
-    auto b2 = next_halfedge_handle( b1 );
+    const auto v0 = to_vertex_handle( o0 );
+    const auto v1 = to_vertex_handle( h0 );
 
-    const Point p  = Point( f * point( v1 ) + ( 1_ra - f ) * point( v0 ) );
-    VertexHandle v = add_vertex( p );
-    auto v0widx    = property( m_wedgeIndexPph, b0 );
-    auto wd0       = m_wedges.getWedgeData( v0widx );
-    auto v1widx    = property( m_wedgeIndexPph, a0 );
-    auto wd1       = m_wedges.getWedgeData( v1widx );
-    auto wd        = interpolateWedgeAttributes( wd0, wd1, f );
-    wd.m_position  = p;
-    auto widx      = m_wedges.add( wd );
+    //   LOG( logINFO ) << "* split **** " << v0 << " ----> " << v1;
 
-    base::split_edge( eh, v );
+    // add the new point
+    const Point p   = Point( f * point( v1 ) + ( 1_ra - f ) * point( v0 ) );
+    VertexHandle vh = add_vertex( p );
 
-    auto r0 = find_halfedge( v1, v );
+    const auto h1 = next_halfedge_handle( h0 );
+    const auto h2 = next_halfedge_handle( h1 );
+
+    const auto o1 = next_halfedge_handle( o0 );
+    const auto o2 = next_halfedge_handle( o1 );
+
+    // compute interpolated wedge, or the two wedges if not the same wedges
+    // around the two vertices of the edge (we always compute for two wedges,
+    // even if add will return the same wedge.
+    const auto hw0idx = property( m_wedgeIndexPph, h2 );
+    const auto hw1idx = property( m_wedgeIndexPph, h0 );
+    const auto ow0idx = property( m_wedgeIndexPph, o2 );
+    const auto ow1idx = property( m_wedgeIndexPph, o0 );
+    const auto hw0    = m_wedges.getWedgeData( hw0idx );
+    const auto hw1    = m_wedges.getWedgeData( hw1idx );
+    const auto ow0    = m_wedges.getWedgeData( ow0idx );
+    const auto ow1    = m_wedges.getWedgeData( ow1idx );
+    auto hvw          = interpolateWedgeAttributes( hw0, hw1, f );
+    auto ovw          = interpolateWedgeAttributes( ow1, ow0, f );
+    hvw.m_position    = p;
+    ovw.m_position    = p;
+    auto hvwidx       = m_wedges.add( hvw );
+    auto ovwidx       = m_wedges.add( ovw );
+
+    split_copy( eh, vh );
+
+    auto r0 = find_halfedge( v0, vh );
+    auto s0 = find_halfedge( vh, v1 );
+    auto t0 = find_halfedge( v1, vh );
+    auto u0 = find_halfedge( vh, v0 );
+
     auto r1 = next_halfedge_handle( r0 );
     auto r2 = next_halfedge_handle( r1 );
 
-    auto s0 = find_halfedge( v, v0 );
     auto s1 = next_halfedge_handle( s0 );
     auto s2 = next_halfedge_handle( s1 );
 
-    auto t0 = find_halfedge( v0, v );
     auto t1 = next_halfedge_handle( t0 );
     auto t2 = next_halfedge_handle( t1 );
 
-    auto u0 = find_halfedge( v, v1 );
     auto u1 = next_halfedge_handle( u0 );
     auto u2 = next_halfedge_handle( u1 );
 
-    auto updateWedgeIndex1 = [this, widx]( HalfedgeHandle t0_,
-                                           HalfedgeHandle t1_,
-                                           HalfedgeHandle t2_,
-                                           HalfedgeHandle a1_,
-                                           HalfedgeHandle a2_ ) {
-        CORE_UNUSED( t2_ );
-        CORE_UNUSED( a2_ );
+    CORE_ASSERT( s0 == h0, "TopologicalMesh: splitEdgeWedge inconsistency" );
+    CORE_ASSERT( t0 == o0, "TopologicalMesh: splitEdgeWedge inconsistency" );
 
-        if ( !is_boundary( t0_ ) )
+    auto updateWedgeIndex1 = [this]( WedgeIndex widx_,
+                                     HalfedgeHandle r0_,
+                                     HalfedgeHandle r1_,
+                                     HalfedgeHandle r2_,
+                                     HalfedgeHandle h1_,
+                                     HalfedgeHandle h2_ ) {
+        CORE_UNUSED( r2_ );
+        CORE_UNUSED( h2_ );
+
+        if ( !is_boundary( r0_ ) )
         {
-            CORE_ASSERT( t2_ == a2_, "TopologicalMesh: splitEdgeWedge inconsistency" );
-            property( this->m_wedgeIndexPph, t0_ ) = widx;
-            property( this->m_wedgeIndexPph, t1_ ) =
-                this->m_wedges.newReference( property( this->m_wedgeIndexPph, a1_ ) );
+            CORE_ASSERT( r2_ == h2_, "TopologicalMesh: splitEdgeWedge inconsistency" );
+
+            // Increment here, the first reference is for the other he
+            property( this->m_wedgeIndexPph, r0_ ) = this->m_wedges.newReference( widx_ );
+            property( this->m_wedgeIndexPph, r1_ ) =
+                this->m_wedges.newReference( property( this->m_wedgeIndexPph, h1_ ) );
         }
         else
-        { property( this->m_wedgeIndexPph, t0_ ) = WedgeIndex(); }
+        { property( this->m_wedgeIndexPph, r0_ ) = WedgeIndex(); }
     };
 
-    updateWedgeIndex1( t0, t1, t2, a1, a2 );
-    updateWedgeIndex1( r0, r1, r2, b1, b2 );
-
-    auto updateWedgeIndex2 = [this, widx]( HalfedgeHandle s0_,
-                                           HalfedgeHandle s1_,
-                                           HalfedgeHandle s2_,
-                                           HalfedgeHandle b1_,
-                                           TopologicalMesh::WedgeIndex v0widx_ ) {
+    auto updateWedgeIndex2 = [this]( WedgeIndex widx_,
+                                     HalfedgeHandle s0_,
+                                     HalfedgeHandle s1_,
+                                     HalfedgeHandle s2_,
+                                     HalfedgeHandle h0_,
+                                     HalfedgeHandle h1_ ) {
         CORE_UNUSED( s1_ );
-        CORE_UNUSED( b1_ );
+        CORE_UNUSED( h1_ );
 
         if ( !is_boundary( s0_ ) )
         {
-            CORE_ASSERT( s1_ == b1_, "TopologicalMesh: splitEdgeWedge inconsistency" );
-            property( this->m_wedgeIndexPph, s2_ ) = widx;
-            property( this->m_wedgeIndexPph, s0_ ) = this->m_wedges.newReference( v0widx_ );
+            CORE_ASSERT( s1_ == h1_, "TopologicalMesh: splitEdgeWedge inconsistency" );
+            // do not increment here, since add has set ref to 1
+            property( this->m_wedgeIndexPph, s2_ ) = widx_;
+            // "steal" ref from previous he (actually s0 is h0, u0 is the steal
+            // from o0.
+            property( this->m_wedgeIndexPph, s0_ ) = property( this->m_wedgeIndexPph, h0_ );
         }
         else
         { property( this->m_wedgeIndexPph, s0_ ) = WedgeIndex(); }
     };
 
-    updateWedgeIndex2( s0, s1, s2, b1, v0widx );
-    updateWedgeIndex2( u0, u1, u2, a1, v1widx );
+    // this update read from o0, must be done before t which reads from o0
+    updateWedgeIndex2( ovwidx, u0, u1, u2, o0, o1 );
+    // those update might be in any order
+    updateWedgeIndex2( hvwidx, s0, s1, s2, h0, h1 );
+    updateWedgeIndex1( hvwidx, r0, r1, r2, h1, h2 );
+    updateWedgeIndex1( ovwidx, t0, t1, t2, o1, o2 );
+
+    // LOG( logINFO ) << "* after ************************";
+    //  printWedgesInfo( *this );
 
     return true;
 }
@@ -995,115 +1272,6 @@ std::vector<int> TopologicalMesh::WedgeCollection::computeCleanupOffset() const 
         { ret[i] = currentOffset; }
     }
     return ret;
-}
-
-///////////////// HELPERS ///////////////
-
-std::string wedgeInfo( const Ra::Core::Geometry::TopologicalMesh& topo,
-                       const Ra::Core::Geometry::TopologicalMesh::WedgeIndex& idx ) {
-
-    std::stringstream buffer;
-    if ( !idx.isValid() )
-    {
-        buffer << "wedge (invalid) ";
-        return buffer.str();
-    }
-
-    const Ra::Core::Geometry::TopologicalMesh::WedgeData& wd = topo.getWedgeData( idx );
-
-    buffer << "wedge (" << idx << "), ";
-    auto& floatAttrNames = topo.getFloatAttribNames();
-    for ( size_t i = 0; i < floatAttrNames.size(); ++i )
-    {
-        buffer << floatAttrNames[i];
-        buffer << "[";
-        buffer << wd.m_floatAttrib[i];
-        buffer << "], ";
-    }
-    auto vec2AttrNames = topo.getVec2AttribNames();
-    for ( size_t i = 0; i < vec2AttrNames.size(); ++i )
-    {
-        buffer << vec2AttrNames[i];
-        buffer << "[";
-        buffer << wd.m_vector2Attrib[i].transpose();
-        buffer << "], ";
-    }
-    auto vec3AttrNames = topo.getVec3AttribNames();
-    for ( size_t i = 0; i < vec3AttrNames.size(); ++i )
-    {
-        buffer << vec3AttrNames[i];
-        buffer << "[";
-        buffer << wd.m_vector3Attrib[i].transpose();
-        buffer << "], ";
-    }
-
-    auto vec4AttrNames = topo.getVec4AttribNames();
-    for ( size_t i = 0; i < vec4AttrNames.size(); ++i )
-    {
-        buffer << vec4AttrNames[i];
-        buffer << "[";
-        buffer << wd.m_vector4Attrib[i].transpose();
-        buffer << "], ";
-    }
-
-    return buffer.str();
-}
-
-bool TopologicalMesh::checkIntegrity() const {
-    std::vector<unsigned int> count( m_wedges.size(), 0 );
-    bool ret = true;
-    for ( auto he_itr{halfedges_begin()}; he_itr != halfedges_end(); ++he_itr )
-    {
-        auto widx = property( m_wedgeIndexPph, *he_itr );
-        if ( widx.isValid() )
-        {
-            count[widx]++;
-
-            if ( m_wedges.getWedgeData( widx ).m_position != point( to_vertex_handle( *he_itr ) ) )
-            {
-                LOG( logWARNING ) << "topological mesh wedge inconsistency, wedge and to position "
-                                     "differ for widx "
-                                  << widx << ", have "
-                                  << m_wedges.getWedgeData( widx ).m_position.transpose()
-                                  << "instead of "
-                                  << point( to_vertex_handle( *he_itr ) ).transpose();
-            }
-        }
-    }
-
-    for ( int widx = 0; widx < int( m_wedges.size() ); ++widx )
-    {
-        if ( m_wedges.getWedge( WedgeIndex{widx} ).getRefCount() != count[widx] )
-        {
-            LOG( logWARNING ) << "topological mesh wedge count inconsistency, have  " << count[widx]
-                              << " instead of "
-                              << m_wedges.getWedge( WedgeIndex{widx} ).getRefCount()
-                              << " for wedge id " << widx;
-            ret = false;
-        }
-    }
-    return ret;
-}
-
-void printWedgesInfo( const Ra::Core::Geometry::TopologicalMesh& topo ) {
-    using namespace Ra::Core;
-
-    for ( auto itr = topo.vertices_sbegin(); itr != topo.vertices_end(); ++itr )
-    {
-        LOG( Utils::logINFO ) << "vertex " << *itr;
-        auto wedges = topo.getVertexWedges( *itr );
-        for ( auto wedgeIndex : wedges )
-        {
-            LOG( Utils::logINFO ) << wedgeInfo( topo, wedgeIndex );
-        }
-    }
-
-    for ( auto itr = topo.halfedges_sbegin(); itr != topo.halfedges_end(); ++itr )
-    {
-        LOG( Utils::logINFO ) << "he " << *itr
-                              << ( topo.is_boundary( *itr ) ? " boundary " : " inner " );
-        LOG( Utils::logINFO ) << wedgeInfo( topo, topo.property( topo.getWedgeIndexPph(), *itr ) );
-    }
 }
 
 } // namespace Geometry

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -720,17 +720,49 @@ bool TopologicalMesh::splitEdgeWedge( TopologicalMesh::EdgeHandle eh, Scalar f )
 }
 
 void TopologicalMesh::collapseWedge( TopologicalMesh::HalfedgeHandle heh ) {
-    auto opposite = opposite_halfedge_handle( heh );
-    auto v0       = to_vertex_handle( opposite );
+
+    HalfedgeHandle h  = heh;
+    HalfedgeHandle hn = next_halfedge_handle( h );
+    HalfedgeHandle hp = prev_halfedge_handle( h );
+
+    HalfedgeHandle o  = opposite_halfedge_handle( h );
+    HalfedgeHandle on = next_halfedge_handle( o );
+    HalfedgeHandle op = prev_halfedge_handle( o );
+
+    FaceHandle fh = face_handle( h );
+    FaceHandle fo = face_handle( o );
+
+    VertexHandle vh = to_vertex_handle( h );
+    VertexHandle vo = to_vertex_handle( o );
+
+    auto position = m_wedges.getWedgeData( property( m_wedgeIndexPph, heh ) ).m_position;
     auto widx     = property( m_wedgeIndexPph, heh );
 
-    for ( VertexIHalfedgeIter vih_it = vih_iter( v0 ); vih_it; ++vih_it )
+    for ( VertexIHalfedgeIter vih_it( vih_iter( vo ) ); vih_it.is_valid(); ++vih_it )
     {
+        // delete and set to new widx
         m_wedges.del( property( m_wedgeIndexPph, *vih_it ) );
         property( m_wedgeIndexPph, *vih_it ) = m_wedges.newReference( widx );
     }
-    m_wedges.del( property( m_wedgeIndexPph, opposite ) );
-    base::collapse( heh );
+    // but remove one ref for the deleted opposite he
+    m_wedges.del( property( m_wedgeIndexPph, o ) );
+    // and delete wedge of the remove he
+    property( m_wedgeIndexPph, hp ) =
+        m_wedges.newReference( property( m_wedgeIndexPph, opposite_halfedge_handle( hn ) ) );
+    m_wedges.del( property( m_wedgeIndexPph, hn ) );
+    m_wedges.del( property( m_wedgeIndexPph, opposite_halfedge_handle( hn ) ) );
+
+    property( m_wedgeIndexPph, on ) =
+        m_wedges.newReference( property( m_wedgeIndexPph, opposite_halfedge_handle( op ) ) );
+    m_wedges.del( property( m_wedgeIndexPph, op ) );
+    m_wedges.del( property( m_wedgeIndexPph, opposite_halfedge_handle( op ) ) );
+
+    base::collapse( h );
+    for ( VertexIHalfedgeIter vih_it( vih_iter( vh ) ); vih_it.is_valid(); ++vih_it )
+    {
+        // delete and set to new widx
+        m_wedges.setWedgePosition( property( m_wedgeIndexPph, *vih_it ), position );
+    }
 }
 
 void TopologicalMesh::garbage_collection() {

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -249,7 +249,7 @@ TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh ) {
                                  &wd );
 
             face_wedges[j] = m_wedges.add( wd );
-            if ( face_wedges[j] != m_wedges.getSize() - 1 )
+            if ( face_wedges[j] != m_wedges.size() - 1 )
             { LOG( logINFO ) << "New wedge " << face_wedges[j]; }
             else
             { LOG( logINFO ) << "Old wedge " << face_wedges[j]; }
@@ -274,7 +274,7 @@ TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh ) {
         face_normals.clear();
         face_vertexIndex.clear();
     }
-    LOG( logINFO ) << "TopologicalMesh: load end with  " << m_wedges.getSize() << " wedges ";
+    LOG( logINFO ) << "TopologicalMesh: load end with  " << m_wedges.size() << " wedges ";
 
     printWedgesInfo( *this );
 }
@@ -358,7 +358,7 @@ void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh ) {
         m_wedges.m_data.emplace_back( wd );
     }
 
-    LOG( logINFO ) << "TopologicalMesh: have  " << m_wedges.getSize() << " wedges ";
+    LOG( logINFO ) << "TopologicalMesh: have  " << m_wedges.size() << " wedges ";
 
     for ( unsigned int i = 0; i < num_triangles; i++ )
     {
@@ -406,7 +406,7 @@ void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh ) {
         face_normals.clear();
         face_vertexIndex.clear();
     }
-    LOG( logINFO ) << "TopologicalMesh: load end with  " << m_wedges.getSize() << " wedges ";
+    LOG( logINFO ) << "TopologicalMesh: load end with  " << m_wedges.size() << " wedges ";
 }
 
 TriangleMesh TopologicalMesh::toTriangleMesh() {
@@ -566,7 +566,7 @@ TriangleMesh TopologicalMesh::toTriangleMeshFromWedges() {
         m_wedges.m_vector4AttribNames.size() );
 
     /// Wedges are output vertices !
-    for ( WedgeIndex widx{0}; widx < WedgeIndex( m_wedges.getSize() ); ++widx )
+    for ( WedgeIndex widx{0}; widx < WedgeIndex( m_wedges.size() ); ++widx )
     {
         const auto& wd = m_wedges.getWedgeData( widx );
         wedgePosition.push_back( wd.m_position );
@@ -953,7 +953,7 @@ void TopologicalMesh::garbage_collection() {
         CORE_ASSERT( !idx.isValid() || !m_wedges.getWedge( idx ).isDeleted(),
                      "references deleted wedge remains after garbage collection" );
     }
-    for ( size_t i = 0; i < m_wedges.getSize(); ++i )
+    for ( size_t i = 0; i < m_wedges.size(); ++i )
     {
         CORE_ASSERT( !m_wedges.getWedge( WedgeIndex( i ) ).isDeleted(),
                      "deleted wedge remains after garbage collection" );
@@ -1060,7 +1060,7 @@ std::string wedgeInfo( const Ra::Core::Geometry::TopologicalMesh& topo,
 }
 
 bool TopologicalMesh::checkIntegrity() const {
-    std::vector<unsigned int> count( m_wedges.getSize(), 0 );
+    std::vector<unsigned int> count( m_wedges.size(), 0 );
     bool ret = true;
     for ( auto he_itr{halfedges_begin()}; he_itr != halfedges_end(); ++he_itr )
     {
@@ -1081,7 +1081,7 @@ bool TopologicalMesh::checkIntegrity() const {
         }
     }
 
-    for ( int widx = 0; widx < int( m_wedges.getSize() ); ++widx )
+    for ( int widx = 0; widx < int( m_wedges.size() ); ++widx )
     {
         if ( m_wedges.getWedge( WedgeIndex{widx} ).getRefCount() != count[widx] )
         {

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -615,6 +615,11 @@ void TopologicalMesh::garbage_collection() {
     {
         ON_ASSERT( auto idx = property( m_wedgeIndexPph, *he_it ); );
         CORE_ASSERT( !idx.isValid() || !m_wedges.getWedge( idx ).deleted(),
+                     "references deleted wedge remains after garbage collection" );
+    }
+    for ( size_t i = 0; i<m_wedges.size(); ++i)
+    {
+        CORE_ASSERT( !m_wedges.getWedge( WedgeIndex(i) ).deleted(),
                      "deleted wedge remains after garbage collection" );
     }
 }

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -617,9 +617,9 @@ void TopologicalMesh::garbage_collection() {
         CORE_ASSERT( !idx.isValid() || !m_wedges.getWedge( idx ).deleted(),
                      "references deleted wedge remains after garbage collection" );
     }
-    for ( size_t i = 0; i<m_wedges.size(); ++i)
+    for ( size_t i = 0; i < m_wedges.size(); ++i )
     {
-        CORE_ASSERT( !m_wedges.getWedge( WedgeIndex(i) ).deleted(),
+        CORE_ASSERT( !m_wedges.getWedge( WedgeIndex( i ) ).deleted(),
                      "deleted wedge remains after garbage collection" );
     }
 }

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -719,10 +719,25 @@ bool TopologicalMesh::splitEdgeWedge( TopologicalMesh::EdgeHandle eh, Scalar f )
     return true;
 }
 
+void TopologicalMesh::collapseWedge( TopologicalMesh::HalfedgeHandle heh ) {
+    auto opposite = opposite_halfedge_handle( heh );
+    auto v0       = to_vertex_handle( opposite );
+    auto widx     = property( m_wedgeIndexPph, heh );
+
+    for ( VertexIHalfedgeIter vih_it = vih_iter( v0 ); vih_it; ++vih_it )
+    {
+        m_wedges.del( property( m_wedgeIndexPph, *vih_it ) );
+        property( m_wedgeIndexPph, *vih_it ) = m_wedges.newReference( widx );
+    }
+    m_wedges.del( property( m_wedgeIndexPph, opposite ) );
+    base::collapse( heh );
+}
+
 void TopologicalMesh::garbage_collection() {
     for ( HalfedgeIter he_it = halfedges_begin(); he_it != halfedges_end(); ++he_it )
     {
-        if ( status( *he_it ).deleted() ) { m_wedges.del( property( m_wedgeIndexPph, *he_it ) ); }
+        // already done in collapseWedge     if ( status( *he_it ).deleted() ) { m_wedges.del(
+        // property( m_wedgeIndexPph, *he_it ) ); }
     }
     auto offset = m_wedges.computeCleanupOffset();
     for ( HalfedgeIter he_it = halfedges_begin(); he_it != halfedges_end(); ++he_it )

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -1240,6 +1240,7 @@ void TopologicalMesh::delete_face( FaceHandle _fh, bool _delete_isolated_vertice
 }
 
 /////////////// WEDGES RELATED STUFF /////////////////
+
 TopologicalMesh::WedgeIndex
 TopologicalMesh::WedgeCollection::add( const TopologicalMesh::WedgeData& wd ) {
     WedgeIndex idx;

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -536,7 +536,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
         /// merge wedges with same data
         /// return old->new index correspondance to update wedgeIndexPph
         /// inline void removeDuplicateWedge
-        inline size_t getSize() const { return m_data.size(); }
+        inline size_t size() const { return m_data.size(); }
 
         /// attrib names associated to vertex/wedges, getted from CoreMesh, if any,
         std::vector<std::string> m_floatAttribNames;

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -130,19 +130,26 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      * Return the half-edge associated with a given vertex and face.
      * \note Asserts if vh is not a member of fh.
      */
-    inline HalfedgeHandle halfedge_handle( VertexHandle vh, FaceHandle fh ) const;
+    [[deprecated]] inline HalfedgeHandle halfedge_handle( VertexHandle vh, FaceHandle fh ) const;
+    inline HalfedgeHandle getHalfedgeHandle( VertexHandle vh, FaceHandle fh ) const {
+        return halfedge_handle( vh, fh );
+    }
 
     /**
      * Get normal of the vertex vh, when member of fh.
      * \note Asserts if vh is not a member of fh.
      */
-    inline const Normal& normal( VertexHandle vh, FaceHandle fh ) const;
+    [[deprecated]] inline const Normal& normal( VertexHandle vh, FaceHandle fh ) const;
+    inline const Normal& getNormal( VertexHandle vh, FaceHandle fh ) const {
+        return normal( vh, fh );
+    }
 
     /**
      * Set normal of the vertex vh, when member of fh.
      * \note Asserts if vh is not a member of fh.
      */
-    void set_normal( VertexHandle vh, FaceHandle fh, const Normal& n );
+    [[deprecated]] void set_normal( VertexHandle vh, FaceHandle fh, const Normal& n );
+    void setNormal( VertexHandle vh, FaceHandle fh, const Normal& n ) { set_normal( vh, fh, n ); }
 
     /// Import Base definition of normal and set normal.
     ///@{
@@ -156,7 +163,8 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      * If you work with vertex normals, please call this function on all vertex
      * handles before convertion with toTriangleMesh.
      */
-    void propagate_normal_to_halfedges( VertexHandle vh );
+    [[deprecated]] void propagate_normal_to_halfedges( VertexHandle vh );
+    void propagateNormalToHalfedges( VertexHandle vh ) { propagate_normal_to_halfedges( vh ); }
 
     /**
      * Return a handle to the halfedge property storing vertices indices within
@@ -283,11 +291,10 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
                                   const std::vector<OpenMesh::HPropHandleT<T>>& hProps,
                                   const std::vector<OpenMesh::FPropHandleT<T>>& fProps );
     ///@}
-
     /**
-     * \name Deal with all attributes
-     * Utils to deal with the normal and custom properties when modifying the mesh topology.
-     */
+        * \name Deal with all attributes* Utils to deal with the normal and
+        custom properties when modifying the mesh topology.*/
+
     ///@{
 
     /**
@@ -383,7 +390,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      * Return the set of WedgeIndex incident to a given Vertex \a vh.
      * only valid non deleted wedges are present in the set.
      */
-    inline std::set<WedgeIndex> vertex_wedges( OpenMesh::VertexHandle vh ) const;
+    inline std::set<WedgeIndex> getVertexWedges( OpenMesh::VertexHandle vh ) const;
 
     /**
      * Access to wedge data.
@@ -401,14 +408,15 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     /**
      * Change the WedgeData associated for \a idx, for attrib \a name to \a value.
      * The data is changed for all halfedges referencing this wedge.
-     * \return true if the wedge is set, false if nothing set, i.e. if name is not an attrib of type
-     * T.
+     * \return true if the wedge is set, false if nothing set, i.e. if name is not an attrib of
+     * type T.
      */
     template <typename T>
     inline bool setWedgeData( const WedgeIndex& idx, const std::string& name, const T& value );
 
     /// Remove deleted element from the mesh, including wedges.
-    void garbage_collection();
+    [[deprecated]] void garbage_collection();
+    void garbageCollection() { garbage_collection(); }
 
     inline const std::vector<std::string>& getVec4AttribNames() const;
     inline const std::vector<std::string>& getVec3AttribNames() const;
@@ -425,7 +433,10 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
 
     inline const OpenMesh::HPropHandleT<WedgeIndex>& getWedgeIndexPph() const;
 
-    void delete_face( FaceHandle _fh, bool _delete_isolated_vertices = true );
+    [[deprecated]] void delete_face( FaceHandle _fh, bool _delete_isolated_vertices = true );
+    void deleteFace( FaceHandle fh, bool deleteIsolatedVertices = true ) {
+        delete_face( fh, deleteIsolatedVertices );
+    }
 
     /// Check if evrything looks right in the data structure
     /// \return true if ok, false if ko.
@@ -456,7 +467,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
         /// comparison ignore refCount
         bool operator==( const Wedge& lhs ) const { return m_wedgeData == lhs.m_wedgeData; }
 
-        bool deleted() const { return m_refCount == 0; }
+        bool isDeleted() const { return m_refCount == 0; }
         unsigned int getRefCount() const { return m_refCount; }
 
         friend WedgeCollection;
@@ -490,7 +501,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
         ///\todo remove optional ? we can state that only valid idx are fine,
         /// and a deleted wedge should not correspond to a non deleted halfedge.
         const WedgeData& getWedgeData( const WedgeIndex& idx ) const {
-            CORE_ASSERT( idx.isValid() && !m_data[idx].deleted(),
+            CORE_ASSERT( idx.isValid() && !m_data[idx].isDeleted(),
                          "access to invalid or deleted wedge is prohibited" );
 
             return m_data[idx].getWedgeData();
@@ -524,7 +535,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
         /// merge wedges with same data
         /// return old->new index correspondance to update wedgeIndexPph
         /// inline void removeDuplicateWedge
-        inline size_t size() const { return m_data.size(); }
+        inline size_t getSize() const { return m_data.size(); }
 
         /// attrib names associated to vertex/wedges, getted from CoreMesh, if any,
         std::vector<std::string> m_floatAttribNames;

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -131,7 +131,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      * Return the half-edge associated with a given vertex and face.
      * \note Asserts if vh is not a member of fh.
      */
-    [[deprecated]] inline HalfedgeHandle halfedge_handle( VertexHandle vh, FaceHandle fh ) const;
+    inline HalfedgeHandle halfedge_handle( VertexHandle vh, FaceHandle fh ) const;
     inline HalfedgeHandle getHalfedgeHandle( VertexHandle vh, FaceHandle fh ) const {
         return halfedge_handle( vh, fh );
     }
@@ -140,7 +140,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      * Get normal of the vertex vh, when member of fh.
      * \note Asserts if vh is not a member of fh.
      */
-    [[deprecated]] inline const Normal& normal( VertexHandle vh, FaceHandle fh ) const;
+    inline const Normal& normal( VertexHandle vh, FaceHandle fh ) const;
     inline const Normal& getNormal( VertexHandle vh, FaceHandle fh ) const {
         return normal( vh, fh );
     }
@@ -149,7 +149,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      * Set normal of the vertex vh, when member of fh.
      * \note Asserts if vh is not a member of fh.
      */
-    [[deprecated]] void set_normal( VertexHandle vh, FaceHandle fh, const Normal& n );
+    void set_normal( VertexHandle vh, FaceHandle fh, const Normal& n );
     void setNormal( VertexHandle vh, FaceHandle fh, const Normal& n ) { set_normal( vh, fh, n ); }
 
     /// Import Base definition of normal and set normal.
@@ -164,7 +164,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      * If you work with vertex normals, please call this function on all vertex
      * handles before convertion with toTriangleMesh.
      */
-    [[deprecated]] void propagate_normal_to_halfedges( VertexHandle vh );
+    void propagate_normal_to_halfedges( VertexHandle vh );
     void propagateNormalToHalfedges( VertexHandle vh ) { propagate_normal_to_halfedges( vh ); }
 
     /**
@@ -434,7 +434,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     }
 
     /// Remove deleted element from the mesh, including wedges.
-    [[deprecated]] void garbage_collection();
+    void garbage_collection();
     void garbageCollection() { garbage_collection(); }
 
     inline const std::vector<std::string>& getVec4AttribNames() const;
@@ -452,7 +452,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
 
     inline const OpenMesh::HPropHandleT<WedgeIndex>& getWedgeIndexPph() const;
 
-    [[deprecated]] void delete_face( FaceHandle _fh, bool _delete_isolated_vertices = true );
+    void delete_face( FaceHandle _fh, bool _delete_isolated_vertices = true );
     void deleteFace( FaceHandle fh, bool deleteIsolatedVertices = true ) {
         delete_face( fh, deleteIsolatedVertices );
     }

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -363,6 +363,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      */
     bool splitEdge( TopologicalMesh::EdgeHandle eh, Scalar f );
     ///@}
+    bool splitEdgeWedge( TopologicalMesh::EdgeHandle eh, Scalar f );
 
     /// Return the set of WedgeIndex incident to a given Vertex \p vh.
     /// only valid non deleted wedges are present in the set.
@@ -468,6 +469,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
         /// If the wedge is still referenced by other halfedges, it will not be
         /// removed during garbageCollection.
         void del( const WedgeIndex& idx );
+        WedgeIndex newReference( const WedgeIndex& idx );
 
         ///\todo remove optional ? we can state that only valid idx are fine,
         /// and a deleted wedge should not correspond to a non deleted halfedge.
@@ -488,6 +490,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
         /// \see TopologicalMesh::setWedgeData<T>
         template <typename T>
         inline bool setWedgeData( const WedgeIndex& idx, const std::string& name, const T& value );
+        inline bool setWedgePosition( const WedgeIndex& idx, const Vector3& value );
 
         // name is supposed to be unique within all attribs
         // not checks are performed
@@ -517,6 +520,8 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
 
     /// Wedge data management
     WedgeCollection m_wedges;
+
+    WedgeData interpolateWedgeAttributes( const WedgeData&, const WedgeData&, Scalar alpha );
 
     ///\todo to be deleted/updated
     OpenMesh::HPropHandleT<Index> m_inputTriangleMeshIndexPph;

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -96,6 +96,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      * \note This is a costly operation.
      */
     explicit TopologicalMesh( const Ra::Core::Geometry::TriangleMesh& triMesh );
+    void initWithWedge( const Ra::Core::Geometry::TriangleMesh& triMesh );
 
     /**
      * Construct an empty topological mesh
@@ -549,7 +550,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
         std::vector<AttribHandle<Vector3>> m_wedgeVector3AttribHandles;
         std::vector<AttribHandle<Vector4>> m_wedgeVector4AttribHandles;
 
-      private:
+        //      private:
         AlignedStdVector<Wedge> m_data;
     };
 

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -36,6 +36,7 @@ struct TopologicalMeshTraits : OpenMesh::DefaultTraits {
     VertexAttributes( OpenMesh::Attributes::Status | OpenMesh::Attributes::Normal );
     FaceAttributes( OpenMesh::Attributes::Status | OpenMesh::Attributes::Normal );
     EdgeAttributes( OpenMesh::Attributes::Status );
+    // Add  OpenMesh::Attributes::PrevHalfedge for efficiency ?
     HalfedgeAttributes( OpenMesh::Attributes::Status | OpenMesh::Attributes::Normal );
 };
 

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -495,6 +495,9 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     friend class TMOperations;
 };
 
+// heplers
+void printWedgesInfo( const TopologicalMesh& );
+
 } // namespace Geometry
 } // namespace Core
 } // namespace Ra

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -1,5 +1,4 @@
-#ifndef TOPOLOGICALMESH_H
-#define TOPOLOGICALMESH_H
+#pragma once
 
 #include <Core/RaCore.hpp>
 
@@ -86,6 +85,19 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
         inline bool operator!=( const WedgeData& lhs ) const;
         inline bool operator<( const WedgeData& lhs ) const;
         friend Wedge;
+
+      private:
+        // return 1 : equals, 2: strict less, 3: strict greater
+        template <typename T>
+        static int compareVector( const T& a, const T& b ) {
+            for ( int i = 0; i < T::RowsAtCompileTime; i++ )
+            {
+                if ( a[i] < b[i] ) return 2;
+                if ( a[i] > b[i] ) return 3;
+            }
+            // (a == b)
+            return 1;
+        }
     };
 
     /**
@@ -606,5 +618,3 @@ void printWedgesInfo( const TopologicalMesh& );
 } // namespace Ra
 
 #include <Core/Geometry/TopologicalMesh.inl>
-
-#endif // TOPOLOGICALMESH_H

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -474,8 +474,11 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
         friend WedgeCollection;
     };
 
-    /// This private class manage the wedge collection, most of the data members are public so
-    /// that the enclosing class can easily manage the data.
+    /**
+     * This private class manage the wedge collection.
+     * Most of the data members are public so that the enclosing class can
+     * easily manage the data.
+     */
     class WedgeCollection
     {
       public:
@@ -487,20 +490,27 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
         template <typename T>
         inline std::vector<std::string>& getNameArray();
 
-        /// Add wd to the wedge collection, and return the index.
-        /// If a wedge with same data is already present, it's index is returned.
+        /**
+         * Add wd to the wedge collection, and return the index.
+         * If a wedge with same data is already present, it's index is returned,
+         * otherwise a new wedge is added to the wedges collection.
+         * \param wd Data to insert.
+         * \return the index of the inserted (or found) wedge.
+         */
         WedgeIndex add( const WedgeData& wd );
 
-        /// Delete the wedge \a idx from the collection.
-        /// These deletion actually just remove one reference from an halfedge
-        /// to the wedge data.
-        /// If the wedge is still referenced by other halfedges, it will not be
-        /// removed during garbageCollection.
+        /**
+         * Delete the wedge \a idx from the collection.
+         * These deletion actually just remove one reference from an halfedge
+         * to the wedge data. If the wedge is still referenced by other
+         * halfedges, it will not be removed during garbageCollection.
+         */
         void del( const WedgeIndex& idx );
         WedgeIndex newReference( const WedgeIndex& idx );
 
-        ///\todo remove optional ? we can state that only valid idx are fine,
-        /// and a deleted wedge should not correspond to a non deleted halfedge.
+        /**
+         * Return the wedge data associated with \a idx
+         */
         const WedgeData& getWedgeData( const WedgeIndex& idx ) const {
             CORE_ASSERT( idx.isValid() && !m_data[idx].isDeleted(),
                          "access to invalid or deleted wedge is prohibited" );

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -44,7 +44,11 @@ struct TopologicalMeshTraits : OpenMesh::DefaultTraits {
  * This class represents a mesh with topological information on the
  * vertex graph, using a half-edge representation.
  *
- * This integration is inspired by: https://gist.github.com/Unril/03fa353d0461ed6bd41d
+ * This integration is inspired by:
+ * https://gist.github.com/Unril/03fa353d0461ed6bd41d
+ *
+ * \todo rename methods to respect Radium guideline (get/set/is, camelCase)
+ * \todo private inheritance from OpenMesh, and import relevant methods.
  */
 class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<TopologicalMeshTraits>
 {
@@ -185,25 +189,25 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     ///@{
 
     /**
-     * Create a new property for normals on faces of \p mesh.
+     * Create a new property for normals on faces of \a mesh.
      * \note This new property will have to be propagated onto the newly created
      * halfedges with copyNormal().
      */
     inline void createNormalPropOnFaces( OpenMesh::FPropHandleT<Normal>& fProp );
 
     /**
-     * Remove face property \p prop from \p mesh.
+     * Remove face property \a prop from \a mesh.
      * \note Invalidates the property handle.
      */
     inline void clearProp( OpenMesh::FPropHandleT<Normal>& fProp );
 
     /**
-     * Copy the normal property from \p input_heh to \p copy_heh.
+     * Copy the normal property from \a input_heh to \a copy_heh.
      */
     inline void copyNormal( HalfedgeHandle input_heh, HalfedgeHandle copy_heh );
 
-    /** Copy the face normal property \p fProp from \p fh to \p heh.
-     * \note \p fProp must have been previously created through createNormalPropOnFaces().
+    /** Copy the face normal property \a fProp from \a fh to \a heh.
+     * \note \a fProp must have been previously created through createNormalPropOnFaces().
      */
     inline void
     copyNormalFromFace( FaceHandle fh, HalfedgeHandle heh, OpenMesh::FPropHandleT<Normal> fProp );
@@ -215,7 +219,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     interpolateNormal( HalfedgeHandle in_a, HalfedgeHandle in_b, HalfedgeHandle out, Scalar f );
 
     /** Interpolate normal property on face center.
-     * \note \p fProp must have been previously created through createNormalPropOnFaces().
+     * \note \a fProp must have been previously created through createNormalPropOnFaces().
      */
     inline void interpolateNormalOnFaces( FaceHandle fh, OpenMesh::FPropHandleT<Normal> fProp );
     ///@}
@@ -227,7 +231,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     ///@{
 
     /**
-     * Create a new property for each \p input properties of \p mesh on faces.
+     * Create a new property for each \a input properties of \a mesh on faces.
      * \note This new property will have to be propagated onto the newly created
      * halfedges with copyProps().
      */
@@ -236,14 +240,14 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
                              std::vector<OpenMesh::FPropHandleT<T>>& output );
 
     /**
-     * Remove \p props from \p mesh.
-     * \note Clears \p props.
+     * Remove \a props from \a mesh.
+     * \note Clears \a props.
      */
     template <typename T>
     void clearProps( std::vector<OpenMesh::FPropHandleT<T>>& props );
 
     /**
-     * Copy \p props properties from \p input_heh to \p copy_heh.
+     * Copy \a props properties from \a input_heh to \a copy_heh.
      */
     template <typename T>
     void copyProps( HalfedgeHandle input_heh,
@@ -251,8 +255,8 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
                     const std::vector<OpenMesh::HPropHandleT<T>>& props );
 
     /**
-     * Copy face properties \p props from \p fh to \p heh.
-     * \note \p fProps must have been previously created through createPropsOnFaces().
+     * Copy face properties \a props from \a fh to \a heh.
+     * \note \a fProps must have been previously created through createPropsOnFaces().
      */
     template <typename T>
     void copyPropsFromFace( FaceHandle fh,
@@ -261,7 +265,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
                             const std::vector<OpenMesh::HPropHandleT<T>>& hProps );
 
     /**
-     * Interpolate \p props on edge center (after edge split).
+     * Interpolate \a props on edge center (after edge split).
      */
     template <typename T>
     void interpolateProps( HalfedgeHandle in_a,
@@ -271,8 +275,8 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
                            const std::vector<OpenMesh::HPropHandleT<T>>& props );
 
     /**
-     * Interpolate \p hprops on face center.
-     * \note \p fProps must have been previously created through createPropsOnFaces().
+     * Interpolate \a hprops on face center.
+     * \note \a fProps must have been previously created through createPropsOnFaces().
      */
     template <typename T>
     void interpolatePropsOnFaces( FaceHandle fh,
@@ -287,7 +291,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     ///@{
 
     /**
-     * Create a new property for each property of \p mesh on faces.
+     * Create a new property for each property of \a mesh on faces.
      * Outputs the new face properties handles in the corresponding output parameters.
      * \note These new properties will have to be propagated onto the newly created
      * halfedges with copyAllProps().
@@ -299,8 +303,8 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
                                        std::vector<OpenMesh::FPropHandleT<Vector4>>& vec4Props );
 
     /**
-     * Remove all the given properties from \p mesh.
-     * \note Invalidates \p normalProp and clears the given property containers.
+     * Remove all the given properties from \a mesh.
+     * \note Invalidates \a normalProp and clears the given property containers.
      */
     inline void clearAllProps( OpenMesh::FPropHandleT<Normal>& normalProp,
                                std::vector<OpenMesh::FPropHandleT<Scalar>>& floatProps,
@@ -309,12 +313,12 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
                                std::vector<OpenMesh::FPropHandleT<Vector4>>& vec4Props );
 
     /**
-     * Copy all properties from \p input_heh to \p copy_heh.
+     * Copy all properties from \a input_heh to \a copy_heh.
      */
     inline void copyAllProps( HalfedgeHandle input_heh, HalfedgeHandle copy_heh );
 
     /**
-     * Copy all given face properties from \p fh to \p heh.
+     * Copy all given face properties from \a fh to \a heh.
      * \note Each property must have been previously created either all at once
      * through createAllPropsOnFaces(), or individually through
      * createNormalPropOnFaces() and createPropsOnFaces().
@@ -334,7 +338,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     interpolateAllProps( HalfedgeHandle in_a, HalfedgeHandle in_b, HalfedgeHandle out, Scalar f );
 
     /**
-     * Interpolate \p hprops on face center.
+     * Interpolate \a hprops on face center.
      * \note Each property must have been previously created either all at once
      * through createAllPropsOnFaces(), or individually through
      * createNormalPropOnFaces() and createPropsOnFaces().
@@ -353,46 +357,57 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      */
     ///@{
     /**
-     * \brief Apply a 2-4 edge split.
+     * Apply a 2-4 edge split.
      * \param eh The handle to the edge to split.
      * \param f The interpolation factor to place the new point on the edge.
      *          Must be in [0,1].
      * \return True if the edge has been split, false otherwise.
-     * \note Only applies on edges between 3 triangles, and if \p f is in [0,1].
+     * \note Only applies on edges between 3 triangles, and if \a f is in [0,1].
      * \note Mesh attributes are linearly interpolated on the newly created halfedge.
      */
     bool splitEdge( TopologicalMesh::EdgeHandle eh, Scalar f );
     bool splitEdgeWedge( TopologicalMesh::EdgeHandle eh, Scalar f );
 
     /**
-     * \brief Halfedge collapes he, vo=from_vertex_handle(he) is deleted.
-     * after collapse vo incoming halfedges points to vh = to_vertex_handle(he).
-     * Wedge index are updated to reflect the change in topology.
+     * Halfedge collapes \a he.
+     * vo=from_vertex_handle(he) is deleted.
+     * After collapse vo incoming halfedges points to vh = to_vertex_handle(he).
+     * Wedge indices are updated to reflect the change in topology.
      * For detailed topological modifications see \ref develmeshes.
+     * \param he halfedge's hangle to collapse.
      */
     void collapseWedge( TopologicalMesh::HalfedgeHandle he );
     ///@}
 
-    /// Return the set of WedgeIndex incident to a given Vertex \p vh.
-    /// only valid non deleted wedges are present in the set.
+    /**
+     * Return the set of WedgeIndex incident to a given Vertex \a vh.
+     * only valid non deleted wedges are present in the set.
+     */
     inline std::set<WedgeIndex> vertex_wedges( OpenMesh::VertexHandle vh ) const;
 
-    /// Access to wedge data.
-    /// \p idx must be valid and correspond to a non delete wedge index.
+    /**
+     * Access to wedge data.
+     * \param idx must be valid and correspond to a non delete wedge index.
+     */
     inline const WedgeData& getWedgeData( const WedgeIndex& idx ) const;
 
-    /// set WedgeData \p wedge to the wedge with index widx. All halfedge that
-    /// point to widx will get the new values.
-    inline void setWedgeData( WedgeIndex widx, const WedgeData& wedge );
+    /** set WedgeData \a wd to the wedge with index \a widx.
+     * All halfedge that point to widx will get the new values.
+     * \param widx index of the wedge
+     * \param wd data to set to wedge that correspond to widx
+     */
+    inline void setWedgeData( WedgeIndex widx, const WedgeData& wd );
 
-    /// change the WedgeData associated for \p idx, for attrib \p name to \p value.
-    /// The data is changed for all halfedges referencing this wedge.
-    /// return true if the wedge is set
-    /// return false if nothing set, i.e. if name is not an attrib of type T
+    /**
+     * Change the WedgeData associated for \a idx, for attrib \a name to \a value.
+     * The data is changed for all halfedges referencing this wedge.
+     * \return true if the wedge is set, false if nothing set, i.e. if name is not an attrib of type
+     * T.
+     */
     template <typename T>
     inline bool setWedgeData( const WedgeIndex& idx, const std::string& name, const T& value );
 
-    /// Remove deleted element from the mesh, including wedge informations
+    /// Remove deleted element from the mesh, including wedges.
     void garbage_collection();
 
     inline const std::vector<std::string>& getVec4AttribNames() const;
@@ -400,7 +415,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     inline const std::vector<std::string>& getVec2AttribNames() const;
     inline const std::vector<std::string>& getFloatAttribNames() const;
 
-    /// true if more than one wedge arount vertex \p vh, false if only one wedge
+    /// true if more than one wedge arount vertex \a vh, false if only one wedge
     inline bool isFeatureVertex( const VertexHandle& vh ) const;
 
     /// true if at least one of edge's vertex as two different wedge arount the
@@ -454,28 +469,17 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
       public:
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-        /// attrib names associated to vertex/wedges
-        std::vector<std::string> m_floatAttribNames;
-        std::vector<std::string> m_vector2AttribNames;
-        std::vector<std::string> m_vector3AttribNames;
-        std::vector<std::string> m_vector4AttribNames;
-
         template <typename T>
         inline const std::vector<std::string>& getNameArray() const;
 
         template <typename T>
         inline std::vector<std::string>& getNameArray();
 
-        std::vector<AttribHandle<float>> m_wedgeFloatAttribHandles;
-        std::vector<AttribHandle<Vector2>> m_wedgeVector2AttribHandles;
-        std::vector<AttribHandle<Vector3>> m_wedgeVector3AttribHandles;
-        std::vector<AttribHandle<Vector4>> m_wedgeVector4AttribHandles;
-
         /// Add wd to the wedge collection, and return the index.
         /// If a wedge with same data is already present, it's index is returned.
         WedgeIndex add( const WedgeData& wd );
 
-        /// Delete the wedge \p idx from the collection.
+        /// Delete the wedge \a idx from the collection.
         /// These deletion actually just remove one reference from an halfedge
         /// to the wedge data.
         /// If the wedge is still referenced by other halfedges, it will not be
@@ -520,20 +524,28 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
         /// merge wedges with same data
         /// return old->new index correspondance to update wedgeIndexPph
         /// inline void removeDuplicateWedge
-
         inline size_t size() const { return m_data.size(); }
+
+        /// attrib names associated to vertex/wedges, getted from CoreMesh, if any,
+        std::vector<std::string> m_floatAttribNames;
+        std::vector<std::string> m_vector2AttribNames;
+        std::vector<std::string> m_vector3AttribNames;
+        std::vector<std::string> m_vector4AttribNames;
+
+        /// attrib handle from the CoreMesh given at construction, if any.
+        std::vector<AttribHandle<float>> m_wedgeFloatAttribHandles;
+        std::vector<AttribHandle<Vector2>> m_wedgeVector2AttribHandles;
+        std::vector<AttribHandle<Vector3>> m_wedgeVector3AttribHandles;
+        std::vector<AttribHandle<Vector4>> m_wedgeVector4AttribHandles;
 
       private:
         AlignedStdVector<Wedge> m_data;
     };
 
-    /// Wedges indices stored in halfedges
-    OpenMesh::HPropHandleT<WedgeIndex> m_wedgeIndexPph;
-
-    /// Wedge data management
-    WedgeCollection m_wedges;
-
     WedgeData interpolateWedgeAttributes( const WedgeData&, const WedgeData&, Scalar alpha );
+
+    OpenMesh::HPropHandleT<WedgeIndex> m_wedgeIndexPph; /**< Halfedges' Wedge index */
+    WedgeCollection m_wedges;                           /**< Wedge data management */
 
     ///\todo to be deleted/updated
     OpenMesh::HPropHandleT<Index> m_inputTriangleMeshIndexPph;

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -362,10 +362,16 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      * \note Mesh attributes are linearly interpolated on the newly created halfedge.
      */
     bool splitEdge( TopologicalMesh::EdgeHandle eh, Scalar f );
-    ///@}
     bool splitEdgeWedge( TopologicalMesh::EdgeHandle eh, Scalar f );
 
-    void collapseWedge( TopologicalMesh::HalfedgeHandle heh );
+    /**
+     * \brief Halfedge collapes he, vo=from_vertex_handle(he) is deleted.
+     * after collapse vo incoming halfedges points to vh = to_vertex_handle(he).
+     * Wedge index are updated to reflect the change in topology.
+     * For detailed topological modifications see \ref develmeshes.
+     */
+    void collapseWedge( TopologicalMesh::HalfedgeHandle he );
+    ///@}
 
     /// Return the set of WedgeIndex incident to a given Vertex \p vh.
     /// only valid non deleted wedges are present in the set.
@@ -405,6 +411,10 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     inline const OpenMesh::HPropHandleT<WedgeIndex>& getWedgeIndexPph() const;
 
     void delete_face( FaceHandle _fh, bool _delete_isolated_vertices = true );
+
+    /// Check if evrything looks right in the data structure
+    /// \return true if ok, false if ko.
+    bool checkIntegrity() const;
 
   private:
     class WedgeCollection;

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -365,6 +365,8 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     ///@}
     bool splitEdgeWedge( TopologicalMesh::EdgeHandle eh, Scalar f );
 
+    void collapseWedge( TopologicalMesh::HalfedgeHandle heh );
+
     /// Return the set of WedgeIndex incident to a given Vertex \p vh.
     /// only valid non deleted wedges are present in the set.
     inline std::set<WedgeIndex> vertex_wedges( OpenMesh::VertexHandle vh ) const;

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -415,6 +415,24 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     template <typename T>
     inline bool setWedgeData( const WedgeIndex& idx, const std::string& name, const T& value );
 
+    /**
+     * Replace the wedge data associated with an halfedge.
+     * The old wedge is "deleted". If wedge data correspond to an already
+     * present wedge, it's index is used.
+     */
+    void replaceWedge( OpenMesh::HalfedgeHandle he, const WedgeData& wd ) {
+        m_wedges.del( property( getWedgeIndexPph(), he ) );
+        property( getWedgeIndexPph(), he ) = m_wedges.add( wd );
+    }
+    /**
+     * Replace the wedge index associated with an halfedge.
+     * The old wedge is "deleted". The new wedge reference count is incremented.
+     */
+    void replaceWedgeIndex( OpenMesh::HalfedgeHandle he, const WedgeIndex& widx ) {
+        m_wedges.del( property( getWedgeIndexPph(), he ) );
+        property( getWedgeIndexPph(), he ) = m_wedges.newReference( widx );
+    }
+
     /// Remove deleted element from the mesh, including wedges.
     [[deprecated]] void garbage_collection();
     void garbageCollection() { garbage_collection(); }

--- a/src/Core/Geometry/TopologicalMesh.inl
+++ b/src/Core/Geometry/TopologicalMesh.inl
@@ -331,10 +331,10 @@ inline bool TopologicalMesh::isFeatureEdge( const EdgeHandle& eh ) const {
     auto heh0 = halfedge_handle( eh, 0 );
     auto heh1 = halfedge_handle( eh, 1 );
 
-    return property( m_wedgeIndexPph, heh0 ) ==
+    return property( m_wedgeIndexPph, heh0 ) !=
                property( m_wedgeIndexPph,
                          prev_halfedge_handle( opposite_halfedge_handle( heh0 ) ) ) ||
-           property( m_wedgeIndexPph, heh1 ) ==
+           property( m_wedgeIndexPph, heh1 ) !=
                property( m_wedgeIndexPph,
                          prev_halfedge_handle( opposite_halfedge_handle( heh1 ) ) );
 }
@@ -461,18 +461,6 @@ inline bool TopologicalMesh::WedgeData::operator==( const TopologicalMesh::Wedge
         m_position == lhs.m_position && m_floatAttrib == lhs.m_floatAttrib &&
         m_vector2Attrib == lhs.m_vector2Attrib && m_vector3Attrib == lhs.m_vector3Attrib &&
         m_vector4Attrib == lhs.m_vector4Attrib;
-}
-
-// return 1 : equals, 2: strict less, 3: strich greater
-template <typename T>
-int compareVector( const T& a, const T& b ) {
-    for ( int i = 0; i < T::RowsAtCompileTime; i++ )
-    {
-        if ( a[i] < b[i] ) return 2;
-        if ( a[i] > b[i] ) return 3;
-    }
-    // (a == b)
-    return 1;
 }
 
 inline bool TopologicalMesh::WedgeData::operator<( const TopologicalMesh::WedgeData& lhs ) const {

--- a/src/Core/Geometry/TopologicalMesh.inl
+++ b/src/Core/Geometry/TopologicalMesh.inl
@@ -372,7 +372,7 @@ void TopologicalMesh::WedgeCollection::addProp( std::string name ) {
 }
 
 inline void TopologicalMesh::WedgeCollection::garbageCollection() {
-    std::remove_if( m_data.begin(), m_data.end(), []( const Wedge& w ) { return w.deleted(); } );
+    m_data.erase(std::remove_if( m_data.begin(), m_data.end(), []( const Wedge& w ) { return w.deleted(); } ), m_data.end());
 }
 
 inline bool TopologicalMesh::WedgeData::operator==( const TopologicalMesh::WedgeData& lhs ) const {

--- a/src/Core/Geometry/TopologicalMesh.inl
+++ b/src/Core/Geometry/TopologicalMesh.inl
@@ -349,6 +349,12 @@ inline void TopologicalMesh::WedgeCollection::del( const TopologicalMesh::WedgeI
     if ( idx.isValid() ) m_data[idx].decrementRefCount();
 }
 
+inline TopologicalMesh::WedgeIndex
+TopologicalMesh::WedgeCollection::newReference( const TopologicalMesh::WedgeIndex& idx ) {
+    if ( idx.isValid() ) m_data[idx].incrementRefCount();
+    return idx;
+}
+
 inline const TopologicalMesh::Wedge&
 TopologicalMesh::WedgeCollection::getWedge( const TopologicalMesh::WedgeIndex& idx ) const {
     return m_data[idx];
@@ -420,6 +426,17 @@ inline bool TopologicalMesh::WedgeCollection::setWedgeData( const TopologicalMes
             LOG( logERROR ) << "Warning, set wedge: no wedge attrib named " << name << " of type "
                             << typeid( T ).name();
         }
+    }
+    return false;
+}
+
+inline bool
+TopologicalMesh::WedgeCollection::setWedgePosition( const TopologicalMesh::WedgeIndex& idx,
+                                                    const Vector3& value ) {
+    if ( idx.isValid() )
+    {
+        m_data[idx].getWedgeData().m_position = value;
+        return true;
     }
     return false;
 }

--- a/src/Core/Geometry/TopologicalMesh.inl
+++ b/src/Core/Geometry/TopologicalMesh.inl
@@ -398,6 +398,7 @@ inline const std::vector<std::string>& TopologicalMesh::WedgeCollection::getName
     //    static_assert( sizeof( T ) == -1, "this type is not supported" );
     return {};
 }
+
 template <typename T>
 inline std::vector<std::string>& TopologicalMesh::WedgeCollection::getNameArray() {
 

--- a/src/Core/Geometry/TopologicalMesh.inl
+++ b/src/Core/Geometry/TopologicalMesh.inl
@@ -281,13 +281,13 @@ inline void TopologicalMesh::interpolateAllPropsOnFaces(
 }
 
 inline std::set<TopologicalMesh::WedgeIndex>
-TopologicalMesh::vertex_wedges( OpenMesh::VertexHandle vh ) const {
+TopologicalMesh::getVertexWedges( OpenMesh::VertexHandle vh ) const {
     std::set<TopologicalMesh::WedgeIndex> ret;
 
     for ( ConstVertexIHalfedgeIter vh_it = cvih_iter( vh ); vh_it.is_valid(); ++vh_it )
     {
         auto widx = property( m_wedgeIndexPph, *vh_it );
-        if ( widx.isValid() && !m_wedges.getWedge( widx ).deleted() ) ret.insert( widx );
+        if ( widx.isValid() && !m_wedges.getWedge( widx ).isDeleted() ) ret.insert( widx );
     }
     return ret;
 }
@@ -323,7 +323,7 @@ inline const std::vector<std::string>& TopologicalMesh::getFloatAttribNames() co
 }
 
 inline bool TopologicalMesh::isFeatureVertex( const VertexHandle& vh ) const {
-    return vertex_wedges( vh ).size() != 1;
+    return getVertexWedges( vh ).size() != 1;
 }
 
 inline bool TopologicalMesh::isFeatureEdge( const EdgeHandle& eh ) const {
@@ -447,8 +447,9 @@ void TopologicalMesh::WedgeCollection::addProp( const std::string& name ) {
 }
 
 inline void TopologicalMesh::WedgeCollection::garbageCollection() {
-    m_data.erase( std::remove_if(
-                      m_data.begin(), m_data.end(), []( const Wedge& w ) { return w.deleted(); } ),
+    m_data.erase( std::remove_if( m_data.begin(),
+                                  m_data.end(),
+                                  []( const Wedge& w ) { return w.isDeleted(); } ),
                   m_data.end() );
 }
 

--- a/src/Core/Geometry/TriangleMesh.cpp
+++ b/src/Core/Geometry/TriangleMesh.cpp
@@ -18,9 +18,9 @@ bool AttribArrayGeometry::append( const AttribArrayGeometry& other ) {
     // Deal with all attributes the same way (vertices and normals too)
     other.m_vertexAttribs.for_each_attrib( [this]( const auto& attr ) {
         if ( attr->isFloat() ) this->append_attrib<float>( attr );
-        if ( attr->isVec2() ) this->append_attrib<Vector2>( attr );
-        if ( attr->isVec3() ) this->append_attrib<Vector3>( attr );
-        if ( attr->isVec4() ) this->append_attrib<Vector4>( attr );
+        if ( attr->isVector2() ) this->append_attrib<Vector2>( attr );
+        if ( attr->isVector3() ) this->append_attrib<Vector3>( attr );
+        if ( attr->isVector4() ) this->append_attrib<Vector4>( attr );
     } );
 
     return true;

--- a/src/Core/Geometry/TriangleMesh.hpp
+++ b/src/Core/Geometry/TriangleMesh.hpp
@@ -116,6 +116,7 @@ class RA_CORE_API AttribArrayGeometry : public AbstractGeometry
     /// Add attribute with the given name.
     /// \see AttribManager::addAttrib() for more info.
     /// \param name: attrib name, uniquely identify the attrib
+    /// \return handle to set the attrib data with getAttrib(handle).setData()
     template <typename T>
     inline Utils::AttribHandle<T> addAttrib( const std::string& name );
 

--- a/src/Core/Utils/Attribs.cpp
+++ b/src/Core/Utils/Attribs.cpp
@@ -33,17 +33,17 @@ void AttribManager::copyAllAttributes( const AttribManager& m ) {
             auto h = addAttrib<float>( attr->getName() );
             getAttrib( h ).setData( static_cast<Attrib<float>*>( attr.get() )->data() );
         }
-        else if ( attr->isVec2() )
+        else if ( attr->isVector2() )
         {
             auto h = addAttrib<Vector2>( attr->getName() );
             getAttrib( h ).setData( static_cast<Attrib<Vector2>*>( attr.get() )->data() );
         }
-        else if ( attr->isVec3() )
+        else if ( attr->isVector3() )
         {
             auto h = addAttrib<Vector3>( attr->getName() );
             getAttrib( h ).setData( static_cast<Attrib<Vector3>*>( attr.get() )->data() );
         }
-        else if ( attr->isVec4() )
+        else if ( attr->isVector4() )
         {
             auto h = addAttrib<Vector4>( attr->getName() );
             getAttrib( h ).setData( static_cast<Attrib<Vector4>*>( attr.get() )->data() );

--- a/src/Core/Utils/Attribs.hpp
+++ b/src/Core/Utils/Attribs.hpp
@@ -1,6 +1,4 @@
-#ifndef RADIUMENGINE_ATTRIBS_HPP
-#define RADIUMENGINE_ATTRIBS_HPP
-
+#pragma once
 #include <map>
 
 #include <Core/Containers/VectorArray.hpp>
@@ -76,13 +74,13 @@ class RA_CORE_API AttribBase : public ObservableVoid
     virtual bool isFloat() const = 0;
 
     /// Return true if the attribute content is of Vector2 type, false otherwise.
-    virtual bool isVec2() const = 0;
+    virtual bool isVector2() const = 0;
 
     /// Return true if the attribute content is of Vector3 type, false otherwise.
-    virtual bool isVec3() const = 0;
+    virtual bool isVector3() const = 0;
 
     /// Return true if the attribute content is of Vector4 type, false otherwise.
-    virtual bool isVec4() const = 0;
+    virtual bool isVector4() const = 0;
 
     /// Return a void * on the attrib data
     virtual const void* dataPtr() const = 0;
@@ -143,9 +141,9 @@ class Attrib : public AttribBase
     int getStride() const override;
     size_t getBufferSize() const override;
     bool isFloat() const override;
-    bool isVec2() const override;
-    bool isVec3() const override;
-    bool isVec4() const override;
+    bool isVector2() const override;
+    bool isVector3() const override;
+    bool isVector4() const override;
 
     /// check if attrib is a given type, as in attr.isType<MyMatrix>()
     template <typename U>
@@ -365,5 +363,3 @@ class RA_CORE_API AttribManager : public Observable<const std::string&>
 } // namespace Ra
 
 #include <Core/Utils/Attribs.inl>
-
-#endif // RADIUMENGINE_ATTRIBS_HPP

--- a/src/Core/Utils/Attribs.inl
+++ b/src/Core/Utils/Attribs.inl
@@ -105,17 +105,17 @@ bool Attrib<T>::isFloat() const {
 }
 
 template <typename T>
-bool Attrib<T>::isVec2() const {
+bool Attrib<T>::isVector2() const {
     return std::is_same<Eigen::Matrix<Scalar, 2, 1>, T>::value;
 }
 
 template <typename T>
-bool Attrib<T>::isVec3() const {
+bool Attrib<T>::isVector3() const {
     return std::is_same<Eigen::Matrix<Scalar, 3, 1>, T>::value;
 }
 
 template <typename T>
-bool Attrib<T>::isVec4() const {
+bool Attrib<T>::isVector4() const {
     return std::is_same<Eigen::Matrix<Scalar, 4, 1>, T>::value;
 }
 

--- a/src/Engine/RadiumEngine.hpp
+++ b/src/Engine/RadiumEngine.hpp
@@ -1,6 +1,4 @@
-#ifndef RADIUMENGINE_ENGINE_HPP
-#define RADIUMENGINE_ENGINE_HPP
-
+#pragma once
 #include <Engine/RaEngine.hpp>
 
 #include <Core/Types.hpp>
@@ -117,7 +115,6 @@ class RA_ENGINE_API RadiumEngine
      * Access to the content is only available at loading time. As soon as the loaded file is
      * released, its content is no more available outside the Entity/Component architecture.
      * @pre The Engine must be in "loading state".
-     * @param filename the name of the loaded file
      * @return
      */
     const Core::Asset::FileData& getFileData() const;
@@ -230,5 +227,3 @@ class RA_ENGINE_API RadiumEngine
 
 } // namespace Engine
 } // namespace Ra
-
-#endif // RADIUMENGINE_ENGINE_HPP

--- a/src/GuiBase/Viewer/Gizmo/GizmoManager.hpp
+++ b/src/GuiBase/Viewer/Gizmo/GizmoManager.hpp
@@ -27,6 +27,7 @@ class RA_GUIBASE_API GizmoManager : public QObject,
 
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     enum GizmoType { NONE, TRANSLATION, ROTATION, SCALE };
 
     explicit GizmoManager( QObject* parent = nullptr );

--- a/tests/unittest/Core/topomesh.cpp
+++ b/tests/unittest/Core/topomesh.cpp
@@ -291,4 +291,16 @@ TEST_CASE( "Core/Geometry/TopologicalMesh", "[Core][Core/Geometry][TopologicalMe
         REQUIRE( check1 );
         REQUIRE( check2 );
     }
+
+    // create a triangle mesh with 4 vertices
+
+    // add a float attrib
+
+    // convert to topomesh
+
+    // split middle edge
+
+    // check topology and interpolated values
+    // split boundary edge
+    // check topology and interpolated values
 }

--- a/tests/unittest/Core/topomesh.cpp
+++ b/tests/unittest/Core/topomesh.cpp
@@ -301,7 +301,7 @@ void test_split( TopologicalMesh& topo, TopologicalMesh::EdgeHandle eh, float f 
     auto he0 = topo.halfedge_handle( eh, 0 );
     auto he1 = topo.halfedge_handle( eh, 1 );
     auto v0  = topo.from_vertex_handle( he0 ); // i.e. to_vertex_handle(he1)
-    REQUIRE(v0 == topo.to_vertex_handle(he1));
+    REQUIRE( v0 == topo.to_vertex_handle( he1 ) );
     auto v1  = topo.to_vertex_handle( he0 );
     auto p0  = topo.point( v0 );
     float f0 = topo.getWedgeData( *( topo.getVertexWedges( v0 ) ).begin() ).m_floatAttrib[0];
@@ -319,7 +319,7 @@ void test_split( TopologicalMesh& topo, TopologicalMesh::EdgeHandle eh, float f 
 
     // he1 point to inserted vertex
     auto vsplit = topo.to_vertex_handle( he1 ); // i.e. from_vertex_handle(he0)
-    REQUIRE(vsplit == topo.from_vertex_handle(he0));
+    REQUIRE( vsplit == topo.from_vertex_handle( he0 ) );
 
     auto psplit = topo.point( vsplit );
     auto vcheck = ( f * p1 + ( 1.f - f ) * p0 );
@@ -347,6 +347,7 @@ TEST_CASE( "Core/Geometry/TopologicalMesh/EdgeSplit", "[Core][Core/Geometry][Top
     meshSplit.m_indices = {Vector3ui( 0, 1, 2 ), Vector3ui( 0, 2, 3 )};
     // add a float attrib
     auto handle = meshSplit.addAttrib<float>( "test", {0.f, 1.f, 2.f, 3.f} );
+    CORE_UNUSED( handle ); // until unit test is finished.
 
     // convert to topomesh
     TopologicalMesh topo = TopologicalMesh( meshSplit );
@@ -370,4 +371,5 @@ TEST_CASE( "Core/Geometry/TopologicalMesh/EdgeSplit", "[Core][Core/Geometry][Top
     test_split( topo, eh, f );
     // split boundary edge
     // collapse
+    // check float attrib value
 }

--- a/tests/unittest/Core/topomesh.cpp
+++ b/tests/unittest/Core/topomesh.cpp
@@ -10,14 +10,11 @@
 #include <OpenMesh/Tools/Decimater/ModQuadricT.hh>
 
 using namespace Ra::Core;
+using namespace Ra::Core::Utils;
 using namespace Ra::Core::Geometry;
 
 bool isSameMesh( Ra::Core::Geometry::TriangleMesh& meshOne,
                  Ra::Core::Geometry::TriangleMesh& meshTwo ) {
-
-    using Ra::Core::Vector3;
-    using Ra::Core::Geometry::TopologicalMesh;
-    using Ra::Core::Geometry::TriangleMesh;
 
     bool result = true;
     int i       = 0;
@@ -27,8 +24,8 @@ bool isSameMesh( Ra::Core::Geometry::TriangleMesh& meshOne,
     if ( meshOne.m_indices.size() != meshTwo.m_indices.size() ) return false;
 
     // Check triangles
-    std::vector<Ra::Core::Vector3> stackVertices;
-    std::vector<Ra::Core::Vector3> stackNormals;
+    std::vector<Vector3> stackVertices;
+    std::vector<Vector3> stackNormals;
 
     i = 0;
     while ( result && i < int( meshOne.m_indices.size() ) )
@@ -82,7 +79,7 @@ class WedgeDataAndIdx
     bool operator!=( const WedgeDataAndIdx& lhs ) const { return !( *this == lhs ); }
 };
 
-#define COPY_TO_WEDGES_VECTOR_HELPER( UPTYPE, DOWNTYPE, REALTYPE )                            \
+#define COPY_TO_WEDGES_VECTOR_HELPER( UPTYPE, REALTYPE )                                      \
     if ( attr->is##UPTYPE() )                                                                 \
     {                                                                                         \
         auto data =                                                                           \
@@ -105,18 +102,17 @@ void copyToWedgesVector( size_t size,
     }
     else if ( attr->getName() != std::string( "in_position" ) )
     {
-        auto data = meshOne.vertices();
-        for ( size_t i = 0; i < size; ++i )
         {
-            wedgesMeshOne[i].m_data.m_position = data[i];
+            auto data = meshOne.vertices();
+            for ( size_t i = 0; i < size; ++i )
+            {
+                wedgesMeshOne[i].m_data.m_position = data[i];
+            }
         }
-    }
-    if ( attr->getName() != std::string( "in_position" ) )
-    {
-        COPY_TO_WEDGES_VECTOR_HELPER( Float, float, float );
-        COPY_TO_WEDGES_VECTOR_HELPER( Vector2, vector2, Vector2 );
-        COPY_TO_WEDGES_VECTOR_HELPER( Vector3, vector3, Vector3 );
-        COPY_TO_WEDGES_VECTOR_HELPER( Vector4, vector4, Vector4 );
+        COPY_TO_WEDGES_VECTOR_HELPER( Float, float );
+        COPY_TO_WEDGES_VECTOR_HELPER( Vector2, Vector2 );
+        COPY_TO_WEDGES_VECTOR_HELPER( Vector3, Vector3 );
+        COPY_TO_WEDGES_VECTOR_HELPER( Vector4, Vector4 );
     }
 }
 #undef COPY_TO_WEDGES_VECTOR_HELPER

--- a/tests/unittest/Core/topomesh.cpp
+++ b/tests/unittest/Core/topomesh.cpp
@@ -194,7 +194,7 @@ void copyToWedgesVector( size_t size,
                 wedgesMeshOne[i].m_data.m_floatAttrib.push_back( data[i] );
             }
         }
-        else if ( attr->isVec2() )
+        else if ( attr->isVector2() )
         {
             auto data =
                 meshOne.getAttrib( meshOne.getAttribHandle<Vector2>( attr->getName() ) ).data();
@@ -203,7 +203,7 @@ void copyToWedgesVector( size_t size,
                 wedgesMeshOne[i].m_data.m_vector2Attrib.push_back( data[i] );
             }
         }
-        else if ( attr->isVec3() )
+        else if ( attr->isVector3() )
         {
             auto data =
                 meshOne.getAttrib( meshOne.getAttribHandle<Vector3>( attr->getName() ) ).data();
@@ -212,7 +212,7 @@ void copyToWedgesVector( size_t size,
                 wedgesMeshOne[i].m_data.m_vector3Attrib.push_back( data[i] );
             }
         }
-        else if ( attr->isVec4() )
+        else if ( attr->isVector4() )
         {
             auto data =
                 meshOne.getAttrib( meshOne.getAttribHandle<Vector4>( attr->getName() ) ).data();

--- a/tests/unittest/Core/topomesh.cpp
+++ b/tests/unittest/Core/topomesh.cpp
@@ -77,100 +77,9 @@ class WedgeDataAndIdx
     TopologicalMesh::WedgeData m_data;
     size_t m_idx;
 
-    // return 1 : equals, 2: strict less, 3: strich greater
-    int comp_vec( const Vector3& a, const Vector3& b ) const {
-        if ( a == b ) return 1;
-        if ( a[0] < b[0] || ( a[0] == b[0] && a[1] < b[1] ) ||
-             ( a[0] == b[0] && a[1] == b[1] && a[2] < b[2] ) )
-            return 2;
-        return 3;
-    }
-
-    int comp_vec( const Vector2& a, const Vector2& b ) const {
-        if ( a == b ) return 1;
-        if ( a[0] < b[0] || ( a[0] == b[0] && a[1] < b[1] ) ) return 2;
-        return 3;
-    }
-    int comp_vec( const Vector4& a, const Vector4& b ) const {
-        if ( a == b ) return 1;
-        if ( a[0] < b[0] || ( a[0] == b[0] && a[1] < b[1] ) ||
-             ( a[0] == b[0] && a[1] == b[1] && a[2] < b[2] ) ||
-             ( a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] < b[3] ) )
-            return 2;
-        return 3;
-    }
-
-    bool operator<( const WedgeDataAndIdx& lhs ) const {
-        {
-            int comp = comp_vec( m_data.m_position, lhs.m_data.m_position );
-            if ( comp == 2 ) return true;
-            if ( comp == 3 ) return false;
-        }
-        for ( size_t i = 0; i < m_data.m_floatAttrib.size(); i++ )
-        {
-            if ( m_data.m_floatAttrib[i] < lhs.m_data.m_floatAttrib[i] )
-                return true;
-            else if ( m_data.m_floatAttrib[i] > lhs.m_data.m_floatAttrib[i] )
-                return false;
-        }
-
-        for ( size_t i = 0; i < m_data.m_vector2Attrib.size(); i++ )
-        {
-            int comp = comp_vec( m_data.m_vector2Attrib[i], lhs.m_data.m_vector2Attrib[i] );
-            if ( comp == 2 ) return true;
-            if ( comp == 3 ) return false;
-        }
-        for ( size_t i = 0; i < m_data.m_vector3Attrib.size(); i++ )
-        {
-            int comp = comp_vec( m_data.m_vector3Attrib[i], lhs.m_data.m_vector3Attrib[i] );
-            if ( comp == 2 ) return true;
-            if ( comp == 3 ) return false;
-        }
-        for ( size_t i = 0; i < m_data.m_vector4Attrib.size(); i++ )
-        {
-            int comp = comp_vec( m_data.m_vector4Attrib[i], lhs.m_data.m_vector4Attrib[i] );
-            if ( comp == 2 ) return true;
-            if ( comp == 3 ) return false;
-        }
-        return false;
-    }
-
-    bool operator==( const WedgeDataAndIdx& lhs ) const { return !( *this != lhs ); }
-
-    bool operator!=( const WedgeDataAndIdx& lhs ) const {
-        {
-            int comp = comp_vec( m_data.m_position, lhs.m_data.m_position );
-            if ( comp == 2 ) return true;
-            if ( comp == 3 ) return true;
-        }
-        for ( size_t i = 0; i < m_data.m_floatAttrib.size(); i++ )
-        {
-            if ( m_data.m_floatAttrib[i] < lhs.m_data.m_floatAttrib[i] )
-                return true;
-            else if ( m_data.m_floatAttrib[i] > lhs.m_data.m_floatAttrib[i] )
-                return true;
-        }
-
-        for ( size_t i = 0; i < m_data.m_vector2Attrib.size(); i++ )
-        {
-            int comp = comp_vec( m_data.m_vector2Attrib[i], lhs.m_data.m_vector2Attrib[i] );
-            if ( comp == 2 ) return true;
-            if ( comp == 3 ) return true;
-        }
-        for ( size_t i = 0; i < m_data.m_vector3Attrib.size(); i++ )
-        {
-            int comp = comp_vec( m_data.m_vector3Attrib[i], lhs.m_data.m_vector3Attrib[i] );
-            if ( comp == 2 ) return true;
-            if ( comp == 3 ) return true;
-        }
-        for ( size_t i = 0; i < m_data.m_vector4Attrib.size(); i++ )
-        {
-            int comp = comp_vec( m_data.m_vector4Attrib[i], lhs.m_data.m_vector4Attrib[i] );
-            if ( comp == 2 ) return true;
-            if ( comp == 3 ) return true;
-        }
-        return false;
-    }
+    bool operator<( const WedgeDataAndIdx& lhs ) const { return m_data < lhs.m_data; }
+    bool operator==( const WedgeDataAndIdx& lhs ) const { return !( m_data != lhs.m_data ); }
+    bool operator!=( const WedgeDataAndIdx& lhs ) const { return !( *this == lhs ); }
 };
 
 #define COPY_TO_WEDGES_VECTOR_HELPER( UPTYPE, DOWNTYPE, REALTYPE )                            \
@@ -180,7 +89,7 @@ class WedgeDataAndIdx
             meshOne.getAttrib( meshOne.getAttribHandle<REALTYPE>( attr->getName() ) ).data(); \
         for ( size_t i = 0; i < size; ++i )                                                   \
         {                                                                                     \
-            wedgesMeshOne[i].m_data.m_##DOWNTYPE##Attrib.push_back( data[i] );                \
+            wedgesMeshOne[i].m_data.getAttribArray<REALTYPE>().push_back( data[i] );          \
         }                                                                                     \
     }
 

--- a/tests/unittest/Core/topomesh.cpp
+++ b/tests/unittest/Core/topomesh.cpp
@@ -334,9 +334,13 @@ TEST_CASE( "Core/Geometry/TopologicalMesh", "[Core][Core/Geometry][TopologicalMe
     topologicalMesh = TopologicalMesh( mesh );
     newMesh         = topologicalMesh.toTriangleMesh();
     newMesh2        = topologicalMesh.toTriangleMeshFromWedges();
+    topologicalMesh.setWedgeData( TopologicalMesh::WedgeIndex{0}, "in_normal", Vector3( 0, 0, 0 ) );
+    auto newMesh3 = topologicalMesh.toTriangleMeshFromWedges();
+
     REQUIRE( isSameMesh( mesh, newMesh ) );
     REQUIRE( isSameMesh( mesh, newMesh2 ) );
     REQUIRE( isSameMeshWedge( mesh, newMesh2 ) );
+    REQUIRE( !isSameMeshWedge( mesh, newMesh3 ) );
 
     // Test skip empty attributes
     mesh.addAttrib<float>( "empty" );

--- a/tests/unittest/Core/topomesh.cpp
+++ b/tests/unittest/Core/topomesh.cpp
@@ -215,11 +215,12 @@ TEST_CASE( "Core/Geometry/TopologicalMesh", "[Core][Core/Geometry][TopologicalMe
     // Test for close mesh
     mesh            = Ra::Core::Geometry::makeBox();
     topologicalMesh = TopologicalMesh( mesh );
-    newMesh         = topologicalMesh.toTriangleMesh();
     newMesh2        = topologicalMesh.toTriangleMeshFromWedges();
+    newMesh         = topologicalMesh.toTriangleMesh();
     REQUIRE( isSameMesh( mesh, newMesh ) );
     REQUIRE( isSameMesh( mesh, newMesh2 ) );
     REQUIRE( isSameMeshWedge( mesh, newMesh2 ) );
+    REQUIRE( topologicalMesh.checkIntegrity() );
 
     mesh            = Ra::Core::Geometry::makeSharpBox();
     topologicalMesh = TopologicalMesh( mesh );
@@ -228,6 +229,7 @@ TEST_CASE( "Core/Geometry/TopologicalMesh", "[Core][Core/Geometry][TopologicalMe
     REQUIRE( isSameMesh( mesh, newMesh ) );
     REQUIRE( isSameMesh( mesh, newMesh2 ) );
     REQUIRE( isSameMeshWedge( mesh, newMesh2 ) );
+    REQUIRE( topologicalMesh.checkIntegrity() );
 
     // Test for mesh with boundaries
     mesh            = Ra::Core::Geometry::makePlaneGrid( 2, 2 );
@@ -237,6 +239,7 @@ TEST_CASE( "Core/Geometry/TopologicalMesh", "[Core][Core/Geometry][TopologicalMe
     REQUIRE( isSameMesh( mesh, newMesh ) );
     REQUIRE( isSameMesh( mesh, newMesh2 ) );
     REQUIRE( isSameMeshWedge( mesh, newMesh2 ) );
+    REQUIRE( topologicalMesh.checkIntegrity() );
 
     mesh = Ra::Core::Geometry::makeCylinder( Vector3( 0, 0, 0 ), Vector3( 0, 0, 1 ), 1 );
 
@@ -250,12 +253,14 @@ TEST_CASE( "Core/Geometry/TopologicalMesh", "[Core][Core/Geometry][TopologicalMe
     REQUIRE( isSameMesh( mesh, newMesh2 ) );
     REQUIRE( isSameMeshWedge( mesh, newMesh2 ) );
     REQUIRE( !isSameMeshWedge( mesh, newMesh3 ) );
+    REQUIRE( topologicalMesh.checkIntegrity() );
 
     // Test skip empty attributes
     mesh.addAttrib<float>( "empty" );
     topologicalMesh = TopologicalMesh( mesh );
     newMesh         = topologicalMesh.toTriangleMesh();
     REQUIRE( !newMesh.hasAttrib( "empty" ) );
+    REQUIRE( topologicalMesh.checkIntegrity() );
 
     // Test normals
     mesh            = Ra::Core::Geometry::makeBox();
@@ -290,6 +295,7 @@ TEST_CASE( "Core/Geometry/TopologicalMesh", "[Core][Core/Geometry][TopologicalMe
         }
         REQUIRE( check1 );
         REQUIRE( check2 );
+        REQUIRE( topologicalMesh.checkIntegrity() );
     }
 
     // create a triangle mesh with 4 vertices
@@ -303,4 +309,6 @@ TEST_CASE( "Core/Geometry/TopologicalMesh", "[Core][Core/Geometry][TopologicalMe
     // check topology and interpolated values
     // split boundary edge
     // check topology and interpolated values
+
+    // collapse
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature : have explicit wedge management in topomesh. 
Should superspeed and replace current attrib/prop on halfedges

* **What is the current behavior?** (You can also link to an open issue here)
Halfedges store vertices attribs, with data duplication and no explicit wedge management

* **What is the new behavior (if this is a feature change)?**
Wedges are explicitly identified by indices on halfedges. If a vertex as the same data for all adjacent faces, the corresponding halfedges have the same wedge index. Wedge indices for a given vertex identify its data.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Sort of, even if after completion, client code should not change to much. But if you manipulate attrib/prop on topomesh, you will have to use wedge instead.

* **Other information**:
There are lots of todos ! help is welcome. Please do not comment to ask for doc or something, just do it ;) But if something is not clear, we can discuss it in this PR.

* **TODO**
- [x] topo to core mesh with data from wedges
- [ ] remove duplicate wedges (if after some modifications, some wedges should merged)
- [x] High level documentation on wedge concept
- [x] edge split
- [x] wedge data update (linear interpolation)
- [ ] remove deprecated attrib/prop mechanism
- [ ] cope with subdivision
- [ ] add a lot of unit tests ;)

