### PR TITLE
Viewer: check isExposed before swap.

### DIFF
--- a/src/GuiBase/Viewer/Viewer.cpp
+++ b/src/GuiBase/Viewer/Viewer.cpp
@@ -657,7 +657,7 @@ void Gui::Viewer::startRendering( const Scalar dt ) {
 }
 
 void Gui::Viewer::swapBuffers() {
-    m_context->swapBuffers( this );
+    if ( isExposed() ) { m_context->swapBuffers( this ); }
     doneCurrent();
 }
 


### PR DESCRIPTION


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
firsts draws raise a warning `QOpenGLContext::swapBuffers() called with non-exposed window, behavior is undefined`

* **What is the new behavior (if this is a feature change)?**
Test if viewer is exposed before swap

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no