### PR TITLE
BaseApplication: qt need a reference to argc !

### DIFF
--- a/src/GuiBase/BaseApplication.cpp
+++ b/src/GuiBase/BaseApplication.cpp
@@ -51,7 +51,7 @@ static const bool expectPluginsDebug = true;
 static const bool expectPluginsDebug = false;
 #endif
 
-BaseApplication::BaseApplication( int argc,
+BaseApplication::BaseApplication( int& argc,
                                   char** argv,
                                   const WindowFactory& factory,
                                   QString applicationName,

--- a/src/GuiBase/BaseApplication.hpp
+++ b/src/GuiBase/BaseApplication.hpp
@@ -53,7 +53,7 @@ class RA_GUIBASE_API BaseApplication : public QApplication
      * \param applicationName
      * \param organizationName
      */
-    BaseApplication( int argc,
+    BaseApplication( int& argc,
                      char** argv,
                      const WindowFactory& factory,
                      QString applicationName  = "RadiumEngine",


### PR DESCRIPTION
see https://doc.qt.io/qt-5/qapplication.html

"Warning: The data referred to by argc and argv must stay valid for the entire lifetime of the QApplication object. In addition, argc must be greater than zero and argv must contain at least one valid character string."

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
main-app, and all other BaseApplications, (segfault somtimes ...) 


* **What is the new behavior (if this is a feature change)?**
Fixed, 
But still need deferred opengl initialization (I will open an issue on that).

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

nope.

* **Other information**:
Hard to find ;)