### PR TITLE
 No need to set draw or read buffers …, fix #504

### DIFF
--- a/src/Engine/Renderer/Renderer.cpp
+++ b/src/Engine/Renderer/Renderer.cpp
@@ -177,8 +177,6 @@ void Renderer::initialize( uint width, uint height ) {
 
     resize( m_width, m_height );
 
-    glDrawBuffer( GL_BACK );
-    glReadBuffer( GL_BACK );
 }
 
 Renderer::PickingResult Renderer::doPickingNow( const PickingQuery& query,
@@ -563,12 +561,10 @@ void Renderer::restoreExternalFBOInternal() {
     if ( m_qtPlz == 0 )
     {
         GL_ASSERT( glBindFramebuffer( GL_FRAMEBUFFER, 0 ) );
-        glDrawBuffer( GL_BACK );
     }
     else
     {
         GL_ASSERT( glBindFramebuffer( GL_FRAMEBUFFER, m_qtPlz ) );
-        GL_ASSERT( glDrawBuffers( 1, buffers ) );
     }
 }
 


### PR DESCRIPTION
…on default framebuffers

UPDATE the form below to describe your PR.


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)
Application crashes when used with a single-buffered default framebuffer. 


* **What is the new behavior (if this is a feature change)?**
Application will no crash and keep the default framebuffer with its default configuration according to the openGL Spec.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
