### PR TITLE
Clean use of the PlainMaterial, fix #505

### DIFF
--- a/Shaders/Materials/Plain/Plain.vert.glsl
+++ b/Shaders/Materials/Plain/Plain.vert.glsl
@@ -5,6 +5,7 @@
 // declare expected attributes
 layout( location = 0 ) in vec3 in_position;
 layout( location = 1 ) in vec3 in_normal;
+layout( location = 2 ) in vec3 in_tangent;
 layout( location = 4 ) in vec3 in_texcoord;
 layout( location = 5 ) in vec4 in_color;
 
@@ -17,6 +18,7 @@ layout( location = 0 ) out vec3 out_position;
 layout( location = 1 ) out vec3 out_normal;
 layout( location = 2 ) out vec3 out_texcoord;
 layout( location = 3 ) out vec3 out_vertexcolor;
+layout( location = 4 ) out vec3 out_tangent;
 
 // Main function for vertex shader
 void main() {
@@ -44,4 +46,7 @@ void main() {
 
     vec3 normal = mat3( transform.worldNormal ) * in_normal;
     out_normal  = normal;
+
+    vec3 tangent = mat3( transform.model ) * in_tangent;
+    out_tangent = tangent;
 }

--- a/src/Engine/Renderer/Camera/Camera.cpp
+++ b/src/Engine/Renderer/Camera/Camera.cpp
@@ -17,7 +17,10 @@ using Core::Math::PiDiv4;
 namespace Engine {
 
 Camera::Camera( Entity* entity, const std::string& name, Scalar height, Scalar width ) :
-    Component( name, entity ), m_width{width}, m_height{height}, m_aspect{width / height} {}
+    Component( name, entity ),
+    m_width{width},
+    m_height{height},
+    m_aspect{width / height} {}
 
 Camera::~Camera() = default;
 
@@ -35,14 +38,11 @@ void Camera::initialize() {
                           {0_ra, .7_ra, -1_ra},
                           {.3_ra, .5_ra, -1_ra}} );
     triMesh.m_indices = {{0, 1, 2}, {0, 2, 3}, {0, 3, 4}, {0, 4, 1}, {5, 6, 7}};
-    Core::Vector4Array c( 8, {.2_ra, .2_ra, .2_ra, 1_ra} );
-    triMesh.addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ), c );
-
     m->loadGeometry( std::move( triMesh ) );
 
     // Create the RO
-    auto mat              = Core::make_shared<PlainMaterial>( m_name + "_Material" );
-    mat->m_perVertexColor = true;
+    auto mat     = Core::make_shared<PlainMaterial>( m_name + "_Material" );
+    mat->m_color = Color( .2_ra, .2_ra, .2_ra, 1_ra );
     RenderTechnique rt;
     auto cfg = ShaderConfigurationFactory::getConfiguration( "Plain" );
     rt.setConfiguration( *cfg );
@@ -75,7 +75,8 @@ void Camera::updateProjMatrix() {
 
     switch ( m_projType )
     {
-    case ProjType::ORTHOGRAPHIC: {
+    case ProjType::ORTHOGRAPHIC:
+    {
         const Scalar dx = m_zoomFactor * .5_ra;
         const Scalar dy = dx / m_aspect;
         // ------------
@@ -98,7 +99,8 @@ void Camera::updateProjMatrix() {
     }
     break;
 
-    case ProjType::PERSPECTIVE: {
+    case ProjType::PERSPECTIVE:
+    {
         // Compute projection matrix as describe in the doc of gluPerspective()
         const Scalar f    = std::tan( ( PiDiv2 ) - ( m_fov * m_zoomFactor * .5_ra ) );
         const Scalar diff = m_zNear - m_zFar;

--- a/src/GuiBase/Viewer/Gizmo/Gizmo.hpp
+++ b/src/GuiBase/Viewer/Gizmo/Gizmo.hpp
@@ -5,7 +5,6 @@
 #include <Core/Types.hpp>
 #include <Core/Utils/Index.hpp>
 #include <Engine/RadiumEngine.hpp>
-#include <Engine/Renderer/RenderObject/RenderObjectManager.hpp>
 
 namespace Ra {
 namespace Engine {
@@ -21,6 +20,7 @@ class RenderTechnique;
 namespace Ra {
 namespace Engine {
 class Camera;
+class Material;
 class Mesh;
 } // namespace Engine
 } // namespace Ra
@@ -92,27 +92,31 @@ class Gizmo
     //////////////////////////////
     // Render objects management
 
-    /// read access to the gizmo render objects id
-    inline const std::vector<Core::Utils::Index>& roIds() const { return m_renderObjects; }
-    /// read access to the gizmo render objects Meshes
-    /// \note Only the std::vector is const, which allows to modify the meshes
-    inline const std::vector<std::shared_ptr<Engine::Mesh>>& roMeshes() const { return m_meshes; }
+    /// read access to the gizmo render objects
+    /// \note Only the std::vector is const, which allows to modify the render objects.
+    inline const std::vector<Engine::RenderObject*>& ros() const { return m_ros; }
+
     /// add a render object to display the Gizmo
     /// \param mesh Except declaration type, must be equal to ro->getMesh();
-    void addRenderObject( Engine::RenderObject* ro, const std::shared_ptr<Engine::Mesh>& mesh );
+    void addRenderObject( Engine::RenderObject* ro );
+
+    /// Changes the material used to display the given RenderObject.
+    void changeMat( uint ro, uint mat );
 
     /// Generate a plain rendertechnique to draw the gizmo.
-    Engine::RenderTechnique* makeRenderTechnique( const std::string& mtlName,
-                                                  bool rtPerVertexColor );
+    static Engine::RenderTechnique* makeRenderTechnique();
 
   protected:
     Core::Transform m_worldTo;   ///< World to local space where the transform lives.
     Core::Transform m_transform; ///< Transform to be edited.
     Engine::Component* m_comp;   ///< Engine Ui component.
     Mode m_mode;                 ///< local or global.
+
+    /// The RenderTechnique used to diplay the gizmo: 1-Red, 2-Green, 3-Blue, 4-Yellow.
+    static std::array<std::shared_ptr<Ra::Engine::Material>, 4> s_material;
+
   private:
-    std::vector<Core::Utils::Index> m_renderObjects;     ///< ros for the gizmo.
-    std::vector<std::shared_ptr<Engine::Mesh>> m_meshes; ///< Display meshes of the gizmo
+    std::vector<Engine::RenderObject*> m_ros; ///< ros for the gizmo.
 };
 } // namespace Gui
 } // namespace Ra

--- a/src/GuiBase/Viewer/Gizmo/RotateGizmo.cpp
+++ b/src/GuiBase/Viewer/Gizmo/RotateGizmo.cpp
@@ -12,13 +12,13 @@
 namespace Ra {
 namespace Gui {
 
-const std::string colorAttribName = Engine::Mesh::getAttribName( Engine::Mesh::VERTEX_COLOR );
-
 RotateGizmo::RotateGizmo( Engine::Component* c,
                           const Core::Transform& worldTo,
                           const Core::Transform& t,
                           Mode mode ) :
-    Gizmo( c, worldTo, t, mode ), m_initialPix( Core::Vector2::Zero() ), m_selectedAxis( -1 ) {
+    Gizmo( c, worldTo, t, mode ),
+    m_initialPix( Core::Vector2::Zero() ),
+    m_selectedAxis( -1 ) {
     constexpr Scalar torusOutRadius   = .1_ra;
     constexpr Scalar torusAspectRatio = .08_ra;
     // For x,y,z
@@ -36,31 +36,21 @@ RotateGizmo::RotateGizmo( Engine::Component* c,
         }
         torus.verticesUnlock();
 
-        // set color
-        {
-            Core::Utils::Color color = Core::Utils::Color::Black();
-            color[i]                 = 1_ra;
-            auto colorAttribHandle   = torus.addAttrib<Core::Vector4>( colorAttribName );
-            torus.getAttrib( colorAttribHandle )
-                .setData( Core::Vector4Array( torus.vertices().size(), color ) );
-        }
-
         auto mesh = std::shared_ptr<Engine::Mesh>( new Engine::Mesh( "Gizmo Torus" ) );
         mesh->loadGeometry( std::move( torus ) );
 
-        Engine::RenderObject* arrowDrawable =
+        auto torusDrawable =
             new Engine::RenderObject( "Gizmo Torus", m_comp, Engine::RenderObjectType::UI );
 
-        std::shared_ptr<Engine::RenderTechnique> rt(
-            makeRenderTechnique( "Rotate Gizmo material",
-                                 mesh->getCoreGeometry().hasAttrib( Engine::Mesh::getAttribName(
-                                     Engine::Mesh::VERTEX_COLOR ) ) ) );
+        auto rt = std::shared_ptr<Engine::RenderTechnique>( makeRenderTechnique() );
 
-        arrowDrawable->setRenderTechnique( rt );
-        arrowDrawable->setMesh( mesh );
-        updateTransform( mode, m_worldTo, m_transform );
-        addRenderObject( arrowDrawable, mesh );
+        torusDrawable->setRenderTechnique( rt );
+        torusDrawable->setMesh( mesh );
+        addRenderObject( torusDrawable );
+        changeMat( i, i );
     }
+
+    updateTransform( mode, m_worldTo, m_transform );
 }
 
 void RotateGizmo::updateTransform( Gizmo::Mode mode,
@@ -80,38 +70,28 @@ void RotateGizmo::updateTransform( Gizmo::Mode mode,
         displayTransform.rotate( R );
     }
 
-    /// \fixme Cause multiple search in Ro map.
-    for ( auto roIdx : roIds() )
+    for ( auto ro : ros() )
     {
-        Engine::RadiumEngine::getInstance()
-            ->getRenderObjectManager()
-            ->getRenderObject( roIdx )
-            ->setLocalTransform( m_worldTo * displayTransform );
+        ro->setLocalTransform( m_worldTo * displayTransform );
     }
 }
 
 void RotateGizmo::selectConstraint( int drawableIdx ) {
-
     // reColor constraint
-    if ( m_selectedAxis != -1 )
-    {
-        Core::Utils::Color color = Core::Utils::Color::Black();
-        color[m_selectedAxis]    = 1_ra;
-        const auto& mesh         = roMeshes()[size_t( m_selectedAxis )];
-        mesh->getCoreGeometry().colorize( color );
-    }
+    if ( m_selectedAxis != -1 ) { changeMat( m_selectedAxis, m_selectedAxis ); }
+
     // prepare selection
     m_selectedAxis = -1;
-    if ( drawableIdx >= 0 )
+    if ( drawableIdx < 0 ) { return; }
+
+    // select the one
+    auto found = std::find_if( ros().cbegin(), ros().cend(), [drawableIdx]( const auto& ro ) {
+        return ro->getIndex() == Core::Utils::Index( drawableIdx );
+    } );
+    if ( found != ros().cend() )
     {
-        auto found =
-            std::find( roIds().cbegin(), roIds().cend(), Core::Utils::Index( drawableIdx ) );
-        if ( found != roIds().cend() )
-        {
-            m_selectedAxis   = int( std::distance( roIds().cbegin(), found ) );
-            const auto& mesh = roMeshes()[size_t( m_selectedAxis )];
-            mesh->getCoreGeometry().colorize( Core::Utils::Color::Yellow() );
-        }
+        m_selectedAxis = int( std::distance( ros().cbegin(), found ) );
+        changeMat( m_selectedAxis, 3 );
     }
 }
 


### PR DESCRIPTION
UPDATE the form below to describe your PR.

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix #505 .


* **What is the current behavior?** (You can also link to an open issue here)
Gizmos use the PlainMaterial, bt with the same color for each RO vertex.
When the Gizmo needs to change the color of its ROs, it changes the color of all the ROs vertices.

* **What is the new behavior (if this is a feature change)?**
Gizmos don't use per-vertex colors anymore.
The Gizmo class has 4 static PlainMaterials, one per axis with the corresponding RGB color, one for RO selection with yellow color.
When the Gizmo needs to change the color of its ROs, it just switches the Material.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
