### PR TITLE
Allow read-Only access to Shader renderParameter.

### DIFF
--- a/src/Engine/Renderer/RenderTechnique/RenderParameters.inl
+++ b/src/Engine/Renderer/RenderTechnique/RenderParameters.inl
@@ -22,5 +22,83 @@ inline void RenderParameters::TextureParameter::bind( const ShaderProgram* shade
     { shader->setUniform( m_name, m_texture, m_texUnit ); }
 }
 
+template <>
+inline const RenderParameters::UniformBindableSet<RenderParameters::IntParameter>&
+RenderParameters::getParameterSet() const {
+    return m_intParamsVector;
+}
+
+template <>
+inline const RenderParameters::UniformBindableSet<RenderParameters::UIntParameter>&
+RenderParameters::getParameterSet() const {
+    return m_uintParamsVector;
+}
+
+template <>
+inline const RenderParameters::UniformBindableSet<RenderParameters::ScalarParameter>&
+RenderParameters::getParameterSet() const {
+    return m_scalarParamsVector;
+}
+
+template <>
+inline const RenderParameters::UniformBindableSet<RenderParameters::IntsParameter>&
+RenderParameters::getParameterSet() const {
+    return m_intsParamsVector;
+}
+
+template <>
+inline const RenderParameters::UniformBindableSet<RenderParameters::UIntsParameter>&
+RenderParameters::getParameterSet() const {
+    return m_uintsParamsVector;
+}
+
+template <>
+inline const RenderParameters::UniformBindableSet<RenderParameters::ScalarsParameter>&
+RenderParameters::getParameterSet() const {
+    return m_scalarsParamsVector;
+}
+
+template <>
+inline const RenderParameters::UniformBindableSet<RenderParameters::Vec2Parameter>&
+RenderParameters::getParameterSet() const {
+    return m_vec2ParamsVector;
+}
+
+template <>
+inline const RenderParameters::UniformBindableSet<RenderParameters::Vec3Parameter>&
+RenderParameters::getParameterSet() const {
+    return m_vec3ParamsVector;
+}
+
+template <>
+inline const RenderParameters::UniformBindableSet<RenderParameters::Vec4Parameter>&
+RenderParameters::getParameterSet() const {
+    return m_vec4ParamsVector;
+}
+
+template <>
+inline const RenderParameters::UniformBindableSet<RenderParameters::Mat2Parameter>&
+RenderParameters::getParameterSet() const {
+    return m_mat2ParamsVector;
+}
+
+template <>
+inline const RenderParameters::UniformBindableSet<RenderParameters::Mat3Parameter>&
+RenderParameters::getParameterSet() const {
+    return m_mat3ParamsVector;
+}
+
+template <>
+inline const RenderParameters::UniformBindableSet<RenderParameters::Mat4Parameter>&
+RenderParameters::getParameterSet() const {
+    return m_mat4ParamsVector;
+}
+
+template <>
+inline const RenderParameters::UniformBindableSet<RenderParameters::TextureParameter>&
+RenderParameters::getParameterSet() const {
+    return m_texParamsVector;
+}
+
 } // namespace Engine
 } // namespace Ra


### PR DESCRIPTION
This PR add basic functionalities to allow material parameters inspection.
This is a first sketch that allow to develop scene exporters. 
See the GLTF2.0 private plugin for a usage example.

UPDATE the form below to describe your PR.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
