### PR TITLE
Fix #519

### DIFF
--- a/src/Engine/Renderer/RenderTechnique/RenderTechnique.cpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderTechnique.cpp
@@ -82,7 +82,7 @@ void RenderTechnique::updateGL() {
         {
             m_activePasses[p].second =
                 ShaderProgramManager::getInstance()->getShaderProgram( m_activePasses[p].first );
-            m_dirtyBits |= ( 1 << p );
+            m_dirtyBits &= ~( 1 << p );
         }
     }
     for ( auto p = Index( 0 ); p < m_numActivePass; ++p )


### PR DESCRIPTION
dirty bit was not reset on a pass of a renderTechnique after OpenGL Update.

* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix (see issue #519)


* **What is the current behavior?** (You can also link to an open issue here)
dirty bit on RenderTechnique/pass was not reset


* **What is the new behavior (if this is a feature change)?**
dirty bit on RenderTechnique/pass  is reset
