### PR TITLE
Shader parameter provider can add #define to the shader

### DIFF
--- a/cmake/filelistEngine.cmake
+++ b/cmake/filelistEngine.cmake
@@ -118,6 +118,7 @@ set( engine_inlines
     Renderer/Material/VolumetricMaterial.inl
     Renderer/Mesh/Mesh.inl
     Renderer/RenderTechnique/RenderParameters.inl
+    Renderer/RenderTechnique/RenderTechnique.inl
 )
 
 set(engine_shaders

--- a/src/Engine/Renderer/Material/Material.cpp
+++ b/src/Engine/Renderer/Material/Material.cpp
@@ -14,5 +14,9 @@ Material::Material( const std::string& instanceName,
 bool Material::isTransparent() const {
     return m_aspect == MaterialAspect::MAT_TRANSPARENT;
 }
+
+std::list<std::string> Material::getPropertyList() const {
+    return ShaderParameterProvider::getPropertyList();
+}
 } // namespace Engine
 } // namespace Ra

--- a/src/Engine/Renderer/Material/Material.hpp
+++ b/src/Engine/Renderer/Material/Material.hpp
@@ -77,6 +77,18 @@ class RA_ENGINE_API Material : public ShaderParameterProvider
      */
     virtual bool isTransparent() const;
 
+    /**
+     * Get the list of properties the material migh use in a shader.
+     * each property will be added to the shader used for rendering this material under the form
+     * "#define theProperty". Shaders that support the given property could then fully render the
+     * material. Others migh render the meterial eroneously.
+     *
+     * The defaul implementation returns an empty list.
+     *
+     * @todo : Validate this proposal
+     */
+    std::list<std::string> getPropertyList() const override;
+
     /** Mark the Material as needing update before the next OpenGL call
      *
      */

--- a/src/Engine/Renderer/RenderTechnique/RenderParameters.cpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderParameters.cpp
@@ -127,5 +127,8 @@ void RenderParameters::concatParameters( const RenderParameters& params ) {
     }
 }
 
+std::list<std::string> ShaderParameterProvider::getPropertyList() const {
+    return {};
+}
 } // namespace Engine
 } // namespace Ra

--- a/src/Engine/Renderer/RenderTechnique/RenderParameters.cpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderParameters.cpp
@@ -127,8 +127,5 @@ void RenderParameters::concatParameters( const RenderParameters& params ) {
     }
 }
 
-std::list<std::string> ShaderParameterProvider::getPropertyList() const {
-    return {};
-}
 } // namespace Engine
 } // namespace Ra

--- a/src/Engine/Renderer/RenderTechnique/RenderParameters.hpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderParameters.hpp
@@ -224,6 +224,17 @@ class ShaderParameterProvider
      */
     virtual void updateGL() = 0;
 
+    /**
+     * Get the list of properties the provider migh use  in a shader.
+     * Each property will be added to the shader used for rendering under the form
+     * "#define theProperty" when the provider is associated with the render technique.
+     *
+     * The defaul implementation returns an empty list.
+     *
+     * @todo : Validate this proposal
+     */
+    virtual std::list<std::string> getPropertyList() const;
+
   protected:
     /// The parameters to set for a shader
     RenderParameters m_renderParameters;

--- a/src/Engine/Renderer/RenderTechnique/RenderParameters.hpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderParameters.hpp
@@ -211,7 +211,7 @@ class RA_ENGINE_API RenderParameters final
  * rendertechnique, the ShaderParameterProvider associated to the renderTechnique is responsible to
  * set all the uniforms needed by the rendertechnique.
  */
-class ShaderParameterProvider
+class RA_ENGINE_API ShaderParameterProvider
 {
   public:
     virtual ~ShaderParameterProvider() = default;
@@ -233,7 +233,7 @@ class ShaderParameterProvider
      *
      * @todo : Validate this proposal
      */
-    virtual std::list<std::string> getPropertyList() const;
+    virtual std::list<std::string> getPropertyList() const { return {}; };
 
   protected:
     /// The parameters to set for a shader

--- a/src/Engine/Renderer/RenderTechnique/RenderTechnique.cpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderTechnique.cpp
@@ -26,7 +26,7 @@ RenderTechnique::RenderTechnique( const RenderTechnique& o ) :
     m_numActivePass{o.m_numActivePass}, m_dirtyBits{o.m_dirtyBits}, m_setPasses{o.m_setPasses} {
     for ( auto p = Index( 0 ); p < m_numActivePass; ++p )
     {
-        if ( m_setPasses & ( 1 << p ) )
+        if ( hasConfiguration( p ) )
         {
             m_activePasses[p]     = o.m_activePasses[p];
             m_passesParameters[p] = o.m_passesParameters[p];
@@ -40,12 +40,12 @@ void RenderTechnique::setConfiguration( const ShaderConfiguration& newConfig,
                                         Core::Utils::Index pass ) {
     m_numActivePass      = std::max( m_numActivePass, pass + 1 );
     m_activePasses[pass] = std::move( PassConfiguration( newConfig, nullptr ) );
-    m_dirtyBits |= ( 1 << pass );
-    m_setPasses |= ( 1 << pass );
+    setDirty( pass );
+    setConfiguration( pass );
 }
 
 const ShaderProgram* RenderTechnique::getShader( Core::Utils::Index pass ) const {
-    if ( m_setPasses & ( 1 << pass ) ) { return m_activePasses[pass].second; }
+    if ( hasConfiguration( pass ) ) { return m_activePasses[pass].second; }
     return nullptr;
 }
 
@@ -58,12 +58,15 @@ void RenderTechnique::setParametersProvider(
             << "Unable to set pass parameters : is passes configured using setConfiguration ? ";
         return;
     }
-    if ( pass.isValid() ) { m_passesParameters[pass] = provider; }
+    if ( pass.isValid() )
+    {
+        if ( hasConfiguration( pass ) ) { m_passesParameters[pass] = provider; }
+    }
     else
     {
         for ( int i = 0; i < m_numActivePass; ++i )
         {
-            m_passesParameters[i] = provider;
+            if ( hasConfiguration( i ) ) { m_passesParameters[i] = provider; }
         }
     }
     // add the provider specific properties to the configuration
@@ -78,19 +81,19 @@ void RenderTechnique::addPassProperties( const std::list<std::string>& props,
             << "Unable to set pass properties : is passes configured using setConfiguration ? ";
         return;
     }
-    if ( pass.isValid() && ( m_setPasses & ( 1 << pass ) ) )
+    if ( pass.isValid() && hasConfiguration( pass ) )
     {
         m_activePasses[pass].first.addProperties( props );
-        m_dirtyBits |= ( 1 << pass );
+        setDirty( pass );
     }
     else
     {
         for ( int i = 0; i < m_numActivePass; ++i )
         {
-            if ( m_setPasses & ( 1 << i ) )
+            if ( hasConfiguration( i ) )
             {
                 m_activePasses[i].first.addProperties( props );
-                m_dirtyBits |= ( 1 << i );
+                setDirty( i );
             }
         }
     }
@@ -98,37 +101,24 @@ void RenderTechnique::addPassProperties( const std::list<std::string>& props,
 
 const ShaderParameterProvider*
 RenderTechnique::getParametersProvider( Core::Utils::Index pass ) const {
-    if ( m_setPasses & ( 1 << pass ) ) { return m_passesParameters[pass].get(); }
+    if ( hasConfiguration( pass ) ) { return m_passesParameters[pass].get(); }
     return nullptr;
 }
 
 void RenderTechnique::updateGL() {
     for ( auto p = Index( 0 ); p < m_numActivePass; ++p )
     {
-        if ( ( m_setPasses & ( 1 << p ) ) &&
-             ( ( nullptr == m_activePasses[p].second ) || ( m_dirtyBits & ( 1 << p ) ) ) )
+        if ( hasConfiguration( p ) && ( ( nullptr == m_activePasses[p].second ) || isDirty( p ) ) )
         {
             m_activePasses[p].second =
                 ShaderProgramManager::getInstance()->getShaderProgram( m_activePasses[p].first );
-            m_dirtyBits &= ~( 1 << p );
+            clearDirty( p );
         }
     }
     for ( auto p = Index( 0 ); p < m_numActivePass; ++p )
     {
         if ( m_passesParameters[p] ) { m_passesParameters[p]->updateGL(); }
     }
-}
-
-bool RenderTechnique::hasConfiguration( Core::Utils::Index pass ) const {
-    return m_setPasses & ( 1 << pass );
-}
-
-const ShaderConfiguration& RenderTechnique::getConfiguration( Core::Utils::Index pass ) const {
-    return m_activePasses[pass].first;
-}
-
-bool RenderTechnique::shaderIsDirty( Core::Utils::Index pass ) const {
-    return m_dirtyBits & ( 1 << pass );
 }
 
 ///////////////////////////////////////////////

--- a/src/Engine/Renderer/RenderTechnique/RenderTechnique.cpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderTechnique.cpp
@@ -66,6 +66,34 @@ void RenderTechnique::setParametersProvider(
             m_passesParameters[i] = provider;
         }
     }
+    // add the provider specific properties to the configuration
+    addPassProperties( provider->getPropertyList() );
+}
+
+void RenderTechnique::addPassProperties( const std::list<std::string>& props,
+                                         Core::Utils::Index pass ) {
+    if ( m_numActivePass == 0 )
+    {
+        LOG( logERROR )
+            << "Unable to set pass properties : is passes configured using setConfiguration ? ";
+        return;
+    }
+    if ( pass.isValid() && ( m_setPasses & ( 1 << pass ) ) )
+    {
+        m_activePasses[pass].first.addProperties( props );
+        m_dirtyBits |= ( 1 << pass );
+    }
+    else
+    {
+        for ( int i = 0; i < m_numActivePass; ++i )
+        {
+            if ( m_setPasses & ( 1 << i ) )
+            {
+                m_activePasses[i].first.addProperties( props );
+                m_dirtyBits |= ( 1 << i );
+            }
+        }
+    }
 }
 
 const ShaderParameterProvider*

--- a/src/Engine/Renderer/RenderTechnique/RenderTechnique.hpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderTechnique.hpp
@@ -133,6 +133,13 @@ class RA_ENGINE_API RenderTechnique final
     bool shaderIsDirty( Core::Utils::Index pass = DefaultRenderingPasses::LIGHTING_OPAQUE ) const;
 
     /**
+     * Add properties (several #define in the shader) for the given pass
+     * @param props the properties list, only strings without the #define
+     * @param pass the pass. If left by default, all active passes will get the properties
+     */
+    void addPassProperties( const std::list<std::string>& props,
+                            Core::Utils::Index pass = Core::Utils::Index( -1 ) );
+    /**
      * Creates a default technique based on the ForwarRenderer sementic.
      *  pass 1 --> Z_PREPASS
      *  pass 0 --> LIGHTING_OPAQUE

--- a/src/Engine/Renderer/RenderTechnique/RenderTechnique.hpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderTechnique.hpp
@@ -83,14 +83,29 @@ class RA_ENGINE_API RenderTechnique final
      * @param pass The index of the pass
      * @return true if the pass was configured
      */
-    bool hasConfiguration( Core::Utils::Index pass ) const;
+    inline bool
+    hasConfiguration( Core::Utils::Index pass = DefaultRenderingPasses::LIGHTING_OPAQUE ) const;
+
+    /**
+     * Mark the given configured.
+     * @param pass The index of the pass
+     */
+    inline void
+    setConfiguration( Core::Utils::Index pass = DefaultRenderingPasses::LIGHTING_OPAQUE );
+
+    /**
+     * Mark the given not configured.
+     * @param pass The index of the pass
+     */
+    inline void
+    clearConfiguration( Core::Utils::Index pass = DefaultRenderingPasses::LIGHTING_OPAQUE );
 
     /**
      * Get the configuration of the given pass
      * @param pass The index of the pass
      * @return The pass shader configuration
      */
-    const ShaderConfiguration&
+    inline const ShaderConfiguration&
     getConfiguration( Core::Utils::Index pass = DefaultRenderingPasses::LIGHTING_OPAQUE ) const;
 
     /**
@@ -130,7 +145,19 @@ class RA_ENGINE_API RenderTechnique final
      * @param pass The index of the pass
      * @return Tru if pass must be updated.
      */
-    bool shaderIsDirty( Core::Utils::Index pass = DefaultRenderingPasses::LIGHTING_OPAQUE ) const;
+    inline bool isDirty( Core::Utils::Index pass = DefaultRenderingPasses::LIGHTING_OPAQUE ) const;
+
+    /**
+     * Set the given pass dirty (openGL state not updated)
+     * @param pass The index of the pass
+     */
+    inline void setDirty( Core::Utils::Index pass = DefaultRenderingPasses::LIGHTING_OPAQUE );
+
+    /**
+     * Clear the dirty bit for the given pass (openGL state updated)
+     * @param pass The index of the pass
+     */
+    inline void clearDirty( Core::Utils::Index pass = DefaultRenderingPasses::LIGHTING_OPAQUE );
 
     /**
      * Add properties (several #define in the shader) for the given pass
@@ -209,5 +236,6 @@ getDefaultTechnique( const std::string& name );
 RA_ENGINE_API bool cleanup();
 } // namespace EngineRenderTechniques
 
+#include <Engine/Renderer/RenderTechnique/RenderTechnique.inl>
 } // namespace Engine
 } // namespace Ra

--- a/src/Engine/Renderer/RenderTechnique/RenderTechnique.inl
+++ b/src/Engine/Renderer/RenderTechnique/RenderTechnique.inl
@@ -1,0 +1,37 @@
+/**
+ * Test if the given pass is dirty (openGL state not updated)
+ * @param pass The index of the pass
+ * @return Tru if pass must be updated.
+ */
+inline bool RenderTechnique::isDirty( Core::Utils::Index pass ) const {
+    return m_dirtyBits & ( 1 << pass );
+}
+
+/**
+ * Set the given pass dirty (openGL state updated)
+ * @param pass The index of the pass
+ */
+inline void RenderTechnique::setDirty( Core::Utils::Index pass ) {
+    m_dirtyBits |= ( 1 << pass );
+}
+
+inline void RenderTechnique::clearDirty( Core::Utils::Index pass ) {
+    m_dirtyBits &= ~( 1 << pass );
+}
+
+inline bool RenderTechnique::hasConfiguration( Core::Utils::Index pass ) const {
+    return m_setPasses & ( 1 << pass );
+}
+
+inline void RenderTechnique::setConfiguration( Core::Utils::Index pass ) {
+    m_setPasses |= ( 1 << pass );
+}
+
+inline void RenderTechnique::clearConfiguration( Core::Utils::Index pass ) {
+    m_setPasses &= ~( 1 << pass );
+}
+
+inline const ShaderConfiguration&
+RenderTechnique::getConfiguration( Core::Utils::Index pass ) const {
+    return m_activePasses[pass].first;
+}


### PR DESCRIPTION
This is related to issue/feature request #518 and must come after PR #520.

This PR allow to add  several `#define PROPERTY` to a shader configuration from a ShaderParameterProvide when the provider is associated to a pass.
This PR must be discussed to study its extensibility to other source elements (#include, snippets, ...)


* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.
