### PR TITLE
Fix compilation error with Qt version < 5.10.0

### DIFF
--- a/src/GuiBase/Utils/KeyMappingManager.cpp
+++ b/src/GuiBase/Utils/KeyMappingManager.cpp
@@ -3,6 +3,8 @@
 #include <Core/Resources/Resources.hpp>
 #include <Core/Utils/Log.hpp>
 
+#include <QtGlobal> //QT_VERSION, QT_VERSION_CHECK
+
 namespace Ra::Gui {
 
 using namespace Core::Utils; // log
@@ -75,8 +77,16 @@ void KeyMappingManager::addAction( const std::string& context,
     QString xmlAction;
     QTextStream s( &xmlAction );
     s << elementToAdd;
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+    QString xmlActionChopped = xmlAction;
+    xmlActionChopped.chop( 1 );
+    LOG( logDEBUG ) << "KeyMappingManager : adding The action  "
+                    << xmlActionChopped.toStdString();
+    
+#else
     LOG( logDEBUG ) << "KeyMappingManager : adding The action  "
                     << xmlAction.chopped( 1 ).toStdString();
+#endif
 
     domElement.appendChild( elementToAdd );
     saveConfiguration();


### PR DESCRIPTION
Restrict use of Qstring::chopped if Qt version is more than 5.10

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Compilation fails if compiled with qt < 5.10, due to call to `QString::chopped` (introduced in Qt 5.10)
https://doc.qt.io/qt-5/qstring.html#chopped

* **What is the new behavior (if this is a feature change)?**
Use `QString::chop` for old versions of Qt.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
