### PR TITLE
Skip non-plugin dynamic libraries when loading plugins.

### DIFF
--- a/src/GuiBase/BaseApplication.cpp
+++ b/src/GuiBase/BaseApplication.cpp
@@ -557,10 +557,14 @@ bool BaseApplication::loadPlugins( const std::string& pluginsPath,
             // Force symbol resolution at load time.
             pluginLoader.setLoadHints( QLibrary::ResolveAllSymbolsHint );
 
+            // Looking for Radium plugin signature on metadata
             auto metadata = pluginLoader.metaData()["MetaData"].toObject();
-            if ( metadata.isEmpty() ) { continue; } // Not a Radium plugin, skip the file
-
-            LOG( logINFO ) << "Found plugin " << filename.toStdString();
+            if ( metadata.isEmpty() || !metadata.contains( "com.storm-irit.RadiumEngine" ) ||
+                 metadata["com.storm-irit.RadiumEngine"].toString().compare( "plugin" ) != 0 )
+            {
+                LOG( logDEBUG ) << "File " << filename.toStdString() << " is not a Radium plugin.";
+                continue;
+            }
 
             // detect if the plugin meets the minimal requirements
             // if not, triggers a QDialog explaining the error, and abort the application
@@ -579,6 +583,7 @@ bool BaseApplication::loadPlugins( const std::string& pluginsPath,
             bool isPluginDebug = metadata["isDebug"].toString().compare( "true" ) == 0;
             if ( expectPluginsDebug == isPluginDebug )
             {
+                LOG( logINFO ) << "Found plugin " << filename.toStdString();
                 // load the plugin
                 QObject* plugin = pluginLoader.instance();
                 if ( plugin )
@@ -620,8 +625,8 @@ bool BaseApplication::loadPlugins( const std::string& pluginsPath,
                         {
                             if ( m_viewer->isOpenGlInitialized() )
                             {
-                                LOG( logINFO ) << "Direct OpenGL initialization for plugin "
-                                               << filename.toStdString();
+                                LOG( logDEBUG ) << "Direct OpenGL initialization for plugin "
+                                                << filename.toStdString();
                                 // OpenGL is ready, initialize openGL part of the plugin
                                 m_viewer->makeCurrent();
                                 loadedPlugin->openGlInitialize( m_pluginContext );
@@ -630,8 +635,8 @@ bool BaseApplication::loadPlugins( const std::string& pluginsPath,
                             else
                             {
                                 // Defer OpenGL initialisation
-                                LOG( logINFO ) << "Defered OpenGL initialization for plugin "
-                                               << filename.toStdString();
+                                LOG( logDEBUG ) << "Defered OpenGL initialization for plugin "
+                                                << filename.toStdString();
                                 m_openGLPlugins.push_back( loadedPlugin );
                             }
                         }

--- a/src/GuiBase/BaseApplication.cpp
+++ b/src/GuiBase/BaseApplication.cpp
@@ -557,9 +557,10 @@ bool BaseApplication::loadPlugins( const std::string& pluginsPath,
             // Force symbol resolution at load time.
             pluginLoader.setLoadHints( QLibrary::ResolveAllSymbolsHint );
 
-            LOG( logINFO ) << "Found plugin " << filename.toStdString();
-
             auto metadata = pluginLoader.metaData()["MetaData"].toObject();
+            if ( metadata.isEmpty() ) { continue; } // Not a Radium plugin, skip the file
+
+            LOG( logINFO ) << "Found plugin " << filename.toStdString();
 
             // detect if the plugin meets the minimal requirements
             // if not, triggers a QDialog explaining the error, and abort the application

--- a/src/PluginBase/pluginMetaDataDebug.json
+++ b/src/PluginBase/pluginMetaDataDebug.json
@@ -1,1 +1,4 @@
-{ "isDebug": "true" }
+{
+  "com.storm-irit.RadiumEngine": "plugin",
+  "isDebug": "true"
+}

--- a/src/PluginBase/pluginMetaDataRelease.json
+++ b/src/PluginBase/pluginMetaDataRelease.json
@@ -1,1 +1,4 @@
-{ "isDebug": "false" }
+{
+  "com.storm-irit.RadiumEngine": "plugin",
+  "isDebug": "false"
+}


### PR DESCRIPTION
UPDATE the form below to describe your PR.


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Allow to load plugins even if there are non-plugin dynamic libraries in the searched directories.


* **What is the current behavior?** (You can also link to an open issue here)
When a directory searched by BaseApplication when loading plugins contains dynamic libraries that are not Radium Plugin, the application stops with an error message. This prevent storing plugins and their dependences in the same directory.


* **What is the new behavior (if this is a feature change)?**
When a dynamic library that is not a Radium plugin is found, the file is just skipped instead of raising an error.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:

Beware that when this PR will be accepted, all plugins have to be configured again (and compiled again) to bring the modified radium plugin metadata json file into the  plugin buildtree.