### PR TITLE
[cmake] Export dependency to OpenMP only when required

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -31,7 +31,9 @@ ENDIF("${isSystemDir}" STREQUAL "-1")
 
 include(CMakeFindDependencyMacro)
 find_dependency(Threads REQUIRED)
-find_dependency(OpenMP REQUIRED)
+if(@OPENMP_FOUND@) # Indicates if OpenMP has been used when compiling the Radium libraries
+    find_dependency(OpenMP REQUIRED)
+endif()
 # Theses paths reflect the paths founds in RadiumEngine/src/Core/external/package
 set(Eigen3_DIR    "${CMAKE_CURRENT_LIST_DIR}/../../../share/eigen3/cmake/")
 set(OpenMesh_DIR  "${CMAKE_CURRENT_LIST_DIR}/../../../share/OpenMesh/cmake/")
@@ -90,11 +92,11 @@ if(IO_FOUND)
     if( depAssimpFound GREATER_EQUAL "0")
         set(assimp_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../lib/cmake/assimp-5.0/")
         find_dependency(assimp 5.0 REQUIRED NO_DEFAULT_PATH)
-	# Assimp do not have minsizerel nor relwithdebinfo target, so map it to release (\todo deep check)
-	set_target_properties(assimp::assimp PROPERTIES
-	  MAP_IMPORTED_CONFIG_MINSIZEREL Release
-	  MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
-	)
+        # Assimp do not have minsizerel nor relwithdebinfo target, so map it to release (\todo deep check)
+        set_target_properties(assimp::assimp PROPERTIES
+          MAP_IMPORTED_CONFIG_MINSIZEREL Release
+          MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
+        )
 
     endif()
     if( depTinyPLYFound GREATER_EQUAL "0")


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix issue #533 


* **What is the current behavior?** (You can also link to an open issue here)
CMake package forces the dependency with OpenMP, which makes it unusable when not available. 

* **What is the new behavior (if this is a feature change)?**
Export dependency only when OpenMP is used when compiling Radium


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
