### PR TITLE
Fix normals for TriangleMeshComponent ;

### DIFF
--- a/src/Engine/Component/GeometryComponent.cpp
+++ b/src/Engine/Component/GeometryComponent.cpp
@@ -48,7 +48,8 @@ const Index* GeometryComponent::roIndexRead() const {
 TriangleMeshComponent::TriangleMeshComponent( const std::string& name,
                                               Entity* entity,
                                               const Ra::Core::Asset::GeometryData* data ) :
-    GeometryComponent( name, entity ), m_displayMesh( nullptr ) {
+    GeometryComponent( name, entity ),
+    m_displayMesh( nullptr ) {
     generateTriangleMesh( data );
 }
 
@@ -56,7 +57,8 @@ TriangleMeshComponent::TriangleMeshComponent( const std::string& name,
                                               Entity* entity,
                                               Core::Geometry::TriangleMesh&& mesh,
                                               Core::Asset::MaterialData* mat ) :
-    GeometryComponent( name, entity ), m_displayMesh( new Engine::Mesh( name ) ) {
+    GeometryComponent( name, entity ),
+    m_displayMesh( new Engine::Mesh( name ) ) {
     setContentName( name );
     m_displayMesh->loadGeometry( std::move( mesh ) );
     finalizeROFromGeometry( mat );
@@ -93,9 +95,9 @@ void TriangleMeshComponent::generateTriangleMesh( const Ra::Core::Asset::Geometr
         vertices[i] = T * data->getVertices()[i];
     }
 
+    normals.resize( data->getVerticesSize(), Ra::Core::Vector3::Zero() );
     if ( data->hasNormals() )
     {
-        normals.resize( data->getVerticesSize(), Ra::Core::Vector3::Zero() );
 #pragma omp parallel for
         for ( int i = 0; i < int( data->getVerticesSize() ); ++i )
         {
@@ -202,7 +204,8 @@ Ra::Core::Geometry::TriangleMesh* TriangleMeshComponent::getMeshRw() {
 PointCloudComponent::PointCloudComponent( const std::string& name,
                                           Entity* entity,
                                           const Ra::Core::Asset::GeometryData* data ) :
-    GeometryComponent( name, entity ), m_displayMesh( nullptr ) {
+    GeometryComponent( name, entity ),
+    m_displayMesh( nullptr ) {
     generatePointCloud( data );
 }
 
@@ -210,7 +213,8 @@ PointCloudComponent::PointCloudComponent( const std::string& name,
                                           Entity* entity,
                                           Core::Geometry::PointCloud&& mesh,
                                           Core::Asset::MaterialData* mat ) :
-    GeometryComponent( name, entity ), m_displayMesh( new Engine::PointCloud( name ) ) {
+    GeometryComponent( name, entity ),
+    m_displayMesh( new Engine::PointCloud( name ) ) {
     m_displayMesh->loadGeometry( std::move( mesh ) );
     finalizeROFromGeometry( mat );
 }
@@ -348,7 +352,8 @@ Ra::Core::Geometry::PointCloud* PointCloudComponent::getPointCloudRw() {
 VolumeComponent::VolumeComponent( const std::string& name,
                                   Entity* entity,
                                   const Ra::Core::Asset::VolumeData* data ) :
-    Component( name, entity ), m_displayVolume{nullptr} {
+    Component( name, entity ),
+    m_displayVolume{nullptr} {
     generateVolumeRender( data );
 }
 


### PR DESCRIPTION
UPDATE the form below to describe your PR.


* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.
The doc about `AttribArrayGeometry` says that `Points and Normals, defining the geometry, are always present.`
But this is not always the case with the `TriangleMeshComponent`.

* **What is the current behavior?** (You can also link to an open issue here)
When building a `TriangleMeshComponent` from a `GeometryData`, the created `TriangleMesh` might not have normals if the `GeometryData` does not provide them.

* **What is the new behavior (if this is a feature change)?**
When building a `TriangleMeshComponent` from a `GeometryData`, the created `TriangleMesh` will have normals initialized to 0 if the `GeometryData` does not provide them.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
