### PR TITLE
Fix Mesh pre-transform problem.

### DIFF
--- a/src/Engine/Component/GeometryComponent.cpp
+++ b/src/Engine/Component/GeometryComponent.cpp
@@ -2,11 +2,9 @@
 
 #include <iostream>
 
-#include <Core/Asset/FileData.hpp>
 #include <Core/Asset/GeometryData.hpp>
 #include <Core/Containers/MakeShared.hpp>
 #include <Core/Geometry/Normal.hpp>
-#include <Core/Resources/Resources.hpp>
 #include <Core/Utils/Color.hpp>
 #include <Core/Utils/Log.hpp>
 
@@ -17,14 +15,10 @@
 #include <Engine/Renderer/Material/MaterialConverters.hpp>
 #include <Engine/Renderer/Material/VolumetricMaterial.hpp>
 #include <Engine/Renderer/Mesh/Mesh.hpp>
-#include <Engine/Renderer/RenderObject/Primitives/DrawPrimitives.hpp>
 #include <Engine/Renderer/RenderObject/RenderObject.hpp>
 #include <Engine/Renderer/RenderObject/RenderObjectManager.hpp>
 #include <Engine/Renderer/RenderObject/RenderObjectTypes.hpp>
 #include <Engine/Renderer/RenderTechnique/RenderTechnique.hpp>
-#include <Engine/Renderer/RenderTechnique/ShaderConfigFactory.hpp>
-#include <Engine/Renderer/RenderTechnique/ShaderProgram.hpp>
-#include <Engine/Renderer/RenderTechnique/ShaderProgramManager.hpp>
 
 #define CHECK_MESH_NOT_NULL \
     CORE_ASSERT( m_displayMesh != nullptr, "DisplayMesh should exist while component is alive" );

--- a/src/Engine/Component/GeometryComponent.hpp
+++ b/src/Engine/Component/GeometryComponent.hpp
@@ -42,6 +42,7 @@ class RA_ENGINE_API GeometryComponent : public Component
     const Ra::Core::Utils::Index* roIndexRead() const;
 
   protected:
+    // the index of the renderObject
     Ra::Core::Utils::Index m_roIndex{};
     std::string m_contentName{};
 };
@@ -87,7 +88,7 @@ class RA_ENGINE_API TriangleMeshComponent : public GeometryComponent
   private:
     void generateTriangleMesh( const Ra::Core::Asset::GeometryData* data );
 
-    void finalizeROFromGeometry( const Core::Asset::MaterialData* data );
+    void finalizeROFromGeometry( const Core::Asset::MaterialData* data, Core::Transform transform );
 
     // Give access to the mesh and (if deformable) to update it
     const Ra::Core::Geometry::TriangleMesh* getMeshOutput() const;
@@ -134,7 +135,7 @@ class RA_ENGINE_API PointCloudComponent : public GeometryComponent
   private:
     void generatePointCloud( const Ra::Core::Asset::GeometryData* data );
 
-    void finalizeROFromGeometry( const Core::Asset::MaterialData* data );
+    void finalizeROFromGeometry( const Core::Asset::MaterialData* data, Core::Transform transform );
 
     // Give access to the mesh and (if deformable) to update it
     const Ra::Core::Geometry::PointCloud* getMeshOutput() const;


### PR DESCRIPTION
resolves #536 

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Store the local transformation matrix of a geometric component into the associated renderobject instead of applying the transformation once at load-time.


* **What is the current behavior?** (You can also link to an open issue here)
See issue #536


* **What is the new behavior (if this is a feature change)?**
Mesh (and point cloud) are not transformed once. The transformation matrix of the associated renderObject store now the mesh local transformation.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
