### PR TITLE
cmake: explicit tags, fix #526

### DIFF
--- a/src/Core/external/CMakeLists.txt
+++ b/src/Core/external/CMakeLists.txt
@@ -14,9 +14,9 @@ set_property(DIRECTORY PROPERTY EP_STEP_TARGETS install)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 ExternalProject_Add(Eigen3
-    GIT_REPOSITORY https://github.com/eigenteam/eigen-git-mirror.git
-    GIT_TAG origin/master
-    GIT_SHALLOW TRUE
+    GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+    GIT_TAG e80ec243
+    GIT_SHALLOW FALSE
     GIT_PROGRESS TRUE
     INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
     CMAKE_ARGS
@@ -33,7 +33,7 @@ ExternalProject_Add(Eigen3
 # TODO, find why only OpenMesh is problematic
 ExternalProject_Add(OpenMesh
     GIT_REPOSITORY https://www.graphics.rwth-aachen.de:9000/OpenMesh/OpenMesh.git
-    GIT_TAG origin/master
+    GIT_TAG tags/OpenMesh-8.1
     GIT_SHALLOW TRUE
     GIT_PROGRESS TRUE
     INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
@@ -46,7 +46,7 @@ ExternalProject_Add(OpenMesh
 
 ExternalProject_Add(cpplocate
     GIT_REPOSITORY https://github.com/cginternals/cpplocate.git
-    GIT_TAG origin/master
+    GIT_TAG tags/v2.2.0
     GIT_SHALLOW TRUE
     GIT_PROGRESS TRUE
     INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"

--- a/src/IO/external/CMakeLists.txt
+++ b/src/IO/external/CMakeLists.txt
@@ -19,7 +19,7 @@ if (RADIUM_IO_ASSIMP)
     # For now, only configure in Debug mode to work with xcode
     ExternalProject_Add(assimp
             GIT_REPOSITORY https://github.com/assimp/assimp.git
-            GIT_TAG origin/master
+            GIT_TAG tags/v5.0.1
             GIT_SHALLOW TRUE
             GIT_PROGRESS TRUE
             INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
@@ -39,7 +39,7 @@ endif()
 if(RADIUM_IO_TINYPLY)
     ExternalProject_Add( tinyply
         GIT_REPOSITORY https://github.com/ddiakopoulos/tinyply.git
-        GIT_TAG origin/master
+        GIT_TAG tags/2.3.2
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"


### PR DESCRIPTION
Closes #538 closes #526 

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

*please test if all functionalities are presents*

From the original PR
I tried loading some animated models to check the skinning plugin is working.
Actually it is not working well with the current version of assimp (the skeleton animation seems broken) so I propose to stick with the last release tag until we fix this. 
Thus we can advance on more urgent stuff.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix, explicit tags for all external project

here is what is set:

```bash
$ find . -path \*external/CMakeLists.txt -exec grep -B2 -H GIT_TAG {} \;

./src/Core/external/CMakeLists.txt-ExternalProject_Add(Eigen3
./src/Core/external/CMakeLists.txt-    GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
./src/Core/external/CMakeLists.txt:    GIT_TAG e80ec243

./src/Core/external/CMakeLists.txt-ExternalProject_Add(OpenMesh
./src/Core/external/CMakeLists.txt-    GIT_REPOSITORY https://www.graphics.rwth-aachen.de:9000/OpenMesh/OpenMesh.git
./src/Core/external/CMakeLists.txt:    GIT_TAG tags/OpenMesh-8.1

./src/Core/external/CMakeLists.txt-ExternalProject_Add(cpplocate
./src/Core/external/CMakeLists.txt-    GIT_REPOSITORY https://github.com/cginternals/cpplocate.git
./src/Core/external/CMakeLists.txt:    GIT_TAG tags/v2.2.0

./src/Engine/external/CMakeLists.txt-ExternalProject_Add( glm
./src/Engine/external/CMakeLists.txt-    GIT_REPOSITORY https://github.com/g-truc/glm.git
./src/Engine/external/CMakeLists.txt:    GIT_TAG 0.9.9.5

./src/Engine/external/CMakeLists.txt-ExternalProject_Add( glbinding
./src/Engine/external/CMakeLists.txt-    GIT_REPOSITORY https://github.com/cginternals/glbinding.git
./src/Engine/external/CMakeLists.txt:    GIT_TAG 663e19cf1ae6a5fa1acfb1bd952fc43f647ca79c

./src/Engine/external/CMakeLists.txt-ExternalProject_Add( globjects
./src/Engine/external/CMakeLists.txt-    GIT_REPOSITORY https://github.com/dlyr/globjects.git
./src/Engine/external/CMakeLists.txt:    GIT_TAG 11c559a07d9e310abb2f53725fd47cfaf538f8b1

./src/Engine/external/CMakeLists.txt-ExternalProject_Add( stb
./src/Engine/external/CMakeLists.txt-    GIT_REPOSITORY https://github.com/nothings/stb.git
./src/Engine/external/CMakeLists.txt:    GIT_TAG 1034f5e5c4809ea0a7f4387e0cd37c5184de3cdd

./src/IO/external/CMakeLists.txt-    ExternalProject_Add(assimp
./src/IO/external/CMakeLists.txt-            GIT_REPOSITORY https://github.com/assimp/assimp.git
./src/IO/external/CMakeLists.txt:            GIT_TAG tags/v5.0.1

./src/IO/external/CMakeLists.txt-    ExternalProject_Add( tinyply
./src/IO/external/CMakeLists.txt-        GIT_REPOSITORY https://github.com/ddiakopoulos/tinyply.git
./src/IO/external/CMakeLists.txt:        GIT_TAG tags/2.3.2
```


* **What is the current behavior?** (You can also link to an open issue here)
external project points to original/master branch, which can be broken


* **What is the new behavior (if this is a feature change)?**
use tag when provided, explicit git hash otherwise
