### PR TITLE
Cleaner plugin loading error and debug messages

### DIFF
--- a/src/GuiBase/BaseApplication.cpp
+++ b/src/GuiBase/BaseApplication.cpp
@@ -251,7 +251,7 @@ BaseApplication::BaseApplication( int& argc,
     // Load installed plugins plugins
     if ( !loadPlugins(
              pluginsPath, parser.values( pluginLoadOpt ), parser.values( pluginIgnoreOpt ) ) )
-    { LOG( logERROR ) << "An error occurred while trying to load plugins."; }
+    { LOG( logDEBUG ) << "No plugin found in default path " << pluginsPath; }
     // load supplemental plugins
     {
         QSettings settings;
@@ -506,16 +506,19 @@ bool BaseApplication::loadPlugins( const std::string& pluginsPath,
                                    const QStringList& loadList,
                                    const QStringList& ignoreList ) {
     QDir pluginsDir( qApp->applicationDirPath() );
-    LOG( logINFO ) << " *** Loading Plugins from " << pluginsPath << " ***";
     bool result = pluginsDir.cd( pluginsPath.c_str() );
 
-    if ( !result )
+    if ( result )
     {
-        LOG( logERROR ) << "Cannot open specified plugins directory " << pluginsPath;
+        LOG( logINFO ) << " *** Loading Plugins from " << pluginsDir.absolutePath().toStdString()
+                       << " ***";
+    }
+    else
+    {
+        LOG( logDEBUG ) << "Cannot open specified plugins directory "
+                        << pluginsDir.absolutePath().toStdString();
         return false;
     }
-
-    LOG( logDEBUG ) << "Plugin directory :" << pluginsDir.absolutePath().toStdString();
     bool res       = true;
     uint pluginCpt = 0;
 


### PR DESCRIPTION
This PR propose less disturbing messages when loading plugins.


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Less disturbing messages when loading plugins (No error message  are printed when there is no error!)

* **What is the current behavior?** (You can also link to an open issue here)

If there is no plugin installed in the default plugin directory, the current base application print an error messages even if this is not an error.


* **What is the new behavior (if this is a feature change)?**

Error messages are limited to real error at plugin loading and if no plugin is found in the default directory, only a debug message is logged.

for user specified directory, informational messages are logged to inform the user where plugins are loaded from.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

