### PR TITLE
[engine] use string instead of char*

### DIFF
--- a/src/Engine/Renderer/RenderTechnique/RenderParameters.cpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderParameters.cpp
@@ -19,59 +19,59 @@ void RenderParameters::bind( const ShaderProgram* shader ) const {
     m_texParamsVector.bind( shader );
 }
 
-void RenderParameters::addParameter( const char* name, int value ) {
+void RenderParameters::addParameter( const std::string& name, int value ) {
     m_intParamsVector[name] = IntParameter( name, value );
 }
 
-void RenderParameters::addParameter( const char* name, uint value ) {
+void RenderParameters::addParameter( const std::string& name, uint value ) {
     m_uintParamsVector[name] = UIntParameter( name, value );
 }
 
-void RenderParameters::addParameter( const char* name, Scalar value ) {
+void RenderParameters::addParameter( const std::string& name, Scalar value ) {
     m_scalarParamsVector[name] = ScalarParameter( name, value );
 }
 
 ///!! array version
 
-void RenderParameters::addParameter( const char* name, std::vector<int> value ) {
+void RenderParameters::addParameter( const std::string& name, std::vector<int> value ) {
     m_intsParamsVector[name] = IntsParameter( name, value );
 }
 
-void RenderParameters::addParameter( const char* name, std::vector<uint> value ) {
+void RenderParameters::addParameter( const std::string& name, std::vector<uint> value ) {
     m_uintsParamsVector[name] = UIntsParameter( name, value );
 }
 
-void RenderParameters::addParameter( const char* name, std::vector<Scalar> value ) {
+void RenderParameters::addParameter( const std::string& name, std::vector<Scalar> value ) {
     m_scalarsParamsVector[name] = ScalarsParameter( name, value );
 }
 
 ///!!
 
-void RenderParameters::addParameter( const char* name, const Core::Vector2& value ) {
+void RenderParameters::addParameter( const std::string& name, const Core::Vector2& value ) {
     m_vec2ParamsVector[name] = Vec2Parameter( name, value );
 }
 
-void RenderParameters::addParameter( const char* name, const Core::Vector3& value ) {
+void RenderParameters::addParameter( const std::string& name, const Core::Vector3& value ) {
     m_vec3ParamsVector[name] = Vec3Parameter( name, value );
 }
 
-void RenderParameters::addParameter( const char* name, const Core::Vector4& value ) {
+void RenderParameters::addParameter( const std::string& name, const Core::Vector4& value ) {
     m_vec4ParamsVector[name] = Vec4Parameter( name, value );
 }
 
-void RenderParameters::addParameter( const char* name, const Core::Matrix2& value ) {
+void RenderParameters::addParameter( const std::string& name, const Core::Matrix2& value ) {
     m_mat2ParamsVector[name] = Mat2Parameter( name, value );
 }
 
-void RenderParameters::addParameter( const char* name, const Core::Matrix3& value ) {
+void RenderParameters::addParameter( const std::string& name, const Core::Matrix3& value ) {
     m_mat3ParamsVector[name] = Mat3Parameter( name, value );
 }
 
-void RenderParameters::addParameter( const char* name, const Core::Matrix4& value ) {
+void RenderParameters::addParameter( const std::string& name, const Core::Matrix4& value ) {
     m_mat4ParamsVector[name] = Mat4Parameter( name, value );
 }
 
-void RenderParameters::addParameter( const char* name, Texture* tex, int texUnit ) {
+void RenderParameters::addParameter( const std::string& name, Texture* tex, int texUnit ) {
     m_texParamsVector[name] = TextureParameter( name, tex, texUnit );
 }
 

--- a/src/Engine/Renderer/RenderTechnique/RenderParameters.hpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderParameters.hpp
@@ -27,11 +27,13 @@ class RA_ENGINE_API RenderParameters final
 {
   public:
     /// Base abstract parameter Class
+    ///\todo use globjects Uniform directly (which seems to correspond to the
+    ///same data/purpose, even if not well documented
     class Parameter
     {
       public:
         Parameter() = default;
-        explicit Parameter( const char* name ) : m_name( name ) {}
+        explicit Parameter( const std::string & name ) : m_name( name ) {}
         virtual ~Parameter() = default;
         /** Bind the parameter uniform on the shader program
          *
@@ -41,7 +43,7 @@ class RA_ENGINE_API RenderParameters final
         /** The name of the parameter.
          * This must correspond to the name of a Uniform in the shader the Parameter is bound to.
          */
-        const char* m_name{nullptr};
+        std::string m_name{};
     };
 
     /** Typed parameter.
@@ -53,7 +55,7 @@ class RA_ENGINE_API RenderParameters final
     {
       public:
         TParameter() = default;
-        TParameter( const char* name, const T& value ) : Parameter( name ), m_value( value ) {}
+        TParameter( const std::string &name, const T& value ) : Parameter( name ), m_value( value ) {}
         ~TParameter() override = default;
         void bind( const ShaderProgram* shader ) const override;
         /// The value of the parameter
@@ -67,7 +69,7 @@ class RA_ENGINE_API RenderParameters final
     {
       public:
         TextureParameter() = default;
-        TextureParameter( const char* name, Texture* tex, int texUnit ) :
+        TextureParameter( const std::string & name, Texture* tex, int texUnit ) :
             Parameter( name ), m_texture( tex ), m_texUnit( texUnit ) {}
         ~TextureParameter() override = default;
         void bind( const ShaderProgram* shader ) const override;
@@ -136,21 +138,21 @@ class RA_ENGINE_API RenderParameters final
      * Overloaded operators to set shader parameters
      * @{
      */
-    void addParameter( const char* name, int value );
-    void addParameter( const char* name, uint value );
-    void addParameter( const char* name, Scalar value );
+    void addParameter( const std::string & name, int value );
+    void addParameter( const std::string & name, uint value );
+    void addParameter( const std::string & name, Scalar value );
 
-    void addParameter( const char* name, std::vector<int> values );
-    void addParameter( const char* name, std::vector<uint> values );
-    void addParameter( const char* name, std::vector<Scalar> values );
+    void addParameter( const std::string & name, std::vector<int> values );
+    void addParameter( const std::string & name, std::vector<uint> values );
+    void addParameter( const std::string & name, std::vector<Scalar> values );
 
-    void addParameter( const char* name, const Core::Vector2& value );
-    void addParameter( const char* name, const Core::Vector3& value );
-    void addParameter( const char* name, const Core::Vector4& value );
+    void addParameter( const std::string & name, const Core::Vector2& value );
+    void addParameter( const std::string & name, const Core::Vector3& value );
+    void addParameter( const std::string & name, const Core::Vector4& value );
 
-    void addParameter( const char* name, const Core::Matrix2& value );
-    void addParameter( const char* name, const Core::Matrix3& value );
-    void addParameter( const char* name, const Core::Matrix4& value );
+    void addParameter( const std::string & name, const Core::Matrix2& value );
+    void addParameter( const std::string & name, const Core::Matrix3& value );
+    void addParameter( const std::string & name, const Core::Matrix4& value );
 
     /**
      * Adding a texture parameter.
@@ -158,7 +160,7 @@ class RA_ENGINE_API RenderParameters final
      * texture unit associated with the named sampler.
      * If texUnit is given, then uniform binding will be made at this explicit location.
      */
-    void addParameter( const char* name, Texture* tex, int texUnit = -1 );
+    void addParameter( const std::string & name, Texture* tex, int texUnit = -1 );
     /**@}*/
     /***
      * Concatenates two RenderParameters
@@ -217,7 +219,8 @@ class RA_ENGINE_API ShaderParameterProvider
 {
   public:
     virtual ~ShaderParameterProvider() = default;
-    const RenderParameters& getParameters() const { return m_renderParameters; }
+    RenderParameters& getParameters() { return m_renderParameters; }
+    const RenderParameters& getParameters() const{ return m_renderParameters; }
     /**
      * Update the OpenGL states used by the ShaderParameterProvider.
      * These state could be the ones from an associated material (textures, precomputed tables or

--- a/src/Engine/Renderer/RenderTechnique/RenderParameters.inl
+++ b/src/Engine/Renderer/RenderTechnique/RenderParameters.inl
@@ -13,13 +13,13 @@ inline void RenderParameters::UniformBindableSet<T>::bind( const ShaderProgram* 
 
 template <typename T>
 inline void RenderParameters::TParameter<T>::bind( const ShaderProgram* shader ) const {
-    shader->setUniform( m_name, m_value );
+    shader->setUniform( m_name.c_str(), m_value );
 }
 
 inline void RenderParameters::TextureParameter::bind( const ShaderProgram* shader ) const {
-    if ( m_texUnit == -1 ) { shader->setUniformTexture( m_name, m_texture ); }
+    if ( m_texUnit == -1 ) { shader->setUniformTexture( m_name.c_str(), m_texture ); }
     else
-    { shader->setUniform( m_name, m_texture, m_texUnit ); }
+    { shader->setUniform( m_name.c_str(), m_texture, m_texUnit ); }
 }
 
 template <>


### PR DESCRIPTION
UPDATE the form below to describe your PR.


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Buf fix

There is also one feature which give access to renderparameters non const, so one can add directly parameters by name, without having to pass thru specific material implementation. This feature can be postpone if needed.

* **What is the current behavior?** (You can also link to an open issue here)
A const char* ptr is passed to and stored in, RenderParameter.
But there is nothing that guarantees this ptr is valid during the whole program execution.


* **What is the new behavior (if this is a feature change)?**
Use const std::string instead. I have changed all the call, but I think only the Parameter data member is needed, the rest is a question of style.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope, except now it's working :)

* **Other information**:
