### PR TITLE
Fix topomesh compilation issue.

### DIFF
--- a/src/Core/Geometry/TopologicalMesh.inl
+++ b/src/Core/Geometry/TopologicalMesh.inl
@@ -409,14 +409,15 @@ GET_NAME_ARRAY_HELPER( Vector3, vector3 )
 GET_NAME_ARRAY_HELPER( Vector4, vector4 )
 
 #undef GET_NAME_ARRAY_HELPER
-
+// These template functions, for supported types are explicitly instanciated above. For unsupported
+// types, generates a compile error.
 template <typename T>
 inline const std::vector<std::string>& TopologicalMesh::WedgeCollection::getNameArray() const {
 
     LOG( logWARNING ) << "Warning, mesh attribute " << typeid( T ).name()
                       << " is not supported (only float, vec2, vec3 nor vec4 are supported)";
-    //    static_assert( sizeof( T ) == -1, "this type is not supported" );
-    return {};
+    static_assert( sizeof( T ) == -1, "this type is not supported" );
+    return m_floatAttribNames;
 }
 
 template <typename T>

--- a/src/Core/Geometry/TopologicalMesh.inl
+++ b/src/Core/Geometry/TopologicalMesh.inl
@@ -409,8 +409,8 @@ GET_NAME_ARRAY_HELPER( Vector3, vector3 )
 GET_NAME_ARRAY_HELPER( Vector4, vector4 )
 
 #undef GET_NAME_ARRAY_HELPER
-// These template functions, for supported types are explicitly instanciated above. For unsupported
-// types, generates a compile error.
+// These template functions are defined above for supported types.
+// For unsupported types they simply generate a compile error.
 template <typename T>
 inline const std::vector<std::string>& TopologicalMesh::WedgeCollection::getNameArray() const {
 


### PR DESCRIPTION
Alow to compile topomesh with older version than on CI of compiler

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Compilation fix

* **What is the current behavior?** (You can also link to an open issue here)

error on non-instanciated template method returning ref to temporary

* **What is the new behavior (if this is a feature change)?**

the template method compile and rais a static_assert if instantiated with an unsupported type.
