### PR TITLE
Add a way to access to the emissivity of a material.

### DIFF
--- a/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
+++ b/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
@@ -40,14 +40,20 @@ struct Material {
     BlinnPhongTextures tex;
 };
 
+// Implementation of the emissivity interface.
+// For now, BlinnPhong Material is not emissive
+vec3 getEmissiveColor(Material material, vec3 textCoord) {
+    return vec3(0);
+}
+
 // Du to access to in_vertexColor this does not respect the "Material.glsl" interface as it access
 // data outside the material
-vec4 getDiffuseColor( Material material, vec3 texCoord ) {
-    vec4 dc = vec4( material.kd.rgb, material.alpha );
-    if ( material.hasPerVertexKd == 1 ) { dc.rgb = getPerVertexBaseColor().rgb; }
-    if ( material.tex.hasKd == 1 ) { dc.rgb = texture( material.tex.kd, texCoord.xy ).rgb; }
-    if ( material.tex.hasAlpha == 1 ) { dc.a *= texture( material.tex.alpha, texCoord.xy ).r; }
-    if ( material.renderAsSplat == 1 ) { dc.a = ( dot( texCoord.xy, texCoord.xy ) > 1 ) ? 0 : 1; }
+vec4 getDiffuseColor(Material material, vec3 texCoord) {
+    vec4 dc = vec4(material.kd.rgb, material.alpha);
+    if (material.hasPerVertexKd == 1) { dc.rgb = getPerVertexBaseColor().rgb; }
+    if (material.tex.hasKd == 1) { dc.rgb = texture(material.tex.kd, texCoord.xy).rgb; }
+    if (material.tex.hasAlpha == 1) { dc.a *= texture(material.tex.alpha, texCoord.xy).r; }
+    if (material.renderAsSplat == 1) { dc.a = (dot(texCoord.xy, texCoord.xy) > 1) ? 0 : 1; }
     return dc;
 }
 

--- a/Shaders/Materials/BlinnPhong/BlinnPhongZPrepass.frag.glsl
+++ b/Shaders/Materials/BlinnPhong/BlinnPhongZPrepass.frag.glsl
@@ -19,8 +19,8 @@ void main() {
     vec3 normalWorld = getNormal(
         material, getPerVertexTexCoord(), getWorldSpaceNormal(), getWorldSpaceTangent(), binormal );
 
-    out_ambient  = vec4( bc.rgb * 0.01, 1.0 );
-    out_normal   = vec4( normalWorld * 0.5 + 0.5, 1.0 );
+    out_ambient  = vec4(bc.rgb * 0.01 + getEmissiveColor(material, getPerVertexTexCoord()), 1.0);
+    out_normal   = vec4(normalWorld * 0.5 + 0.5, 1.0);
     out_diffuse  = vec4( bc.xyz, 1.0 );
     out_specular = vec4( getSpecularColor( material, getPerVertexTexCoord() ), 1.0 );
 }

--- a/Shaders/Materials/Lambertian/Lambertian.glsl
+++ b/Shaders/Materials/Lambertian/Lambertian.glsl
@@ -23,13 +23,19 @@ vec3 getWorldSpaceNormal();
 //----------------------------------------------------------------
 const float Pi = 3.141592653589793;
 
-vec4 getBaseColor( Material material, vec3 texCoord ) {
-    vec4 dc = vec4( material.color.rgb, 1 );
+// Implementation of the emissivity interface.
+// For now, Lambertian Material is not emissive
+vec3 getEmissiveColor(Material material, vec3 textCoord) {
+    return vec3(0);
+}
 
-    if ( material.perVertexColor == 1 ) { dc.rgb = getPerVertexBaseColor().rgb; }
-    if ( material.tex.hasColor == 1 ) { dc.rgb = texture( material.tex.color, texCoord.xy ).rgb; }
+vec4 getBaseColor(Material material, vec3 texCoord) {
+    vec4 dc = vec4(material.color.rgb, 1);
 
-    if ( material.tex.hasMask == 1 && texture( material.tex.mask, texCoord.xy ).r < 0.1 )
+    if (material.perVertexColor == 1) { dc.rgb = getPerVertexBaseColor().rgb; }
+    if (material.tex.hasColor == 1) { dc.rgb = texture(material.tex.color, texCoord.xy).rgb; }
+
+    if (material.tex.hasMask == 1 && texture(material.tex.mask, texCoord.xy).r < 0.1)
     { dc.a = 0; }
     return dc;
 }

--- a/Shaders/Materials/Lambertian/LambertianZPrepass.frag.glsl
+++ b/Shaders/Materials/Lambertian/LambertianZPrepass.frag.glsl
@@ -10,7 +10,7 @@ void main() {
     vec4 bc = getBaseColor( material, getPerVertexTexCoord() );
     if ( toDiscard( material, bc ) ) discard;
 
-    out_ambient = vec4( bc.rgb * 0.01, 1.0 );
-    out_normal  = vec4( getWorldSpaceNormal() * 0.5 + 0.5, 1.0 );
+    out_ambient = vec4(bc.rgb * 0.01  + getEmissiveColor(material, getPerVertexTexCoord()), 1.0);
+    out_normal  = vec4(getWorldSpaceNormal() * 0.5 + 0.5, 1.0);
     out_diffuse = vec4( bc.rgb, 1.0 );
 }

--- a/Shaders/Materials/Plain/Plain.glsl
+++ b/Shaders/Materials/Plain/Plain.glsl
@@ -23,14 +23,19 @@ vec3 getWorldSpaceNormal();
 #define DONT_USE_INPUT_TANGENT
 
 //----------------------------------------------------------------
+// Implementation of the emissivity interface.
+// Plain Material is not emissive
+vec3 getEmissiveColor(Material material, vec3 textCoord) {
+    return vec3(0);
+}
 
-vec4 getBaseColor( Material material, vec3 texCoord ) {
-    vec4 dc = vec4( material.color.rgb, 1 );
+vec4 getBaseColor(Material material, vec3 texCoord) {
+    vec4 dc = vec4(material.color.rgb, 1);
 
-    if ( material.perVertexColor == 1 ) { dc.rgb = getPerVertexBaseColor().rgb; }
-    if ( material.tex.hasColor == 1 ) { dc.rgb = texture( material.tex.color, texCoord.xy ).rgb; }
+    if (material.perVertexColor == 1) { dc.rgb = getPerVertexBaseColor().rgb; }
+    if (material.tex.hasColor == 1) { dc.rgb = texture(material.tex.color, texCoord.xy).rgb; }
 
-    if ( material.tex.hasMask == 1 && texture( material.tex.mask, texCoord.xy ).r < 0.1 )
+    if (material.tex.hasMask == 1 && texture(material.tex.mask, texCoord.xy).r < 0.1)
     { dc.a = 0; }
     return dc;
 }

--- a/cmake/filelistEngine.cmake
+++ b/cmake/filelistEngine.cmake
@@ -140,7 +140,7 @@ set(engine_shaders
     Materials/BlinnPhong/BlinnPhong.frag.glsl
     Materials/BlinnPhong/BlinnPhong.glsl
     Materials/BlinnPhong/BlinnPhong.vert.glsl
-    Materials/BlinnPhong/DepthAmbientBlinnPhong.frag.glsl
+    Materials/BlinnPhong/BlinnPhongZPrepass.frag.glsl
     Materials/BlinnPhong/LitOITBlinnPhong.frag.glsl
     Materials/Lambertian/Lambertian.frag.glsl
     Materials/Lambertian/Lambertian.glsl

--- a/doc/developer/material.md
+++ b/doc/developer/material.md
@@ -286,7 +286,7 @@ vec3 getSpecularColor(Material material, vec3 texCoord);
 vec3 evaluateBSDF(Material material, vec3 texCoord, vec3 wi, vec3 wo);
 ~~~
 
-### Emissivity interface {#bsdf-interface}
+### Emissivity interface {#emissivity-interface}
 Some materials are not only reflective, hence implementing the BSDF interface, but also can be emissive. 
 To allow a renderer to access the emissivity of a material the following GLSL function  must 
 defined in the same GLSL file than the BSDF and microgeometry interface :

--- a/doc/developer/material.md
+++ b/doc/developer/material.md
@@ -210,7 +210,7 @@ vec3 getPerVertexSpecularColor();
 Note also that if a function is not needed by a shader, there is no need to implement its interface.
 
 
-#### Microgeometry interface {#microgeometry-interface}
+### Microgeometry interface {#microgeometry-interface}
 Defining the micro-geometry procedurally or by using textures allows to de-correlates the geometric sampling from the
 appearance parameters sampling.
 The best example of procedural micro-geometry is normal mapping.
@@ -237,7 +237,7 @@ bool toDiscard(Material material, vec4 color);
 ~~~
 
 
-#### BSDF interface {#bsdf-interface}
+### BSDF interface {#bsdf-interface}
 Implementing or using the GLSL BSDF interface is based on the fact that the method Ra::Engine::Material::getMaterialName()
  must return a string that contains the `name_of_the_BSDF` implemented in a file named `name_of_the_BSDF.glsl`.
 This file is preloaded at [material registration](#registration-mtl-lib) into a `glNamedString` to allow inclusion by others.
@@ -284,6 +284,15 @@ vec3 getSpecularColor(Material material, vec3 texCoord);
 // The local Frame is the Frame wher the Geometric normal is the Z axis,
 // and the tangent defined the X axis.
 vec3 evaluateBSDF(Material material, vec3 texCoord, vec3 wi, vec3 wo);
+~~~
+
+### Emissivity interface {#bsdf-interface}
+Some materials are not only reflective, hence implementing the BSDF interface, but also can be emissive. 
+To allow a renderer to access the emissivity of a material the following GLSL function  must 
+defined in the same GLSL file than the BSDF and microgeometry interface :
+~~~
+// Return the emissivity of the material
+vec3 getEmissiveColor(GLTFCommon material, vec3 textCoord);
 ~~~
 
 ## Material registration into the Engine {#registration-mtl-lib}

--- a/src/Engine/Renderer/Material/BlinnPhongMaterial.cpp
+++ b/src/Engine/Renderer/Material/BlinnPhongMaterial.cpp
@@ -120,7 +120,7 @@ void BlinnPhongMaterial::registerMaterial() {
     Ra::Engine::ShaderConfiguration zprepassconfig(
         "ZprepassBlinnPhong",
         resourcesRootDir + "Shaders/Materials/BlinnPhong/BlinnPhong.vert.glsl",
-        resourcesRootDir + "Shaders/Materials/BlinnPhong/DepthAmbientBlinnPhong.frag.glsl" );
+        resourcesRootDir + "Shaders/Materials/BlinnPhong/BlinnPhongZPrepass.frag.glsl" );
     Ra::Engine::ShaderConfigurationFactory::addConfiguration( zprepassconfig );
 
     Ra::Engine::ShaderConfiguration transparentpassconfig(


### PR DESCRIPTION


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR define a GLSL interface to access the emissivity of a surfacic material.

For now, emissive materials are not supported in Radium and there is a need, when compositing shaders, to access the individual components of a material : microgeometry, BSDF (that are already managed by the GLSL interface of Materials) and emissivity.

This PR just add the definition of the interface in the documentation and implement this interface in BlinnPhong and Lambertian GLSL implementation. (For now, these materials can't be emissive so the function returns black color)

The GLSL shaders are modified so that the emissivity of materials is taken into account in the zPrepass of the forward renderer.

Specific renderers will be able to access to the emissivity of the material to compute some effects like glow.

