### PR TITLE
Reinstall external when moving install + fix external updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,3 +203,6 @@ message(STATUS "RADIUM_INSTALL_DOC:    ${RADIUM_INSTALL_DOC}")
 message(STATUS "  possible options: Debug Release RelWithDebInfo MinSizeRel")
 message(STATUS "  set with ` cmake -DCMAKE_BUILD_TYPE=Debug .. `")
 message(STATUS "")
+
+
+set( CACHED_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE INTERNAL "Previous value of CMAKE_INSTALL_PREFIX")

--- a/cmake/externalFunc.cmake
+++ b/cmake/externalFunc.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.12)
+
 include(ExternalInclude)
 
 macro(addExternalFolder NAME FOLDER )
@@ -47,27 +49,11 @@ macro(addExternalFolder NAME FOLDER )
             message(STATUS "[addExternalFolder] Enable compatibility mode for Xcode Generator")
         endif ()
 
-        if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.12)
-            execute_process(
-                    COMMAND ${CMAKE_COMMAND} --build . -j ${RADIUM_BUILD_EXTERNAL_PARALLEL_LEVEL} --config ${CMAKE_BUILD_TYPE} --target ${RadiumExternalMakeTarget}
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/external
-                    RESULT_VARIABLE ret
-            )
-        else ()
-            set(TOOL_OPTIONS "")
-            if( ${generator_lower} MATCHES "|makefile|" OR ${generator_lower} MATCHES "|ninja|" )
-              set( TOOL_OPTIONS -- -j${RADIUM_BUILD_EXTERNAL_PARALLEL_LEVEL} )
-            elseif( ${generator_lower} MATCHES "|visual|" )
-              set( TOOL_OPTIONS -- /m )
-            else()
-              message(WARNING "[addExternalFolder] Parallel build are not supported with your generator ${CMAKE_GENERATOR}")
-            endif()
-            execute_process(
-              COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE} --target ${RadiumExternalMakeTarget} ${TOOL_OPTIONS}
-              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/external
-              RESULT_VARIABLE ret
-              )
-        endif()
+        execute_process(
+                COMMAND ${CMAKE_COMMAND} --build . -j ${RADIUM_BUILD_EXTERNAL_PARALLEL_LEVEL} --config ${CMAKE_BUILD_TYPE} --target ${RadiumExternalMakeTarget}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/external
+                RESULT_VARIABLE ret
+        )
 
         if(NOT ret EQUAL "0")
             message( FATAL_ERROR "[addExternalFolder] Cmake build step failed. ")

--- a/cmake/externalFunc.cmake
+++ b/cmake/externalFunc.cmake
@@ -23,6 +23,13 @@ macro(addExternalFolder NAME FOLDER )
         set( UPDATE_EXTERNAL OFF)
     endif()
 
+    # Check if install prefix has changed. If yes, force installing the externals again
+    if( DEFINED CACHED_INSTALL_PREFIX )
+        if( NOT "${CACHED_INSTALL_PREFIX}" STREQUAL "${CMAKE_INSTALL_PREFIX}" )
+            message(STATUS "[addExternalFolder] CMAKE_INSTALL_PREFIX has changed (from ${CACHED_INSTALL_PREFIX} to ${CMAKE_INSTALL_PREFIX}), reinstalling dependency")
+            set( UPDATE_EXTERNAL ON)
+        endif()
+    endif()
 
     if ( UPDATE_EXTERNAL )
         execute_process(

--- a/src/Core/Animation/KeyFramedValueInterpolators.hpp
+++ b/src/Core/Animation/KeyFramedValueInterpolators.hpp
@@ -28,6 +28,8 @@ template <>
 inline bool linearInterpolate<bool>( const KeyFramedValue<bool>& keyframes, const Scalar t ) {
     CORE_ASSERT( keyframes.size() > 0, "Keyframe vectors must contain at least one keyframe." );
     auto [i, j, dt] = keyframes.findRange( t );
+    CORE_UNUSED( j )
+    CORE_UNUSED( dt )
     return keyframes[i].second;
 }
 
@@ -36,6 +38,8 @@ template <>
 inline int linearInterpolate<int>( const KeyFramedValue<int>& keyframes, const Scalar t ) {
     CORE_ASSERT( keyframes.size() > 0, "Keyframe vectors must contain at least one keyframe." );
     auto [i, j, dt] = keyframes.findRange( t );
+    CORE_UNUSED( j )
+    CORE_UNUSED( dt )
     return keyframes[i].second;
 }
 

--- a/src/Core/external/CMakeLists.txt
+++ b/src/Core/external/CMakeLists.txt
@@ -46,7 +46,7 @@ ExternalProject_Add(cpplocate
     GIT_TAG tags/v2.2.0
     GIT_SHALLOW TRUE
     GIT_PROGRESS TRUE
-    PATCH_COMMAND git apply -v --ignore-whitespace "${CMAKE_CURRENT_LIST_DIR}/patches/cpplocate.patch"
+    PATCH_COMMAND git reset --hard && git apply -v --ignore-whitespace "${CMAKE_CURRENT_LIST_DIR}/patches/cpplocate.patch"
     INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
     CMAKE_ARGS
     ${RADIUM_EXTERNAL_CMAKE_OPTIONS}

--- a/src/Engine/external/CMakeLists.txt
+++ b/src/Engine/external/CMakeLists.txt
@@ -32,7 +32,7 @@ ExternalProject_Add(glbinding
     GIT_TAG 663e19cf1ae6a5fa1acfb1bd952fc43f647ca79c
     GIT_SHALLOW FALSE
     GIT_PROGRESS TRUE
-    PATCH_COMMAND git apply -v --ignore-whitespace "${CMAKE_CURRENT_LIST_DIR}/patches/glbinding.patch"
+    PATCH_COMMAND git reset --hard && git apply -v --ignore-whitespace "${CMAKE_CURRENT_LIST_DIR}/patches/glbinding.patch"
     INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
     CMAKE_ARGS
     ${RADIUM_EXTERNAL_CMAKE_OPTIONS}
@@ -46,7 +46,7 @@ ExternalProject_Add(globjects
     GIT_REPOSITORY https://github.com/dlyr/globjects.git
     GIT_TAG 11c559a07d9e310abb2f53725fd47cfaf538f8b1
     GIT_PROGRESS TRUE
-    PATCH_COMMAND git apply -v --ignore-whitespace "${CMAKE_CURRENT_LIST_DIR}/patches/globjects.patch"
+    PATCH_COMMAND git reset --hard && git apply -v --ignore-whitespace "${CMAKE_CURRENT_LIST_DIR}/patches/globjects.patch"
     INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
     DEPENDS glbinding glm
     CMAKE_ARGS

--- a/tests/unittest/Core/animation.cpp
+++ b/tests/unittest/Core/animation.cpp
@@ -54,10 +54,10 @@ TEST_CASE( "Core/Animation/KeyFramedValue", "[Core][Core/Animation][KeyFramedVal
         REQUIRE( Math::areApproxEqual( p.second, value ) );
     };
 
-    auto checkSorting = []( auto& kf ) {
-        for ( size_t i = 1; i < kf.size(); ++i )
+    auto checkSorting = []( auto& lkf ) {
+        for ( size_t i = 1; i < lkf.size(); ++i )
         {
-            REQUIRE( kf[i - 1].first < kf[i].first );
+            REQUIRE( lkf[i - 1].first < lkf[i].first );
         }
     };
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
1. acabddf  CMake bug fix: allow consecutive external updates
2. d7896df CMake new functionality: automatically reinstall externals when moving the installation dir
3. 12df1c5 and 093cc85 Cleaning: remove dead code in CMake and compilation warnings

* **What is the current behavior?** (You can also link to an open issue here)
1. Unskipping external compilation for `Core` and `Engine` might fail during the patch step for cpplocate, glbinding and globject.
2. Changing the `CMAKE_INSTALL_DIR` for an already configured radium project might fail at configure time (`find_package`) if external compilation is skipped: Radium looks for externals in the new `CMAKE_INSTALL_DIR`, which would be empty in that case.

* **What is the new behavior (if this is a feature change)?**
1. git repository is reset before patching.
2. Externals are re-installed if `CMAKE_INSTALL_DIR` is updated, whatever the value of `SKIP` options.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
