### PR TITLE
[hotfix] Add missing install directive for Windeployqt.cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,6 +80,14 @@ install(
         ${ConfigPackageLocation}
 )
 
+if (MSVC OR MSVC_IDE OR MINGW)
+    install(
+        FILES
+        "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/Windeployqt.cmake"
+        DESTINATION
+            ${ConfigPackageLocation}
+    )
+endif()
 
 # # #-------------------------------------------------------------------------------
 # # # exampleApp executable setup


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Hotfix


* **What is the current behavior?** (You can also link to an open issue here)
Windeployqt is not installed, which breaks the cmake package on windows.
On this build (https://github.com/STORM-IRIT/Radium-Releases/runs/898362991?check_suite_focus=true), the applications cannot be generated because the file is missing


* **What is the new behavior (if this is a feature change)?**
Add proper installation directives for Windeployqt.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
