### PR TITLE
Add separable BSDF interface to materials.

### DIFF
--- a/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
+++ b/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
@@ -92,50 +92,50 @@ bool toDiscard( Material material, vec4 color ) {
     return color.a < 1;
 }
 
-
-
-vec3 diffuseBSDF(Material material, vec3 texC) {
+vec3 diffuseBSDF( Material material, vec3 texC ) {
     return getDiffuseColor( material, texC ).rgb / Pi;
 }
 
-vec3 specularBSDF(Material material, vec3 texC, vec3 L, vec3 V, vec3 N) {
+vec3 specularBSDF( Material material, vec3 texC, vec3 L, vec3 V, vec3 N ) {
     // http://www.thetenthplanet.de/archives/255
     // Minimalist Cook-Torrance using Blinn-Phong approximation
     vec3 Ks  = getSpecularColor( material, texC );
     float Ns = getNs( material, texC.xy );
     vec3 H = V+L;
-    if ( length(H) < 0.001 )
-        H = N;
-    else
-        H = normalize(H);
-    float D   = ( Ns + 1 ) * OneOver2Pi * pow( max( dot(N, H), 0.0 ), Ns );
-    float FV  = 0.25 * pow( clamp( dot(L, H), 0.001, 1), -3. );
+    if ( length( H ) < 0.001 ) { H = N; }
+    else { H = normalize(H); }
+    float D   = ( Ns + 1 ) * OneOver2Pi * pow( max( dot( N, H ), 0.0 ), Ns );
+    float FV  = 0.25 * pow( clamp( dot( L, H ), 0.001, 1), -3. );
     return Ks * D * FV;
 }
 
 // Note that diffuse and specular must not be multiplied by cos(wi) as this will be done when using de BSDF
-int getSeparateBSDFComponent(Material material, vec3 texC, vec3 L, vec3 V, vec3 N, out vec3 diffuse, out vec3 specular) {
-    diffuse = diffuseBSDF(material, texC) ;
-    specular = specularBSDF(material, texC, L, V, N);
+int getSeparateBSDFComponent( Material material,
+                              vec3 texC,
+                              vec3 L,
+                              vec3 V,
+                              vec3 N,
+                              out vec3 diffuse,
+                              out vec3 specular ) {
+    diffuse = diffuseBSDF( material, texC ) ;
+    specular = specularBSDF( material, texC, L, V, N );
     return 1;
 }
 
 // Blinn-Phong exponent to Roughness conversiont :
 // https://computergraphics.stackexchange.com/questions/1515/what-is-the-accepted-method-of-converting-shininess-to-roughness-and-vice-versa
-float getGGXRoughness(Material material, vec3 texC) {
+float getGGXRoughness( Material material, vec3 texC ) {
     float Ns = getNs( material, texC.xy );
-    if (Ns > 1) {
-        Ns = Ns/128;
-    }
-    float r = clamp(1-Ns, 0.04, 0.96);
-    return r*r;
+    if ( Ns > 1 ) { Ns = Ns/128; }
+    float r = clamp( 1-Ns, 0.04, 0.96 );
+    return r * r;
 }
 
 // wi (light direction) and wo (view direction) are in local frame
 // wi dot N is then wi.z ...
 vec3 evaluateBSDF( Material material, vec3 texC, vec3 l, vec3 v ) {
     vec3 diff = diffuseBSDF( material, texC );
-    vec3 spec = specularBSDF( material, texC, l, v, vec3(0, 0, 1) );
+    vec3 spec = specularBSDF( material, texC, l, v, vec3( 0, 0, 1 ) );
     return ( diff + spec ) * max( l.z, 0.0 );
 }
 

--- a/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
+++ b/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
@@ -110,7 +110,8 @@ vec3 specularBSDF( Material material, vec3 texC, vec3 L, vec3 V, vec3 N ) {
     return Ks * D * FV;
 }
 
-// Note that diffuse and specular must not be multiplied by cos(wi) as this will be done when using de BSDF
+// Note that diffuse and specular must not be multiplied by cos(wi) as this will be done when using
+// the BSDF
 int getSeparateBSDFComponent( Material material,
                               vec3 texC,
                               vec3 L,

--- a/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
+++ b/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
@@ -92,25 +92,50 @@ bool toDiscard( Material material, vec4 color ) {
     return color.a < 1;
 }
 
-// 139 ou 236
+
+
+vec3 diffuseBSDF(Material material, vec3 texC) {
+    return getDiffuseColor( material, texC ).rgb / Pi;
+}
+
+vec3 specularBSDF(Material material, vec3 texC, vec3 L, vec3 V, vec3 N) {
+    // http://www.thetenthplanet.de/archives/255
+    // Minimalist Cook-Torrance using Blinn-Phong approximation
+    vec3 Ks  = getSpecularColor( material, texC );
+    float Ns = getNs( material, texC.xy );
+    vec3 H = V+L;
+    if ( length(H) < 0.001 )
+        H = N;
+    else
+        H = normalize(H);
+    float D   = ( Ns + 1 ) * OneOver2Pi * pow( max( dot(N, H), 0.0 ), Ns );
+    float FV  = 0.25 * pow( clamp( dot(L, H), 0.001, 1), -3. );
+    return Ks * D * FV;
+}
+
+// Note that diffuse and specular must not be multiplied by cos(wi) as this will be done when using de BSDF
+int getSeparateBSDFComponent(Material material, vec3 texC, vec3 L, vec3 V, vec3 N, out vec3 diffuse, out vec3 specular) {
+    diffuse = diffuseBSDF(material, texC) ;
+    specular = specularBSDF(material, texC, L, V, N);
+    return 1;
+}
+
+// Blinn-Phong exponent to Roughness conversiont :
+// https://computergraphics.stackexchange.com/questions/1515/what-is-the-accepted-method-of-converting-shininess-to-roughness-and-vice-versa
+float getGGXRoughness(Material material, vec3 texC) {
+    float Ns = getNs( material, texC.xy );
+    if (Ns > 1) {
+        Ns = Ns/128;
+    }
+    float r = clamp(1-Ns, 0.04, 0.96);
+    return r*r;
+}
 
 // wi (light direction) and wo (view direction) are in local frame
 // wi dot N is then wi.z ...
-
 vec3 evaluateBSDF( Material material, vec3 texC, vec3 l, vec3 v ) {
-    // compute half vector
-    vec3 h = normalize( l + v );
-    // http://www.thetenthplanet.de/archives/255
-    // Minimalist Cook-Torrance using Blinn-Phong approximation
-    vec3 Kd   = getDiffuseColor( material, texC ).rgb / Pi;
-    vec3 diff = Kd;
-
-    vec3 Ks  = getSpecularColor( material, texC );
-    float Ns = getNs( material, texC.xy );
-
-    float D   = ( Ns + 1 ) * OneOver2Pi * pow( max( h.z, 0.0 ), Ns );
-    float FV  = 0.25 * pow( dot( l, h ), -3. );
-    vec3 spec = Ks * D * FV;
+    vec3 diff = diffuseBSDF( material, texC );
+    vec3 spec = specularBSDF( material, texC, l, v, vec3(0, 0, 1) );
     return ( diff + spec ) * max( l.z, 0.0 );
 }
 

--- a/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
+++ b/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
@@ -104,9 +104,9 @@ vec3 specularBSDF( Material material, vec3 texC, vec3 L, vec3 V, vec3 N ) {
     vec3 H   = V + L;
     if ( length( H ) < 0.001 ) { H = N; }
     else
-    { H = normalize(H); }
+    { H = normalize( H ); }
     float D  = ( Ns + 1 ) * OneOver2Pi * pow( max( dot( N, H ), 0.0 ), Ns );
-    float FV = 0.25 * pow( clamp( dot( L, H ), 0.001, 1), -3. );
+    float FV = 0.25 * pow( clamp( dot( L, H ), 0.001, 1 ), -3. );
     return Ks * D * FV;
 }
 
@@ -118,7 +118,7 @@ int getSeparateBSDFComponent( Material material,
                               vec3 N,
                               out vec3 diffuse,
                               out vec3 specular ) {
-    diffuse  = diffuseBSDF( material, texC ) ;
+    diffuse  = diffuseBSDF( material, texC );
     specular = specularBSDF( material, texC, L, V, N );
     return 1;
 }

--- a/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
+++ b/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
@@ -130,7 +130,7 @@ float getGGXRoughness( Material material, vec3 texC ) {
     float Ns = getNs( material, texC.xy );
     if ( Ns > 1 ) { Ns = Ns / 128; }
     float r = clamp( 1 - Ns, 0.04, 0.96 );
-    return r * r;
+    return pow( r, 4 );
 }
 
 // wi (light direction) and wo (view direction) are in local frame

--- a/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
+++ b/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
@@ -101,11 +101,12 @@ vec3 specularBSDF( Material material, vec3 texC, vec3 L, vec3 V, vec3 N ) {
     // Minimalist Cook-Torrance using Blinn-Phong approximation
     vec3 Ks  = getSpecularColor( material, texC );
     float Ns = getNs( material, texC.xy );
-    vec3 H = V+L;
+    vec3 H   = V + L;
     if ( length( H ) < 0.001 ) { H = N; }
-    else { H = normalize(H); }
-    float D   = ( Ns + 1 ) * OneOver2Pi * pow( max( dot( N, H ), 0.0 ), Ns );
-    float FV  = 0.25 * pow( clamp( dot( L, H ), 0.001, 1), -3. );
+    else
+    { H = normalize(H); }
+    float D  = ( Ns + 1 ) * OneOver2Pi * pow( max( dot( N, H ), 0.0 ), Ns );
+    float FV = 0.25 * pow( clamp( dot( L, H ), 0.001, 1), -3. );
     return Ks * D * FV;
 }
 
@@ -117,7 +118,7 @@ int getSeparateBSDFComponent( Material material,
                               vec3 N,
                               out vec3 diffuse,
                               out vec3 specular ) {
-    diffuse = diffuseBSDF( material, texC ) ;
+    diffuse  = diffuseBSDF( material, texC ) ;
     specular = specularBSDF( material, texC, L, V, N );
     return 1;
 }
@@ -126,8 +127,8 @@ int getSeparateBSDFComponent( Material material,
 // https://computergraphics.stackexchange.com/questions/1515/what-is-the-accepted-method-of-converting-shininess-to-roughness-and-vice-versa
 float getGGXRoughness( Material material, vec3 texC ) {
     float Ns = getNs( material, texC.xy );
-    if ( Ns > 1 ) { Ns = Ns/128; }
-    float r = clamp( 1-Ns, 0.04, 0.96 );
+    if ( Ns > 1 ) { Ns = Ns / 128; }
+    float r = clamp( 1 - Ns, 0.04, 0.96 );
     return r * r;
 }
 

--- a/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
+++ b/Shaders/Materials/BlinnPhong/BlinnPhong.glsl
@@ -130,7 +130,7 @@ float getGGXRoughness( Material material, vec3 texC ) {
     float Ns = getNs( material, texC.xy );
     if ( Ns > 1 ) { Ns = Ns / 128; }
     float r = clamp( 1 - Ns, 0.04, 0.96 );
-    return pow( r, 4 );
+    return pow( r, 0.5 );
 }
 
 // wi (light direction) and wo (view direction) are in local frame

--- a/Shaders/Materials/BlinnPhong/BlinnPhongZPrepass.frag.glsl
+++ b/Shaders/Materials/BlinnPhong/BlinnPhongZPrepass.frag.glsl
@@ -19,6 +19,7 @@ void main() {
     vec3 normalWorld = getNormal(
         material, getPerVertexTexCoord(), getWorldSpaceNormal(), getWorldSpaceTangent(), binormal );
 
+    // TODO : use BSDF separable interface ?
     out_ambient = vec4( bc.rgb * 0.01 + getEmissiveColor( material, getPerVertexTexCoord() ), 1.0 );
     out_normal  = vec4( normalWorld * 0.5 + 0.5, 1.0 );
     out_diffuse = vec4( bc.xyz, 1.0 );

--- a/Shaders/Materials/Lambertian/Lambertian.glsl
+++ b/Shaders/Materials/Lambertian/Lambertian.glsl
@@ -50,7 +50,6 @@ vec3 getSpecularColor( Material material, vec3 texCoord ) {
     return vec3( 0 );
 }
 
-
 // Return the world-space normal computed according to the microgeometry definition`
 // As no normal map is defined, return N
 vec3 getNormal( Material material, vec3 texCoord, vec3 N, vec3 T, vec3 B ) {
@@ -67,15 +66,16 @@ vec3 diffuseBSDF( Material material, vec3 texC ) {
     return getDiffuseColor( material, texC ).rgb / Pi;
 }
 
-// Note that diffuse and specular must not be multiplied by cos(wi) as this will be done when using de BSDF
+// Note that diffuse and specular must not be multiplied by cos(wi) as this will be done when using
+// the BSDF
 int getSeparateBSDFComponent( Material material,
                               vec3 texC,
                               vec3 L,
                               vec3 V,
                               vec3 N,
                               out vec3 diffuse,
-                              out vec3 specular) {
-    diffuse = diffuseBSDF( material, texC ) ;
+                              out vec3 specular ) {
+    diffuse  = diffuseBSDF( material, texC ) ;
     specular = vec3( 0 );
     return 1;
 }
@@ -88,7 +88,7 @@ float getGGXRoughness( Material material, vec3 texC ) {
 // wi dot N is then wi.z ...
 vec3 evaluateBSDF( Material material, vec3 texC, vec3 l, vec3 v ) {
     vec3 diff = diffuseBSDF( material, texC );
-    return ( diff ) * max( l.z, 0.0 );
+    return diff * max( l.z, 0.0 );
 }
 uniform Material material;
 

--- a/Shaders/Materials/Lambertian/Lambertian.glsl
+++ b/Shaders/Materials/Lambertian/Lambertian.glsl
@@ -50,11 +50,6 @@ vec3 getSpecularColor( Material material, vec3 texCoord ) {
     return vec3( 0 );
 }
 
-// wi (light direction) and wo (view direction) are in local frame
-// wi dot N is then wi.z ...
-vec3 evaluateBSDF( Material material, vec3 texC, vec3 l, vec3 v ) {
-    return max( l.z, 0.0 ) * getDiffuseColor( material, texC ).rgb / Pi;
-}
 
 // Return the world-space normal computed according to the microgeometry definition`
 // As no normal map is defined, return N
@@ -68,6 +63,27 @@ bool toDiscard( Material material, vec4 color ) {
     return ( color.a < 0.1 );
 }
 
+vec3 diffuseBSDF(Material material, vec3 texC) {
+    return getDiffuseColor( material, texC ).rgb / Pi;
+}
+
+// Note that diffuse and specular must not be multiplied by cos(wi) as this will be done when using de BSDF
+int getSeparateBSDFComponent(Material material, vec3 texC, vec3 L, vec3 V, vec3 N, out vec3 diffuse, out vec3 specular) {
+    diffuse = diffuseBSDF(material, texC) ;
+    specular = vec3(0);
+    return 1;
+}
+
+float getGGXRoughness(Material material, vec3 texC) {
+    return 1;
+}
+
+// wi (light direction) and wo (view direction) are in local frame
+// wi dot N is then wi.z ...
+vec3 evaluateBSDF( Material material, vec3 texC, vec3 l, vec3 v ) {
+    vec3 diff = diffuseBSDF( material, texC );
+    return ( diff ) * max( l.z, 0.0 );
+}
 uniform Material material;
 
 #endif

--- a/Shaders/Materials/Lambertian/Lambertian.glsl
+++ b/Shaders/Materials/Lambertian/Lambertian.glsl
@@ -63,18 +63,24 @@ bool toDiscard( Material material, vec4 color ) {
     return ( color.a < 0.1 );
 }
 
-vec3 diffuseBSDF(Material material, vec3 texC) {
+vec3 diffuseBSDF( Material material, vec3 texC ) {
     return getDiffuseColor( material, texC ).rgb / Pi;
 }
 
 // Note that diffuse and specular must not be multiplied by cos(wi) as this will be done when using de BSDF
-int getSeparateBSDFComponent(Material material, vec3 texC, vec3 L, vec3 V, vec3 N, out vec3 diffuse, out vec3 specular) {
-    diffuse = diffuseBSDF(material, texC) ;
-    specular = vec3(0);
+int getSeparateBSDFComponent( Material material,
+                              vec3 texC,
+                              vec3 L,
+                              vec3 V,
+                              vec3 N,
+                              out vec3 diffuse,
+                              out vec3 specular) {
+    diffuse = diffuseBSDF( material, texC ) ;
+    specular = vec3( 0 );
     return 1;
 }
 
-float getGGXRoughness(Material material, vec3 texC) {
+float getGGXRoughness( Material material, vec3 texC ) {
     return 1;
 }
 

--- a/Shaders/Materials/Lambertian/Lambertian.glsl
+++ b/Shaders/Materials/Lambertian/Lambertian.glsl
@@ -75,7 +75,7 @@ int getSeparateBSDFComponent( Material material,
                               vec3 N,
                               out vec3 diffuse,
                               out vec3 specular ) {
-    diffuse  = diffuseBSDF( material, texC ) ;
+    diffuse  = diffuseBSDF( material, texC );
     specular = vec3( 0 );
     return 1;
 }

--- a/Shaders/Materials/Plain/Plain.glsl
+++ b/Shaders/Materials/Plain/Plain.glsl
@@ -62,25 +62,31 @@ bool toDiscard( Material material, vec4 color ) {
 }
 
 
-vec3 diffuseBSDF(Material material, vec3 texC) {
+vec3 diffuseBSDF( Material material, vec3 texC ) {
     return getDiffuseColor( material, texC ).rgb;
 }
 
 // Note that diffuse and specular must not be multiplied by cos(wi) as this will be done when using de BSDF
-int getSeparateBSDFComponent(Material material, vec3 texC, vec3 L, vec3 V, vec3 N, out vec3 diffuse, out vec3 specular) {
-    diffuse = diffuseBSDF(material, texC) ;
-    specular = vec3(0);
+int getSeparateBSDFComponent( Material material,
+                              vec3 texC,
+                              vec3 L,
+                              vec3 V,
+                              vec3 N,
+                              out vec3 diffuse,
+                              out vec3 specular ) {
+    diffuse = diffuseBSDF( material, texC ) ;
+    specular = vec3( 0 );
     return 1;
 }
 
-float getGGXRoughness(Material material, vec3 texC) {
+float getGGXRoughness( Material material, vec3 texC ) {
     return 1;
 }
 
 // wi (light direction) and wo (view direction) are in local frame
 // wi dot N is then wi.z ...
 vec3 evaluateBSDF( Material material, vec3 texC, vec3 l, vec3 v ) {
-    return ( diffuseBSDF( material, texC ) );
+    return diffuseBSDF( material, texC );
 }
 
 uniform Material material;

--- a/Shaders/Materials/Plain/Plain.glsl
+++ b/Shaders/Materials/Plain/Plain.glsl
@@ -50,12 +50,6 @@ vec3 getSpecularColor( Material material, vec3 texCoord ) {
     return vec3( 0 );
 }
 
-// wi (light direction) and wo (view direction) are in local frame
-// wi dot N is then wi.z ...
-vec3 evaluateBSDF( Material material, vec3 texC, vec3 l, vec3 v ) {
-    return getDiffuseColor( material, texC ).rgb;
-}
-
 // Return the world-space normal computed according to the microgeometry definition`
 // As no normal map is defined, return N
 vec3 getNormal( Material material, vec3 texCoord, vec3 N, vec3 T, vec3 B ) {
@@ -65,6 +59,28 @@ vec3 getNormal( Material material, vec3 texCoord, vec3 N, vec3 T, vec3 B ) {
 // return true if the fragment must be condidered as transparent (either fully or partially)
 bool toDiscard( Material material, vec4 color ) {
     return ( color.a < 0.1 );
+}
+
+
+vec3 diffuseBSDF(Material material, vec3 texC) {
+    return getDiffuseColor( material, texC ).rgb;
+}
+
+// Note that diffuse and specular must not be multiplied by cos(wi) as this will be done when using de BSDF
+int getSeparateBSDFComponent(Material material, vec3 texC, vec3 L, vec3 V, vec3 N, out vec3 diffuse, out vec3 specular) {
+    diffuse = diffuseBSDF(material, texC) ;
+    specular = vec3(0);
+    return 1;
+}
+
+float getGGXRoughness(Material material, vec3 texC) {
+    return 1;
+}
+
+// wi (light direction) and wo (view direction) are in local frame
+// wi dot N is then wi.z ...
+vec3 evaluateBSDF( Material material, vec3 texC, vec3 l, vec3 v ) {
+    return ( diffuseBSDF( material, texC ) );
 }
 
 uniform Material material;

--- a/Shaders/Materials/Plain/Plain.glsl
+++ b/Shaders/Materials/Plain/Plain.glsl
@@ -73,7 +73,7 @@ int getSeparateBSDFComponent( Material material,
                               vec3 N,
                               out vec3 diffuse,
                               out vec3 specular ) {
-    diffuse  = diffuseBSDF( material, texC ) ;
+    diffuse  = diffuseBSDF( material, texC );
     specular = vec3( 0 );
     return 1;
 }

--- a/Shaders/Materials/Plain/Plain.glsl
+++ b/Shaders/Materials/Plain/Plain.glsl
@@ -61,7 +61,6 @@ bool toDiscard( Material material, vec4 color ) {
     return ( color.a < 0.1 );
 }
 
-
 vec3 diffuseBSDF( Material material, vec3 texC ) {
     return getDiffuseColor( material, texC ).rgb;
 }
@@ -74,7 +73,7 @@ int getSeparateBSDFComponent( Material material,
                               vec3 N,
                               out vec3 diffuse,
                               out vec3 specular ) {
-    diffuse = diffuseBSDF( material, texC ) ;
+    diffuse  = diffuseBSDF( material, texC ) ;
     specular = vec3( 0 );
     return 1;
 }

--- a/Shaders/Materials/Plain/Plain.glsl
+++ b/Shaders/Materials/Plain/Plain.glsl
@@ -65,7 +65,8 @@ vec3 diffuseBSDF( Material material, vec3 texC ) {
     return getDiffuseColor( material, texC ).rgb;
 }
 
-// Note that diffuse and specular must not be multiplied by cos(wi) as this will be done when using de BSDF
+// Note that diffuse and specular must not be multiplied by cos(wi) as this will be done when using
+// the BSDF
 int getSeparateBSDFComponent( Material material,
                               vec3 texC,
                               vec3 L,

--- a/doc/developer/material.md
+++ b/doc/developer/material.md
@@ -272,18 +272,36 @@ vec4 getBaseColor(Material material, vec3 texCoord);
 // Returns the so called "Diffuse Color" of the material, at the surface coordinates defined by texCoord.
 // This could be the same that the base color or obtained by a more or less complex computation (Fresnel, ...)
 // The alpha channel is the same than the one computed for getBaseColor().
+// Note : might be deprecated in a near future (see getSeparateBSDFComponent)
 vec4 getDiffuseColor(Material material, vec3 texCoord);
 
 // Returns the so called "Specular Color" of the material, at the surface coordinates defined by texCoord.
 // This could be the same that the base color (without the alpha channel) or obtained by
 // a more or less complex computation
+// Note : might be deprecated in a near future (see getSeparateBSDFComponent)
 vec3 getSpecularColor(Material material, vec3 texCoord);
 
-// Return the bsdf value for the material, at surface coordinates defined by texCoord,
-// for the incoming and outgoing directions `wi` and `wo`. These directions MUST be in local frame.
+// Return the reflectance value for the material, at surface coordinates defined by texCoord,
+// for the incoming and outgoing directions `wi` and `wo`. 
+// the reflectance value is defined as bsdf * cos(Theta_i).
+// IMPORTANT : for efficiency reasons, these directions MUST be in local frame.
 // The local Frame is the Frame wher the Geometric normal is the Z axis,
 // and the tangent defined the X axis.
 vec3 evaluateBSDF(Material material, vec3 texCoord, vec3 wi, vec3 wo);
+
+// Extract separated components of the bsdf value for the material according to the Light/View/Normal configuration. 
+// This function must return 0 if the bsdf is not defined for the given configuration (e.g. back-face lighting) and 1 
+// if the results are usable.
+// Separated components are the diffuse part of the BSDF and the specular part of the BSDF.
+// NOTE : these separated components must not include the cos(Theta_i).
+// NOTE : For non separable bsdf model (e.g. bsdf encoded on shperical Harmonics), it is recomended to set the diffuse 
+// part to 0 and to evaluate the bsdf in the specular part.
+int getSeparateBSDFComponent(Material material, vec3 texCoord, vec3 Light, vec3 View, vec3 Normal, out vec3 diffuse, out vec3 specular);
+
+// Return the GGX equivalent "roughness" of the BSDF as defined in the GGX microfacet bsdf model.
+// Roughness might range from 0.04 to 1 for specular to diffuse materials.
+// This roughness might be used, e.g. to filter environment map when computing environment lighting.
+float getGGXRoughness(Material material, vec3 texCoord);
 ~~~
 
 ### Emissivity interface {#emissivity-interface}


### PR DESCRIPTION
_Check if you branch history is PR compatible_
- Your branch need to be up to date with origin/master AND to have linear history (i.e. no merge commit).
- Update your git repository `git fetch origin` if origin is this remote
- Check with the script provided in `scripts/is-history-pr-compatible.sh`
- You must use clang-format style
_These checks are enforced by github workflow actions_
_Please refer to the corresponding log in case of failure_

_UPDATE the form below to describe your PR._

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR introduce separable BSDF interface in the GLSL representation of the shaders.
This will allow renderers to use diffuse/specular components of the BSDF for computing the lighting. This is needed for environment lighting for example.


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
