### PR TITLE
Allow component registration into a system from outside the system.

### DIFF
--- a/src/Engine/System/System.hpp
+++ b/src/Engine/System/System.hpp
@@ -65,6 +65,15 @@ class RA_ENGINE_API System
      */
     std::vector<Component*> getEntityComponents( const Entity* entity );
 
+    /** Register an already configured component to the system.
+     * @param entity The entity owning the component
+     * @param component The component to add to the system
+     * @note the component is added to the system without any compatibility check.
+     */
+    void addComponent( Entity* entity, Component* component ) {
+        registerComponent( entity, component );
+    }
+
   protected:
     /**
      * Registers a component belonging to an entity, making it active within the system.


### PR DESCRIPTION
_Check if you branch history is PR compatible_
- Your branch need to be up to date with origin/master AND to have linear history (i.e. no merge commit).
- Update your git repository `git fetch origin` if origin is this remote
- Check with the script provided in `scripts/is-history-pr-compatible.sh`
- You must use clang-format style
_These checks are enforced by github workflow actions_
_Please refer to the corresponding log in case of failure_

_UPDATE the form below to describe your PR._

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add a public method to the base class System so that directly configured components (e.g. that do not come from file loading) might be added to systems.


* **What is the current behavior?** (You can also link to an open issue here)
The only way to add components to any system is through the `System::handleAssetLoading` method that requires the representation of the component as a `Core::Asset::FileData`.


* **What is the new behavior (if this is a feature change)?**
Components could be created programmatically from scratch, without loading them from a file, and added to any system through a call to the public method `System::addComponent`


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
