### PR TITLE
Point cloud parameter provider

### DIFF
--- a/Shaders/Points/PointCloud.geom.glsl
+++ b/Shaders/Points/PointCloud.geom.glsl
@@ -26,7 +26,7 @@ layout( location = 5 ) in vec3 in_viewVector[];
 layout( location = 6 ) in vec3 in_lightVector[];
 
 uniform Transform transform;
-float pointCloudSplatRadius = 0.0025; // fixme -> uniform
+uniform float pointCloudSplatRadius;
 
 layout( location = 0 ) out vec3 out_position;
 layout( location = 1 ) out vec3 out_normal;

--- a/src/Engine/Component/GeometryComponent.hpp
+++ b/src/Engine/Component/GeometryComponent.hpp
@@ -152,14 +152,10 @@ class RA_ENGINE_API PointCloudComponent : public GeometryComponent
     PointCloud* getGeometry();
 
     /// set the splat size for rendering
-    void setSplatSize(float s) {
-        m_splatSize = s;
-    }
+    inline void setSplatSize( float s ) { m_splatSize = s; }
 
     /// get the splat size for rendering
-    float getSplatSize() const {
-        return m_splatSize;
-    }
+    inline float getSplatSize() const { return m_splatSize; }
 
   public:
     // Component communication management
@@ -179,7 +175,7 @@ class RA_ENGINE_API PointCloudComponent : public GeometryComponent
     // directly hold a reference to the displayMesh to simplify accesses in handlers
     std::shared_ptr<PointCloud> m_displayMesh {nullptr};
     // The diameter of the splat when rendered
-    float m_splatSize{ 0.0025 };
+    float m_splatSize {0.0025};
 };
 
 /*-----------------------------------------------------------------------------------------------*/

--- a/src/Engine/Component/GeometryComponent.hpp
+++ b/src/Engine/Component/GeometryComponent.hpp
@@ -151,6 +151,16 @@ class RA_ENGINE_API PointCloudComponent : public GeometryComponent
     const Ra::Core::Geometry::PointCloud& getCoreGeometry() const;
     PointCloud* getGeometry();
 
+    /// set the splat size for rendering
+    void setSplatSize(float s) {
+        m_splatSize = s;
+    }
+
+    /// get the splat size for rendering
+    float getSplatSize() const {
+        return m_splatSize;
+    }
+
   public:
     // Component communication management
     void setupIO( const std::string& id ) override;
@@ -168,6 +178,8 @@ class RA_ENGINE_API PointCloudComponent : public GeometryComponent
   private:
     // directly hold a reference to the displayMesh to simplify accesses in handlers
     std::shared_ptr<PointCloud> m_displayMesh {nullptr};
+    // The diameter of the splat when rendered
+    float m_splatSize{ 0.0025 };
 };
 
 /*-----------------------------------------------------------------------------------------------*/

--- a/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
+++ b/src/Engine/Renderer/Renderers/ForwardRenderer.cpp
@@ -560,26 +560,26 @@ void ForwardRenderer::resizeInternal() {
 
 /* Test Point cloud parameter provider */
 /*
- * TODO : put this class elsewhere so that others renderers might use it
- * TODO : make point cloud management less specific
+ * WARNING : this class is here only for testing and experimentation purpose.
+ * It will be replace soon by a better management of the way components could add specific
+ * properties to a rendertechnique
+ * TODO : see PR Draft and gist subShaderBlob
  */
-class PointCloudParameterProvider : public ShaderParameterProvider {
+class PointCloudParameterProvider : public ShaderParameterProvider
+{
   public:
-    PointCloudParameterProvider(std::shared_ptr<Material> mat, PointCloudComponent *pointCloud) :
-        ShaderParameterProvider(),
-        m_displayMaterial(mat),
-        m_component(pointCloud) {
-
-    }
+    PointCloudParameterProvider( std::shared_ptr<Material> mat, PointCloudComponent* pointCloud ) :
+        ShaderParameterProvider(), m_displayMaterial( mat ), m_component( pointCloud ) {}
     ~PointCloudParameterProvider() override = default;
     void updateGL() override {
         m_displayMaterial->updateGL();
         m_renderParameters = m_displayMaterial->getParameters();
         m_renderParameters.addParameter( "pointCloudSplatRadius", m_component->getSplatSize() );
     }
-  private :
+
+  private:
     std::shared_ptr<Material> m_displayMaterial;
-    PointCloudComponent *m_component;
+    PointCloudComponent* m_component;
 };
 
 /*
@@ -596,6 +596,12 @@ bool ForwardRenderer::buildRenderTechnique( RenderObject* ro ) const {
     // If renderObject is a point cloud,  add geometry shader for splatting
     auto RenderedGeometry = ro->getMesh().get();
 
+    /*
+     * WARNING : this way of managing specifi geometries is here only for testing and
+     * experimentation purpose. It will be replace soon by a better management of the way components
+     * could add specific properties to a rendertechnique
+     * TODO : see PR Draft and gist subShaderBlob
+     */
     if ( RenderedGeometry && RenderedGeometry->getNumFaces() == 0 )
     {
 
@@ -614,14 +620,17 @@ bool ForwardRenderer::buildRenderTechnique( RenderObject* ro ) const {
         addGeomShader( DefaultRenderingPasses::LIGHTING_TRANSPARENT );
         addGeomShader( DefaultRenderingPasses::Z_PREPASS );
         // construct the parameter provider for the technique
-        auto pointCloud = dynamic_cast<PointCloudComponent *>( ro->getComponent() );
-        if ( pointCloud ) {
+        auto pointCloud = dynamic_cast<PointCloudComponent*>( ro->getComponent() );
+        if ( pointCloud )
+        {
             auto pr = std::make_shared<PointCloudParameterProvider>( material, pointCloud );
             rt->setParametersProvider( pr );
-        } else {
-            rt->setParametersProvider( material );
         }
-    } else {
+        else
+        { rt->setParametersProvider( material ); }
+    }
+    else
+    {
         // make the material the parameter provider for the technique
         rt->setParametersProvider( material );
     }

--- a/tests/ExampleApps/SimpleSimulationApp/main.cpp
+++ b/tests/ExampleApps/SimpleSimulationApp/main.cpp
@@ -82,6 +82,7 @@ int main( int argc, char* argv[] ) {
 
     //! [Create a geometry component with the cloud]
     auto c = new Ra::Engine::PointCloudComponent( "cloud Mesh", e, std::move( cloud ), nullptr );
+    c->setSplatSize( 0.05f );
     //! [Create a geometry component with the cloud]
 
     //! [Register the entity/component association to the geometry system ]


### PR DESCRIPTION
Draft PR to discuss how to allow renderObjects/Component to define some specific rendertechnique part.
For now, when building the rendertechniques, forward renderer make explicitely check for point clouds and add a geometry shader (already in the master branch) and setup a specific shaderParameterProvider (new in this branch).

We must discuss how to make this fully general so that renderObject (and thus components that generates those renderobjects) ca add specific things to any render technique


_Check if you branch history is PR compatible_
- Your branch need to be up to date with origin/master AND to have linear history (i.e. no merge commit).
- Update your git repository `git fetch origin` if origin is this remote
- Check with the script provided in `scripts/is-history-pr-compatible.sh`
- You must use clang-format style
_These checks are enforced by github workflow actions_
_Please refer to the corresponding log in case of failure_

_UPDATE the form below to describe your PR._

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
