### PR TITLE
[GLSL] Fix implicit cast

### DIFF
--- a/Shaders/Materials/Lambertian/Lambertian.glsl
+++ b/Shaders/Materials/Lambertian/Lambertian.glsl
@@ -81,7 +81,7 @@ int getSeparateBSDFComponent( Material material,
 }
 
 float getGGXRoughness( Material material, vec3 texC ) {
-    return 1;
+    return 1.f;
 }
 
 // wi (light direction) and wo (view direction) are in local frame

--- a/Shaders/Materials/Plain/Plain.glsl
+++ b/Shaders/Materials/Plain/Plain.glsl
@@ -80,7 +80,7 @@ int getSeparateBSDFComponent( Material material,
 }
 
 float getGGXRoughness( Material material, vec3 texC ) {
-    return 1;
+    return 1.f;
 }
 
 // wi (light direction) and wo (view direction) are in local frame


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
The implementation of `getGGXRoughness` returns `int` for some materials. The function is expected to return `float`, which create compilation errors on some systems (e.g. ubuntu 18.04. with Intel GPU).

* **What is the new behavior (if this is a feature change)?**
`getGGXRoughness` implementations return `float` values.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
