### PR TITLE
fix issue #584

### DIFF
--- a/external/Engine/CMakeLists.txt
+++ b/external/Engine/CMakeLists.txt
@@ -26,6 +26,7 @@ if (NOT DEFINED glm_DIR)
         ${RADIUM_EXTERNAL_CMAKE_OPTIONS}
         -DGLM_TEST_ENABLE=OFF
         -DBUILD_STATIC_LIBS=OFF
+        -DCMAKE_INSTALL_LIBDIR=lib
         )
 
     set(glm_DIR ${CMAKE_INSTALL_PREFIX}/lib/cmake/glm)
@@ -53,7 +54,7 @@ if (NOT DEFINED glbinding_DIR)
         -DOPTION_BUILD_EXAMPLES=OFF
         )
 
-    set(glbiniding_DIR ${CMAKE_INSTALL_PREFIX})
+    set(glbinding_DIR ${CMAKE_INSTALL_PREFIX}/share/glbinding)
 else()
     add_custom_target(glbinding)
     StatusMessage("[EngineExternal]" "glbinding"  "${glbinding_DIR}")
@@ -84,6 +85,8 @@ if (NOT DEFINED globjects_DIR)
         -Dglm_DIR=${glm_DIR}
         -DEigen3_DIR=${Eigen3_DIR}
         )
+
+    set(globjects_DIR ${CMAKE_INSTALL_PREFIX}/share/globjects)
 else()
     StatusMessage("[EngineExternal]" "globjects" "${globjects_DIR}")
 endif()
@@ -106,5 +109,4 @@ else()
     message(STATUS  "Installing stb_image.h to ${CMAKE_INSTALL_PREFIX}/include")
     file(COPY ${stb_DIR}/stb_image.h DESTINATION  ${CMAKE_INSTALL_PREFIX}/include/stb/)
     file(COPY ${stb_DIR}/stb_image_write.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include/stb/)
-       
 endif()

--- a/external/Engine/package.cmake
+++ b/external/Engine/package.cmake
@@ -1,6 +1,6 @@
-
+# WARNING : if some paths are changed in the following variables, think to change it also in CMakeLists.txt
 if(NOT DEFINED glm_DIR)
-    set(glm_sub_DIR lib/${CMAKE_LIBRARY_ARCHITECTURE}/cmake/glm/ CACHE INTERNAL "")
+    set(glm_sub_DIR lib/cmake/glm/ CACHE INTERNAL "")
     set(glm_DIR ${CMAKE_INSTALL_PREFIX}/${glm_sub_DIR})
 endif()
 


### PR DESCRIPTION
Closes #584 

The issue was due to wrong `external_DIR` variable values for glm, glbinding and globjects.
as the variables are set in two different files, there was some errors not detected by the CI nor our tests : 
 - `external/Engine/CMakeLists.txt` has errors in its paths but is used only to configure/build/install dependencies. These errors were at the origin of the issue.
 - `external/Engine/package.cmake` was correct and used by other Radium component so that the issue was hard to identify.

This PR set the right paths and try to set the paths as simple as possible and add a WARNING comment at the beginning of the `external/Engine/package.cmake` to prevent future errors.