### PR TITLE
Expose manipulator keys (protected)

### DIFF
--- a/src/GuiBase/Viewer/FlightCameraManipulator.hpp
+++ b/src/GuiBase/Viewer/FlightCameraManipulator.hpp
@@ -71,6 +71,7 @@ class RA_GUIBASE_API FlightCameraManipulator : public CameraManipulator,
     Scalar m_flightSpeed {1._ra};
     static void configureKeyMapping_impl();
 
+  protected:
 #define KeyMappingFlightManipulator      \
     KMA_VALUE( FLIGHTMODECAMERA_ROTATE ) \
     KMA_VALUE( FLIGHTMODECAMERA_PAN )    \

--- a/src/GuiBase/Viewer/TrackballCameraManipulator.hpp
+++ b/src/GuiBase/Viewer/TrackballCameraManipulator.hpp
@@ -102,6 +102,7 @@ class RA_GUIBASE_API TrackballCameraManipulator
     bool checkIntegrity( const std::string& mess ) const;
     static void configureKeyMapping_impl();
 
+  protected:
 #define KeyMappingCamera                \
     KMA_VALUE( TRACKBALLCAMERA_ROTATE ) \
     KMA_VALUE( TRACKBALLCAMERA_PAN )    \


### PR DESCRIPTION
_Check if you branch history is PR compatible_
- Your branch need to be up to date with origin/master AND to have linear history (i.e. no merge commit).
- Update your git repository `git fetch origin` if origin is this remote
- Check with the script provided in `scripts/is-history-pr-compatible.sh`
- You must use clang-format style
_These checks are enforced by github workflow actions_
_Please refer to the corresponding log in case of failure_

_UPDATE the form below to describe your PR._

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Small change in camera manipulators API


* **What is the current behavior?** (You can also link to an open issue here)
Right now the keys used in Radium manipulators are defined as `private` fields, which prevent there use in child classes.
This limits the creation of new manipulators extending existing ones.

* **What is the new behavior (if this is a feature change)?**
Define keys (`KeyMappingManager::KeyMappingAction`) as protected fields instead of private.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No change required.

* **Other information**:
