### PR TITLE
Add self debugging function StackTrace and better Debug messages

### DIFF
--- a/cmake/filelistCore.cmake
+++ b/cmake/filelistCore.cmake
@@ -40,6 +40,7 @@ set( core_sources
     Tasks/TaskQueue.cpp
     Utils/Attribs.cpp
     Utils/CircularIndex.cpp
+    Utils/StackTrace.cpp
     Utils/StringUtils.cpp
 )
 
@@ -129,6 +130,7 @@ set( core_headers
     Utils/Log.hpp
     Utils/Observable.hpp
     Utils/Singleton.hpp
+    Utils/StackTrace.hpp
     Utils/StdOptional.hpp
     Utils/StdUtils.hpp
     Utils/StringUtils.hpp

--- a/src/Core/Utils/StackTrace.cpp
+++ b/src/Core/Utils/StackTrace.cpp
@@ -1,0 +1,72 @@
+#include <Core/Utils/StackTrace.hpp>
+namespace Ra {
+namespace Core {
+namespace Utils {
+
+#ifndef OS_WINDOWS
+
+// A C++ function that will produce a stack trace with demangled function and method names.
+#    include <cxxabi.h>   // for __cxa_demangle
+#    include <dlfcn.h>    // for dladdr
+#    include <execinfo.h> // for backtrace
+#    include <sstream>
+#    include <string>
+#    if defined( COMPILER_CLANG )
+#        pragma clang diagnostic ignored "-Wformat"
+#        pragma clang diagnostic ignored "-Wformat-extra-args"
+#    elif defined( COMPILER_GCC )
+#        pragma GCC diagnostic ignored "-Wformat"
+#        pragma GCC diagnostic ignored "-Wformat-extra-args"
+#    endif
+
+std::string StackTrace( int skip ) {
+    void* callstack[128];
+    const int nMaxFrames = sizeof( callstack ) / sizeof( callstack[0] );
+    char buf[1024];
+    int nFrames = backtrace( callstack, nMaxFrames );
+
+    std::ostringstream trace_buf;
+    for ( int i = skip; i < nFrames; i++ )
+    {
+        Dl_info info;
+        if ( dladdr( callstack[i], &info ) )
+        {
+            char* demangled = nullptr;
+            int status;
+            demangled = abi::__cxa_demangle( info.dli_sname, NULL, 0, &status );
+            snprintf( buf,
+                      sizeof( buf ),
+                      "%-3d %*0p %s + %td\n",
+                      i,
+                      int( 2 + sizeof( void* ) * 2 ),
+                      callstack[i],
+                      status == 0 ? demangled : info.dli_sname,
+                      (char*)callstack[i] - (char*)info.dli_saddr );
+            free( demangled );
+        }
+        else
+        {
+            snprintf( buf,
+                      sizeof( buf ),
+                      "%-3d %*0p\n",
+                      i,
+                      int( 2 + sizeof( void* ) * 2 ),
+                      callstack[i] );
+        }
+        trace_buf << buf;
+    }
+    if ( nFrames == nMaxFrames ) trace_buf << "  [truncated]\n";
+    return trace_buf.str();
+}
+
+#else
+
+inline std::string Backtrace( int skip = 1 ) {
+    return "No execution stack trace on windows.";
+}
+
+#endif
+
+} // namespace Utils
+} // namespace Core
+} // namespace Ra

--- a/src/Core/Utils/StackTrace.hpp
+++ b/src/Core/Utils/StackTrace.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include <Core/RaCore.hpp>
+
+#include <string>
+
+namespace Ra {
+namespace Core {
+namespace Utils {
+
+RA_CORE_API std::string StackTrace( int skip = 1 );
+
+} // namespace Utils
+} // namespace Core
+} // namespace Ra

--- a/src/Engine/Renderer/Mesh/Mesh.hpp
+++ b/src/Engine/Renderer/Mesh/Mesh.hpp
@@ -138,13 +138,16 @@ class RA_ENGINE_API AttribArrayDisplayable : public Displayable
         explicit AttribObserver( AttribArrayDisplayable* displayable, int idx ) :
             m_displayable( displayable ), m_idx( idx ) {}
         void operator()() {
-            if ( m_idx < m_displayable->m_dataDirty.size() )
+            if ( m_idx < int( m_displayable->m_dataDirty.size() ) )
             {
                 m_displayable->m_dataDirty[m_idx] = true;
                 m_displayable->m_isDirty          = true;
             }
             else
-                LOG( logDEBUG ) << "Invalid dirty bit notified"; /// \fixme Should never be here
+            {
+                /// \fixme Should never be here
+                LOG( logDEBUG ) << "Invalid dirty bit notified on " << m_displayable->getName();
+            }
         }
 
       private:

--- a/src/Engine/Renderer/OpenGL/OpenGL.hpp
+++ b/src/Engine/Renderer/OpenGL/OpenGL.hpp
@@ -72,6 +72,7 @@ inline const char* glErrorString( gl::GLenum err ) {
 
 #ifdef _DEBUG
 #    include <Core/Utils/Log.hpp>
+#    include <Core/Utils/StackTrace.hpp>
 #    define GL_ASSERT( x )                                                                       \
         x;                                                                                       \
         {                                                                                        \
@@ -97,7 +98,8 @@ inline const char* glErrorString( gl::GLenum err ) {
                 LOG( Ra::Core::Utils::logERROR )                                             \
                     << "OpenGL error (" << __FILE__ << ":" << __LINE__                       \
                     << ", glCheckError()) : " << errBuf << "(" << err << " : 0x" << std::hex \
-                    << err << std::dec << ").";                                              \
+                    << err << std::dec << ")." << '\n'                                       \
+                    << Ra::Core::Utils::StackTrace();                                        \
                 BREAKPOINT( 0 );                                                             \
             }                                                                                \
         }

--- a/src/Engine/Renderer/RenderTechnique/ShaderProgram.cpp
+++ b/src/Engine/Renderer/RenderTechnique/ShaderProgram.cpp
@@ -156,7 +156,6 @@ void ShaderProgram::loadShader( ShaderType type,
     std::unique_ptr<globjects::StaticStringSource> fullsource {nullptr};
     if ( fromFile )
     {
-        LOG( logDEBUG ) << "Loading shader " << name;
         auto loadedSource = globjects::Shader::sourceFromFile( name );
         fullsource = globjects::Shader::sourceFromString( shaderHeader + loadedSource->string() );
     }


### PR DESCRIPTION
This PR add only a `Ra::Core::Utils` fonction to display the execution stack and to ease self debugging. This function is called, e.g. by the macro `GL_CHECK_ERROR` in debug mode to ease locating in which call sequence an OpenGL error is thrown.
