### PR TITLE
[cmake] make doc CMakeLists.txt working standalone.

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -44,6 +44,20 @@ if(DOXYGEN_FOUND)
     # configure doxygen target 
     set(RADIUM_DOC_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/)
     set(RADIUM_MAIN_DOC_FILE ${CMAKE_CURRENT_SOURCE_DIR}/main.md)
+
+    find_package(Git QUIET)
+    if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../.git")
+        execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            OUTPUT_VARIABLE GIT_CHANGESET)
+        if ( GIT_CHANGESET )
+            # remove new line sometime appearing in git changeset
+            string(REGEX REPLACE "\n$" "" GIT_CHANGESET "${GIT_CHANGESET}")
+        endif()
+    else()
+        set(GIT_CHANGESET "")
+    endif()
+
     set(RADIUM_PROJECT_NUMBER ${GIT_CHANGESET})
 
     # be nice with IDE: add .md files
@@ -101,7 +115,7 @@ if(DOXYGEN_FOUND)
     set( DOXYGEN_IMAGE_PATH             "${CMAKE_CURRENT_SOURCE_DIR}/images")
     
     doxygen_add_docs(RadiumDoc
-        ${md_pages_order} ${md_files} ${RADIUM_SRC_DIR} ${CURRENT_SRC_DIR}
+        ${md_pages_order} ${md_files} ${CMAKE_CURRENT_SOURCE_DIR}/../src/ ${CURRENT_SRC_DIR}
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMENT "Generating API documentation with Doxygen"
         )


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** 
bug fix


* **What is the current behavior?**
github workflow use doc/CMakeLists.txt as a standalone project, but some cmake variables are then not set.
For instance there is no sources files listed when generating the doc, so no documentation for the classes ;)

* **What is the new behavior (if this is a feature change)?**
(re-)define virables in the doc/CMakeLists.txt, so the documentation can be generated as a standalone cmake project.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
I focus on documentation pages in the previous PRs, and just realize "something" is missing.