### PR TITLE
Fix windows external

### DIFF
--- a/cmake/externalFunc.cmake
+++ b/cmake/externalFunc.cmake
@@ -70,7 +70,7 @@ macro(addExternalFolder NAME FOLDER )
             message(STATUS "Enable compatibility mode for Xcode Generator")
         endif ()
 
-                message(STATUS "EXEC")
+        message(STATUS "EXEC")
         execute_process(
             COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE} --target ${RadiumExternalMakeTarget}
                 WORKING_DIRECTORY ${EXT_WORKING_DIR}

--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -34,7 +34,6 @@ addExternalFolder(Engine ${CMAKE_SOURCE_DIR}/external/Engine ${LocalDependencies
 
 find_package(glbinding REQUIRED NO_DEFAULT_PATH )
 find_package(globjects REQUIRED NO_DEFAULT_PATH )
-
 find_package(Eigen3 REQUIRED  NO_DEFAULT_PATH )
 
 #This one should be extracted directly from external project properties.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,19 +18,31 @@ endif()
 
 if (MSVC OR MSVC_IDE OR MINGW)
     # must find the RadiumExternal directory. This will be set by RadiumConfig.cmake after install
-    # 
+    #
     # TODO : find a way to that more efficiently
-    find_dependency(cpplocate REQUIRED NO_DEFAULT_PATH)
-    find_dependency(glbinding REQUIRED NO_DEFAULT_PATH)
-    find_dependency(globjects REQUIRED NO_DEFAULT_PATH)
-    if(RADIUM_IO_TINYPLY)
+    if(DEFINED cpplocate_DIR)
+        find_dependency(cpplocate REQUIRED NO_DEFAULT_PATH)
+    endif()
+    if(DEFINED glbinding_DIR)
+        find_dependency(glbinding REQUIRED NO_DEFAULT_PATH)
+    endif()
+    if(DEFINED globjects_DIR)
+        find_dependency(globjects REQUIRED NO_DEFAULT_PATH)
+    endif()
+    if(RADIUM_IO_TINYPLY AND DEFINED tinyply_DIR)
         find_dependency(tinyply REQUIRED NO_DEFAULT_PATH)
     endif()
     set(RadiumExternalDlls_location "")
-    addImportedDir( FROM cpplocate::cpplocate TO RadiumExternalDlls_location) 
-    addImportedDir( FROM glbinding::glbinding TO RadiumExternalDlls_location) 
-    addImportedDir( FROM globjects::globjects TO RadiumExternalDlls_location)
-    if(RADIUM_IO_TINYPLY)
+    if(cpplocate_DIR)
+        addImportedDir( FROM cpplocate::cpplocate TO RadiumExternalDlls_location)
+    endif()
+    if(glbinding_DIR)
+        addImportedDir( FROM glbinding::glbinding TO RadiumExternalDlls_location)
+    endif()
+    if(DEFINED globjects_DIR)
+        addImportedDir( FROM globjects::globjects TO RadiumExternalDlls_location)
+    endif()
+    if(RADIUM_IO_TINYPLY AND DEFINED tinyply_DIR)
         addImportedDir( FROM tinyply TO RadiumExternalDlls_location)
     endif()
 endif()
@@ -43,7 +55,7 @@ endif()
 
 add_subdirectory(external)
 
-# unittest use catch2 to define unittests on low level functions 
+# unittest use catch2 to define unittests on low level functions
 add_subdirectory(unittest)
 
 # integration run whole program with parameters,
@@ -51,7 +63,7 @@ add_subdirectory(unittest)
 add_subdirectory(integration)
 
 # example apps are simple complete application, no test for now.
-# TODO : we can imagine to capture screen output and compare to refs 
+# TODO : we can imagine to capture screen output and compare to refs
 add_subdirectory(ExampleApps)
 add_subdirectory(ExamplePluginWithLib EXCLUDE_FROM_ALL)
 


### PR DESCRIPTION
HOT FIX 
#644 introduce a fix for windows compilation with pre built externals, but breaks configure time built externals.
This hot fix checks if externals *_DIR is define before trying to find externals. If such *_DIR cmake variable is not defined, it means that build needs to find them in build dir, and their setup is done along with Radium libs.