### PR TITLE
Disable warning C4275 with MSVC

### DIFF
--- a/src/Core/CoreMacros.hpp
+++ b/src/Core/CoreMacros.hpp
@@ -385,6 +385,7 @@ MACRO_END
     #pragma warning(disable: 4244) // Conversion from double to float loses data.
     #pragma warning(disable: 4251) // stl dllexports
     #pragma warning(disable: 4267) // conversion from size_t to uint
+    #pragma warning(disable: 4275) // non - DLL-interface class 'class_1' used as base for DLL-interface class 'class_2'
     #pragma warning(disable: 4577) // noexcept used with no exception handling mode
     #pragma warning(disable: 4838) // conversion from enum to uint.
     #pragma warning(disable: 4996) // sprintf unsafe


### PR DESCRIPTION
_Check if you branch history is PR compatible_
- Your branch need to be up to date with origin/master AND to have linear history (i.e. no merge commit).
- Update your git repository `git fetch origin` if origin is this remote
- Check with the script provided in `scripts/is-history-pr-compatible.sh`
- You must use clang-format style
_These checks are enforced by github workflow actions_
_Please refer to the corresponding log in case of failure_

_UPDATE the form below to describe your PR._

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Disable compiler warning with MSVC.

* **What is the current behavior?** (You can also link to an open issue here)
MSVC issue warnings when an exported dll class inherit a template (non-exported) class.
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275?view=msvc-160
We have many classes like this in the code, where the base class is a template for generosity purpose.

* **What is the new behavior (if this is a feature change)?**
Disable this warning when compiling Radium.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No change


* **Other information**:
