### PR TITLE
[Hotfix] Load radium_setup_functions at the beginning

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -24,6 +24,9 @@ ENDIF("${isSystemDir}" STREQUAL "-1")
 
 #--------------------------- Configuration of the Radium exported targets and definitions ---------------------------
 
+# Load Radium cmake functions
+include(${CMAKE_CURRENT_LIST_DIR}/radium_setup_functions.cmake)
+
 include(CMakeFindDependencyMacro)
 find_dependency(Threads REQUIRED)
 if(@OPENMP_FOUND@) # Indicates if OpenMP has been used when compiling the Radium libraries
@@ -174,5 +177,3 @@ endwhile()
 set(RADIUM_ROOT_DIR "${SELF_DIR}")
 set(RADIUM_RESOURCES_DIR "${SELF_DIR}/Resources")
 set(RADIUM_PLUGINS_DIR "${SELF_DIR}/Plugins")
-
-include(${CMAKE_CURRENT_LIST_DIR}/radium_setup_functions.cmake)


### PR DESCRIPTION
_Check if you branch history is PR compatible_
- Your branch need to be up to date with origin/master AND to have linear history (i.e. no merge commit).
- Update your git repository `git fetch origin` if origin is this remote
- Check with the script provided in `scripts/is-history-pr-compatible.sh`
- You must use clang-format style
_These checks are enforced by github workflow actions_
_Please refer to the corresponding log in case of failure_

_UPDATE the form below to describe your PR._

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix https://github.com/STORM-IRIT/Radium-Releases/runs/1679772652?check_suite_focus=true


* **What is the current behavior?** (You can also link to an open issue here)
CMake package use functions defined in `radium_setup_functions.cmake` before including the file, which cause a compilation error with Visual Studio.

* **What is the new behavior (if this is a feature change)?**
Include `radium_setup_functions.cmake` at the beginning of the file.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
