### PR TITLE
Fix Radium resources for app install on windows

### DIFF
--- a/src/Core/Resources/Resources.cpp
+++ b/src/Core/Resources/Resources.cpp
@@ -27,13 +27,13 @@ std::string searchPath( std::string pattern, std::string offset, void* libSymbol
 std::string getRadiumResourcesDir() {
     const std::string baseDir = searchPath(
         "Resources/Shaders", "../..", reinterpret_cast<void*>( getRadiumResourcesDir ) );
-    return baseDir + "Resources/";
+    return baseDir + "/Resources/";
 }
 
 std::string getRadiumPluginsDir() {
     const std::string baseDir =
         searchPath( "Plugins/lib", "../../..", reinterpret_cast<void*>( getRadiumPluginsDir ) );
-    return baseDir + "Plugins/lib/";
+    return baseDir + "/Plugins/lib/";
 }
 
 std::string getBaseDir() {


### PR DESCRIPTION
On windows, when installing an app outside of the Radium bundle, install also the Radium resources (shaders, ...).