### PR TITLE
Fix topo init

### DIFF
--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -470,7 +470,7 @@ void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh ) {
         w.setWedgeData( std::move( wd ) );
         // the newly added wedge is not referenced yet, will be done with `newReference` when
         // creating faces just below
-        m_wedges.m_data.emplace_back( w );
+        m_wedges.m_data.push_back( w );
     }
 
     LOG( logINFO ) << "TopologicalMesh: have  " << m_wedges.size() << " wedges ";

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -454,6 +454,9 @@ void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh ) {
 
     for ( size_t i = 0; i < triMesh.vertices().size(); ++i )
     {
+        // create an empty wedge, with 0 ref
+        Wedge w;
+
         WedgeData wd;
         wd.m_position = triMesh.vertices()[i];
         copyMeshToWedgeData( triMesh,
@@ -463,8 +466,11 @@ void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh ) {
                              m_wedges.m_wedgeVector3AttribHandles,
                              m_wedges.m_wedgeVector4AttribHandles,
                              &wd );
-
-        m_wedges.m_data.emplace_back( wd );
+        // here ref is not incremented
+        w.setWedgeData( std::move( wd ) );
+        // the newly added wedge is not referenced yet, will be done with `newReference` when
+        // creating faces just below
+        m_wedges.m_data.emplace_back( w );
     }
 
     LOG( logINFO ) << "TopologicalMesh: have  " << m_wedges.size() << " wedges ";
@@ -473,7 +479,6 @@ void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh ) {
     {
         std::vector<TopologicalMesh::VertexHandle> face_vhandles( 3 );
         std::vector<TopologicalMesh::Normal> face_normals( 3 );
-        std::vector<unsigned int> face_vertexIndex( 3 );
         std::vector<WedgeIndex> face_wedges( 3 );
         const auto& triangle = triMesh.getIndices()[i];
 
@@ -493,10 +498,10 @@ void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh ) {
             else
             { vh = vtr->second; }
 
-            face_vhandles[j]    = vh;
-            face_normals[j]     = n;
-            face_vertexIndex[j] = inMeshVertexIndex;
-            face_wedges[j]      = WedgeIndex {int( i )};
+            face_vhandles[j] = vh;
+            face_normals[j]  = n;
+            face_wedges[j] =
+                WedgeIndex {static_cast<WedgeIndex::Index::IntegerType>( inMeshVertexIndex )};
         }
 
         // Add the face, then add attribs to vh
@@ -514,7 +519,6 @@ void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh ) {
         { LOG( logWARNING ) << "Invalid face handle returned : face not added (2)"; }
         face_vhandles.clear();
         face_normals.clear();
-        face_vertexIndex.clear();
     }
     LOG( logINFO ) << "TopologicalMesh: load end with  " << m_wedges.size() << " wedges ";
 }

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -481,6 +481,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
         explicit Wedge( const WedgeData& wd ) : m_wedgeData {wd}, m_refCount {1} {};
         const WedgeData& getWedgeData() const { return m_wedgeData; }
         void setWedgeData( const WedgeData& wedgeData ) { m_wedgeData = wedgeData; }
+        void setWedgeData( WedgeData&& wedgeData ) { m_wedgeData = std::move( wedgeData ); }
         void incrementRefCount() { ++m_refCount; }
         void decrementRefCount() {
             if ( m_refCount ) --m_refCount;

--- a/tests/unittest/Core/topomesh.cpp
+++ b/tests/unittest/Core/topomesh.cpp
@@ -228,6 +228,16 @@ TEST_CASE( "Core/Geometry/TopologicalMesh", "[Core][Core/Geometry][TopologicalMe
     REQUIRE( isSameMeshWedge( mesh, newMesh2 ) );
     REQUIRE( topologicalMesh.checkIntegrity() );
 
+    mesh            = Ra::Core::Geometry::makeSharpBox();
+    topologicalMesh = TopologicalMesh();
+    topologicalMesh.initWithWedge( mesh );
+    newMesh  = topologicalMesh.toTriangleMesh();
+    newMesh2 = topologicalMesh.toTriangleMeshFromWedges();
+    REQUIRE( isSameMesh( mesh, newMesh ) );
+    REQUIRE( isSameMesh( mesh, newMesh2 ) );
+    REQUIRE( isSameMeshWedge( mesh, newMesh2 ) );
+    REQUIRE( topologicalMesh.checkIntegrity() );
+
     // Test for mesh with boundaries
     mesh            = Ra::Core::Geometry::makePlaneGrid( 2, 2 );
     topologicalMesh = TopologicalMesh( mesh );


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)
When a TopologicalMesh is create with the initWithWedge method, face indices are broken

* **Other information**:

This patch is a hot fix, adapted from some part of #589, but a bit differently. 
After merge, take care when rebasing #589 to have the new version (since the initWithWedge method move from cpp to inl, it will not be automatic).
