### PR TITLE
[github] remove mirror options.

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -39,7 +39,6 @@ jobs:
         uses: jurplel/install-qt-action@v2
         with:
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
-          mirror: 'http://mirrors.ocf.berkeley.edu/qt/'
       - name: Prepare directories
         run: |
           mkdir -p install/
@@ -115,7 +114,6 @@ jobs:
         uses: jurplel/install-qt-action@v2
         with:
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
-          mirror: 'http://mirrors.ocf.berkeley.edu/qt/'
       - name: Install lcov
         run: sudo apt-get install -y lcov
       - name: Prepare directories


### PR DESCRIPTION
according to https://github.com/jurplel/install-qt-action/commit/49465b8677c54237625d80d9294b4c42fa43a645#commitcomment-46393956

mirror option is not needed nor supported anymore.