### PR TITLE
Engine init 3steps

### DIFF
--- a/cmake/radium_setup_functions.cmake
+++ b/cmake/radium_setup_functions.cmake
@@ -82,10 +82,12 @@ function(configure_cmdline_Radium_app)
     if (MSVC OR MSVC_IDE OR MINGW)
         # Construction of the  dependency paths
         set(FIX_LIBRARY_DIR "${CMAKE_INSTALL_PREFIX}")
+        list(APPEND FIX_LIBRARY_DIR "${RadiumDlls_Location}")
         # Add the Qt bin dir ...
         list(APPEND FIX_LIBRARY_DIR "${QtDlls_location}")
         # Add the Radium externals's dll location 
         list(APPEND FIX_LIBRARY_DIR "${RadiumExternalDlls_location}")
+        list(REMOVE_DUPLICATES FIX_LIBRARY_DIR)
         # Fix the bundled directory
         install(CODE "message(STATUS \"Fixing application with Qt base directory at ${FIX_LIBRARY_DIR} !!\")
                        include(BundleUtilities)
@@ -496,6 +498,8 @@ function(configure_Windows_Radium_app)
         TARGETS ${ARGS_NAME}
         BUNDLE DESTINATION "bin/"
     )
+    message(STATUS "[configure_Windows_Radium_app] Installing  ${ARGS_NAME} (Radium dll from ${RADIUM_ROOT_DIR}/bin)")
+    SET(RadiumDlls_Location ${RADIUM_ROOT_DIR}/bin)
     configure_cmdline_Radium_app(${ARGN})
     # install qtPlugins (QPA plugin name found here https://doc.qt.io/qt-5/qpa.html)
     get_target_property(IsUsingQt ${ARGS_NAME} LINK_LIBRARIES)

--- a/doc/concepts/plantUML/initEngineGL-polymorphic.puml
+++ b/doc/concepts/plantUML/initEngineGL-polymorphic.puml
@@ -1,0 +1,212 @@
+@startuml
+'https://plantuml.com/sequence-diagram
+
+title Initialisation and run sequence for GuiBase::BaseApplication related applications \n Customizable BaseApplication initialization \n
+
+participant main
+participant UserApplication
+participant "Guibase::BaseApplication"
+participant "Engine::RadiumEngine"
+participant "GuiBase::MainWindowInterface"
+participant "Gui::Viewer"
+participant "Gui::WindowQt"
+participant OpenGL
+
+group Kind of user applications
+    group Mara (User defined app)
+    note left of "Engine::RadiumEngine" #AACCFF
+    UserApplication = class derived from "Guibase::BaseApplication".
+    Usage of the inherited class with specific implementation of MainWindowInterface.
+    Application is controlled by the MainWindowInterface implementation.
+    end note
+    -> main : start
+    activate main #AACCFF
+    main -> UserApplication ++ : create( **WindowFactory** )
+
+    end
+
+    group Radium Sandbox (Radium Apps)
+    note left of "Engine::RadiumEngine" #BBFFCC
+    UserApplication = main function.
+    Direct usage of "Guibase::BaseApplication" with specific implementation of MainWindowInterface.
+    Application is controlled by the MainWindowInterface implementation.
+    end note
+    -> UserApplication : start
+    activate UserApplication #BBFFCC
+    end
+
+    group Radium demos (Example Apps)
+    note left of "Engine::RadiumEngine" #FFCCBB
+    UserApplication = main function.
+    Direct usage of "Guibase::BaseApplication" with GuiBase::SimpleWindow as MainWindowInterface.
+    The application populates the Engine and parameterizes timers before entering event loop.
+    Application is automatic.
+    end note
+    -> UserApplication : start
+    activate UserApplication #FFCCBB
+    end
+end
+
+== Application creation and internal configuration ==
+UserApplication -> "Guibase::BaseApplication" ++ : create( argc, argv, appname )
+return
+
+== Engine and gui configuration ==
+UserApplication -> "Guibase::BaseApplication" ++ : initialize( **WindowFactory** )
+
+"Guibase::BaseApplication" -> "Engine::RadiumEngine" ++ : Create & initialize
+return Engine singleton
+
+== Configure Engine and scene services ==
+"Guibase::BaseApplication" -> "Guibase::BaseApplication" ++ : engineBaseInitialization
+group #FF5555 Do we define some "engine default services"
+alt Add initDefaultSystems() method in Engine::RadiumEngine class
+"Guibase::BaseApplication" -> "Engine::RadiumEngine" : initDefaultSystems()
+end
+alt Configure the systems explicitely in the application
+"Guibase::BaseApplication" -> "Engine::RadiumEngine" : Add geometry system
+end
+end
+
+"Guibase::BaseApplication" -> "Engine::RadiumEngine" : Configure time management
+group Overridden engineBaseInitialization methods
+    group #AACCFF Mara (User defined app)
+    "Guibase::BaseApplication" -> UserApplication ++ : specific engine internals
+    return
+    end
+end
+return
+
+== Configure OpenGL context and drawing/application window ==
+"Guibase::BaseApplication" -> "GuiBase::MainWindowInterface" ++ : createMainWindow from **WindowFactory**
+        "GuiBase::MainWindowInterface" -> "Gui::Viewer" ++ : create
+            "Gui::Viewer" -> "Gui::WindowQt" ++ : create
+                "Gui::WindowQt" -> OpenGL ++ : create context
+                return context
+            return
+        return
+        group Connections made by specific implementations of "GuiBase::MainWindowInterface"
+            group #FFCCBB  GuiBase:: SimpleWindow
+            "GuiBase::MainWindowInterface" -> "GuiBase::MainWindowInterface" : no connections
+            end
+            group #BBFFCC Sandbox::mainWindow
+            "GuiBase::MainWindowInterface" -> "Gui::Viewer" : connect slot onGLInitialized() to signal glInitialized
+            "GuiBase::MainWindowInterface" -> "Gui::Viewer" : connect slot onRendererReady() to signal rendererReady
+            end
+            group #AACCFF Mara::mainWindow
+            "GuiBase::MainWindowInterface" -> "GuiBase::MainWindowInterface" : no connections
+            end
+        end
+return mainWindow
+
+"Guibase::BaseApplication" -> "GuiBase::MainWindowInterface" ++ : getViewer()
+return viewer
+
+== Configure event management on the drawing/application window ==
+
+"Guibase::BaseApplication" -> "Gui::Viewer" : connect slot engineOpenGLInitialize() to  signal requestEngineOpenGLInitialization
+
+"Guibase::BaseApplication" -> "Gui::Viewer" : connect slot initializeGL() to signal glInitialized
+"Guibase::BaseApplication" -> "Gui::Viewer" : connect slot askForUpdate() to signal needUpdate
+
+== Make OpenGL and drawing environment to be initialized ==
+"Guibase::BaseApplication" -> "GuiBase::MainWindowInterface" : show
+    "GuiBase::MainWindowInterface" -> "Gui::Viewer" : show
+    "Gui::Viewer" -> "Gui::WindowQt" : show
+    "Gui::WindowQt" -> OpenGL ++ : makeCurrent
+    "Gui::WindowQt" -> "Gui::Viewer" ++ : InitializeGL
+        "Gui::Viewer" -> "Gui::Viewer" : globject init
+        group Signal requestEngineOpenGLInitialization
+        "Gui::Viewer" -> "Guibase::BaseApplication" ++ : engineOpenGLInitialize
+            "Guibase::BaseApplication" -> "Engine::RadiumEngine" ++ : initializeGL()
+            return
+            group #AACCFF Mara (User defined app)
+            "Guibase::BaseApplication" -> UserApplication ++: addRenderers()
+                UserApplication -> "Gui::Viewer" : addRenderer(Forward)
+                UserApplication -> "GuiBase::MainWindowInterface" : build Forward renderer gui
+                UserApplication -> "Gui::Viewer" : addRenderer(NodeBased)
+                UserApplication -> "GuiBase::MainWindowInterface" : build NodeBased renderer gui
+            return
+            end
+        return
+        end
+        "Gui::Viewer" -> "Gui::Viewer" : Services init
+        note left
+        Gizmos and other OpenGL related internals.
+        end note
+        group Signal glInitialized
+            group #BBFFCC Sandbox::mainWindow
+            "GuiBase::MainWindowInterface" <- "Gui::Viewer" ++: onGLInitialized()
+            "GuiBase::MainWindowInterface" -> "Gui::Viewer" : addRenderer(Forward)
+            return
+            end
+
+            "Guibase::BaseApplication" <- "Gui::Viewer" ++ : initializeGL()
+            "Guibase::BaseApplication" -> "Guibase::BaseApplication" : init pre-inserted plugin's GL
+            group Overridden initializeGl methods
+                group #AACCFF Mara (User defined app)
+                "Guibase::BaseApplication" -> UserApplication ++ : initializeGl()
+                return
+                end
+            end
+            return
+        end
+        "Gui::Viewer" -> "Gui::Viewer" : openGL OK
+        "Gui::Viewer" -> "Gui::Viewer" : check renderers
+        note left
+        If no renderer was added, add the default one.
+        Initializes all added renderers.
+        end note
+    return
+
+    "Gui::WindowQt" -> OpenGL : doneCurrent
+    return
+    "Gui::WindowQt" --> "Gui::Viewer"
+    "Gui::Viewer" --> "GuiBase::MainWindowInterface"
+    "GuiBase::MainWindowInterface" --> "Guibase::BaseApplication"
+== Configure and initialize extensions/plugins for application and input/output capabilities on the Engine ==
+    "Guibase::BaseApplication" -> "Guibase::BaseApplication" : Load Plugins
+    "Guibase::BaseApplication" -> "Engine::RadiumEngine" ++ : registerFileLoaders
+    note left of "Engine::RadiumEngine"
+    Radium::IO loaders if configured :
+      - Tinyply
+      - Assimp
+    end note
+    return
+    group Overridden addApplicationExtension methods
+        group #AACCFF Mara (User defined app)
+        "Guibase::BaseApplication" -> UserApplication ++ : addApplicationExtension()
+        UserApplication -> "Engine::RadiumEngine" : registerFileLoader
+        return
+        end
+    end
+return
+== Application / Engine ready to be used ==
+group after "Guibase::BaseApplication" creation
+
+    group Radium demos (Example Apps)
+
+        UserApplication -> "Engine::RadiumEngine" : scene configuration
+        UserApplication -> "Guibase::BaseApplication" ++: event loop
+        return exit()
+        deactivate UserApplication #FFCCBB
+        <- UserApplication : exit
+    end
+    group Radium Sandbox (Radium Apps)
+
+        UserApplication -> "Guibase::BaseApplication" ++: event loop
+        return  exit()
+        deactivate UserApplication #BBFFCC
+        <- UserApplication : exit
+    end
+
+    group Mara (User defined app)
+        main -> UserApplication ++: event loop
+        return exit()
+        deactivate main #AACCFF
+        <- main : exit
+    end
+end
+
+
+@enduml

--- a/src/Engine/RadiumEngine.hpp
+++ b/src/Engine/RadiumEngine.hpp
@@ -28,6 +28,7 @@ class RenderObjectManager;
 class EntityManager;
 class SignalManager;
 class TextureManager;
+class ShaderProgramManager;
 } // namespace Engine
 
 namespace Engine {
@@ -50,9 +51,14 @@ class RA_ENGINE_API RadiumEngine
     void initialize();
 
     /**
-     * Register default shaders, materials and named strings
+     * Initialize all the OpenGL functionalities of the Engine.
+     *   Shader set : reusable shaders, materials and named strings
+     *   Texture set : reusable textures
+     *
+     *   @note When calling this function, caller must ensures that a valid openGL context is bound.
+     *   All initialisations will be done in the bound openGl context.
      */
-    void registerDefaultPrograms();
+    void initializeGL();
 
     /**
      * Free all resources acquired during initialize
@@ -159,6 +165,13 @@ class RA_ENGINE_API RadiumEngine
      * @return the texture manager
      */
     TextureManager* getTextureManager() const;
+
+    /**
+     * Get the shader program manager attached to the engine.
+     * @note, the engine keep ownership on the pointer returned
+     * @return the shader program manager
+     */
+    ShaderProgramManager* getShaderProgramManager() const;
 
     /**
      * Register a new file loader to the engine.
@@ -300,6 +313,11 @@ class RA_ENGINE_API RadiumEngine
     std::string getResourcesDir() { return m_resourcesRootDir; }
 
   private:
+    /**
+     * Register default shaders, materials and named strings
+     */
+    void registerDefaultPrograms();
+
     using Priority  = int;
     using SystemKey = std::pair<Priority, std::string>;
     // use transparent functors :
@@ -321,6 +339,7 @@ class RA_ENGINE_API RadiumEngine
     std::unique_ptr<EntityManager> m_entityManager;
     std::unique_ptr<SignalManager> m_signalManager;
     std::unique_ptr<TextureManager> m_textureManager;
+    std::unique_ptr<ShaderProgramManager> m_shaderProgramManager;
     std::unique_ptr<Core::Asset::FileData> m_loadedFile;
 
     bool m_loadingState {false};

--- a/src/Engine/Renderer/Material/BlinnPhongMaterial.cpp
+++ b/src/Engine/Renderer/Material/BlinnPhongMaterial.cpp
@@ -98,13 +98,14 @@ bool BlinnPhongMaterial::isTransparent() const {
 void BlinnPhongMaterial::registerMaterial() {
     // For resources access (glsl files) in a filesystem
     auto resourcesRootDir {RadiumEngine::getInstance()->getResourcesDir()};
+    auto shaderProgramManager = RadiumEngine::getInstance()->getShaderProgramManager();
 
     // Defining the material converter
     EngineMaterialConverters::registerMaterialConverter( materialName,
                                                          BlinnPhongMaterialConverter() );
 
     // adding the material glsl implementation file
-    ShaderProgramManager::getInstance()->addNamedString(
+    shaderProgramManager->addNamedString(
         "/BlinnPhong.glsl", resourcesRootDir + "Shaders/Materials/BlinnPhong/BlinnPhong.glsl" );
     // registering re-usable shaders
     Ra::Engine::ShaderConfiguration lpconfig(

--- a/src/Engine/Renderer/Material/LambertianMaterial.cpp
+++ b/src/Engine/Renderer/Material/LambertianMaterial.cpp
@@ -20,8 +20,9 @@ LambertianMaterial::~LambertianMaterial() {}
 void LambertianMaterial::registerMaterial() {
     // Get the Radium Resource location on the filesystem
     auto resourcesRootDir {RadiumEngine::getInstance()->getResourcesDir()};
+    auto shaderProgramManager = RadiumEngine::getInstance()->getShaderProgramManager();
 
-    ShaderProgramManager::getInstance()->addNamedString(
+    shaderProgramManager->addNamedString(
         "/Lambertian.glsl", resourcesRootDir + "Shaders/Materials/Lambertian/Lambertian.glsl" );
     // registering re-usable shaders
     Ra::Engine::ShaderConfiguration lpconfig(

--- a/src/Engine/Renderer/Material/PlainMaterial.cpp
+++ b/src/Engine/Renderer/Material/PlainMaterial.cpp
@@ -20,9 +20,10 @@ PlainMaterial::~PlainMaterial() = default;
 void PlainMaterial::registerMaterial() {
     // Get the Radium Resource location on the filesystem
     auto resourcesRootDir {RadiumEngine::getInstance()->getResourcesDir()};
+    auto shaderProgramManager = RadiumEngine::getInstance()->getShaderProgramManager();
 
-    ShaderProgramManager::getInstance()->addNamedString(
-        "/Plain.glsl", resourcesRootDir + "Shaders/Materials/Plain/Plain.glsl" );
+    shaderProgramManager->addNamedString( "/Plain.glsl",
+                                          resourcesRootDir + "Shaders/Materials/Plain/Plain.glsl" );
     // registering re-usable shaders
     Ra::Engine::ShaderConfiguration lpconfig(
         "Plain",

--- a/src/Engine/Renderer/Material/VolumetricMaterial.cpp
+++ b/src/Engine/Renderer/Material/VolumetricMaterial.cpp
@@ -50,14 +50,15 @@ bool VolumetricMaterial::isTransparent() const {
 void VolumetricMaterial::registerMaterial() {
     // For resources access (glsl files) in a filesystem
     auto resourcesRootDir {RadiumEngine::getInstance()->getResourcesDir()};
+    auto shaderProgramManager = RadiumEngine::getInstance()->getShaderProgramManager();
 
-    ShaderProgramManager::getInstance()->addShaderProgram(
+    shaderProgramManager->addShaderProgram(
         {{"ComposeVolume"},
          resourcesRootDir + "Shaders/2DShaders/Basic2D.vert.glsl",
          resourcesRootDir + "Shaders/Materials/Volumetric/ComposeVolumeRender.frag.glsl"} );
 
     // adding the material glsl implementation file
-    ShaderProgramManager::getInstance()->addNamedString(
+    shaderProgramManager->addNamedString(
         "/Volumetric.glsl", resourcesRootDir + "Shaders/Materials/Volumetric/Volumetric.glsl" );
 
     // registering re-usable shaders

--- a/src/Engine/Renderer/RenderTechnique/RenderTechnique.cpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderTechnique.cpp
@@ -1,5 +1,6 @@
 #include <Engine/Renderer/RenderTechnique/RenderTechnique.hpp>
 
+#include <Engine/RadiumEngine.hpp>
 #include <Engine/Renderer/Material/BlinnPhongMaterial.hpp>
 #include <Engine/Renderer/RenderTechnique/RenderParameters.hpp>
 #include <Engine/Renderer/RenderTechnique/ShaderConfigFactory.hpp>
@@ -105,12 +106,14 @@ RenderTechnique::getParametersProvider( Core::Utils::Index pass ) const {
 }
 
 void RenderTechnique::updateGL() {
+    auto shaderProgramManager = RadiumEngine::getInstance()->getShaderProgramManager();
+
     for ( auto p = Index( 0 ); p < m_numActivePass; ++p )
     {
         if ( hasConfiguration( p ) && ( ( nullptr == m_activePasses[p].second ) || isDirty( p ) ) )
         {
             m_activePasses[p].second =
-                ShaderProgramManager::getInstance()->getShaderProgram( m_activePasses[p].first );
+                shaderProgramManager->getShaderProgram( m_activePasses[p].first );
             clearDirty( p );
         }
     }

--- a/src/Engine/Renderer/RenderTechnique/ShaderConfiguration.cpp
+++ b/src/Engine/Renderer/RenderTechnique/ShaderConfiguration.cpp
@@ -1,7 +1,6 @@
 #include <Core/Resources/Resources.hpp>
 #include <Engine/RadiumEngine.hpp>
 #include <Engine/Renderer/RenderTechnique/ShaderConfiguration.hpp>
-#include <Engine/Renderer/RenderTechnique/ShaderProgramManager.hpp>
 /**
  * Plain will be the default shader program
  */

--- a/src/Engine/Renderer/RenderTechnique/ShaderProgramManager.cpp
+++ b/src/Engine/Renderer/RenderTechnique/ShaderProgramManager.cpp
@@ -149,6 +149,5 @@ void ShaderProgramManager::insertShader( const ShaderConfiguration& config,
     m_shaderPrograms.insert( {config, shader} );
 }
 
-RA_SINGLETON_IMPLEMENTATION( ShaderProgramManager );
 } // namespace Engine
 } // namespace Ra

--- a/src/Engine/Renderer/RenderTechnique/ShaderProgramManager.cpp
+++ b/src/Engine/Renderer/RenderTechnique/ShaderProgramManager.cpp
@@ -1,3 +1,4 @@
+#include <Engine/Renderer/RenderTechnique/ShaderConfiguration.hpp>
 #include <Engine/Renderer/RenderTechnique/ShaderProgram.hpp>
 #include <Engine/Renderer/RenderTechnique/ShaderProgramManager.hpp>
 
@@ -5,7 +6,6 @@
 #include <Core/Utils/Log.hpp>
 
 #include <globjects/NamedString.h>
-#include <globjects/Program.h>
 #include <globjects/Shader.h>
 #include <globjects/base/File.h>
 
@@ -41,9 +41,10 @@ bool ShaderProgramManager::addNamedString( const std::string& includepath,
         return false;
     }
 
-    auto file                   = globjects::File::create( realfile );
-    m_namedStrings[includepath] = std::make_pair(
-        std::move( file ), globjects::NamedString::create( includepath, file.get() ) );
+    auto file    = globjects::File::create( realfile );
+    auto filePtr = file.get();
+    m_namedStrings[includepath] =
+        std::make_pair( std::move( file ), globjects::NamedString::create( includepath, filePtr ) );
 
     return true;
 }

--- a/src/Engine/Renderer/RenderTechnique/ShaderProgramManager.hpp
+++ b/src/Engine/Renderer/RenderTechnique/ShaderProgramManager.hpp
@@ -40,9 +40,11 @@ class RA_ENGINE_API ShaderProgramManager final
 {
 
   public:
-    /// TODO ? need Initialization after ctr and before use
+    /// Rule of three needed here to prevent copy on this manager (only movable)
     ShaderProgramManager();
     ~ShaderProgramManager();
+    ShaderProgramManager( const ShaderProgramManager& ) = delete;
+    ShaderProgramManager& operator=( const ShaderProgramManager& ) = delete;
 
     /**
      * Add a shader program to the program collection according to the given configuration.

--- a/src/Engine/Renderer/RenderTechnique/ShaderProgramManager.hpp
+++ b/src/Engine/Renderer/RenderTechnique/ShaderProgramManager.hpp
@@ -38,9 +38,12 @@ namespace Engine {
  */
 class RA_ENGINE_API ShaderProgramManager final
 {
-    RA_SINGLETON_INTERFACE( ShaderProgramManager );
 
   public:
+    /// TODO ? need Initialization after ctr and before use
+    ShaderProgramManager();
+    ~ShaderProgramManager();
+
     /**
      * Add a shader program to the program collection according to the given configuration.
      * This method must be called only once an opeGL context is bound.
@@ -99,9 +102,6 @@ class RA_ENGINE_API ShaderProgramManager final
     void reloadNamedString();
 
   private:
-    /// need Initialization after ctr and before use
-    ShaderProgramManager();
-    ~ShaderProgramManager();
     void insertShader( const ShaderConfiguration& config,
                        const std::shared_ptr<ShaderProgram>& shader );
 

--- a/src/Engine/Renderer/Renderer.hpp
+++ b/src/Engine/Renderer/Renderer.hpp
@@ -387,8 +387,17 @@ class RA_ENGINE_API Renderer
     uint m_width {0};
     uint m_height {0};
 
-    ShaderProgramManager* m_shaderMgr {nullptr};
-    RenderObjectManager* m_roMgr {nullptr};
+    /// This raw pointer is used as an alias to a std::unique_ptr own by the engine.
+    /// It is guaranteed that the lifetime of the engine is longer than the lifetime of a Renderer.
+    /// \see https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Ri-raw
+    /// \see https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-ptr
+    ShaderProgramManager* m_shaderProgramManager {nullptr};
+
+    /// This raw pointer is used as an alias to a std::unique_ptr own by the engine.
+    /// It is guaranteed that the lifetime of the engine is longer than the lifetime of a Renderer.
+    /// \see https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Ri-raw
+    /// \see https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-ptr
+    RenderObjectManager* m_renderObjectManager {nullptr};
 
     //                It would make more sense if we are able to show the
     //                debugged texture in its own viewport.

--- a/src/Engine/Renderer/Renderers/DebugRender.cpp
+++ b/src/Engine/Renderer/Renderers/DebugRender.cpp
@@ -1,5 +1,6 @@
 #include <Engine/Renderer/Renderers/DebugRender.hpp>
 
+#include <Engine/RadiumEngine.hpp>
 #include <Engine/Renderer/Mesh/Mesh.hpp>
 #include <Engine/Renderer/OpenGL/OpenGL.hpp>
 #include <Engine/Renderer/RenderObject/Primitives/DrawPrimitives.hpp>
@@ -41,7 +42,7 @@ void DebugRender::initialize() {
         { return nullptr; }
     };
 
-    auto shaderMgr = ShaderProgramManager::getInstance();
+    auto shaderProgramManager = RadiumEngine::getInstance()->getShaderProgramManager();
 
     const char* lineVertStr = R"(
                 layout (location = 0) in vec3 in_pos;
@@ -122,9 +123,9 @@ void DebugRender::initialize() {
                 }
                 )";
 
-    m_lineProg  = setShader( shaderMgr, "dbgLineShader", lineVertStr, lineFragStr );
-    m_pointProg = setShader( shaderMgr, "dbgPointShader", pointVertStr, pointFragStr );
-    m_meshProg  = setShader( shaderMgr, "dbgMeshShader", meshVertStr, meshFragStr );
+    m_lineProg  = setShader( shaderProgramManager, "dbgLineShader", lineVertStr, lineFragStr );
+    m_pointProg = setShader( shaderProgramManager, "dbgPointShader", pointVertStr, pointFragStr );
+    m_meshProg  = setShader( shaderProgramManager, "dbgMeshShader", meshVertStr, meshFragStr );
 
     GL_CHECK_ERROR;
 }

--- a/src/GuiBase/BaseApplication.hpp
+++ b/src/GuiBase/BaseApplication.hpp
@@ -153,6 +153,7 @@ class RA_GUIBASE_API BaseApplication : public QApplication
 
     /// slot called when the OpenGL need to be initialized
     virtual void engineOpenGLInitialize();
+
     /// slot called once the application window and its OpenGL services are ready.
     /// TODO : rename this to be more representative of post opengl & gui operations
     virtual void initializeGl();

--- a/src/GuiBase/BaseApplication.hpp
+++ b/src/GuiBase/BaseApplication.hpp
@@ -11,7 +11,7 @@
 #include <PluginBase/RadiumPluginInterface.hpp>
 
 class QTimer;
-
+class QCommandLineParser;
 namespace Ra {
 namespace Engine {
 class RadiumEngine;
@@ -49,16 +49,75 @@ class RA_GUIBASE_API BaseApplication : public QApplication
     /** Setup the application, create main window and main connections.
      * \param argc from main()
      * \param argv from main()
-     * \param factory : a functor that instanciate the mainWindow
      * \param applicationName
      * \param organizationName
      */
     BaseApplication( int& argc,
                      char** argv,
-                     const WindowFactory& factory,
                      QString applicationName  = "RadiumEngine",
                      QString organizationName = "STORM-IRIT" );
-    ~BaseApplication();
+
+    ~BaseApplication() override;
+
+    /** Initialize the application, create the Gui and OpenGL environment.
+     * The initialization of an application is made in several steps
+     *   1. Create and initialize the engine and its non-OpenGL services
+     *     - Once the engine singleton is instanciated, call the BaseApplication's virtual method
+     *     engineBaseInitialization to populate the engine with the base systems
+     *     (eg. GeometrySystem) and configure the non-openGL engine services.
+     *   2. Create and initialize the openGL environment
+     *     - When the openGL context is ready and bound, call the BaseApplication's virtual method
+     *     engineOpenGLInitialize (this method is a virtual slot connected to the event
+     *     Gui::Viewer::requestEngineOpenGLInitialization).
+     *     - When the application and its opengl window are ready, call the BaseApplication's
+     *     virtual method  initializeGl (this method is a virtual slot connected to the event
+     *     Gui::Viewer::glInitialized).
+     *   3. Create Plugin context, load plugins, configure base Radium::IO services
+     *     - The plugins located int the registered plugin paths (into the Radium Engine or
+     *     bundled with the installed application, into paths found in the app configuration file)
+     *     are loaded automatically.
+     *     - The Radium::IO services compiled into the Radium bundle are configured (file loaders)
+     *     - After plugins and default services are configured, call the BaseApplication's virtual
+     *     method addApplicationExtension.
+     *   4. Manage scene related command-line argument
+     *     - loads the given scene, ...
+     *
+     * \param factory : a functor that instanciate the mainWindow
+     * @note The initialize method call virtual methods on the object being initialized to
+     * configure the engine and application services.
+     * When redefining those methods, it is recommended to call the inherited one to have
+     * consistent initialization wrt the BaseApplication ancestor.
+     * The initialize method could be also overloaded by derived classes. In this case, it is
+     * recommended that the overload explicetely call the ancestor method..
+     */
+    void initialize( const WindowFactory& factory );
+
+    /**
+     * This method configure the base, non opengl dependant, scene services.
+     *
+     * It is expected that this method add the Engine's systems required by the application.
+     * and configure the engine time management properties.
+     * The default implementation add the following systems :
+     *   - Ra::Engine::GeometrySystem
+     *
+     * The default implementation also configure the time system according to the user requested
+     * frame rate (app command line argument -framerate) or to the default 60fps.
+     */
+    virtual void engineBaseInitialization();
+
+    /**
+     * Allow derived applications to add specific extensions to the engine and the base application.
+     * Such extensions are expected to be :
+     *  - specific file loaders
+     *  - specific plugins
+     *  - specific global resources needed by the application (Textures, shaders, ...)
+     *  This method could also be used to populate the engine with systems or with OpenGL related
+     *  services if this was not already done in the appropriate methods (engineBaseInitialization,
+     *  engineOpenGLInitialize, initializeGl)
+     *  - specific renderers (could be added instead when configuring OpenGL)
+     *  -
+     */
+    virtual void addApplicationExtension() {};
 
     /// Advance the engine for one frame.
     void radiumFrame();
@@ -92,6 +151,12 @@ class RA_GUIBASE_API BaseApplication : public QApplication
 
   public slots:
 
+    /// slot called when the OpenGL need to be initialized
+    virtual void engineOpenGLInitialize();
+    /// slot called once the application window and its OpenGL services are ready.
+    /// TODO : rename this to be more representative of post opengl & gui operations
+    virtual void initializeGl();
+
     void updateRadiumFrameIfNeeded() {
         // Main loop
         if ( m_isUpdateNeeded.load() ) radiumFrame();
@@ -106,7 +171,6 @@ class RA_GUIBASE_API BaseApplication : public QApplication
     bool loadFile( QString path );
     void framesCountForStatsChanged( uint count );
     void appNeedsToQuit();
-    void initializeOpenGlPlugins();
 
     void setRealFrameRate( bool on );
     void setRecordFrames( bool on );
@@ -177,6 +241,7 @@ class RA_GUIBASE_API BaseApplication : public QApplication
     uint m_numFrames;
     uint m_maxThreads;
     std::vector<FrameTimerData> m_timerData;
+    std::string m_pluginPath;
 
     /// If true, use the wall clock to advance the engine. If false, use a fixed time step.
     bool m_realFrameRate;
@@ -202,6 +267,7 @@ class RA_GUIBASE_API BaseApplication : public QApplication
     std::atomic<int> m_continuousUpdateRequest {1};
 
     Plugins::Context m_pluginContext;
+    QCommandLineParser* m_parser;
 };
 } // namespace GuiBase
 } // namespace Ra

--- a/src/GuiBase/MainWindowInterface.hpp
+++ b/src/GuiBase/MainWindowInterface.hpp
@@ -67,6 +67,9 @@ class RA_GUIBASE_API MainWindowInterface : public QMainWindow
   signals:
     /// Emitted when the closed button has been hit.
     void closed();
+
+    /// Emitted when the viewer request OpenGL initialization of the engine
+    void requestEngineOpenGLInitialization();
 };
 } // namespace GuiBase
 } // namespace Ra

--- a/src/GuiBase/RadiumWindow/SimpleWindow.cpp
+++ b/src/GuiBase/RadiumWindow/SimpleWindow.cpp
@@ -18,7 +18,6 @@ SimpleWindow::SimpleWindow( uint w, uint h, QWidget* parent ) : MainWindowInterf
 
     // Initialize the minimum tools for a Radium-Guibased Application
     m_viewer = std::make_unique<Viewer>();
-    connect( m_viewer.get(), &Viewer::glInitialized, this, &SimpleWindow::onGLInitialized );
     m_viewer->setObjectName( QStringLiteral( "m_viewer" ) );
 
     // Initialize the scene interactive representation
@@ -77,11 +76,6 @@ void SimpleWindow::cleanup() {
 }
 
 void SimpleWindow::createConnections() {}
-
-void SimpleWindow::onGLInitialized() {
-    auto forwardRenderer = std::make_shared<ForwardRenderer>();
-    addRenderer( "Forward renderer (default)", forwardRenderer );
-}
 
 } // namespace GuiBase
 } // namespace Ra

--- a/src/GuiBase/RadiumWindow/SimpleWindow.hpp
+++ b/src/GuiBase/RadiumWindow/SimpleWindow.hpp
@@ -71,10 +71,6 @@ class RA_GUIBASE_API SimpleWindow : public Ra::GuiBase::MainWindowInterface
 
     /// Stores the internal model of engine objects for selection and visibility.
     std::unique_ptr<Ra::GuiBase::ItemModel> m_sceneModel;
-
-  private slots:
-    /// Slot to init renderers once gl is ready
-    void onGLInitialized();
 };
 
 } // namespace GuiBase

--- a/src/GuiBase/Viewer/Viewer.hpp
+++ b/src/GuiBase/Viewer/Viewer.hpp
@@ -141,8 +141,10 @@ class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewe
     const Core::Utils::Color& getBackgroundColor() const { return m_backgroundColor; }
 
     ///@}
-
   signals:
+    /// Emitted when GL context is ready and the engine OpenGL part must be initialized.
+    /// Renderers might be added here using addRenderer.
+    void requestEngineOpenGLInitialization();
     bool glInitialized(); //! Emitted when GL context is ready. We except call to addRenderer here
     void rendererReady(); //! Emitted when the rendered is correctly initialized
     void rightClickPicking( const Ra::Engine::Renderer::PickingResult& result );
@@ -185,14 +187,10 @@ class RA_GUIBASE_API Viewer : public WindowQt, public KeyMappingManageable<Viewe
     /// Initialize renderer internal state + configure lights.
     void initializeRenderer( Engine::Renderer* renderer );
 
-    //
-    // OpenGL primitives
-    // Not herited, defined here in the same way QOpenGLWidget define them.
-    //
-
     /// Initialize openGL. Called on by the first "show" call to the main window.
     /// \warning This function is NOT reentrant, and may behave incorrectly
     /// if called at the same time than #intializeRenderer
+    /// @note Must be called only when a valid openGLContext is bound (see WindowsQt::initialize)
     bool initializeGL() override;
 
     /// Resize the view port and the camera. Called by the resize event.

--- a/src/GuiBase/Viewer/WindowQt.hpp
+++ b/src/GuiBase/Viewer/WindowQt.hpp
@@ -71,11 +71,15 @@ class RA_GUIBASE_API WindowQt : public QWindow
     void initialize();
     void resizeInternal( QResizeEvent* event );
 
-    // note when updating from globjets
-    // paintGL done by base app rendering loop
-
+    //
+    // OpenGL related methods
+    // Not inherited, defined here in the same way QOpenGLWidget define them.
+    //
+    /// Initialize the openGL related part of the Window
     virtual bool initializeGL();
+    /// DeInitialize the OpenGL
     virtual void deinitializeGL();
+    /// Resize the OpenGL related part of the Window
     virtual void resizeGL( QResizeEvent* event );
 
     // note when updating from globjets

--- a/tests/ExampleApps/CustomCameraManipulator/main.cpp
+++ b/tests/ExampleApps/CustomCameraManipulator/main.cpp
@@ -56,7 +56,8 @@ class CameraManipulator2D : public Ra::Gui::TrackballCameraManipulator
 
 int main( int argc, char* argv[] ) {
     //! [Creating the application]
-    Ra::GuiBase::BaseApplication app( argc, argv, Ra::GuiBase::SimpleWindowFactory {} );
+    Ra::GuiBase::BaseApplication app( argc, argv );
+    app.initialize( Ra::GuiBase::SimpleWindowFactory {} );
     //! [Creating the application]
 
     //! [Creating the cube]

--- a/tests/ExampleApps/DrawPrimitivesApp/minimalapp.cpp
+++ b/tests/ExampleApps/DrawPrimitivesApp/minimalapp.cpp
@@ -34,7 +34,10 @@ MinimalApp::MinimalApp( int& argc, char** argv ) :
     m_viewer.reset( new Ra::Gui::Viewer );
 
     CORE_ASSERT( m_viewer != nullptr, "GUI was not initialized" );
-    connect( m_viewer.get(), &Ra::Gui::Viewer::glInitialized, this, &MinimalApp::onGLInitialized );
+    connect( m_viewer.get(),
+             &Ra::Gui::Viewer::requestEngineOpenGLInitialization,
+             this,
+             &MinimalApp::onGLInitialized );
     m_viewer->setupKeyMappingCallbacks();
 
     // Initialize timer for the spinning cube.
@@ -51,6 +54,9 @@ MinimalApp::~MinimalApp() {
 }
 
 void MinimalApp::onGLInitialized() {
+    // initialize here the OpenGL part of the engine used by the application
+    m_engine->initializeGL();
+    // add the renderer
     std::shared_ptr<Ra::Engine::Renderer> e( new Ra::Engine::ForwardRenderer() );
     m_viewer->addRenderer( e );
     connect( m_frame_timer, &QTimer::timeout, this, &MinimalApp::frame );

--- a/tests/ExampleApps/HelloRadium/main.cpp
+++ b/tests/ExampleApps/HelloRadium/main.cpp
@@ -12,7 +12,8 @@
 
 int main( int argc, char* argv[] ) {
     //! [Creating the application]
-    Ra::GuiBase::BaseApplication app( argc, argv, Ra::GuiBase::SimpleWindowFactory {} );
+    Ra::GuiBase::BaseApplication app( argc, argv );
+    app.initialize( Ra::GuiBase::SimpleWindowFactory {} );
     //! [Creating the application]
 
     //! [Creating the cube]

--- a/tests/ExampleApps/RawShaderMaterial/main.cpp
+++ b/tests/ExampleApps/RawShaderMaterial/main.cpp
@@ -120,7 +120,10 @@ std::shared_ptr<Ra::Engine::RenderObject> initQuad( Ra::GuiBase::BaseApplication
 }
 
 int main( int argc, char* argv[] ) {
-    Ra::GuiBase::BaseApplication app( argc, argv, Ra::GuiBase::SimpleWindowFactory {} );
+    //! [Creating the application]
+    Ra::GuiBase::BaseApplication app( argc, argv );
+    app.initialize( Ra::GuiBase::SimpleWindowFactory {} );
+    //! [Creating the application]
 
     //! [add the custom material to the material system]
     Ra::Engine::RawShaderMaterial::registerMaterial();

--- a/tests/ExampleApps/SimpleAnimationApp/main.cpp
+++ b/tests/ExampleApps/SimpleAnimationApp/main.cpp
@@ -125,7 +125,8 @@ class SimpleAnimationSystem : public Ra::Engine::System
 
 int main( int argc, char* argv[] ) {
     //! [Creating the application]
-    Ra::GuiBase::BaseApplication app( argc, argv, Ra::GuiBase::SimpleWindowFactory {} );
+    Ra::GuiBase::BaseApplication app( argc, argv );
+    app.initialize( Ra::GuiBase::SimpleWindowFactory {} );
 
     //![Parameterize the Engine  time loop]
     app.m_engine->setEndTime( 3_ra ); // <-- 3 relates to the keyframes of the demo component.

--- a/tests/ExampleApps/SimpleSimulationApp/main.cpp
+++ b/tests/ExampleApps/SimpleSimulationApp/main.cpp
@@ -58,7 +58,8 @@ class SimpleSimulationSystem : public Ra::Engine::System
 
 int main( int argc, char* argv[] ) {
     //! [Creating the application]
-    Ra::GuiBase::BaseApplication app( argc, argv, Ra::GuiBase::SimpleWindowFactory {} );
+    Ra::GuiBase::BaseApplication app( argc, argv );
+    app.initialize( Ra::GuiBase::SimpleWindowFactory {} );
     //! [Creating the application]
 
     //! [Creating the cloud]


### PR DESCRIPTION
Closes #670 

To test this proposal using Radium-Apps, pull the branch engine_init_3steps from STORM-IRIT/Radium-Apps repo
Apps_examples from this repo works with this proposal.
The only modifications needed by an application relying on Ra::Gui::BaseApplication to use this proposal is just to modify the application creation code.
instead of 
```c++ 
    Ra::GuiBase::BaseApplication app( argc, argv, YourWindowFactory {} );
```
do 
```c++ 
    Ra::GuiBase::BaseApplication app( argc, argv );
    app.initialize( YourWindowFactory {} );
```

Before this PR, engine initialization and BaseApplication initialization where monolithic. This prevented to customize the engine parametrization from an app derived from BaseApplication so that one can add specific services and manage coherently its custom application or prevent to integrate services (e.g. skeleton animation) easily into the engine.

By splitting the Engine initialization, removing some singleton to make them attributes of another singleton, and by allowing applications to truly derived from `GuiBase::BaseApplication`, this proposal is a first step toward fully customizable apps and services.

For now, the monolithic application initialization workflow is the following :
![monolithic_Engine_app_init](https://user-images.githubusercontent.com/11328578/106390211-926acc80-63e7-11eb-90c7-268c94e111b6.png)


The new proposed application initialization workflow is the following. Note that older apps do not need to be modified but custom apps are now able to concentrate into one class (the derived fro BaseApplication) all the initialization instead of spreading these over several classes (window, application, ...) :
![modular_Engine_app_init](https://user-images.githubusercontent.com/11328578/106390220-9b5b9e00-63e7-11eb-9707-bd674714cf76.png)


