### PR TITLE
Request for git when fetching externals

### DIFF
--- a/cmake/ExternalInclude.cmake
+++ b/cmake/ExternalInclude.cmake
@@ -42,3 +42,7 @@ set(RADIUM_EXTERNAL_CMAKE_OPTIONS
 macro(StatusMessage MODULE NAME VAR)
     message(STATUS "${MODULE} Using ${NAME} from ${VAR}")
 endmacro()
+
+macro(CheckExternalsPrerequisite)
+    find_package(Git REQUIRED)
+endmacro()

--- a/external/Core/CMakeLists.txt
+++ b/external/Core/CMakeLists.txt
@@ -14,6 +14,7 @@ string(REPLACE ";" "" indent_string "${CMAKE_MESSAGE_INDENT}")
 set(indent_string "${indent_string}--")
 
 if (NOT DEFINED Eigen3_DIR)
+    CheckExternalsPrerequisite()
     StatusMessage("" "eigen3" "remote git")
 
     ExternalProject_Add(Eigen3
@@ -34,6 +35,7 @@ endif ()
 
 
 if (NOT DEFINED OpenMesh_DIR)
+    CheckExternalsPrerequisite()
     StatusMessage("" "OpenMesh" "remote git")
     # I found some problems when generating xcode project for OpenMesh: the libXXX.dylib link to
     # libXXX.Major.minor.dylib (eg libOpenMesh.2.1.dylib) is not generated and the script failed.
@@ -55,6 +57,7 @@ else()
 endif()
 
 if (NOT DEFINED cpplocate_DIR OR NOT cpplocate_DIR)
+    CheckExternalsPrerequisite()
     StatusMessage("" "cpplocate" "remote git")
     ExternalProject_Add(cpplocate
         GIT_REPOSITORY https://github.com/cginternals/cpplocate.git

--- a/external/Engine/CMakeLists.txt
+++ b/external/Engine/CMakeLists.txt
@@ -18,6 +18,7 @@ string(REPLACE ";" "" indent_string "${CMAKE_MESSAGE_INDENT}")
 set(indent_string "${indent_string}--")
 
 if (NOT DEFINED glm_DIR)
+    CheckExternalsPrerequisite()
     StatusMessage("[EngineExternal]" "glm" "remote git")
     ExternalProject_Add( glm
         GIT_REPOSITORY https://github.com/g-truc/glm.git
@@ -42,6 +43,7 @@ endif()
 
 
 if (NOT DEFINED glbinding_DIR)
+    CheckExternalsPrerequisite()
     StatusMessage("[EngineExternal]" "glbinding" "remote git")
     ExternalProject_Add(glbinding
         GIT_REPOSITORY https://github.com/cginternals/glbinding.git
@@ -73,6 +75,7 @@ else ()
 endif ()
 
 if (NOT DEFINED globjects_DIR)
+    CheckExternalsPrerequisite()
     StatusMessage("" "globjects" "remote git")
     ExternalProject_Add(globjects
         GIT_REPOSITORY https://github.com/dlyr/globjects.git
@@ -98,6 +101,7 @@ else()
 endif()
 
 if (NOT DEFINED stb_DIR)
+    CheckExternalsPrerequisite()
     StatusMessage("" "stb" "remote git")
     ExternalProject_Add( stb
         GIT_REPOSITORY https://github.com/nothings/stb.git

--- a/external/IO/CMakeLists.txt
+++ b/external/IO/CMakeLists.txt
@@ -19,6 +19,7 @@ set(indent_string "${indent_string}--")
 
 if (RADIUM_IO_ASSIMP)
     if (NOT DEFINED assimp_DIR)
+        CheckExternalsPrerequisite()
         StatusMessage("[IOExternal]" "assimp" "remote git")
         # I found some problems when generating xcode project for Assimp. The debug version is expected even in Release mode.
         # As Release build does not generate the debug version, the script fail.
@@ -46,6 +47,7 @@ endif()
 
 if(RADIUM_IO_TINYPLY)
     if (NOT DEFINED tinyply_DIR)
+        CheckExternalsPrerequisite()
         StatusMessage("" "tinyply" "remote git")
         ExternalProject_Add( tinyply
             GIT_REPOSITORY https://github.com/ddiakopoulos/tinyply.git


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bugfix


* **What is the current behavior?** (You can also link to an open issue here)
Radium does not require `git`, while it is a mandatory requirement to fetch the externals.

* **What is the new behavior (if this is a feature change)?**
Check with cmake that `git` package is available.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No change 


* **Other information**:
