### PR TITLE
Set CMAKE_OSX_DEPLOYMENT_TARGET to 10.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 # Enable helpfull warnings and C++17 for all files
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# Require OSX 10.15 to support std::filesystem (https://developer.apple.com/documentation/xcode-release-notes/xcode-11-release-notes)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
+
 
 # Project setup, versioning stuff here, change when changing the version
 # Note: keep the project name lower case only for easy linux packaging support


### PR DESCRIPTION


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
Radium cannot be compiled on OSX<10.15, because `std::filesystem` is not yet available.
https://developer.apple.com/documentation/xcode-release-notes/xcode-11-release-notes

* **What is the new behavior (if this is a feature change)?**
Require OSX 10.15 buildchain (also available on older versions of MACOSX).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
