### PR TITLE
[github] Qt cache use cache@v1 (v2 is not compatible).

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -29,8 +29,16 @@ jobs:
       - name: Add msbuild to PATH
         uses: seanmiddleditch/gha-setup-vsdevenv@master
         if: runner.os == 'Windows'
+      - name: Cache Qt
+        id: cache-qt
+        uses: actions/cache@v1
+        with:
+          path: ../Qt
+          key: ${{ matrix.config.name }}-QtCache
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
+        with:
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
       - name: Prepare directories
         run: |
           mkdir -p install/
@@ -96,8 +104,16 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: seanmiddleditch/gha-setup-ninja@master
+      - name: Cache Qt
+        id: cache-qt
+        uses: actions/cache@v1
+        with:
+          path: ../Qt
+          key: coverage-QtCache
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
+        with:
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
       - name: Install lcov
         run: sudo apt-get install -y lcov
       - name: Prepare directories


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature for github action pull-request-ci
our usage of cache for qt install was not good (using relative path do not work with cache@v2).
so we removed cache for qt 
after a [discussion](https://github.com/jurplel/install-qt-action/issues/51) on install-qt they point out to use cache@v1.
let's give it a try.