### PR TITLE
Topo wedges

### DIFF
--- a/doc/developer/mesh.md
+++ b/doc/developer/mesh.md
@@ -109,8 +109,6 @@ During manipulation, if two wedges become the same (i.e. for the example on the 
 To merge wedges an explicit call to TopologicalMesh::mergeEqualWedges is needed.
 When a wedge is not referenced anymore (because referencing halfedges have been deleted), it is marked for deletation. When one call Ra::Core::Geometry::TopologicalMesh::garbage_collection(), the marked wedges are eventually deleted and halfedges index are updated accordingly.
 
-\todo  TopologicalMesh::mergeEqualWedges
-
 TopologicalMesh methods and types related to wedges: 
 
 - Ra::Core::Geometry::TopologicalMesh::WedgeData the actual wedge data, with one vector array for each of the supported types (float, Vector2, Vector3, Vector4). The order in these arrays follow the names found in getXXXAttribNames referenced below.

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -192,6 +192,11 @@ void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh ) {
 TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh ) :
     TopologicalMesh( triMesh, DefaultNonManifoldFaceCommand( "[default ctor (props)]" ) ) {}
 
+TopologicalMesh::TopologicalMesh() {
+    add_property( m_inputTriangleMeshIndexPph );
+    add_property( m_wedgeIndexPph );
+}
+
 TriangleMesh TopologicalMesh::toTriangleMesh() {
     struct VertexDataInternal {
         Vector3 _vertex;
@@ -914,8 +919,13 @@ void TopologicalMesh::delete_face( FaceHandle _fh, bool _delete_isolated_vertice
     for ( auto itr = fh_begin( _fh ); itr.is_valid(); ++itr )
     {
         auto idx = property( m_wedgeIndexPph, *itr );
-        CORE_ASSERT( idx.isValid(), "delete face, halfedge has an invalid wedge index" );
-        m_wedges.del( idx );
+        if ( idx.isInvalid() )
+        {
+            LOG( logWARNING )
+                << "[TopologicalMesh::delete_face] halfedge has an invalid wedge index";
+        }
+        else
+        { m_wedges.del( idx ); }
         // set an invalid index for the boundary halfedges
         property( m_wedgeIndexPph, *itr ) = WedgeIndex();
     }

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -129,13 +129,13 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      * Get normal of the vertex vh, when member of fh.
      * \note Asserts if vh is not a member of fh.
      */
-    inline const Normal& normal( VertexHandle vh, FaceHandle fh ) const;
+    [[deprecated]] inline const Normal& normal( VertexHandle vh, FaceHandle fh ) const;
 
     /**
      * Set normal of the vertex vh, when member of fh.
      * \note Asserts if vh is not a member of fh.
      */
-    void set_normal( VertexHandle vh, FaceHandle fh, const Normal& n );
+    [[deprecated]] void set_normal( VertexHandle vh, FaceHandle fh, const Normal& n );
 
     /// Import Base definition of normal and set normal.
     ///@{
@@ -149,7 +149,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      * If you work with vertex normals, please call this function on all vertex
      * handles before convertion with toTriangleMesh.
      */
-    void propagate_normal_to_halfedges( VertexHandle vh );
+    [[deprecated]] void propagate_normal_to_halfedges( VertexHandle vh );
 
     /**
      * Return a handle to the halfedge property storing vertices indices within
@@ -169,10 +169,14 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      * the TriangleMesh attributes.
      */
     ///@{
-    inline const std::vector<OpenMesh::HPropHandleT<float>>& getFloatPropsHandles() const;
-    inline const std::vector<OpenMesh::HPropHandleT<Vector2>>& getVector2PropsHandles() const;
-    inline const std::vector<OpenMesh::HPropHandleT<Vector3>>& getVector3PropsHandles() const;
-    inline const std::vector<OpenMesh::HPropHandleT<Vector4>>& getVector4PropsHandles() const;
+    [[deprecated]] inline const std::vector<OpenMesh::HPropHandleT<float>>&
+    getFloatPropsHandles() const;
+    [[deprecated]] inline const std::vector<OpenMesh::HPropHandleT<Vector2>>&
+    getVector2PropsHandles() const;
+    [[deprecated]] inline const std::vector<OpenMesh::HPropHandleT<Vector3>>&
+    getVector3PropsHandles() const;
+    [[deprecated]] inline const std::vector<OpenMesh::HPropHandleT<Vector4>>&
+    getVector4PropsHandles() const;
     ///@}
 
     /**
@@ -674,16 +678,16 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     using PropPair = std::pair<AttribHandle<T>, OpenMesh::HPropHandleT<T>>;
 
     template <typename T>
-    inline void copyAttribToTopo( const TriangleMesh& triMesh,
-                                  const std::vector<PropPair<T>>& vprop,
-                                  TopologicalMesh::HalfedgeHandle heh,
-                                  unsigned int vindex );
+    [[deprecated]] inline void copyAttribToTopo( const TriangleMesh& triMesh,
+                                                 const std::vector<PropPair<T>>& vprop,
+                                                 TopologicalMesh::HalfedgeHandle heh,
+                                                 unsigned int vindex );
 
     template <typename T>
-    inline void addAttribPairToTopo( const TriangleMesh& triMesh,
-                                     AttribManager::pointer_type attr,
-                                     std::vector<PropPair<T>>& vprop,
-                                     std::vector<OpenMesh::HPropHandleT<T>>& pph );
+    [[deprecated]] inline void addAttribPairToTopo( const TriangleMesh& triMesh,
+                                                    AttribManager::pointer_type attr,
+                                                    std::vector<PropPair<T>>& vprop,
+                                                    std::vector<OpenMesh::HPropHandleT<T>>& pph );
 
     void split_copy( EdgeHandle _eh, VertexHandle _vh );
     void split( EdgeHandle _eh, VertexHandle _vh );
@@ -694,10 +698,10 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     ///\todo to be deleted/updated
     OpenMesh::HPropHandleT<Index> m_inputTriangleMeshIndexPph;
     OpenMesh::HPropHandleT<Index> m_outputTriangleMeshIndexPph;
-    std::vector<OpenMesh::HPropHandleT<float>> m_floatPph;
-    std::vector<OpenMesh::HPropHandleT<Vector2>> m_vec2Pph;
-    std::vector<OpenMesh::HPropHandleT<Vector3>> m_vec3Pph;
-    std::vector<OpenMesh::HPropHandleT<Vector4>> m_vec4Pph;
+    [[deprecated]] std::vector<OpenMesh::HPropHandleT<float>> m_floatPph;
+    [[deprecated]] std::vector<OpenMesh::HPropHandleT<Vector2>> m_vec2Pph;
+    [[deprecated]] std::vector<OpenMesh::HPropHandleT<Vector3>> m_vec3Pph;
+    [[deprecated]] std::vector<OpenMesh::HPropHandleT<Vector4>> m_vec4Pph;
 
     friend class TMOperations;
 };

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -90,9 +90,9 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
                         NonManifoldFaceCommand command );
 
     /**
-     * Construct an empty topological mesh
+     * Construct an empty topological mesh, only init mandatory properties.
      */
-    explicit TopologicalMesh() {}
+    explicit TopologicalMesh();
 
     /**
      * Return a triangleMesh from the topological mesh.

--- a/src/Core/Geometry/TopologicalMesh.hpp
+++ b/src/Core/Geometry/TopologicalMesh.hpp
@@ -349,7 +349,7 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      *
      * At any time m_position as to be equal to the wedge's vertex point.
      * All wedges have the same set of attributes.
-     * Access and management is delegated to TopologicalMesh and WedgeCollectiom
+     * Access and management is delegated to TopologicalMesh and WedgeCollection
      */
     class WedgeData
     {
@@ -416,6 +416,11 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
     inline std::set<WedgeIndex> getVertexWedges( OpenMesh::VertexHandle vh ) const;
 
     /**
+     * get the wedge index associated with an halfedge
+     */
+    inline WedgeIndex getWedgeIndex( OpenMesh::HalfedgeHandle heh ) const;
+
+    /**
      * Access to wedge data.
      * \param idx must be valid and correspond to a non delete wedge index.
      */
@@ -454,6 +459,18 @@ class RA_CORE_API TopologicalMesh : public OpenMesh::PolyMesh_ArrayKernelT<Topol
      * The old wedge is "deleted". The new wedge reference count is incremented.
      */
     inline void replaceWedgeIndex( OpenMesh::HalfedgeHandle he, const WedgeIndex& widx );
+
+    /**
+     * call mergeEquelWedges( vh ) for every vertices of the mesh.
+     * \see void mergeEqualWedges( OpenMesh::VertexHandle vh );
+     */
+    inline void mergeEqualWedges();
+
+    /**
+     * Merge (make same index) wegdes with the same data around \a vh
+     * \param vh vertex handle to process
+     */
+    inline void mergeEqualWedges( OpenMesh::VertexHandle vh );
 
     /// Remove deleted element from the mesh, including wedges.
     void garbage_collection();

--- a/src/Core/Geometry/TopologicalMesh.inl
+++ b/src/Core/Geometry/TopologicalMesh.inl
@@ -11,7 +11,8 @@ namespace Geometry {
 
 template <typename NonManifoldFaceCommand>
 inline TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh,
-                                         NonManifoldFaceCommand command ) {
+                                         NonManifoldFaceCommand command ) :
+    TopologicalMesh() {
 
     LOG( logINFO ) << "TopologicalMesh: load triMesh with " << triMesh.getIndices().size()
                    << " faces and " << triMesh.vertices().size() << " vertices.";
@@ -27,9 +28,6 @@ inline TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh,
     // use a hashmap for fast search of existing vertex position
     using VertexMap = std::unordered_map<Vector3, TopologicalMesh::VertexHandle, hash_vec>;
     VertexMap vertexHandles;
-
-    add_property( m_inputTriangleMeshIndexPph );
-    add_property( m_wedgeIndexPph );
 
     std::vector<PropPair<float>> vprop_float;
     std::vector<std::pair<AttribHandle<Vector2>, OpenMesh::HPropHandleT<Vector2>>> vprop_vec2;
@@ -161,9 +159,6 @@ void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh, NonManifoldFac
     // use a hashmap for fast search of existing vertex position
     using VertexMap = std::unordered_map<Vector3, TopologicalMesh::VertexHandle, hash_vec>;
     VertexMap vertexHandles;
-
-    add_property( m_inputTriangleMeshIndexPph );
-    add_property( m_wedgeIndexPph );
 
     // loop over all attribs and build correspondance pair
     triMesh.vertexAttribs().for_each_attrib( InitWedgeProps {this, triMesh} );

--- a/src/Core/Geometry/TopologicalMesh.inl
+++ b/src/Core/Geometry/TopologicalMesh.inl
@@ -625,6 +625,11 @@ TopologicalMesh::getVertexWedges( OpenMesh::VertexHandle vh ) const {
     return ret;
 }
 
+inline TopologicalMesh::WedgeIndex
+TopologicalMesh::getWedgeIndex( OpenMesh::HalfedgeHandle heh ) const {
+    return property( getWedgeIndexPph(), heh );
+}
+
 inline const TopologicalMesh::WedgeData&
 TopologicalMesh::getWedgeData( const WedgeIndex& idx ) const {
     return m_wedges.getWedgeData( idx );
@@ -655,6 +660,22 @@ inline void TopologicalMesh::replaceWedgeIndex( OpenMesh::HalfedgeHandle he,
                                                 const WedgeIndex& widx ) {
     m_wedges.del( property( getWedgeIndexPph(), he ) );
     property( getWedgeIndexPph(), he ) = m_wedges.newReference( widx );
+}
+
+inline void TopologicalMesh::mergeEqualWedges() {
+    for ( auto itr = vertices_begin(), stop = vertices_end(); itr != stop; ++itr )
+    {
+        mergeEqualWedges( *itr );
+    }
+}
+
+inline void TopologicalMesh::mergeEqualWedges( OpenMesh::VertexHandle vh ) {
+
+    for ( auto itr = vih_iter( vh ); itr.is_valid(); ++itr )
+    {
+        // replace will search if wedge already present and use it, so merge occurs.
+        replaceWedge( *itr, getWedgeData( property( getWedgeIndexPph(), *itr ) ) );
+    }
 }
 
 inline const std::vector<std::string>& TopologicalMesh::getVec4AttribNames() const {

--- a/tests/unittest/Core/topomesh.cpp
+++ b/tests/unittest/Core/topomesh.cpp
@@ -758,3 +758,40 @@ TEST_CASE( "Core/Geometry/TopologicalMesh/Manifold", "[Core][Core/Geometry][Topo
         }
     }
 }
+
+TEST_CASE( "Core/Geometry/TopologicalMesh/Initialization",
+           "[Core][Core/Geometry][TopologicalMesh]" ) {
+    Ra::Core::Geometry::TopologicalMesh topologicalMesh;
+    Ra::Core::Geometry::TopologicalMesh::VertexHandle vhandle[3];
+    Ra::Core::Geometry::TopologicalMesh::FaceHandle fhandle;
+
+    vhandle[0] =
+        topologicalMesh.add_vertex( Ra::Core::Geometry::TopologicalMesh::Point( 1, -1, -1 ) );
+    vhandle[1] =
+        topologicalMesh.add_vertex( Ra::Core::Geometry::TopologicalMesh::Point( 1, -1, 1 ) );
+    vhandle[2] =
+        topologicalMesh.add_vertex( Ra::Core::Geometry::TopologicalMesh::Point( -1, -1, 1 ) );
+
+    std::vector<Ra::Core::Geometry::TopologicalMesh::VertexHandle> face_vhandles;
+    face_vhandles.push_back( vhandle[0] );
+    face_vhandles.push_back( vhandle[1] );
+    face_vhandles.push_back( vhandle[2] );
+    fhandle = topologicalMesh.add_face( face_vhandles );
+
+    // newly created face have invalid wedges on halfedges
+    auto heh = topologicalMesh.halfedge_handle( fhandle );
+    REQUIRE( topologicalMesh.property( topologicalMesh.getWedgeIndexPph(), heh ).isInvalid() );
+    heh = topologicalMesh.next_halfedge_handle( heh );
+    REQUIRE( topologicalMesh.property( topologicalMesh.getWedgeIndexPph(), heh ).isInvalid() );
+    heh = topologicalMesh.next_halfedge_handle( heh );
+    REQUIRE( topologicalMesh.property( topologicalMesh.getWedgeIndexPph(), heh ).isInvalid() );
+
+    std::cout << "faces: " << topologicalMesh.n_faces() << std::endl;
+    REQUIRE( topologicalMesh.n_faces() == 1 );
+
+    topologicalMesh.request_face_status();
+    topologicalMesh.delete_face( fhandle, false );
+    topologicalMesh.garbage_collection();
+    std::cout << "faces: " << topologicalMesh.n_faces() << std::endl;
+    REQUIRE( topologicalMesh.n_faces() == 0 );
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A bug fix: always add wedge property to topo mesh, even if create on its own. fixes #693
Also adds the mergeEqualWedge method to "compact" a topo mesh if different wedges end up with the same values.

* **What is the current behavior?** (You can also link to an open issue here)
If a topo mesh is create empty, without a core mesh as reference, wedge property is not initialized, so some function (e.g. delete_face) core asserts.

* **What is the new behavior (if this is a feature change)?**
warning message is printed if a face is deleted and have invalid wedge indices.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope.
