### PR TITLE
fix #694: RawShaderMaterial naming convention, and integration target

### DIFF
--- a/src/Engine/Data/RawShaderMaterial.cpp
+++ b/src/Engine/Data/RawShaderMaterial.cpp
@@ -62,12 +62,12 @@ void RawShaderMaterial::registerDefaultTechnique() {
 
 void RawShaderMaterial::registerMaterial() {
     // Defining the material converter
-    EngineMaterialConverters::registerMaterialConverter( "Rendering::RawShaderMaterialData",
+    EngineMaterialConverters::registerMaterialConverter( "Ra::Engine::Data::RawShaderMaterial",
                                                          RawShaderMaterialConverter() );
 }
 
 void RawShaderMaterial::unregisterMaterial() {
-    EngineMaterialConverters::removeMaterialConverter( "Rendering::RawShaderMaterialData" );
+    EngineMaterialConverters::removeMaterialConverter( "Ra::Engine::Data::RawShaderMaterial" );
 }
 
 void RawShaderMaterial::updateGL() {

--- a/src/Engine/Data/RawShaderMaterial.hpp
+++ b/src/Engine/Data/RawShaderMaterial.hpp
@@ -36,7 +36,7 @@ class RA_ENGINE_API RawShaderMaterialData : public MaterialData
         const std::string& instanceName,
         const std::vector<std::pair<Ra::Engine::Data::ShaderType, std::string>>& shaders,
         std::shared_ptr<Ra::Engine::Data::ShaderParameterProvider> paramProvider ) :
-        MaterialData( instanceName, "Ra::Engine::RawShaderMaterialData" ),
+        MaterialData( instanceName, "Ra::Engine::Data::RawShaderMaterial" ),
         m_shaders {shaders},
         m_paramProvider {std::move( paramProvider )} {}
     RawShaderMaterialData()                               = delete;

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -9,8 +9,6 @@ set(INTEGRATION_TEST TinyPlyFileLoader)
 add_executable(integration_${INTEGRATION_TEST}
     ${INTEGRATION_TEST}/main.cpp)
 target_link_libraries(integration_${INTEGRATION_TEST} PUBLIC Core IO)
-configure_radium_app(NAME integration_${INTEGRATION_TEST})
-addRunAndDebugTargets(integration_${INTEGRATION_TEST})
 
 add_custom_target(integration_${INTEGRATION_TEST}_create_ref)
 add_dependencies(integration_create_ref integration_${INTEGRATION_TEST}_create_ref)


### PR DESCRIPTION
Fix #694

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix, when moving and replacing namespace, something bad happens ...
Even if the converter/material/naming need refactoring, this PR fix the issue.

Remove integration target from install


* **What is the current behavior?** (You can also link to an open issue here)
RawShaderMaterial converter is registered with a inconsistant name regarding RawShaderMaterialData.
tests/ExampleApps/RawShaderMaterial crashes

* **What is the new behavior (if this is a feature change)?**
The names are consistent, the app do not crash

