### PR TITLE
Add other interger ctor to Index. Fix #666

### DIFF
--- a/doc/basics/compilation.md
+++ b/doc/basics/compilation.md
@@ -6,7 +6,7 @@ All the dependencies are automatically fetched and compiled at build time.
  * [Core] Eigen, OpenMesh
  * [Engine] glm, globjects, glbindings
  * [IO] Assimp
- * [GuiBase] Qt Core, Qt Widgets and Qt OpenGL v5.5+ (5.14 recommended)
+ * [Gui] Qt Core, Qt Widgets and Qt OpenGL v5.5+ (5.14 recommended)
  * stb_image
 
 See @ref develbuildchain for technical details on dependencies management and how to provide locally installed dependencies.
@@ -70,8 +70,8 @@ RADIUM_GENERATE_LIB_CORE:BOOL=ON
 // Include Radium::Engine in CMake project
 RADIUM_GENERATE_LIB_ENGINE:BOOL=ON
 --
-// Include Radium::GuiBase in CMake project
-RADIUM_GENERATE_LIB_GUIBASE:BOOL=ON
+// Include Radium::Gui in CMake project
+RADIUM_GENERATE_LIB_GUI:BOOL=ON
 --
 // Include Radium::IO in CMake project
 RADIUM_GENERATE_LIB_IO:BOOL=ON

--- a/doc/basics/radium-as-submodule.md
+++ b/doc/basics/radium-as-submodule.md
@@ -9,7 +9,7 @@ Then, to use Radium in your own project, you need to set `CMAKE_PREFIX_PATH=/pat
 and add the following lines in your `CMakeLists.txt`:
 ~~~cmake
 find_package(Radium REQUIRED)
-target_link_libraries(${target} Radium::Core Radium::Engine Radium::IO Radium::GuiBase)
+target_link_libraries(${target} Radium::Core Radium::Engine Radium::IO Radium::Gui)
 ~~~
 Include directories and link instructions are populated automatically by cmake.
 

--- a/doc/concepts/plantUML/initEngineGL-polymorphic.puml
+++ b/doc/concepts/plantUML/initEngineGL-polymorphic.puml
@@ -1,13 +1,13 @@
 @startuml
 'https://plantuml.com/sequence-diagram
 
-title Initialisation and run sequence for GuiBase::BaseApplication related applications \n Customizable BaseApplication initialization \n
+title Initialisation and run sequence for Gui::BaseApplication related applications \n Customizable BaseApplication initialization \n
 
 participant main
 participant UserApplication
-participant "Guibase::BaseApplication"
+participant "Gui::BaseApplication"
 participant "Engine::RadiumEngine"
-participant "GuiBase::MainWindowInterface"
+participant "Gui::MainWindowInterface"
 participant "Gui::Viewer"
 participant "Gui::WindowQt"
 participant OpenGL
@@ -15,7 +15,7 @@ participant OpenGL
 group Kind of user applications
     group Mara (User defined app)
     note left of "Engine::RadiumEngine" #AACCFF
-    UserApplication = class derived from "Guibase::BaseApplication".
+    UserApplication = class derived from "Gui::BaseApplication".
     Usage of the inherited class with specific implementation of MainWindowInterface.
     Application is controlled by the MainWindowInterface implementation.
     end note
@@ -28,7 +28,7 @@ group Kind of user applications
     group Radium Sandbox (Radium Apps)
     note left of "Engine::RadiumEngine" #BBFFCC
     UserApplication = main function.
-    Direct usage of "Guibase::BaseApplication" with specific implementation of MainWindowInterface.
+    Direct usage of "Gui::BaseApplication" with specific implementation of MainWindowInterface.
     Application is controlled by the MainWindowInterface implementation.
     end note
     -> UserApplication : start
@@ -38,7 +38,7 @@ group Kind of user applications
     group Radium demos (Example Apps)
     note left of "Engine::RadiumEngine" #FFCCBB
     UserApplication = main function.
-    Direct usage of "Guibase::BaseApplication" with GuiBase::SimpleWindow as MainWindowInterface.
+    Direct usage of "Gui::BaseApplication" with Gui::SimpleWindow as MainWindowInterface.
     The application populates the Engine and parameterizes timers before entering event loop.
     Application is automatic.
     end note
@@ -48,84 +48,84 @@ group Kind of user applications
 end
 
 == Application creation and internal configuration ==
-UserApplication -> "Guibase::BaseApplication" ++ : create( argc, argv, appname )
+UserApplication -> "Gui::BaseApplication" ++ : create( argc, argv, appname )
 return
 
 == Engine and gui configuration ==
-UserApplication -> "Guibase::BaseApplication" ++ : initialize( **WindowFactory** )
+UserApplication -> "Gui::BaseApplication" ++ : initialize( **WindowFactory** )
 
-"Guibase::BaseApplication" -> "Engine::RadiumEngine" ++ : Create & initialize
+"Gui::BaseApplication" -> "Engine::RadiumEngine" ++ : Create & initialize
 return Engine singleton
 
 == Configure Engine and scene services ==
-"Guibase::BaseApplication" -> "Guibase::BaseApplication" ++ : engineBaseInitialization
+"Gui::BaseApplication" -> "Gui::BaseApplication" ++ : engineBaseInitialization
 group #FF5555 Do we define some "engine default services"
 alt Add initDefaultSystems() method in Engine::RadiumEngine class
-"Guibase::BaseApplication" -> "Engine::RadiumEngine" : initDefaultSystems()
+"Gui::BaseApplication" -> "Engine::RadiumEngine" : initDefaultSystems()
 end
 alt Configure the systems explicitely in the application
-"Guibase::BaseApplication" -> "Engine::RadiumEngine" : Add geometry system
+"Gui::BaseApplication" -> "Engine::RadiumEngine" : Add geometry system
 end
 end
 
-"Guibase::BaseApplication" -> "Engine::RadiumEngine" : Configure time management
+"Gui::BaseApplication" -> "Engine::RadiumEngine" : Configure time management
 group Overridden engineBaseInitialization methods
     group #AACCFF Mara (User defined app)
-    "Guibase::BaseApplication" -> UserApplication ++ : specific engine internals
+    "Gui::BaseApplication" -> UserApplication ++ : specific engine internals
     return
     end
 end
 return
 
 == Configure OpenGL context and drawing/application window ==
-"Guibase::BaseApplication" -> "GuiBase::MainWindowInterface" ++ : createMainWindow from **WindowFactory**
-        "GuiBase::MainWindowInterface" -> "Gui::Viewer" ++ : create
+"Gui::BaseApplication" -> "Gui::MainWindowInterface" ++ : createMainWindow from **WindowFactory**
+        "Gui::MainWindowInterface" -> "Gui::Viewer" ++ : create
             "Gui::Viewer" -> "Gui::WindowQt" ++ : create
                 "Gui::WindowQt" -> OpenGL ++ : create context
                 return context
             return
         return
-        group Connections made by specific implementations of "GuiBase::MainWindowInterface"
-            group #FFCCBB  GuiBase:: SimpleWindow
-            "GuiBase::MainWindowInterface" -> "GuiBase::MainWindowInterface" : no connections
+        group Connections made by specific implementations of "Gui::MainWindowInterface"
+            group #FFCCBB  Gui:: SimpleWindow
+            "Gui::MainWindowInterface" -> "Gui::MainWindowInterface" : no connections
             end
             group #BBFFCC Sandbox::mainWindow
-            "GuiBase::MainWindowInterface" -> "Gui::Viewer" : connect slot onGLInitialized() to signal glInitialized
-            "GuiBase::MainWindowInterface" -> "Gui::Viewer" : connect slot onRendererReady() to signal rendererReady
+            "Gui::MainWindowInterface" -> "Gui::Viewer" : connect slot onGLInitialized() to signal glInitialized
+            "Gui::MainWindowInterface" -> "Gui::Viewer" : connect slot onRendererReady() to signal rendererReady
             end
             group #AACCFF Mara::mainWindow
-            "GuiBase::MainWindowInterface" -> "GuiBase::MainWindowInterface" : no connections
+            "Gui::MainWindowInterface" -> "Gui::MainWindowInterface" : no connections
             end
         end
 return mainWindow
 
-"Guibase::BaseApplication" -> "GuiBase::MainWindowInterface" ++ : getViewer()
+"Gui::BaseApplication" -> "Gui::MainWindowInterface" ++ : getViewer()
 return viewer
 
 == Configure event management on the drawing/application window ==
 
-"Guibase::BaseApplication" -> "Gui::Viewer" : connect slot engineOpenGLInitialize() to  signal requestEngineOpenGLInitialization
+"Gui::BaseApplication" -> "Gui::Viewer" : connect slot engineOpenGLInitialize() to  signal requestEngineOpenGLInitialization
 
-"Guibase::BaseApplication" -> "Gui::Viewer" : connect slot initializeGL() to signal glInitialized
-"Guibase::BaseApplication" -> "Gui::Viewer" : connect slot askForUpdate() to signal needUpdate
+"Gui::BaseApplication" -> "Gui::Viewer" : connect slot initializeGL() to signal glInitialized
+"Gui::BaseApplication" -> "Gui::Viewer" : connect slot askForUpdate() to signal needUpdate
 
 == Make OpenGL and drawing environment to be initialized ==
-"Guibase::BaseApplication" -> "GuiBase::MainWindowInterface" : show
-    "GuiBase::MainWindowInterface" -> "Gui::Viewer" : show
+"Gui::BaseApplication" -> "Gui::MainWindowInterface" : show
+    "Gui::MainWindowInterface" -> "Gui::Viewer" : show
     "Gui::Viewer" -> "Gui::WindowQt" : show
     "Gui::WindowQt" -> OpenGL ++ : makeCurrent
     "Gui::WindowQt" -> "Gui::Viewer" ++ : InitializeGL
         "Gui::Viewer" -> "Gui::Viewer" : globject init
         group Signal requestEngineOpenGLInitialization
-        "Gui::Viewer" -> "Guibase::BaseApplication" ++ : engineOpenGLInitialize
-            "Guibase::BaseApplication" -> "Engine::RadiumEngine" ++ : initializeGL()
+        "Gui::Viewer" -> "Gui::BaseApplication" ++ : engineOpenGLInitialize
+            "Gui::BaseApplication" -> "Engine::RadiumEngine" ++ : initializeGL()
             return
             group #AACCFF Mara (User defined app)
-            "Guibase::BaseApplication" -> UserApplication ++: addRenderers()
+            "Gui::BaseApplication" -> UserApplication ++: addRenderers()
                 UserApplication -> "Gui::Viewer" : addRenderer(Forward)
-                UserApplication -> "GuiBase::MainWindowInterface" : build Forward renderer gui
+                UserApplication -> "Gui::MainWindowInterface" : build Forward renderer gui
                 UserApplication -> "Gui::Viewer" : addRenderer(NodeBased)
-                UserApplication -> "GuiBase::MainWindowInterface" : build NodeBased renderer gui
+                UserApplication -> "Gui::MainWindowInterface" : build NodeBased renderer gui
             return
             end
         return
@@ -136,16 +136,16 @@ return viewer
         end note
         group Signal glInitialized
             group #BBFFCC Sandbox::mainWindow
-            "GuiBase::MainWindowInterface" <- "Gui::Viewer" ++: onGLInitialized()
-            "GuiBase::MainWindowInterface" -> "Gui::Viewer" : addRenderer(Forward)
+            "Gui::MainWindowInterface" <- "Gui::Viewer" ++: onGLInitialized()
+            "Gui::MainWindowInterface" -> "Gui::Viewer" : addRenderer(Forward)
             return
             end
 
-            "Guibase::BaseApplication" <- "Gui::Viewer" ++ : initializeGL()
-            "Guibase::BaseApplication" -> "Guibase::BaseApplication" : init pre-inserted plugin's GL
+            "Gui::BaseApplication" <- "Gui::Viewer" ++ : initializeGL()
+            "Gui::BaseApplication" -> "Gui::BaseApplication" : init pre-inserted plugin's GL
             group Overridden initializeGl methods
                 group #AACCFF Mara (User defined app)
-                "Guibase::BaseApplication" -> UserApplication ++ : initializeGl()
+                "Gui::BaseApplication" -> UserApplication ++ : initializeGl()
                 return
                 end
             end
@@ -162,11 +162,11 @@ return viewer
     "Gui::WindowQt" -> OpenGL : doneCurrent
     return
     "Gui::WindowQt" --> "Gui::Viewer"
-    "Gui::Viewer" --> "GuiBase::MainWindowInterface"
-    "GuiBase::MainWindowInterface" --> "Guibase::BaseApplication"
+    "Gui::Viewer" --> "Gui::MainWindowInterface"
+    "Gui::MainWindowInterface" --> "Gui::BaseApplication"
 == Configure and initialize extensions/plugins for application and input/output capabilities on the Engine ==
-    "Guibase::BaseApplication" -> "Guibase::BaseApplication" : Load Plugins
-    "Guibase::BaseApplication" -> "Engine::RadiumEngine" ++ : registerFileLoaders
+    "Gui::BaseApplication" -> "Gui::BaseApplication" : Load Plugins
+    "Gui::BaseApplication" -> "Engine::RadiumEngine" ++ : registerFileLoaders
     note left of "Engine::RadiumEngine"
     Radium::IO loaders if configured :
       - Tinyply
@@ -175,26 +175,26 @@ return viewer
     return
     group Overridden addApplicationExtension methods
         group #AACCFF Mara (User defined app)
-        "Guibase::BaseApplication" -> UserApplication ++ : addApplicationExtension()
+        "Gui::BaseApplication" -> UserApplication ++ : addApplicationExtension()
         UserApplication -> "Engine::RadiumEngine" : registerFileLoader
         return
         end
     end
 return
 == Application / Engine ready to be used ==
-group after "Guibase::BaseApplication" creation
+group after "Gui::BaseApplication" creation
 
     group Radium demos (Example Apps)
 
         UserApplication -> "Engine::RadiumEngine" : scene configuration
-        UserApplication -> "Guibase::BaseApplication" ++: event loop
+        UserApplication -> "Gui::BaseApplication" ++: event loop
         return exit()
         deactivate UserApplication #FFCCBB
         <- UserApplication : exit
     end
     group Radium Sandbox (Radium Apps)
 
-        UserApplication -> "Guibase::BaseApplication" ++: event loop
+        UserApplication -> "Gui::BaseApplication" ++: event loop
         return  exit()
         deactivate UserApplication #BBFFCC
         <- UserApplication : exit

--- a/doc/developer/buildchain.md
+++ b/doc/developer/buildchain.md
@@ -18,14 +18,14 @@ By default, `${CMAKE_INSTALL_PREFIX}` is set as follow:
 
 # Radium Libraries
 ## Overview
-Radium is split in 5 libraries: Core, Engine, GuiBase, UI and PluginBase.
+Radium is split in 5 libraries: Core, Engine, Gui, UI and PluginBase.
 The compilation of each library is controlled by the following cmake options
 
 ~~~{.cmake}
 option(RADIUM_GENERATE_LIB_CORE       "Include Radium::Core in CMake project" ON)
 option(RADIUM_GENERATE_LIB_IO         "Include Radium::IO in CMake project" ON)
 option(RADIUM_GENERATE_LIB_ENGINE     "Include Radium::Engine in CMake project" ON)
-option(RADIUM_GENERATE_LIB_GUIBASE    "Include Radium::GuiBase in CMake project" ON)
+option(RADIUM_GENERATE_LIB_GUI    "Include Radium::Gui in CMake project" ON)
 option(RADIUM_GENERATE_LIB_PLUGINBASE "Include Radium::PluginBase in CMake project" ON)
 ~~~
 
@@ -35,7 +35,7 @@ option(RADIUM_GENERATE_LIB_PLUGINBASE "Include Radium::PluginBase in CMake proje
 add_dependencies (${ra_engine_target} PUBLIC Radium::Core)
 add_dependencies (${ra_io_target} PUBLIC Radium::Core)
 add_dependencies (${ra_pluginbase_target} Radium::Core Radium::Engine)
-add_dependencies (${ra_guibase_target} PUBLIC Radium::Core Radium::Engine Radium::PluginBase Radium::IO)
+add_dependencies (${ra_gui_target} PUBLIC Radium::Core Radium::Engine Radium::PluginBase Radium::IO)
 ~~~
 
 \warning Consistency of `RADIUM_GENERATE_LIB_***` options is not checked wrt. the dependencies.
@@ -51,7 +51,7 @@ External dependencies can be fetched and built at configure time or pre build on
 Each library comes with its own dependencies, which are fetched and built at **configure** time:
 
 ~~~{.sh}
-$ cmake .. -DRADIUM_GENERATE_LIB_IO=OFF -DRADIUM_GENERATE_LIB_ENGINE=OFF -DRADIUM_GENERATE_LIB_GUIBASE=OFF -DRADIUM_GENERATE_LIB_PLUGINBASE=OFF -DRADIUM_ENABLE_TESTING=OFF
+$ cmake .. -DRADIUM_GENERATE_LIB_IO=OFF -DRADIUM_GENERATE_LIB_ENGINE=OFF -DRADIUM_GENERATE_LIB_GUI=OFF -DRADIUM_GENERATE_LIB_PLUGINBASE=OFF -DRADIUM_ENABLE_TESTING=OFF
 Starting to parse CMake project.
 Externals will be built with 8 core(s)
     == radiumproject Project configuration ==
@@ -102,7 +102,7 @@ To force processing again the dependencies of a given library, turn on the assoc
 OPTION( RADIUM_SKIP_${NAME_UPPER}_EXTERNAL "[addExternalFolder] Skip updating ${NAME}::external (disable for rebuild)" ON)
 ~~~
 
-where `$NAME_UPPER` is `CORE`, `ENGINE`, `GUIBASE`, `PLUGINBASE` or `IO`.
+where `$NAME_UPPER` is `CORE`, `ENGINE`, `GUI`, `PLUGINBASE` or `IO`.
 \note The option `RADIUM_SKIP_${NAME_UPPER}_EXTERNAL` is generated only if `RADIUM_GENERATE_LIB_${NAME_UPPER}` is `ON`.
 
 

--- a/doc/developer/cameraManipulator.md
+++ b/doc/developer/cameraManipulator.md
@@ -17,13 +17,13 @@ demonstrated by the class `FlightCameraManipulator`.
 1. Define the class that must inherits from `Ra::Gui::CameraManipulator` and, in order to receive interaction events,
 from `Ra::Gui::KeyMappingManageable`. Note that a CameraManipulator is a `Q_OBJECT`
 
- \snippet GuiBase/Viewer/FlightCameraManipulator.hpp Declare class
+ \snippet Gui/Viewer/FlightCameraManipulator.hpp Declare class
 
 2. Implement the constructors (default, copy). Note that it is also very important to implement a constructor
 that will take any `Ra::Gui::CameraManipulator` and will copy the base class before initializing the current
 manipulator.
 
- \snippet GuiBase/Viewer/FlightCameraManipulator.cpp Constructor
+ \snippet Gui/Viewer/FlightCameraManipulator.cpp Constructor
 
 
 3. Implement the `Ra::Gui::KeyMappingManageable` part of the class. This implies defining the method
@@ -32,7 +32,7 @@ by `Ra::Gui::KeyMappingManageable`. It is recommended that, when implementing th
 a default configuration is defined and saved to the xml keymapping configuration file if this later does not already
 contains a configuration. This will allow the users to edit and customize the proposed keymapping configuration.
 
- \snippet GuiBase/Viewer/FlightCameraManipulator.cpp Implement KeyMappingManageable
+ \snippet Gui/Viewer/FlightCameraManipulator.cpp Implement KeyMappingManageable
 
 4. Implement the inherited abstract method according to the wanted behavior of the `Ra::Gui::CameraManipulator`
 

--- a/doc/developer/featurepicking.md
+++ b/doc/developer/featurepicking.md
@@ -13,7 +13,7 @@ The result of a Ra::Engine::Rendering::Renderer::PickingQuery is a Ra::Engine::R
  *   the list of selected element indices, either points for point clouds or triangles for meshes ;
  *   the list of selected edge's opposite vertex indices given w.r.t. the corresponding selected triangle.
 
-Right after a selection, the Ra::Engine::Rendering::Renderer::PickingResult are stored in the Ra::Gui::PickingManager and the Ra::GuiBase::SelectionManager emits Ra::GuiBase::SelectionManager::currentChanged signal so that Plugins are told a new selection has been made.
+Right after a selection, the Ra::Engine::Rendering::Renderer::PickingResult are stored in the Ra::Gui::PickingManager and the Ra::Gui::SelectionManager emits Ra::Gui::SelectionManager::currentChanged signal so that Plugins are told a new selection has been made.
 
 The selection of a mesh feature is activated by holding a specific key while selecting the object (see the `KeyMappingManager` configuration file for those). Multiple selection activation can be activated/de-activated by pressing the corresponding key, which would also make a circle shape, representing the selection area, appear on the screen.
 

--- a/doc/developer/keymapping.md
+++ b/doc/developer/keymapping.md
@@ -93,7 +93,7 @@ The viewer is the main entry point to dispatch key and mouse event.
 The idea is that at a key press or mouse press event, the viewer is capable of determining which class will receive the events.
 
 For instance see `Viewer.cpp` `Viewer::mousePressEvent`:
- \snippet GuiBase/Viewer/Viewer.cpp event dispatch
+ \snippet Gui/Viewer/Viewer.cpp event dispatch
 
 # Key mapping and inheritence.
 If you want to define a derived class that inherits a base class with key mapping, and you want to have key mapping management in this derived, you have to consider the following implementation details:

--- a/doc/developer/oldmanual.md
+++ b/doc/developer/oldmanual.md
@@ -10,7 +10,7 @@
 
     *   `Engine` the Engine module (dynamic library) contains all graphics related code and engine subsystems running.
 
-    *   `GuiBase` has the Qt-based GUI classes.
+    *   `Gui` has the Qt-based GUI classes.
 
 *   `Plugins` contains the plugins which add Systems and Components to the engine.
 

--- a/doc/developer/plugin.md
+++ b/doc/developer/plugin.md
@@ -158,7 +158,7 @@ and _copied_ into the installed locations.
 
 # Using the Plugin
 
-Any application that inherits from `Ra::GuiBase::BaseApplication` could use any Plugin developped using the
+Any application that inherits from `Ra::Gui::BaseApplication` could use any Plugin developped using the
 Radium Engine. 
 As plugins are Qt objects that implement specific interface, it is also permitted to have any Qt
 Application to use plugins. Meanwhile, the following documentation is related to the Radium BaseApplication 
@@ -170,7 +170,7 @@ But, when developping a plugin, the installation in the Radium bundle directory 
 
 It could then be useful to use the Plugin from its own installation directory or directly from its build-tree.
 To do that, the application could register the plugin directory location by calling the 
-`Ra::GuiBase::BaseApplication::addPluginDirectory( const std::string& pluginDir );` method that will record, in the 
+`Ra::Gui::BaseApplication::addPluginDirectory( const std::string& pluginDir );` method that will record, in the 
 QSettings file associated with the application, the directory in which the Radium Engine will look for plugins.
 Once this directory is registered, any plugin that will be found in this directory will be loaded at each application 
 startup if the build type of the plugin is compatible with the build type of the application (release, debug, ...). 

--- a/doc/developer/timeline.md
+++ b/doc/developer/timeline.md
@@ -2,7 +2,7 @@
 [TOC]
 # Timeline And Keyframes
 
-The `Ra::GuiBase::Timeline` class provides display and management of `Ra::Core::Animation::KeyFramedValue`s through
+The `Ra::Gui::Timeline` class provides display and management of `Ra::Core::Animation::KeyFramedValue`s through
 the `Ra::Core::Animation::KeyFramedValueController` class.
 
 ## The Timeline UI
@@ -40,14 +40,14 @@ the time space and the selected KeyFramedValue:
 
 ## Display animated data using the Timeline
 
-`Ra::Core::Animation::KeyFramedValueController`s must be registered into the `Ra::GuiBase::Timeline`, which can be done using the
-`Ra::GuiBase::Timeline::registerKeyFramedValue` methods, binding them to the `Ra::Engine::Scene::Entity`, `Ra::Engine::Scene::Component` or
+`Ra::Core::Animation::KeyFramedValueController`s must be registered into the `Ra::Gui::Timeline`, which can be done using the
+`Ra::Gui::Timeline::registerKeyFramedValue` methods, binding them to the `Ra::Engine::Scene::Entity`, `Ra::Engine::Scene::Component` or
 `Ra::Engine::Rendering::RenderObject` they belong to.
 
 ### Binding "Static" KeyFramedValue
 Those are `Ra::Core::Animation::KeyFramedValue`s that are an explicit part of a `Ra::Engine::Scene::Entity`, `Ra::Engine::Scene::Component` or
-`Ra::Engine::Rendering::RenderObject` data, either filled upon construction or through the `Ra::GuiBase::Timeline`.
-Static `Ra::Core::Animation::KeyFramedValue`s must be registered in the `Ra::GuiBase::Timeline` after the object's
+`Ra::Engine::Rendering::RenderObject` data, either filled upon construction or through the `Ra::Gui::Timeline`.
+Static `Ra::Core::Animation::KeyFramedValue`s must be registered in the `Ra::Gui::Timeline` after the object's
 construction.
 They usually are not bound to an *UpdateCallback* function since the object they
 belong to usually calls `Ra::Core::Animation::KeyFramedValue::at` to query the current value.
@@ -84,7 +84,7 @@ struct MyComponentWithKeyFrame : public Ra::Engine::Scene::Component
 
 struct MyTimeDependantSystem : public Ra::Engine::Scene::System
 {
-   MyTimeDependantSystem( Ra::GuiBase::Timeline* timeline )
+   MyTimeDependantSystem( Ra::Gui::Timeline* timeline )
        : Ra::Engine::Scene::System()
        , m_timeline( timeline )
    {}
@@ -117,7 +117,7 @@ struct MyTimeDependantSystem : public Ra::Engine::Scene::System
    }
 
    /// The Timeline in which we record the Keyframes for visualisation and manipulation.
-   Ra::GuiBase::Timeline* m_timeline{nullptr};
+   Ra::Gui::Timeline* m_timeline{nullptr};
 };
 ```
 
@@ -125,7 +125,7 @@ struct MyTimeDependantSystem : public Ra::Engine::Scene::System
 Those are `Ra::Core::Animation::KeyFramedValue`s that are not part of an `Ra::Engine::Scene::Entity`, `Ra::Engine::Scene::Component` or
 `Ra::Engine::Rendering::RenderObject` data, but are used to keyframe some of its data.
 Dynamic `Ra::Core::Animation::KeyFramedValue`s must be created for and owned by the UI, and registered in the
-`Ra::GuiBase::Timeline`.
+`Ra::Gui::Timeline`.
 They are usually bound to an UpdateCallback function since they have to update the
 object's data they are linked to.
 
@@ -177,7 +177,7 @@ struct MyPlugin : public QObject, Ra::Plugins::RadiumPluginInterface {
         m_selectionManager = context.m_selectionManager;
         if ( m_selectionManager )
         {
-            connect( m_selectionManager, &Ra::GuiBase::SelectionManager::currentChanged, this, &MyPlugin::onCurrentChanged );
+            connect( m_selectionManager, &Ra::Gui::SelectionManager::currentChanged, this, &MyPlugin::onCurrentChanged );
         }
     }
     bool doAddWidget( QString& name ) override {
@@ -234,7 +234,7 @@ struct MyPlugin : public QObject, Ra::Plugins::RadiumPluginInterface {
     };
 
     MyWidget* m_widget{nullptr};
-    Ra::GuiBase::Timeline* m_timeline{nullptr};
+    Ra::Gui::Timeline* m_timeline{nullptr};
     MyComponent* m_current;
     std::map<MyComponent*,KeyFramedValue*> m_keyframes;
 };

--- a/src/Core/Geometry/TopologicalMesh.cpp
+++ b/src/Core/Geometry/TopologicalMesh.cpp
@@ -357,7 +357,7 @@ TriangleMesh TopologicalMesh::toTriangleMeshFromWedges() {
         m_wedges.m_vector4AttribNames.size() );
 
     /// Wedges are output vertices !
-    for ( WedgeIndex widx {0}; widx < WedgeIndex( m_wedges.size() ); ++widx )
+    for ( WedgeIndex widx {0}; widx < WedgeIndex {m_wedges.size()}; ++widx )
     {
         const auto& wd = m_wedges.getWedgeData( widx );
         wedgePosition.push_back( wd.m_position );
@@ -790,7 +790,7 @@ bool TopologicalMesh::splitEdgeWedge( TopologicalMesh::EdgeHandle eh, Scalar f )
                 this->m_wedges.newReference( property( this->m_wedgeIndexPph, h1_ ) );
         }
         else
-        { property( this->m_wedgeIndexPph, r0_ ) = WedgeIndex(); }
+        { property( this->m_wedgeIndexPph, r0_ ) = WedgeIndex {}; }
     };
 
     auto updateWedgeIndex2 = [this]( WedgeIndex widx_,
@@ -812,7 +812,7 @@ bool TopologicalMesh::splitEdgeWedge( TopologicalMesh::EdgeHandle eh, Scalar f )
             property( this->m_wedgeIndexPph, s0_ ) = property( this->m_wedgeIndexPph, h0_ );
         }
         else
-        { property( this->m_wedgeIndexPph, s0_ ) = WedgeIndex(); }
+        { property( this->m_wedgeIndexPph, s0_ ) = WedgeIndex {}; }
     };
 
     // this update read from o0, must be done before t which reads from o0
@@ -910,7 +910,7 @@ void TopologicalMesh::garbage_collection() {
     }
     for ( size_t i = 0; i < m_wedges.size(); ++i )
     {
-        CORE_ASSERT( !m_wedges.getWedge( WedgeIndex( i ) ).isDeleted(),
+        CORE_ASSERT( !m_wedges.getWedge( WedgeIndex {i} ).isDeleted(),
                      "deleted wedge remains after garbage collection" );
     }
 }
@@ -927,7 +927,7 @@ void TopologicalMesh::delete_face( FaceHandle _fh, bool _delete_isolated_vertice
         else
         { m_wedges.del( idx ); }
         // set an invalid index for the boundary halfedges
-        property( m_wedgeIndexPph, *itr ) = WedgeIndex();
+        property( m_wedgeIndexPph, *itr ) = WedgeIndex {};
     }
     base::delete_face( _fh, _delete_isolated_vertices );
 }

--- a/src/Core/Geometry/TopologicalMesh.inl
+++ b/src/Core/Geometry/TopologicalMesh.inl
@@ -221,8 +221,7 @@ void TopologicalMesh::initWithWedge( const TriangleMesh& triMesh, NonManifoldFac
 
             face_vhandles[j] = vh;
             if ( hasNormals ) face_normals[j] = triMesh.normals()[inMeshVertexIndex];
-            face_wedges[j] =
-                WedgeIndex {static_cast<WedgeIndex::Index::IntegerType>( inMeshVertexIndex )};
+            face_wedges[j] = WedgeIndex {inMeshVertexIndex};
         }
 
         // Add the face, then add attribs to vh

--- a/src/Core/Tasks/TaskQueue.cpp
+++ b/src/Core/Tasks/TaskQueue.cpp
@@ -40,7 +40,7 @@ TaskQueue::TaskId TaskQueue::registerTask( Task* task ) {
     CORE_ASSERT( m_tasks.size() == m_dependencies.size(), "Inconsistent task list" );
     CORE_ASSERT( m_tasks.size() == m_remainingDependencies.size(), "Inconsistent task list" );
     CORE_ASSERT( m_tasks.size() == m_timerData.size(), "Inconsistent task list" );
-    return TaskId( m_tasks.size() - 1 );
+    return TaskId {m_tasks.size() - 1};
 }
 
 void TaskQueue::addDependency( TaskQueue::TaskId predecessor, TaskQueue::TaskId successor ) {
@@ -65,7 +65,7 @@ bool TaskQueue::addDependency( const std::string& predecessors, TaskQueue::TaskI
         if ( m_tasks[i]->getName() == predecessors )
         {
             added = true;
-            addDependency( TaskId( i ), successor );
+            addDependency( TaskId {i}, successor );
         }
     }
     return added;
@@ -78,7 +78,7 @@ bool TaskQueue::addDependency( TaskQueue::TaskId predecessor, const std::string&
         if ( m_tasks[i]->getName() == successors )
         {
             added = true;
-            addDependency( predecessor, TaskId( i ) );
+            addDependency( predecessor, TaskId {i} );
         }
     }
     return added;
@@ -160,7 +160,7 @@ void TaskQueue::startTasks() {
     // Enqueue all tasks with no dependencies.
     for ( uint t = 0; t < m_tasks.size(); ++t )
     {
-        if ( m_remainingDependencies[t] == 0 ) { queueTask( TaskId( t ) ); }
+        if ( m_remainingDependencies[t] == 0 ) { queueTask( TaskId {t} ); }
     }
 
     // Wake up all threads.

--- a/src/Core/Utils/Index.hpp
+++ b/src/Core/Utils/Index.hpp
@@ -18,7 +18,7 @@ class RA_CORE_API Index
     constexpr Index( const Index& i );
 
     /// Templated constructor to convert any interger type to index.
-    /// Integer template parameter has to be std::is_integral (static_assert'ed)
+    /// \tparam Integer template parameter has to be std::is_integral (static_assert'ed)
     template <typename Integer>
     explicit constexpr Index( Integer i );
 

--- a/src/Core/Utils/Index.hpp
+++ b/src/Core/Utils/Index.hpp
@@ -16,6 +16,9 @@ class RA_CORE_API Index
     /// Default constructor that allow implicit conversion from integer to Index
     constexpr Index( IntegerType i = s_invalid );
     constexpr Index( const Index& i );
+    template <typename Integer>
+    explicit constexpr Index( Integer i );
+
     constexpr Index& operator=( long int i );
 
     /// DESTRUCTOR: Must not be defined, we need it trivial to be

--- a/src/Core/Utils/Index.hpp
+++ b/src/Core/Utils/Index.hpp
@@ -16,6 +16,9 @@ class RA_CORE_API Index
     /// Default constructor that allow implicit conversion from integer to Index
     constexpr Index( IntegerType i = s_invalid );
     constexpr Index( const Index& i );
+
+    /// Templated constructor to convert any interger type to index.
+    /// Integer template parameter has to be std::is_integral (static_assert'ed)
     template <typename Integer>
     explicit constexpr Index( Integer i );
 

--- a/src/Core/Utils/Index.hpp
+++ b/src/Core/Utils/Index.hpp
@@ -19,8 +19,6 @@ class RA_CORE_API Index
     template <typename Integer>
     explicit constexpr Index( Integer i );
 
-    constexpr Index& operator=( long int i );
-
     /// DESTRUCTOR: Must not be defined, we need it trivial to be
     /// constexpr
     // ~Index() { }

--- a/src/Core/Utils/Index.inl
+++ b/src/Core/Utils/Index.inl
@@ -8,7 +8,9 @@ namespace Utils {
 constexpr Index::Index( IntegerType i ) : m_idx( ( i < 0 ) ? s_invalid : i ) {}
 
 template <typename Integer>
-constexpr Index::Index( Integer i ) : m_idx( ( ( i < 0 ) || ( i > s_maxIdx ) ) ? s_invalid : i ) {}
+constexpr Index::Index( Integer i ) : m_idx( ( ( i < 0 ) || ( i > s_maxIdx ) ) ? s_invalid : i ) {
+    static_assert( std::is_integral<Integer>::value, "Integral required." );
+}
 
 constexpr Index::Index( const Index& i ) : m_idx( i.m_idx ) {}
 
@@ -66,6 +68,7 @@ constexpr Index Index::operator+( const Index& id ) {
 }
 template <typename Integer>
 constexpr Index Index::operator+( const Integer& id ) {
+    static_assert( std::is_integral<Integer>::value, "Integral required." );
     return ( *this ) + Index( id );
 }
 
@@ -75,6 +78,7 @@ constexpr Index Index::operator-( const Index& id ) {
 }
 template <typename Integer>
 constexpr Index Index::operator-( const Integer& id ) {
+    static_assert( std::is_integral<Integer>::value, "Integral required." );
     return ( *this ) - Index( id );
 }
 
@@ -83,6 +87,7 @@ constexpr bool Index::operator==( const Index& id ) {
 }
 template <typename Integer>
 constexpr bool Index::operator==( const Integer& i ) {
+    static_assert( std::is_integral<Integer>::value, "Integral required." );
     return ( *this == Index( IntegerType( i ) ) );
 }
 
@@ -91,6 +96,7 @@ constexpr bool Index::operator!=( const Index& id ) {
 }
 template <typename Integer>
 constexpr bool Index::operator!=( const Integer& i ) {
+    static_assert( std::is_integral<Integer>::value, "Integral required." );
     return ( !( *this == Index( IntegerType( i ) ) ) );
 }
 
@@ -109,6 +115,7 @@ constexpr bool Index::operator<=( const Index& id ) {
 }
 template <typename Integer>
 constexpr bool Index::operator<=( const Integer& i ) {
+    static_assert( std::is_integral<Integer>::value, "Integral required." );
     return ( *this <= Index( IntegerType( i ) ) );
 }
 
@@ -118,6 +125,7 @@ constexpr bool Index::operator>( const Index& id ) {
 }
 template <typename Integer>
 constexpr bool Index::operator>( const Integer& i ) {
+    static_assert( std::is_integral<Integer>::value, "Integral required." );
     return ( *this > Index( IntegerType( i ) ) );
 }
 
@@ -127,6 +135,7 @@ constexpr bool Index::operator>=( const Index& id ) {
 }
 template <typename Integer>
 constexpr bool Index::operator>=( const Integer& i ) {
+    static_assert( std::is_integral<Integer>::value, "Integral required." );
     return ( *this >= Index( IntegerType( i ) ) );
 }
 

--- a/src/Core/Utils/Index.inl
+++ b/src/Core/Utils/Index.inl
@@ -7,6 +7,9 @@ namespace Utils {
 /// CONSTRUCTOR
 constexpr Index::Index( IntegerType i ) : m_idx( ( i < 0 ) ? s_invalid : i ) {}
 
+template <typename Integer>
+constexpr Index::Index( Integer i ) : m_idx( ( ( i < 0 ) || ( i > s_maxIdx ) ) ? s_invalid : i ) {}
+
 constexpr Index::Index( const Index& i ) : m_idx( i.m_idx ) {}
 
 constexpr Index& Index::operator=( long int i ) {

--- a/src/Core/Utils/Index.inl
+++ b/src/Core/Utils/Index.inl
@@ -12,10 +12,6 @@ constexpr Index::Index( Integer i ) : m_idx( ( ( i < 0 ) || ( i > s_maxIdx ) ) ?
 
 constexpr Index::Index( const Index& i ) : m_idx( i.m_idx ) {}
 
-constexpr Index& Index::operator=( long int i ) {
-    m_idx = ( i < 0 ) ? s_invalid : i;
-    return *this;
-}
 /// VALID
 constexpr bool Index::isValid() const {
     return ( m_idx != s_invalid );

--- a/src/Engine/Rendering/RenderTechnique.hpp
+++ b/src/Engine/Rendering/RenderTechnique.hpp
@@ -165,7 +165,7 @@ class RA_ENGINE_API RenderTechnique final
      * @param pass the pass. If left by default, all active passes will get the properties
      */
     void addPassProperties( const std::list<std::string>& props,
-                            Core::Utils::Index pass = Core::Utils::Index( -1 ) );
+                            Core::Utils::Index pass = Core::Utils::Index {} );
     /**
      * Creates a default technique based on the ForwarRenderer sementic.
      *  pass 1 --> Z_PREPASS

--- a/tests/unittest/Core/indexmap.cpp
+++ b/tests/unittest/Core/indexmap.cpp
@@ -2,6 +2,9 @@
 #include <catch2/catch.hpp>
 #include <unittestUtils.hpp>
 
+using Ra::Core::Utils::Index;
+using Ra::Core::Utils::IndexMap;
+
 // Just a standard test structure
 struct Foo {
     explicit Foo( int x ) : value( x ) {}
@@ -9,8 +12,6 @@ struct Foo {
 };
 
 TEST_CASE( "Core/Utils/IndexMap", "[Core][Core/Utils][IndexMap]" ) {
-    using Ra::Core::Utils::Index;
-    using Ra::Core::Utils::IndexMap;
 
     SECTION( "Sanity checks" ) {
         IndexMap<Foo> map1;
@@ -124,4 +125,45 @@ TEST_CASE( "Core/Utils/IndexMap", "[Core][Core/Utils][IndexMap]" ) {
         REQUIRE( map2.size() == 0 );
         REQUIRE( map2.empty() );
     }
+}
+
+template <typename T>
+void testType() {
+    T step = std::numeric_limits<T>::max() / T {1000};
+    for ( T i = static_cast<T>( std::numeric_limits<Index::IntegerType>::max() ) + 1;
+          i < static_cast<T>( std::numeric_limits<T>::max() - 2 * step );
+          i += step )
+    {
+        // Index is more than max, so it is invalid
+        Index idx {i};
+        REQUIRE( idx.isInvalid() );
+    }
+}
+
+TEST_CASE( "Core/Utils/Index/Ctor", "[Core][Core/Utils][Index]" ) {
+
+    Index idxInvalid;
+    REQUIRE( idxInvalid.isInvalid() );
+    // testing everything is too long
+    const int step = std::numeric_limits<Index::IntegerType>::max() / 1000;
+    for ( Index::IntegerType i = 0; i < std::numeric_limits<Index::IntegerType>::max() - 2 * step;
+          i += step )
+    {
+        Index idx {i};
+        REQUIRE( idx.isValid() );
+        auto idxUl = Index {static_cast<unsigned long int>( i )};
+        auto idxL  = Index {static_cast<long int>( i )};
+        auto idxU  = Index {static_cast<unsigned int>( i )};
+        REQUIRE( idxUl.isValid() );
+        REQUIRE( idxU.isValid() );
+        REQUIRE( idxL.isValid() );
+        REQUIRE( idx == idxUl );
+        REQUIRE( idx == idxU );
+        REQUIRE( idx == idxL );
+    }
+
+    testType<unsigned long int>();
+    testType<long int>();
+    testType<unsigned int>();
+    testType<size_t>();
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)



* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature: add cast constructor to Index, to avoid static cast

* **What is the current behavior?** (You can also link to an open issue here)
Index takes only int (aka Index::IntegerType) other type may need static cast
Fix #666

* **What is the new behavior (if this is a feature change)?**
Now one can construct an index from unsigned int, long int, and unsigned long int without casts.
If the value is more than int limit, an invalid index is built.
