### PR TITLE
Small fixes

### DIFF
--- a/cmake/radium_setup_functions.cmake
+++ b/cmake/radium_setup_functions.cmake
@@ -431,7 +431,7 @@ function(installTargetResources)
     if (ARGS_FILES)
         set_target_properties(${ARGS_TARGET}
             PROPERTIES
-            RADIUM_TARGET_RESOURCES_FILES ${ARGS_FILES}
+            RADIUM_TARGET_RESOURCES_FILES "${ARGS_FILES}"
             )
     else ()
         file(GLOB_RECURSE ARGS_FILES RELATIVE ${ARGS_DIRECTORY} ${ARGS_DIRECTORY}/*)

--- a/src/Engine/Rendering/ForwardRenderer.cpp
+++ b/src/Engine/Rendering/ForwardRenderer.cpp
@@ -607,25 +607,24 @@ bool ForwardRenderer::buildRenderTechnique( RenderObject* ro ) const {
      */
     if ( RenderedGeometry && RenderedGeometry->getNumFaces() == 0 )
     {
-
-        auto addGeomShader = [&rt]( Core::Utils::Index pass ) {
-            if ( rt->hasConfiguration( pass ) )
-            {
-                Data::ShaderConfiguration config = rt->getConfiguration( pass );
-                config.addShader( Data::ShaderType_GEOMETRY,
-                                  RadiumEngine::getInstance()->getResourcesDir() +
-                                      "Shaders/Points/PointCloud.geom.glsl" );
-                rt->setConfiguration( config, pass );
-            }
-        };
-
-        addGeomShader( DefaultRenderingPasses::LIGHTING_OPAQUE );
-        addGeomShader( DefaultRenderingPasses::LIGHTING_TRANSPARENT );
-        addGeomShader( DefaultRenderingPasses::Z_PREPASS );
-        // construct the parameter provider for the technique
         auto pointCloud = dynamic_cast<Scene::PointCloudComponent*>( ro->getComponent() );
         if ( pointCloud )
         {
+            auto addGeomShader = [&rt]( Core::Utils::Index pass ) {
+                if ( rt->hasConfiguration( pass ) )
+                {
+                    Data::ShaderConfiguration config = rt->getConfiguration( pass );
+                    config.addShader( Data::ShaderType_GEOMETRY,
+                                      RadiumEngine::getInstance()->getResourcesDir() +
+                                          "Shaders/Points/PointCloud.geom.glsl" );
+                    rt->setConfiguration( config, pass );
+                }
+            };
+
+            addGeomShader( DefaultRenderingPasses::LIGHTING_OPAQUE );
+            addGeomShader( DefaultRenderingPasses::LIGHTING_TRANSPARENT );
+            addGeomShader( DefaultRenderingPasses::Z_PREPASS );
+            // construct the parameter provider for the technique
             auto pr = std::make_shared<PointCloudParameterProvider>( material, pointCloud );
             rt->setParametersProvider( pr );
         }


### PR DESCRIPTION
Here is two small fixes

The first one is on the cmake side
the modification add quotes around one variable where I had some issue when there is two much files in the shader list (I got an error at config time wrong number of parameter)
Other variables deserve quotes, but it's another history.
The second one is in ForwardRenderer, the hack about point clouds adds a geomShader even if the geometry is not a point cloud.
It creates problems with any faceless renderered geometry.