### PR TITLE
[tests] Store QSettings org and app name globally.

### DIFF
--- a/tests/unittest/Gui/keymapping.cpp
+++ b/tests/unittest/Gui/keymapping.cpp
@@ -56,8 +56,9 @@ KeyMappingDummy
 }
 
 TEST_CASE( "Gui/Utils/KeyMappingManager", "[Gui][Gui/Utils][KeyMappingManager]" ) {
-    QSettings settings( "RadiumUnitTests", "KeyMappingManager" );
-
+    QCoreApplication::setOrganizationName( "RadiumUnitTests" );
+    QCoreApplication::setApplicationName( "KeyMappingManager" );
+    QSettings settings;
     settings.clear();
     KeyMappingManager::createInstance();
     auto mgr = Gui::KeyMappingManager::getInstance();


### PR DESCRIPTION
Bug fix, QSettings ctor do not store it's org and app string globally, but we need that for testing.
So this PR adds the call to static method  `QCoreApplication::setOrganizationName` and `QCoreApplication::setApplicationName`
for KeyMappingManager's unit tests.
(previous behavior is tests may fail if you have stored a default setting for your application, and pass otherwise, now it pass everytime).