### PR TITLE
Fix namespace for debug display macros ;

### DIFF
--- a/src/Engine/Scene/SystemDisplay.hpp
+++ b/src/Engine/Scene/SystemDisplay.hpp
@@ -73,75 +73,86 @@ class RA_ENGINE_API SystemEntity : public Entity
 
 #ifndef RA_DISABLE_DEBUG_DISPLAY
 /// Macros for debug drawing. All coordinates are in world space.
-#    define RA_DISPLAY_POINT( p, color, scale )              \
-        Ra::Engine::SystemEntity::dbgCmp()->addRenderObject( \
-            Ra::Engine::DrawPrimitives::Primitive(           \
-                Ra::Engine::SystemEntity::dbgCmp(),          \
-                Ra::Engine::DrawPrimitives::Point( p, color, scale ) ) )
+#    define RA_DISPLAY_POINT( p, color, scale )                     \
+        Ra::Engine::Scene::SystemEntity::dbgCmp()->addRenderObject( \
+            Ra::Engine::Data::DrawPrimitives::Primitive(            \
+                Ra::Engine::Scene::SystemEntity::dbgCmp(),          \
+                Ra::Engine::Data::DrawPrimitives::Point( p, color, scale ) ) )
 
-#    define RA_DISPLAY_VECTOR( p, v, color )                 \
-        Ra::Engine::SystemEntity::dbgCmp()->addRenderObject( \
-            Ra::Engine::DrawPrimitives::Primitive(           \
-                Ra::Engine::SystemEntity::dbgCmp(),          \
-                Ra::Engine::DrawPrimitives::Vector( p, v, color ) ) )
+#    define RA_DISPLAY_VECTOR( p, v, color )                        \
+        Ra::Engine::Scene::SystemEntity::dbgCmp()->addRenderObject( \
+            Ra::Engine::Data::DrawPrimitives::Primitive(            \
+                Ra::Engine::Scene::SystemEntity::dbgCmp(),          \
+                Ra::Engine::Data::DrawPrimitives::Vector( p, v, color ) ) )
 
-#    define RA_DISPLAY_RAY( r, color )                                                 \
-        Ra::Engine::SystemEntity::dbgCmp()->addRenderObject(                           \
-            Ra::Engine::DrawPrimitives::Primitive( Ra::Engine::SystemEntity::dbgCmp(), \
-                                                   Ra::Engine::DrawPrimitives::Ray( r, color ) ) )
+#    define RA_DISPLAY_RAY( r, color )                              \
+        Ra::Engine::Scene::SystemEntity::dbgCmp()->addRenderObject( \
+            Ra::Engine::Data::DrawPrimitives::Primitive(            \
+                Ra::Engine::Scene::SystemEntity::dbgCmp(),          \
+                Ra::Engine::Data::DrawPrimitives::Ray( r, color ) ) )
 
-#    define RA_DISPLAY_CIRCLE( c, n, r, color )              \
-        Ra::Engine::SystemEntity::dbgCmp()->addRenderObject( \
-            Ra::Engine::DrawPrimitives::Primitive(           \
-                Ra::Engine::SystemEntity::dbgCmp(),          \
-                Ra::Engine::DrawPrimitives::Circle( c, n, r, 20, color ) ) )
+#    define RA_DISPLAY_CIRCLE( c, n, r, color )                     \
+        Ra::Engine::Scene::SystemEntity::dbgCmp()->addRenderObject( \
+            Ra::Engine::Data::DrawPrimitives::Primitive(            \
+                Ra::Engine::Scene::SystemEntity::dbgCmp(),          \
+                Ra::Engine::Data::DrawPrimitives::Circle( c, n, r, 20, color ) ) )
 
-#    define RA_DISPLAY_TRIANGLE( a, b, c, color )            \
-        Ra::Engine::SystemEntity::dbgCmp()->addRenderObject( \
-            Ra::Engine::DrawPrimitives::Primitive(           \
-                Ra::Engine::SystemEntity::dbgCmp(),          \
-                Ra::Engine::DrawPrimitives::Triangle( a, b, c, color ) ) )
+#    define RA_DISPLAY_TRIANGLE( a, b, c, color )                   \
+        Ra::Engine::Scene::SystemEntity::dbgCmp()->addRenderObject( \
+            Ra::Engine::Data::DrawPrimitives::Primitive(            \
+                Ra::Engine::SystemEntity::dbgCmp(),                 \
+                Ra::Engine::Data::DrawPrimitives::Triangle( a, b, c, color ) ) )
 
-#    define RA_DISPLAY_NORMAL( p, n, color, scale )          \
-        Ra::Engine::SystemEntity::dbgCmp()->addRenderObject( \
-            Ra::Engine::DrawPrimitives::Primitive(           \
-                Ra::Engine::SystemEntity::dbgCmp(),          \
-                Ra::Engine::DrawPrimitives::Normal( p, n, color, scale ) ) )
+#    define RA_DISPLAY_NORMAL( p, n, color, scale )                 \
+        Ra::Engine::Scene::SystemEntity::dbgCmp()->addRenderObject( \
+            Ra::Engine::Scene::DrawPrimitives::Primitive(           \
+                Ra::Engine::Scene::SystemEntity::dbgCmp(),          \
+                Ra::Engine::Scene::DrawPrimitives::Normal( p, n, color, scale ) ) )
 
-#    define RA_DISPLAY_FRAME( t, scale )                     \
-        Ra::Engine::SystemEntity::dbgCmp()->addRenderObject( \
-            Ra::Engine::DrawPrimitives::Primitive(           \
-                Ra::Engine::SystemEntity::dbgCmp(),          \
-                Ra::Engine::DrawPrimitives::Frame( t, scale ) ) )
+#    define RA_DISPLAY_FRAME( t, scale )                            \
+        Ra::Engine::Scene::SystemEntity::dbgCmp()->addRenderObject( \
+            Ra::Engine::Data::DrawPrimitives::Primitive(            \
+                Ra::Engine::Scene::SystemEntity::dbgCmp(),          \
+                Ra::Engine::Data::DrawPrimitives::Frame( t, scale ) ) )
 
-#    define RA_DISPLAY_AABB( a, color )                      \
-        Ra::Engine::SystemEntity::dbgCmp()->addRenderObject( \
-            Ra::Engine::DrawPrimitives::Primitive(           \
-                Ra::Engine::SystemEntity::dbgCmp(),          \
-                Ra::Engine::DrawPrimitives::AABB( a, color ) ) )
+#    define RA_DISPLAY_AABB( a, color )                             \
+        Ra::Engine::Scene::SystemEntity::dbgCmp()->addRenderObject( \
+            Ra::Engine::Data::DrawPrimitives::Primitive(            \
+                Ra::Engine::Scene::SystemEntity::dbgCmp(),          \
+                Ra::Engine::Data::DrawPrimitives::AABB( a, color ) ) )
 
-#    define RA_DISPLAY_OBB( a, color )                                                 \
-        Ra::Engine::SystemEntity::dbgCmp()->addRenderObject(                           \
-            Ra::Engine::DrawPrimitives::Primitive( Ra::Engine::SystemEntity::dbgCmp(), \
-                                                   Ra::Engine::DrawPrimitives::OBB( a, color ) ) )
+#    define RA_DISPLAY_OBB( a, color )                              \
+        Ra::Engine::Scene::SystemEntity::dbgCmp()->addRenderObject( \
+            Ra::Engine::Data::DrawPrimitives::Primitive(            \
+                Ra::Engine::Scene::SystemEntity::dbgCmp(),          \
+                Ra::Engine::Data::DrawPrimitives::OBB( a, color ) ) )
 
-#    define RA_DISPLAY_SPHERE( c, r, color )                 \
-        Ra::Engine::SystemEntity::dbgCmp()->addRenderObject( \
-            Ra::Engine::DrawPrimitives::Primitive(           \
-                Ra::Engine::SystemEntity::dbgCmp(),          \
-                Ra::Engine::DrawPrimitives::Sphere( c, r, color ) ) )
+#    define RA_DISPLAY_SPHERE( c, r, color )                        \
+        Ra::Engine::Scene::SystemEntity::dbgCmp()->addRenderObject( \
+            Ra::Engine::Data::DrawPrimitives::Primitive(            \
+                Ra::Engine::Scene::SystemEntity::dbgCmp(),          \
+                Ra::Engine::Data::DrawPrimitives::Sphere( c, r, color ) ) )
 
-#    define RA_DISPLAY_CAPSULE( p1, p2, r, color )           \
-        Ra::Engine::SystemEntity::dbgCmp()->addRenderObject( \
-            Ra::Engine::DrawPrimitives::Primitive(           \
-                Ra::Engine::SystemEntity::dbgCmp(),          \
-                Ra::Engine::DrawPrimitives::Capsule( p1, p2, r, color ) ) )
+#    define RA_DISPLAY_CAPSULE( p1, p2, r, color )                  \
+        Ra::Engine::Scene::SystemEntity::dbgCmp()->addRenderObject( \
+            Ra::Engine::Data::DrawPrimitives::Primitive(            \
+                Ra::Engine::Scene::SystemEntity::dbgCmp(),          \
+                Ra::Engine::Data::DrawPrimitives::Capsule( p1, p2, r, color ) ) )
 
-#    define RA_DISPLAY_LINE( a, b, color )                   \
-        Ra::Engine::SystemEntity::dbgCmp()->addRenderObject( \
-            Ra::Engine::DrawPrimitives::Primitive(           \
-                Ra::Engine::SystemEntity::dbgCmp(),          \
-                Ra::Engine::DrawPrimitives::Line( a, b, color ) ) )
+#    define RA_DISPLAY_LINE( a, b, color )                          \
+        Ra::Engine::Scene::SystemEntity::dbgCmp()->addRenderObject( \
+            Ra::Engine::Data::DrawPrimitives::Primitive(            \
+                Ra::Engine::Scene::SystemEntity::dbgCmp(),          \
+                Ra::Engine::Data::DrawPrimitives::Line( a, b, color ) ) )
+
+#    define RA_CLEAR_DEBUG_DISPLAY()                                \
+        {                                                           \
+            auto cmp = Ra::Engine::Scene::SystemEntity::dbgCmp();   \
+            while ( cmp->m_renderObjects.size() )                   \
+            {                                                       \
+                cmp->removeRenderObject( cmp->m_renderObjects[0] ); \
+            }                                                       \
+        }
 
 #else // if debug display is disabled
 
@@ -157,5 +168,6 @@ class RA_ENGINE_API SystemEntity : public Entity
 #    define RA_DISPLAY_SPHERE( c, r, color )        // ...
 #    define RA_DISPLAY_CAPSULE( p1, p2, r, color )  // ...
 #    define RA_DISPLAY_LINE( a, b, color )          // ...
+#    define RA_CLEAR_DEBUG_DISPLAY()                // ...
 
 #endif //! defined DISABLED_DEBUG_DISPLAY


### PR DESCRIPTION

_Check if you branch history is PR compatible_
- Your branch need to be up to date with origin/master AND to have linear history (i.e. no merge commit).
- Update your git repository `git fetch origin` if origin is this remote
- Check with the script provided in `scripts/is-history-pr-compatible.sh`
- You must use clang-format style
_These checks are enforced by github workflow actions_
_Please refer to the corresponding log in case of failure_

_UPDATE the form below to describe your PR._

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix the namespace in the RA_DISPLAY_* macros.
Also add the RA_CLEAR_DEBUG_DISPLAY macro to clean the display added through the RA_DISPLAY_* macros (can be useful when debugging animated stuff or an algorithm step by step)


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
