### PR TITLE
Make scene display setting more clear and usable - update drawPrimitive Demo

### DIFF
--- a/src/Gui/BaseApplication.cpp
+++ b/src/Gui/BaseApplication.cpp
@@ -385,7 +385,7 @@ bool BaseApplication::loadFile( QString path ) {
 
     m_engine->releaseFile();
 
-    m_mainWindow->postLoadFile( filename );
+    m_mainWindow->prepareDisplay( filename );
 
     emit loadComplete();
     return true;

--- a/src/Gui/BaseApplication.cpp
+++ b/src/Gui/BaseApplication.cpp
@@ -385,7 +385,7 @@ bool BaseApplication::loadFile( QString path ) {
 
     m_engine->releaseFile();
 
-    m_mainWindow->prepareDisplay( filename );
+    m_mainWindow->prepareDisplay();
 
     emit loadComplete();
     return true;

--- a/src/Gui/MainWindowInterface.hpp
+++ b/src/Gui/MainWindowInterface.hpp
@@ -53,8 +53,12 @@ class RA_GUI_API MainWindowInterface : public QMainWindow
                               std::shared_ptr<Engine::Rendering::Renderer> e ) = 0;
 
   public slots:
-    /// Called when a scene is ready to display to parameterize the application window and the viewer..
-    virtual void prepareDisplay( const std::string& filename ) = 0;
+    /**
+     * Called when a scene is ready to display to parameterize the application window and the
+     * viewer.
+     */
+    virtual void prepareDisplay() = 0;
+
     /// Cleanup resources.
     virtual void cleanup() = 0;
 

--- a/src/Gui/MainWindowInterface.hpp
+++ b/src/Gui/MainWindowInterface.hpp
@@ -53,8 +53,8 @@ class RA_GUI_API MainWindowInterface : public QMainWindow
                               std::shared_ptr<Engine::Rendering::Renderer> e ) = 0;
 
   public slots:
-    /// Call after loading a new file to let the window resetview for instance.
-    virtual void postLoadFile( const std::string& filename ) = 0;
+    /// Called when a scene is ready to display to parameterize the application window and the viewer..
+    virtual void prepareDisplay( const std::string& filename ) = 0;
     /// Cleanup resources.
     virtual void cleanup() = 0;
 

--- a/src/Gui/RadiumWindow/SimpleWindow.cpp
+++ b/src/Gui/RadiumWindow/SimpleWindow.cpp
@@ -6,6 +6,8 @@
 #include <Gui/Viewer/CameraManipulator.hpp>
 #include <Gui/Viewer/Viewer.hpp>
 
+#include <QStatusBar>
+
 namespace Ra {
 using namespace Gui;
 using namespace Engine;
@@ -60,12 +62,9 @@ void SimpleWindow::addRenderer( const std::string&,
     m_viewer->addRenderer( e );
 }
 
-void SimpleWindow::prepareDisplay( const std::string& ) {
+void SimpleWindow::prepareDisplay() {
     m_selectionManager->clear();
-
-    if ( m_viewer->prepareDisplay() ) {
-        emit frameUpdate();
-    }
+    if ( m_viewer->prepareDisplay() ) { emit frameUpdate(); }
 }
 
 void SimpleWindow::cleanup() {

--- a/src/Gui/RadiumWindow/SimpleWindow.cpp
+++ b/src/Gui/RadiumWindow/SimpleWindow.cpp
@@ -60,16 +60,12 @@ void SimpleWindow::addRenderer( const std::string&,
     m_viewer->addRenderer( e );
 }
 
-void SimpleWindow::postLoadFile( const std::string& ) {
-    m_viewer->makeCurrent();
-    m_viewer->getRenderer()->buildAllRenderTechniques();
-    m_viewer->doneCurrent();
+void SimpleWindow::prepareDisplay( const std::string& ) {
     m_selectionManager->clear();
-    auto aabb = Ra::Engine::RadiumEngine::getInstance()->computeSceneAabb();
-    if ( aabb.isEmpty() ) { m_viewer->getCameraManipulator()->resetCamera(); }
-    else
-    { m_viewer->fitCameraToScene( aabb ); }
-    emit frameUpdate();
+
+    if ( m_viewer->prepareDisplay() ) {
+        emit frameUpdate();
+    }
 }
 
 void SimpleWindow::cleanup() {

--- a/src/Gui/RadiumWindow/SimpleWindow.hpp
+++ b/src/Gui/RadiumWindow/SimpleWindow.hpp
@@ -49,8 +49,11 @@ class RA_GUI_API SimpleWindow : public Ra::Gui::MainWindowInterface
                       std::shared_ptr<Ra::Engine::Rendering::Renderer> e ) override;
 
   public slots:
-    /// Call after loading a new file to let the window resetview for instance.
-    virtual void prepareDisplay( const std::string& filename ) override;
+    /**
+     * Called when a scene is ready to display to parameterize the application window and the
+     * viewer.
+     */
+    virtual void prepareDisplay() override;
 
     /// Cleanup resources.
     virtual void cleanup() override;

--- a/src/Gui/RadiumWindow/SimpleWindow.hpp
+++ b/src/Gui/RadiumWindow/SimpleWindow.hpp
@@ -50,7 +50,7 @@ class RA_GUI_API SimpleWindow : public Ra::Gui::MainWindowInterface
 
   public slots:
     /// Call after loading a new file to let the window resetview for instance.
-    virtual void postLoadFile( const std::string& filename ) override;
+    virtual void prepareDisplay( const std::string& filename ) override;
 
     /// Cleanup resources.
     virtual void cleanup() override;

--- a/src/Gui/Viewer/Viewer.cpp
+++ b/src/Gui/Viewer/Viewer.cpp
@@ -748,4 +748,18 @@ Gui::Viewer::pickAtPosition( Core::Vector2 position ) {
     return result;
 }
 
+bool Gui::Viewer::prepareDisplay() {
+    auto renderer = getRenderer();
+    if ( renderer ) {
+        makeCurrent();
+        getRenderer()->buildAllRenderTechniques();
+        auto aabb = Ra::Engine::RadiumEngine::getInstance()->computeSceneAabb();
+        if ( aabb.isEmpty() ) { getCameraManipulator()->resetCamera(); }
+        else
+        { fitCameraToScene( aabb ); }
+        doneCurrent();
+        return true;
+    }
+    return false;
+}
 } // namespace Ra

--- a/src/Gui/Viewer/Viewer.cpp
+++ b/src/Gui/Viewer/Viewer.cpp
@@ -750,7 +750,8 @@ Gui::Viewer::pickAtPosition( Core::Vector2 position ) {
 
 bool Gui::Viewer::prepareDisplay() {
     auto renderer = getRenderer();
-    if ( renderer ) {
+    if ( renderer )
+    {
         makeCurrent();
         getRenderer()->buildAllRenderTechniques();
         auto aabb = Ra::Engine::RadiumEngine::getInstance()->computeSceneAabb();

--- a/src/Gui/Viewer/Viewer.hpp
+++ b/src/Gui/Viewer/Viewer.hpp
@@ -67,6 +67,13 @@ class RA_GUI_API Viewer : public WindowQt, public KeyMappingManageable<Viewer>
     /// add observers to keyMappingManager for gizmo, camera and viewer.
     virtual void setupKeyMappingCallbacks();
 
+    /** Prepare the viewer to display a scene.
+     * This will ask the renderer to build its specific OenGL related objects
+     * and set the camera to its default state
+     * @return true if the scene is ready to display.
+     */
+    virtual bool prepareDisplay();
+
     //
     // Accessors
     //
@@ -140,6 +147,7 @@ class RA_GUI_API Viewer : public WindowQt, public KeyMappingManageable<Viewer>
 
     void enableDebug();
 
+    /// get the currently used background color
     const Core::Utils::Color& getBackgroundColor() const { return m_backgroundColor; }
 
     ///@}

--- a/tests/ExampleApps/CustomCameraManipulator/main.cpp
+++ b/tests/ExampleApps/CustomCameraManipulator/main.cpp
@@ -83,7 +83,7 @@ int main( int argc, char* argv[] ) {
     //! [Register the entity/component association to the geometry system ]
 
     //! [Tell the window that something is to be displayed]
-    app.m_mainWindow->prepareDisplay( "Cube" );
+    app.m_mainWindow->prepareDisplay();
     //! [Tell the window that something is to be displayed]
 
     //! [Install new manipulator]

--- a/tests/ExampleApps/CustomCameraManipulator/main.cpp
+++ b/tests/ExampleApps/CustomCameraManipulator/main.cpp
@@ -83,7 +83,7 @@ int main( int argc, char* argv[] ) {
     //! [Register the entity/component association to the geometry system ]
 
     //! [Tell the window that something is to be displayed]
-    app.m_mainWindow->postLoadFile( "Cube" );
+    app.m_mainWindow->prepareDisplay( "Cube" );
     //! [Tell the window that something is to be displayed]
 
     //! [Install new manipulator]

--- a/tests/ExampleApps/DrawPrimitivesApp/main.cpp
+++ b/tests/ExampleApps/DrawPrimitivesApp/main.cpp
@@ -40,8 +40,8 @@ int main( int argc, char* argv[] ) {
     sys->addComponent( e, c );
     c->initialize();
 
-    auto aabb = Ra::Engine::RadiumEngine::getInstance()->computeSceneAabb();
-    if ( !aabb.isEmpty() ) { app.m_viewer->fitCameraToScene( aabb ); }
+    // prepare the viewer to render the scene (i.e. build RenderTechniques for the active renderer)
+    app.m_viewer->prepareDisplay();
 
     // Start the app.
     app.m_frame_timer->start();

--- a/tests/ExampleApps/DrawPrimitivesApp/minimalradium.cpp
+++ b/tests/ExampleApps/DrawPrimitivesApp/minimalradium.cpp
@@ -35,37 +35,16 @@ void MinimalComponent::initialize() {
     using namespace Ra::Engine::Data;
     using namespace Ra::Engine::Scene;
 
-    ///
-    // basic render technique associated with all object here, they use per vertex kd.
-    RenderTechnique shadedRt;
-    {
-        auto mat              = make_shared<BlinnPhongMaterial>( "Shaded Material" );
-        mat->m_perVertexColor = true;
-        mat->m_ks             = Utils::Color::White();
-        mat->m_ns             = 100_ra;
+    auto blinnPhongMaterial              = make_shared<BlinnPhongMaterial>( "Shaded Material" );
+    blinnPhongMaterial->m_perVertexColor = true;
+    blinnPhongMaterial->m_ks             = Utils::Color::White();
+    blinnPhongMaterial->m_ns             = 100_ra;
 
-        auto builder = EngineRenderTechniques::getDefaultTechnique( "BlinnPhong" );
-        builder.second( shadedRt, false );
-        shadedRt.setParametersProvider( mat );
-    }
-    RenderTechnique plainRt;
-    {
-        auto mat              = make_shared<PlainMaterial>( "Plain Material" );
-        mat->m_perVertexColor = true;
+    auto plainMaterial              = make_shared<PlainMaterial>( "Plain Material" );
+    plainMaterial->m_perVertexColor = true;
 
-        auto builder = EngineRenderTechniques::getDefaultTechnique( "Plain" );
-        builder.second( plainRt, false );
-        plainRt.setParametersProvider( mat );
-    }
-    RenderTechnique lambertianRt;
-    {
-        auto mat              = make_shared<LambertianMaterial>( "Lambertian Material" );
-        mat->m_perVertexColor = true;
-
-        auto builder = EngineRenderTechniques::getDefaultTechnique( "Lambertian" );
-        builder.second( lambertianRt, false );
-        lambertianRt.setParametersProvider( mat );
-    }
+    auto lambertianMaterial                = make_shared<LambertianMaterial>( "Lambertian Material" );
+    lambertianMaterial->m_perVertexColor   = true;
 
     //// setup ////
     Scalar colorBoost = 1_ra; /// since simple primitive are ambient only, boost their color
@@ -82,13 +61,6 @@ void MinimalComponent::initialize() {
 
     //// GRID ////
     {
-        RenderTechnique gridRt;
-        // Plain shader
-        auto builder = EngineRenderTechniques::getDefaultTechnique( "Plain" );
-        builder.second( gridRt, false );
-        auto mat              = Ra::Core::make_shared<PlainMaterial>( "Grid material" );
-        mat->m_perVertexColor = true;
-        gridRt.setParametersProvider( mat );
 
         auto gridPrimitive = DrawPrimitives::Grid( Vector3::Zero(),
                                                    Vector3::UnitX(),
@@ -98,7 +70,8 @@ void MinimalComponent::initialize() {
                                                    8 );
 
         auto gridRo = RenderObject::createRenderObject(
-            "test_grid", this, RenderObjectType::Geometry, gridPrimitive, gridRt );
+            "test_grid", this, RenderObjectType::Geometry, gridPrimitive, {} );
+        gridRo->setMaterial( Ra::Core::make_shared<PlainMaterial>( "Grid material" ) );
         gridRo->setPickable( false );
         addRenderObject( gridRo );
     }
@@ -111,10 +84,10 @@ void MinimalComponent::initialize() {
             "in_color", Vector4Array {cube1->getNumVertices(), Utils::Color::Green()} );
 
         auto renderObject1 = RenderObject::createRenderObject(
-            "CubeRO_1", this, RenderObjectType::Geometry, cube1, shadedRt );
+            "CubeRO_1", this, RenderObjectType::Geometry, cube1, {} );
         renderObject1->setLocalTransform(
             Transform {Translation( Vector3( 3 * cellSize, 0_ra, 0_ra ) )} );
-
+        renderObject1->setMaterial( blinnPhongMaterial );
         addRenderObject( renderObject1 );
 
         // another cube
@@ -125,44 +98,56 @@ void MinimalComponent::initialize() {
 
         cube2->setAttribNameCorrespondance( "colour", "in_color" );
         auto renderObject2 = RenderObject::createRenderObject(
-            "CubeRO_2", this, RenderObjectType::Geometry, cube2, lambertianRt );
+            "CubeRO_2", this, RenderObjectType::Geometry, cube2, {} );
         renderObject2->setLocalTransform(
             Transform {Translation( Vector3( 4 * cellSize, 0_ra, 0_ra ) )} );
-
+        renderObject2->setMaterial( lambertianMaterial );
         addRenderObject( renderObject2 );
     }
     //// POINTS ////
     cellCorner = {-1_ra, 0_ra, 0.0_ra};
-    addRenderObject( RenderObject::createRenderObject(
-        "test_point",
-        this,
-        RenderObjectType::Geometry,
-        DrawPrimitives::Point( cellCorner, colorBoost * Utils::Color {0_ra, 1_ra, 0.3_ra} ),
-        plainRt ) );
+    {
+        auto testpoint = RenderObject::createRenderObject(
+            "test_point",
+            this,
+            RenderObjectType::Geometry,
+            DrawPrimitives::Point( cellCorner, colorBoost * Utils::Color {0_ra, 1_ra, 0.3_ra} ),
+            {} );
+        testpoint->setMaterial( plainMaterial );
+        addRenderObject( testpoint );
+    }
+
 
     for ( int i = 0; i < 10; ++i )
     {
         Vector3 randomVec {cellCorner + offsetVec +
                            Vector3 {dis015( gen ), dis015( gen ), dis015( gen )}};
         Color randomCol {dis01( gen ), dis01( gen ), dis01( gen )};
-        addRenderObject( RenderObject::createRenderObject(
+        auto point = RenderObject::createRenderObject(
             "test_point",
             this,
             RenderObjectType::Geometry,
             DrawPrimitives::Point( randomVec, colorBoost * randomCol, 0.03_ra ),
-            plainRt ) );
+            {} );
+        point->setMaterial( plainMaterial );
+        addRenderObject( point );
     }
 
     //// LINES ////
     cellCorner = {-0.75_ra, 0_ra, 0.0_ra};
-    addRenderObject( RenderObject::createRenderObject(
-        "test_line",
-        this,
-        RenderObjectType::Geometry,
-        DrawPrimitives::Line( cellCorner,
-                              cellCorner + Vector3 {0_ra, 0.4_ra, 0_ra},
-                              colorBoost * Utils::Color::Red() ),
-        plainRt ) );
+    {
+        auto testline =RenderObject::createRenderObject(
+            "test_line",
+            this,
+            RenderObjectType::Geometry,
+            DrawPrimitives::Line( cellCorner,
+                                  cellCorner + Vector3 {0_ra, 0.4_ra, 0_ra},
+                                  colorBoost * Utils::Color::Red() ),
+            {} );
+        testline->setMaterial( plainMaterial );
+        addRenderObject( testline );
+    }
+
 
     for ( int i = 0; i < 20; ++i )
     {
@@ -172,23 +157,29 @@ void MinimalComponent::initialize() {
                             Vector3 {dis015( gen ), dis015( gen ), dis015( gen )}};
         Color randomCol {dis01( gen ), dis01( gen ), dis01( gen )};
 
-        addRenderObject( RenderObject::createRenderObject(
+        auto line = RenderObject::createRenderObject(
             "test_line",
             this,
             RenderObjectType::Geometry,
             DrawPrimitives::Line( randomVec1, randomVec2, colorBoost * randomCol ),
-            plainRt ) );
+            {} );
+        line->setMaterial( plainMaterial );
+        addRenderObject( line );
     }
 
     //// VECTOR ////
     cellCorner = {-0.5_ra, 0_ra, 0.0_ra};
-    addRenderObject( RenderObject::createRenderObject(
-        "test_vector",
-        this,
-        RenderObjectType::Geometry,
-        DrawPrimitives::Vector(
-            cellCorner, Vector3 {0_ra, 0.5_ra, 0_ra}, colorBoost * Utils::Color::Blue() ),
-        plainRt ) );
+    {
+        auto testvector = RenderObject::createRenderObject(
+            "test_vector",
+            this,
+            RenderObjectType::Geometry,
+            DrawPrimitives::Vector(
+                cellCorner, Vector3 { 0_ra, 0.5_ra, 0_ra }, colorBoost * Utils::Color::Blue() ),
+            {} );
+        testvector->setMaterial( plainMaterial );
+        addRenderObject( testvector );
+    }
 
     for ( int i = 0; i < 10; ++i )
     {
@@ -198,53 +189,67 @@ void MinimalComponent::initialize() {
                             Vector3 {dis015( gen ), dis015( gen ), dis015( gen )}};
         Color randomCol {dis01( gen ), dis01( gen ), dis01( gen )};
 
-        addRenderObject( RenderObject::createRenderObject(
+        auto vector = RenderObject::createRenderObject(
             "test_vector",
             this,
             RenderObjectType::Geometry,
             DrawPrimitives::Vector( randomVec1, randomVec2 - randomVec1, colorBoost * randomCol ),
-            plainRt ) );
+            {} );
+        vector->setMaterial( plainMaterial );
+        addRenderObject( vector );
     }
 
     /// RAY ////
     cellCorner = {-0.25_ra, 0_ra, 0.0_ra};
-    addRenderObject( RenderObject::createRenderObject(
-        "test_ray",
-        this,
-        RenderObjectType::Geometry,
-        DrawPrimitives::Ray(
-            {cellCorner, {0_ra, 1_ra, 0_ra}}, colorBoost * Utils::Color::Yellow(), cellSize ),
-        plainRt ) );
+    {
+        auto testray = RenderObject::createRenderObject(
+            "test_ray",
+            this,
+            RenderObjectType::Geometry,
+            DrawPrimitives::Ray(
+                {cellCorner, {0_ra, 1_ra, 0_ra}}, colorBoost * Utils::Color::Yellow(), cellSize ),
+            {} );
+        testray->setMaterial( plainMaterial );
+        addRenderObject( testray);
+    }
+
 
     //// TRIANGLES ////
     cellCorner = {0_ra, 0_ra, 0.0_ra};
-    addRenderObject( RenderObject::createRenderObject(
-        "test_triangle",
-        this,
-        RenderObjectType::Geometry,
-        DrawPrimitives::Triangle( cellCorner + Vector3 {-0.01_ra, 0.0_ra, 0.0_ra},
-                                  cellCorner + Vector3 {+0.01_ra, 0.0_ra, 0.0_ra},
-                                  cellCorner + Vector3 {+0.0_ra, 0.02_ra, 0.0_ra},
-                                  colorBoost * Utils::Color::White(),
-                                  true ),
-        shadedRt ) );
+    {
+        auto triangle = RenderObject::createRenderObject(
+            "test_triangle",
+            this,
+            RenderObjectType::Geometry,
+            DrawPrimitives::Triangle( cellCorner + Vector3 { -0.01_ra, 0.0_ra, 0.0_ra },
+                                      cellCorner + Vector3 { +0.01_ra, 0.0_ra, 0.0_ra },
+                                      cellCorner + Vector3 { +0.0_ra, 0.02_ra, 0.0_ra },
+                                      colorBoost * Utils::Color::White(),
+                                      true ),
+            {} );
+        triangle->setMaterial( plainMaterial );
+        addRenderObject( triangle );
+    }
 
     cellCorner = {0_ra + 0.125_ra, 0_ra, 0.0_ra};
-    addRenderObject( RenderObject::createRenderObject(
-        "test_triangle",
-        this,
-        RenderObjectType::Geometry,
-        DrawPrimitives::Triangle( cellCorner + Vector3 {-0.071_ra, 0.0_ra, 0.0_ra},
-                                  cellCorner + Vector3 {+0.071_ra, 0.0_ra, 0.0_ra},
-                                  cellCorner + Vector3 {+0.0_ra, 0.2_ra, 0.0_ra},
-                                  colorBoost * Utils::Color::Green(),
-                                  true ),
-        shadedRt ) );
+    {
+        auto triangle = RenderObject::createRenderObject(
+            "test_triangle",
+            this,
+            RenderObjectType::Geometry,
+            DrawPrimitives::Triangle( cellCorner + Vector3 {-0.071_ra, 0.0_ra, 0.0_ra},
+                                      cellCorner + Vector3 {+0.071_ra, 0.0_ra, 0.0_ra},
+                                      cellCorner + Vector3 {+0.0_ra, 0.2_ra, 0.0_ra},
+                                      colorBoost * Utils::Color::Green(),
+                                      true ),
+            {} );
+        triangle->setMaterial( plainMaterial );
+        addRenderObject( triangle );
+    }
 
     for ( int i = 0; i < 10; ++i )
     {
-
-        addRenderObject( RenderObject::createRenderObject(
+        auto triwire = RenderObject::createRenderObject(
             "test_triangle_wire",
             this,
             RenderObjectType::Geometry,
@@ -254,7 +259,9 @@ void MinimalComponent::initialize() {
                 cellCorner + Vector3 {+0.0_ra, 0.2_ra, Scalar( i ) / 10_ra * cellSize},
                 colorBoost * Utils::Color::White() * Scalar( i ) / 10_ra,
                 false ),
-            plainRt ) );
+            {} );
+        triwire->setMaterial( plainMaterial );
+        addRenderObject( triwire );
     }
 
     /*
@@ -271,16 +278,20 @@ void MinimalComponent::initialize() {
 
     //// CIRCLE ////
     cellCorner = {0.25_ra, 0_ra, 0.0_ra};
-    addRenderObject( RenderObject::createRenderObject(
-        "test_circle",
-        this,
-        RenderObjectType::Geometry,
-        DrawPrimitives::Circle( cellCorner,
-                                {0_ra, 0_ra, 1_ra},
-                                cellSize / 8_ra,
-                                64,
-                                colorBoost * Utils::Color::White() ),
-        plainRt ) );
+    {
+        auto circle = RenderObject::createRenderObject(
+            "test_circle",
+            this,
+            RenderObjectType::Geometry,
+            DrawPrimitives::Circle( cellCorner,
+                                    { 0_ra, 0_ra, 1_ra },
+                                    cellSize / 8_ra,
+                                    64,
+                                    colorBoost * Utils::Color::White() ),
+            {} );
+        circle->setMaterial( plainMaterial );
+        addRenderObject( circle );
+    }
 
     uint end = 8;
     for ( uint j = 0; j < end; ++j )
@@ -296,31 +307,36 @@ void MinimalComponent::initialize() {
             Scalar circleRadius {Scalar( end / 2 + i ) / Scalar( 2 * end ) * cellSize / 8_ra};
             uint circleSubdiv {3 + j * end + i};
 
-            addRenderObject(
-                RenderObject::createRenderObject( "test_circle",
-                                                  this,
-                                                  RenderObjectType::Geometry,
-                                                  DrawPrimitives::Circle( circleCenter,
-                                                                          circleNormal,
-                                                                          circleRadius,
-                                                                          circleSubdiv,
-                                                                          colorBoost * randomCol ),
-                                                  plainRt ) );
+            auto circle = RenderObject::createRenderObject( "test_circle",
+                                                            this,
+                                                            RenderObjectType::Geometry,
+                                                            DrawPrimitives::Circle( circleCenter,
+                                                                                    circleNormal,
+                                                                                    circleRadius,
+                                                                                    circleSubdiv,
+                                                                                    colorBoost * randomCol ),
+                                                            {} );
+            circle->setMaterial( plainMaterial );
+            addRenderObject( circle );
         }
 
     //// CIRCLE ARC ////
 
-    addRenderObject( RenderObject::createRenderObject(
-        "test_circle",
-        this,
-        RenderObjectType::Geometry,
-        DrawPrimitives::CircleArc( cellCorner + Vector3 {0_ra, 2_ra * offset, 0_ra},
-                                   {0_ra, 0_ra, 1_ra},
-                                   cellSize / 8_ra,
-                                   1_ra,
-                                   64,
-                                   colorBoost * Utils::Color::White() ),
-        plainRt ) );
+    {
+        auto arc = RenderObject::createRenderObject(
+            "test_circle",
+            this,
+            RenderObjectType::Geometry,
+            DrawPrimitives::CircleArc( cellCorner + Vector3 { 0_ra, 2_ra * offset, 0_ra },
+                                       { 0_ra, 0_ra, 1_ra },
+                                       cellSize / 8_ra,
+                                       1_ra,
+                                       64,
+                                       colorBoost * Utils::Color::White() ),
+            {} );
+        arc->setMaterial( plainMaterial );
+        addRenderObject( arc );
+    }
 
     for ( uint j = 0; j < end; ++j )
         for ( uint i = 0; i < end; ++i )
@@ -336,7 +352,7 @@ void MinimalComponent::initialize() {
             Scalar circleArc {Scalar( i ) / Scalar( end ) * 2_ra};
             uint circleSubdiv {2 + j};
 
-            addRenderObject( RenderObject::createRenderObject(
+            auto arc = RenderObject::createRenderObject(
                 "test_circle",
                 this,
                 RenderObjectType::Geometry,
@@ -346,18 +362,24 @@ void MinimalComponent::initialize() {
                                            circleArc,
                                            circleSubdiv,
                                            colorBoost * randomCol ),
-                plainRt ) );
+                {} );
+            arc->setMaterial( plainMaterial );
+            addRenderObject( arc );
         }
 
     //// SPHERE /////
 
     cellCorner = {-1._ra, 0_ra, 0.25_ra};
-    addRenderObject( RenderObject::createRenderObject(
-        "test_sphere",
-        this,
-        RenderObjectType::Geometry,
-        DrawPrimitives::Sphere( cellCorner, 0.02_ra, Utils::Color::White() ),
-        shadedRt ) );
+    {
+        auto sphere = RenderObject::createRenderObject(
+            "test_sphere",
+            this,
+            RenderObjectType::Geometry,
+            DrawPrimitives::Sphere( cellCorner, 0.02_ra, Utils::Color::White() ),
+            {} );
+        sphere->setMaterial( blinnPhongMaterial );
+        addRenderObject( sphere );
+    }
 
     end = 32;
     for ( uint i = 0; i < end; ++i )
@@ -381,63 +403,83 @@ void MinimalComponent::initialize() {
         Color color1 {Utils::Color::Green() * ratio};
         Color color2 {Utils::Color::Red() * ratio};
         Color color3 {Utils::Color::Blue() * ratio};
-
-        addRenderObject( RenderObject::createRenderObject(
+        auto sphere = RenderObject::createRenderObject(
             "test_sphere",
             this,
             RenderObjectType::Geometry,
             DrawPrimitives::Sphere( center1, 0.005_ra + ratio * 0.01_ra, color1 ),
-            shadedRt ) );
-        addRenderObject( RenderObject::createRenderObject(
+            {} );
+        sphere->setMaterial( blinnPhongMaterial );
+        addRenderObject( sphere );
+
+        sphere = RenderObject::createRenderObject(
             "test_sphere",
             this,
             RenderObjectType::Geometry,
             DrawPrimitives::Sphere( center2, 0.005_ra + ratio * 0.01_ra, color2 ),
-            shadedRt ) );
+            {} );
+        sphere->setMaterial( blinnPhongMaterial );
+        addRenderObject( sphere );
 
-        addRenderObject( RenderObject::createRenderObject(
+        sphere = RenderObject::createRenderObject(
             "test_sphere",
             this,
             RenderObjectType::Geometry,
             DrawPrimitives::Sphere( center3, 0.01_ra + ratio * 0.01_ra, color3 ),
-            shadedRt ) );
+            {} );
+        sphere->setMaterial( blinnPhongMaterial );
+        addRenderObject( sphere );
     }
 
     //// CAPSULE ////
     cellCorner = {-0.75_ra, 0_ra, 0.25_ra};
 
-    addRenderObject( RenderObject::createRenderObject(
-        "test_capsule",
-        this,
-        RenderObjectType::Geometry,
-        DrawPrimitives::Capsule(
-            cellCorner, cellCorner + Vector3 {0_ra, 0.1_ra, 0_ra}, 0.02_ra, Utils::Color::White() ),
-        shadedRt ) );
+    {
+        auto capsule = RenderObject::createRenderObject(
+            "test_capsule",
+            this,
+            RenderObjectType::Geometry,
+            DrawPrimitives::Capsule( cellCorner,
+                                     cellCorner + Vector3 { 0_ra, 0.1_ra, 0_ra },
+                                     0.02_ra,
+                                     Utils::Color::White() ),
+            {} );
+        capsule->setMaterial( blinnPhongMaterial );
+        addRenderObject( capsule );
+    }
 
     //// DISK ////
     cellCorner = {-0.5_ra, 0_ra, 0.25_ra};
 
-    addRenderObject( RenderObject::createRenderObject(
-        "test_disk",
-        this,
-        RenderObjectType::Geometry,
-        DrawPrimitives::Disk( cellCorner,
-                              Vector3 {0_ra, 0_ra, 1_ra},
-                              0.05_ra,
-                              32,
-                              colorBoost * Utils::Color::White() ),
-        shadedRt ) );
+    {
+        auto disk = RenderObject::createRenderObject(
+            "test_disk",
+            this,
+            RenderObjectType::Geometry,
+            DrawPrimitives::Disk( cellCorner,
+                                  Vector3 { 0_ra, 0_ra, 1_ra },
+                                  0.05_ra,
+                                  32,
+                                  colorBoost * Utils::Color::White() ),
+            {} );
+        disk->setMaterial( blinnPhongMaterial );
+        addRenderObject( disk );
+    }
 
     /// NORMAL
     cellCorner = {-0.25_ra, 0_ra, 0.25_ra};
 
-    addRenderObject( RenderObject::createRenderObject(
-        "test_normal",
-        this,
-        RenderObjectType::Geometry,
-        DrawPrimitives::Normal(
-            cellCorner, Vector3 {0_ra, 0_ra, 1_ra}, colorBoost * Utils::Color::White() ),
-        plainRt ) );
+    {
+        auto normal = RenderObject::createRenderObject(
+            "test_normal",
+            this,
+            RenderObjectType::Geometry,
+            DrawPrimitives::Normal(
+                cellCorner, Vector3 { 0_ra, 0_ra, 1_ra }, colorBoost * Utils::Color::White() ),
+            {} );
+        normal->setMaterial( plainMaterial );
+        addRenderObject( normal );
+    }
 
     /*
         addRenderObject( RenderObject::createRenderObject(
@@ -537,7 +579,8 @@ void MinimalComponent::initialize() {
                           colorBoost * Utils::Color {1_ra, 0.6_ra, 0.1_ra}} );
 
         auto renderObject1 = RenderObject::createRenderObject(
-            "CubeRO_1", this, RenderObjectType::Geometry, poly1, shadedRt );
+            "CubeRO_1", this, RenderObjectType::Geometry, poly1, {} );
+        renderObject1->setMaterial( blinnPhongMaterial );
         renderObject1->setLocalTransform(
             Transform {Translation( Vector3( 3.5 * cellSize, 0_ra, 1.5 * cellSize ) ) *
                        Eigen::UniformScaling<Scalar>( 0.06_ra )} );

--- a/tests/ExampleApps/DrawPrimitivesApp/minimalradium.cpp
+++ b/tests/ExampleApps/DrawPrimitivesApp/minimalradium.cpp
@@ -43,8 +43,8 @@ void MinimalComponent::initialize() {
     auto plainMaterial              = make_shared<PlainMaterial>( "Plain Material" );
     plainMaterial->m_perVertexColor = true;
 
-    auto lambertianMaterial                = make_shared<LambertianMaterial>( "Lambertian Material" );
-    lambertianMaterial->m_perVertexColor   = true;
+    auto lambertianMaterial              = make_shared<LambertianMaterial>( "Lambertian Material" );
+    lambertianMaterial->m_perVertexColor = true;
 
     //// setup ////
     Scalar colorBoost = 1_ra; /// since simple primitive are ambient only, boost their color
@@ -117,7 +117,6 @@ void MinimalComponent::initialize() {
         addRenderObject( testpoint );
     }
 
-
     for ( int i = 0; i < 10; ++i )
     {
         Vector3 randomVec {cellCorner + offsetVec +
@@ -136,7 +135,7 @@ void MinimalComponent::initialize() {
     //// LINES ////
     cellCorner = {-0.75_ra, 0_ra, 0.0_ra};
     {
-        auto testline =RenderObject::createRenderObject(
+        auto testline = RenderObject::createRenderObject(
             "test_line",
             this,
             RenderObjectType::Geometry,
@@ -147,7 +146,6 @@ void MinimalComponent::initialize() {
         testline->setMaterial( plainMaterial );
         addRenderObject( testline );
     }
-
 
     for ( int i = 0; i < 20; ++i )
     {
@@ -175,7 +173,7 @@ void MinimalComponent::initialize() {
             this,
             RenderObjectType::Geometry,
             DrawPrimitives::Vector(
-                cellCorner, Vector3 { 0_ra, 0.5_ra, 0_ra }, colorBoost * Utils::Color::Blue() ),
+                cellCorner, Vector3 {0_ra, 0.5_ra, 0_ra}, colorBoost * Utils::Color::Blue() ),
             {} );
         testvector->setMaterial( plainMaterial );
         addRenderObject( testvector );
@@ -210,9 +208,8 @@ void MinimalComponent::initialize() {
                 {cellCorner, {0_ra, 1_ra, 0_ra}}, colorBoost * Utils::Color::Yellow(), cellSize ),
             {} );
         testray->setMaterial( plainMaterial );
-        addRenderObject( testray);
+        addRenderObject( testray );
     }
-
 
     //// TRIANGLES ////
     cellCorner = {0_ra, 0_ra, 0.0_ra};
@@ -221,9 +218,9 @@ void MinimalComponent::initialize() {
             "test_triangle",
             this,
             RenderObjectType::Geometry,
-            DrawPrimitives::Triangle( cellCorner + Vector3 { -0.01_ra, 0.0_ra, 0.0_ra },
-                                      cellCorner + Vector3 { +0.01_ra, 0.0_ra, 0.0_ra },
-                                      cellCorner + Vector3 { +0.0_ra, 0.02_ra, 0.0_ra },
+            DrawPrimitives::Triangle( cellCorner + Vector3 {-0.01_ra, 0.0_ra, 0.0_ra},
+                                      cellCorner + Vector3 {+0.01_ra, 0.0_ra, 0.0_ra},
+                                      cellCorner + Vector3 {+0.0_ra, 0.02_ra, 0.0_ra},
                                       colorBoost * Utils::Color::White(),
                                       true ),
             {} );
@@ -284,7 +281,7 @@ void MinimalComponent::initialize() {
             this,
             RenderObjectType::Geometry,
             DrawPrimitives::Circle( cellCorner,
-                                    { 0_ra, 0_ra, 1_ra },
+                                    {0_ra, 0_ra, 1_ra},
                                     cellSize / 8_ra,
                                     64,
                                     colorBoost * Utils::Color::White() ),
@@ -307,15 +304,16 @@ void MinimalComponent::initialize() {
             Scalar circleRadius {Scalar( end / 2 + i ) / Scalar( 2 * end ) * cellSize / 8_ra};
             uint circleSubdiv {3 + j * end + i};
 
-            auto circle = RenderObject::createRenderObject( "test_circle",
-                                                            this,
-                                                            RenderObjectType::Geometry,
-                                                            DrawPrimitives::Circle( circleCenter,
-                                                                                    circleNormal,
-                                                                                    circleRadius,
-                                                                                    circleSubdiv,
-                                                                                    colorBoost * randomCol ),
-                                                            {} );
+            auto circle =
+                RenderObject::createRenderObject( "test_circle",
+                                                  this,
+                                                  RenderObjectType::Geometry,
+                                                  DrawPrimitives::Circle( circleCenter,
+                                                                          circleNormal,
+                                                                          circleRadius,
+                                                                          circleSubdiv,
+                                                                          colorBoost * randomCol ),
+                                                  {} );
             circle->setMaterial( plainMaterial );
             addRenderObject( circle );
         }
@@ -327,8 +325,8 @@ void MinimalComponent::initialize() {
             "test_circle",
             this,
             RenderObjectType::Geometry,
-            DrawPrimitives::CircleArc( cellCorner + Vector3 { 0_ra, 2_ra * offset, 0_ra },
-                                       { 0_ra, 0_ra, 1_ra },
+            DrawPrimitives::CircleArc( cellCorner + Vector3 {0_ra, 2_ra * offset, 0_ra},
+                                       {0_ra, 0_ra, 1_ra},
                                        cellSize / 8_ra,
                                        1_ra,
                                        64,
@@ -440,7 +438,7 @@ void MinimalComponent::initialize() {
             this,
             RenderObjectType::Geometry,
             DrawPrimitives::Capsule( cellCorner,
-                                     cellCorner + Vector3 { 0_ra, 0.1_ra, 0_ra },
+                                     cellCorner + Vector3 {0_ra, 0.1_ra, 0_ra},
                                      0.02_ra,
                                      Utils::Color::White() ),
             {} );
@@ -457,7 +455,7 @@ void MinimalComponent::initialize() {
             this,
             RenderObjectType::Geometry,
             DrawPrimitives::Disk( cellCorner,
-                                  Vector3 { 0_ra, 0_ra, 1_ra },
+                                  Vector3 {0_ra, 0_ra, 1_ra},
                                   0.05_ra,
                                   32,
                                   colorBoost * Utils::Color::White() ),
@@ -475,7 +473,7 @@ void MinimalComponent::initialize() {
             this,
             RenderObjectType::Geometry,
             DrawPrimitives::Normal(
-                cellCorner, Vector3 { 0_ra, 0_ra, 1_ra }, colorBoost * Utils::Color::White() ),
+                cellCorner, Vector3 {0_ra, 0_ra, 1_ra}, colorBoost * Utils::Color::White() ),
             {} );
         normal->setMaterial( plainMaterial );
         addRenderObject( normal );

--- a/tests/ExampleApps/HelloRadium/main.cpp
+++ b/tests/ExampleApps/HelloRadium/main.cpp
@@ -41,7 +41,7 @@ int main( int argc, char* argv[] ) {
     //! [Register the entity/component association to the geometry system ]
 
     //! [Tell the window that something is to be displayed]
-    app.m_mainWindow->prepareDisplay( "Cube" );
+    app.m_mainWindow->prepareDisplay();
     //! [Tell the window that something is to be displayed]
 
     // terminate the app after 4 second (approximatively). Camera can be moved using mouse moves.

--- a/tests/ExampleApps/HelloRadium/main.cpp
+++ b/tests/ExampleApps/HelloRadium/main.cpp
@@ -41,7 +41,7 @@ int main( int argc, char* argv[] ) {
     //! [Register the entity/component association to the geometry system ]
 
     //! [Tell the window that something is to be displayed]
-    app.m_mainWindow->postLoadFile( "Cube" );
+    app.m_mainWindow->prepareDisplay( "Cube" );
     //! [Tell the window that something is to be displayed]
 
     // terminate the app after 4 second (approximatively). Camera can be moved using mouse moves.

--- a/tests/ExampleApps/RawShaderMaterial/main.cpp
+++ b/tests/ExampleApps/RawShaderMaterial/main.cpp
@@ -116,7 +116,7 @@ std::shared_ptr<Ra::Engine::Rendering::RenderObject> initQuad( Ra::Gui::BaseAppl
         c->m_renderObjects[0] );
 
     // Initialize all OpenGL state for the scene content
-    app.m_mainWindow->prepareDisplay( "Cube" );
+    app.m_mainWindow->prepareDisplay();
     return ro;
 }
 

--- a/tests/ExampleApps/RawShaderMaterial/main.cpp
+++ b/tests/ExampleApps/RawShaderMaterial/main.cpp
@@ -116,7 +116,7 @@ std::shared_ptr<Ra::Engine::Rendering::RenderObject> initQuad( Ra::Gui::BaseAppl
         c->m_renderObjects[0] );
 
     // Initialize all OpenGL state for the scene content
-    app.m_mainWindow->postLoadFile( "Cube" );
+    app.m_mainWindow->prepareDisplay( "Cube" );
     return ro;
 }
 

--- a/tests/ExampleApps/SimpleAnimationApp/main.cpp
+++ b/tests/ExampleApps/SimpleAnimationApp/main.cpp
@@ -157,7 +157,7 @@ int main( int argc, char* argv[] ) {
     //! [add the component to the animation system]
 
     //! [Tell the window that something is to be displayed]
-    app.m_mainWindow->prepareDisplay( "Cube" );
+    app.m_mainWindow->prepareDisplay();
     //! [Tell the window that something is to be displayed]
 
     // terminate the app after 6 second (approximatively). Camera can be moved using mouse moves.

--- a/tests/ExampleApps/SimpleAnimationApp/main.cpp
+++ b/tests/ExampleApps/SimpleAnimationApp/main.cpp
@@ -157,7 +157,7 @@ int main( int argc, char* argv[] ) {
     //! [add the component to the animation system]
 
     //! [Tell the window that something is to be displayed]
-    app.m_mainWindow->postLoadFile( "Cube" );
+    app.m_mainWindow->prepareDisplay( "Cube" );
     //! [Tell the window that something is to be displayed]
 
     // terminate the app after 6 second (approximatively). Camera can be moved using mouse moves.

--- a/tests/ExampleApps/SimpleSimulationApp/main.cpp
+++ b/tests/ExampleApps/SimpleSimulationApp/main.cpp
@@ -98,7 +98,7 @@ int main( int argc, char* argv[] ) {
     //! [Create and Register the simulation system ]
 
     //! [Tell the window that something is to be displayed]
-    app.m_mainWindow->postLoadFile( "cloud" );
+    app.m_mainWindow->prepareDisplay( "cloud" );
     //! [Tell the window that something is to be displayed]
 
     // terminate the app after 4 second (approximatively). Camera can be moved using mouse moves.

--- a/tests/ExampleApps/SimpleSimulationApp/main.cpp
+++ b/tests/ExampleApps/SimpleSimulationApp/main.cpp
@@ -98,7 +98,7 @@ int main( int argc, char* argv[] ) {
     //! [Create and Register the simulation system ]
 
     //! [Tell the window that something is to be displayed]
-    app.m_mainWindow->prepareDisplay( "cloud" );
+    app.m_mainWindow->prepareDisplay();
     //! [Tell the window that something is to be displayed]
 
     // terminate the app after 4 second (approximatively). Camera can be moved using mouse moves.


### PR DESCRIPTION
In all the demo applications and Radium apps (PR associated), the method `MainWindowInterface::postLoadFile()` was called each time a scene is set. As the role of this method was not so clear when a scene is built from scratch (without loading a file), This PR rename this function as `MainWindowInterface::prepareDisplay()` and clarifies its reference documentation.
To be more convenient, a new method was added to the `Gui::Viewer` class to prepare the viewer to display a scene and this method is called by `MainWindowInterface::prepareDisplay()` for `Gui::BaseApplication` derived apps.
For other apps, i.e. DrawPrimitiveDemo, this method could be called directly to allow scene creation in a renderer independant way.

Updated packages : 
  - Gui : `MainWindowInterface` and `Viewer`
  - test : all applications now use `MainWindowInterface::prepareDisplay()`
  - test : DrawPrimitiveDemo was update to the correct way of defining custom `RenderObjects` with materials and let the `Viewer` (and hence the active renderer) to manage the `RenderTechnique` that is a renderer-dependent properties of the RenderObjects created by the renderer when calling `Viewer::prepareDisplay()`.