### PR TITLE
[apps] Fix minimal radium when not using assimp

### DIFF
--- a/tests/ExampleApps/DrawPrimitivesApp/minimalradium.cpp
+++ b/tests/ExampleApps/DrawPrimitivesApp/minimalradium.cpp
@@ -652,11 +652,14 @@ void MinimalComponent::initialize() {
         updateCellCorner( cellCorner, cellSize, nCellX, nCellY );
         updateCellCorner( cellCorner, cellSize, nCellX, nCellY );
 
-        Asset::FileData* data;
+        Asset::FileData* data {nullptr};
+
+#ifdef IO_USE_ASSIMP
         auto l               = IO::AssimpFileLoader();
         auto rp              = Resources::getResourcesPath();
         std::string filename = *rp + "/Assets/radium-logo.dae";
         data                 = l.loadFile( filename );
+#endif
         if ( data != nullptr )
         {
             auto geomData = data->getGeometryData();


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
MinimalApp does not compile without assimp


* **What is the new behavior (if this is a feature change)?**
Protect assimp code: Radium logo is disabled when compiling without assimp.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
nop


* **Other information**:
