### PR TITLE
GizmoManager predefine the struct ItemEntry in the wrong namespace

### DIFF
--- a/src/Gui/Viewer/Gizmo/GizmoManager.hpp
+++ b/src/Gui/Viewer/Gizmo/GizmoManager.hpp
@@ -10,8 +10,10 @@
 
 namespace Ra {
 namespace Engine {
+namespace Scene {
 struct ItemEntry;
-}
+} // namespace Scene
+} // namespace Engine
 } // namespace Ra
 namespace Ra {
 namespace Gui {


### PR DESCRIPTION
In the file Gui/Viewer/Gizmo/GizmoManager.hpp the struct ItemEntry is predeclared in the namespace Ra::Engine whereas it must be predeclared in the namespace Ra::Engine::Scene

This wrong predeclaration make compilation failed for client lib or app that include both  GizmoManager.hpp and ItemEntry.hpp

This PR fix this by predeclaring the struct ItemEntry in the right namespace in the file Gui/Viewer/Gizmo/GizmoManager.hpp