### PR TITLE
[engine] add opengl state, and set unpack alignment to 1.

### DIFF
--- a/src/Engine/RadiumEngine.cpp
+++ b/src/Engine/RadiumEngine.cpp
@@ -1,11 +1,5 @@
 #include <Engine/RadiumEngine.hpp>
 
-#include <cstdio>
-#include <iostream>
-#include <streambuf>
-#include <string>
-#include <thread>
-
 #include <Core/Asset/FileData.hpp>
 #include <Core/Asset/FileLoaderInterface.hpp>
 #include <Core/Resources/Resources.hpp>
@@ -28,6 +22,14 @@
 #include <Engine/Scene/SignalManager.hpp>
 #include <Engine/Scene/System.hpp>
 #include <Engine/Scene/SystemDisplay.hpp>
+
+#include <globjects/State.h>
+
+#include <cstdio>
+#include <iostream>
+#include <streambuf>
+#include <string>
+#include <thread>
 
 namespace Ra {
 namespace Engine {
@@ -60,7 +62,11 @@ void RadiumEngine::initialize() {
 }
 
 void RadiumEngine::initializeGL() {
+    m_openglState = std::make_unique<globjects::State>( globjects::State::DeferredMode );
     registerDefaultPrograms();
+    // needed to upload non multiple of 4 width texture loaded with stbi.
+    m_openglState->pixelStore( GL_UNPACK_ALIGNMENT, 1 );
+    m_openglState->apply();
 }
 
 void RadiumEngine::registerDefaultPrograms() {

--- a/src/Engine/RadiumEngine.hpp
+++ b/src/Engine/RadiumEngine.hpp
@@ -10,6 +10,10 @@
 #include <string>
 #include <vector>
 
+namespace globjects {
+class State;
+}
+
 namespace Ra {
 namespace Core {
 class TaskQueue;
@@ -30,15 +34,11 @@ class SignalManager;
 
 namespace Data {
 class ShaderProgramManager;
-}
-
-namespace Data {
 class Displayable;
 class TextureManager;
 } // namespace Data
 
 namespace Rendering {
-
 class RenderObjectManager;
 }
 
@@ -390,6 +390,10 @@ class RA_ENGINE_API RadiumEngine
     };
 
     TimeData m_timeData;
+
+    /// OpenGL State, usefull to set state of the rendering pipeline. Initialized during
+    /// initializedGL()
+    std::unique_ptr<globjects::State> m_openglState {nullptr};
 };
 } // namespace Engine
 } // namespace Ra


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Since stbi loader do not align pixels.

Should be converted to 4 byte alignment by the driver and do not impact performance.

[doc](https://www.khronos.org/opengl/wiki/Common_Mistakes)
[discussion](https://stackoverflow.com/questions/11042027/glpixelstoreigl-unpack-alignment-1-disadvantages)

Fixes #549

* **What is the current behavior?** (You can also link to an open issue here)
See #549 


* **What is the new behavior (if this is a feature change)?**
Correct display of non multiple of 4 pixels widths.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope.


* **Other information**:
