### PR TITLE
[Gui] do not fail when command line parsing fails

### DIFF
--- a/src/Gui/BaseApplication.cpp
+++ b/src/Gui/BaseApplication.cpp
@@ -131,7 +131,8 @@ BaseApplication::BaseApplication( int& argc,
                         maxThreadsOpt,
                         numFramesOpt,
                         recordOpt} );
-    parser.process( *this );
+    if ( !parser.parse( this->arguments() ) )
+        LOG( logWARNING ) << "Command line parsing failed due to unsupported or missing options";
 
     if ( parser.isSet( fpsOpt ) ) m_targetFPS = parser.value( fpsOpt ).toUInt();
     if ( parser.isSet( pluginOpt ) ) m_pluginPath = parser.value( pluginOpt ).toStdString();


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Radium BaseApplication stops when parsing command line with unknown parameters

* **What is the new behavior (if this is a feature change)?**
Print a warning and continue to start the application

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nop
