### PR TITLE
Fix issue #738 (regression)

### DIFF
--- a/src/Engine/RadiumEngine.cpp
+++ b/src/Engine/RadiumEngine.cpp
@@ -46,8 +46,9 @@ void RadiumEngine::initialize() {
     auto resourceDir {Core::Resources::getRadiumResourcesPath()};
     if ( !resourceDir )
     {
-        LOG( logERROR ) << "Default resources dir not found.";
-        exit( -1 );
+        LOG( logWARNING )
+            << "Default Radium resources dir not found. Setting resources path to \".\"";
+        resourceDir = {"."};
     }
     m_resourcesRootDir     = *resourceDir;
     m_signalManager        = std::make_unique<Scene::SignalManager>();


### PR DESCRIPTION
closes #738 

If Radium Resources are not found, do not exit from the application but set the resources path to the current directory.