### PR TITLE
Export io properties

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -111,6 +111,16 @@ if(Engine_FOUND)
 endif()
 
 if(IO_FOUND)
+    define_property(TARGET
+        PROPERTY RADIUM_IO_USE_ASSIMP
+        BRIEF_DOCS "Radium::IO has assimp support."
+        FULL_DOCS "Identify if Radium::IO was compiled with assimp support."
+    )
+    define_property(TARGET
+        PROPERTY RADIUM_IO_USE_TINYPLY
+        BRIEF_DOCS "Radium::IO has tinyply support."
+        FULL_DOCS "Identify if Radium::IO was compiled with tinyply support."
+    )
     include("${CMAKE_CURRENT_LIST_DIR}/IOTargets.cmake" )
 
     # Detect if library has been compiled using assimp and tinyply
@@ -134,6 +144,11 @@ if(IO_FOUND)
         if (MSVC OR MSVC_IDE OR MINGW)
             add_imported_dir( FROM assimp::assimp TO RadiumExternalDlls_location)
         endif()
+        set_target_properties(
+            Radium::IO
+            PROPERTIES
+                RADIUM_IO_USE_ASSIMP TRUE
+        )
     endif()
     if( depTinyPLYFound GREATER_EQUAL "0")
         if ("@tinyply_DIR@" STREQUAL "")
@@ -145,6 +160,11 @@ if(IO_FOUND)
         if (MSVC OR MSVC_IDE OR MINGW)
             add_imported_dir( FROM tinyply TO RadiumExternalDlls_location)
         endif()
+        set_target_properties(
+            Radium::IO
+            PROPERTIES
+                RADIUM_IO_USE_TINYPLY TRUE
+        )
     endif()
 
 endif()

--- a/doc/basics/radium-as-submodule.md
+++ b/doc/basics/radium-as-submodule.md
@@ -1,12 +1,15 @@
 \page basicsRadiumSubmodule Use Radium Libraries in your own project
 [TOC]
 
+## Quick instructions
 Radium is now shiped with a cmake package. To get it:
  - Get latest release,
  - Build from source, and install to the directory of your choice.
 
-Then, to use Radium in your own project, you need to set `CMAKE_PREFIX_PATH=/path/to/install/or/release/dir/lib/cmake/Radium`,
-and add the following lines in your `CMakeLists.txt`:
+Then, to use Radium in your own project, you need to set, at configure time `CMAKE_PREFIX_PATH=/path/to/install/or/release/dir/lib/cmake/Radium` 
+or to define `Radium_DIR=/path/to/install/or/release/dir/lib/cmake/Radium`.
+
+Your `CMakeLists.txt` might then do the following:
 ~~~cmake
 find_package(Radium REQUIRED)
 target_link_libraries(${target} Radium::Core Radium::Engine Radium::IO Radium::Gui)
@@ -17,3 +20,6 @@ In your source code:
 ~~~cpp
 #include <Core/Math/DualQuaternion.hpp>
 ~~~
+
+## Detailed instructions
+See [CMake setup](@ref cmakeutilities).

--- a/doc/developer/cmakeutilities.md
+++ b/doc/developer/cmakeutilities.md
@@ -13,6 +13,7 @@ Complete functional examples using these cmake scripts are accessible in the `sr
 Once installed, either from source or from pre-built binaries, Radium could be used and extended in any application, 
 library or plugin as a cmake package.
 
+## Using Radium in your application
 To integrate the Radium libraries into your build-chain configuration, you have to ask cmake to find the Radium package.
 As for any cmake package, this could be done by adding the following line into your `CMakeLists.txt` file:
 ~~~{.cmake}
@@ -29,6 +30,28 @@ to all the public interface of Radium (include search path, libraries, ...), for
 ~~~{.cmake}
 target_link_libraries (myTarget PUBLIC Radium::Core Radium::Engine)
 ~~~
+
+### Using Radium components
+
+If your application does not need all the radium components, you can select which ones you want among the following :
+- Core : search only for the availability of the target Radium::Core
+- Engine : search only for the availability of the target Radium::Engine
+- Gui : search for the Qt-based Gui toolkit
+- PluginBase : search for the Qt-based plugin development interface
+- IO : search only for the availability of the target Radium::IO
+
+  On this target, you might also ask for support of several file loaders using the following properties defined on the
+  target Radium::IO
+    - RADIUM_IO_USE_ASSIMP : Identify if Radium::IO was compiled with assimp support
+    - RADIUM_IO_USE_TINYPLY : Identify if Radium::IO was compiled with tinyply support.
+      You might use these properties to define compilation macro in your code
+      ~~~{.cmake}
+      get_target_property(USE_ASSIMP Radium::IO RADIUM_IO_USE_ASSIMP)
+      if (${USE_ASSIMP})
+       target_compile_definitions(yourTarget PRIVATE ADD_ASSIMP_LOADER)
+      endif()  
+      ~~~
+
 
 The radium package also defines several cmake functions, described below, that you can use to ease the configuration of 
 your application, library or plugin, mainly to install them in a relocatable way while allowing their use from their 
@@ -661,4 +684,3 @@ where `<resourcesPrefix>` corresponds to the parameter `PREFIX` used when instal
 
 ## Configuring an application plugin
 See [How to write your own plugin](@ref develplugin).
-


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR add properties on the Radium::IO exported target


* **What is the current behavior?** (You can also link to an open issue here)

Applications outside of the Radium source tree can't request for support of assimp or tinyply loaders.


* **What is the new behavior (if this is a feature change)?**

The properties `RADIUM_IO_USE_ASSIMP` and `RADIUM_IO_USE_TINYPLY` are added to the target Radium::IO to allow client applications, library or plugins to tests for support, respectvely, of the assimp or tinyply file loaders


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

