### PR TITLE
Fix keyframedvalue

### DIFF
--- a/src/Core/Animation/KeyFramedValue.hpp
+++ b/src/Core/Animation/KeyFramedValue.hpp
@@ -198,6 +198,8 @@ class KeyFramedValue : public KeyFramedValueBase
             m_keyframes.begin(), m_keyframes.end(), kf0, []( const auto& a, const auto& b ) {
                 return a.first < b.first;
             } );
+
+        // here upper > begin() since before first case is already taken into account.
         auto lower = upper;
         --lower;
         if ( Math::areApproxEqual( lower->first, t ) )

--- a/src/Core/Animation/KeyFramedValue.hpp
+++ b/src/Core/Animation/KeyFramedValue.hpp
@@ -120,13 +120,14 @@ class KeyFramedValue : public KeyFramedValueBase
             m_keyframes.begin(), m_keyframes.end(), kf, []( const auto& a, const auto& b ) {
                 return a.first < b.first;
             } );
-        auto lower = upper;
-        --lower;
         if ( upper == m_keyframes.begin() ) { m_keyframes.insert( upper, kf ); }
-        else if ( Math::areApproxEqual( lower->first, t ) )
-        { lower->second = frame; }
         else
-        { m_keyframes.insert( upper, kf ); }
+        {
+            auto lower = upper - 1;
+            if ( Math::areApproxEqual( lower->first, t ) ) { lower->second = frame; }
+            else
+            { m_keyframes.insert( upper, kf ); }
+        }
     }
 
     /**


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
insert a key frame in front crash on windows in debug, which check iterator decrement before "begin".

so decrement iterator only if it's define.
