### PR TITLE
[core] Add missing const in Dual Quaternion skinning.

### DIFF
--- a/src/Core/Animation/DualQuaternionSkinning.cpp
+++ b/src/Core/Animation/DualQuaternionSkinning.cpp
@@ -108,7 +108,7 @@ DQList computeDQ_naive( const Pose& pose, const Sparse& weight ) {
     return DQ;
 }
 
-Vector3Array applyDualQuaternions( const DQList& DQ, Vector3Array& vertices ) {
+Vector3Array applyDualQuaternions( const DQList& DQ, const Vector3Array& vertices ) {
     Vector3Array out( vertices.size(), Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < int( vertices.size() ); ++i )

--- a/src/Core/Animation/DualQuaternionSkinning.hpp
+++ b/src/Core/Animation/DualQuaternionSkinning.hpp
@@ -38,7 +38,7 @@ DQList RA_CORE_API computeDQ_naive( const Pose& pose, const WeightMatrix& weight
  * \brief Applies the given Dual-Quaternions to the given vertices.
  * \note Parallelized loop inside (using openmp).
  */
-Vector3Array RA_CORE_API applyDualQuaternions( const DQList& DQ, Vector3Array& vertices );
+Vector3Array RA_CORE_API applyDualQuaternions( const DQList& DQ, const Vector3Array& vertices );
 
 // clang-format off
 /**


### PR DESCRIPTION
_Check if you branch history is PR compatible_
- Your branch need to be up to date with origin/master AND to have linear history (i.e. no merge commit).
- Update your git repository `git fetch origin` if origin is this remote
- Check with the script provided in `scripts/is-history-pr-compatible.sh`
- You must use clang-format style
_These checks are enforced by github workflow actions_
_Please refer to the corresponding log in case of failure_

_UPDATE the form below to describe your PR._

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add missing `const` to reference to vertices parameter of DualQuaternion skinning methods. 
As these methods do not modify vertices, this allow to use the methods even from other const context.

* **What is the current behavior?** (You can also link to an open issue here)

The reference to vertices container is not const


* **What is the new behavior (if this is a feature change)?**

The reference to vertices container is const
