### PR TITLE
[gui] remove pre-declaration of Camera in the wrong namespace.

### DIFF
--- a/src/Gui/Viewer/CameraManipulator.cpp
+++ b/src/Gui/Viewer/CameraManipulator.cpp
@@ -1,10 +1,8 @@
 #include <Gui/Viewer/CameraManipulator.hpp>
 
 #include <Core/Math/Math.hpp>
-#include <Engine/Scene/CameraComponent.hpp>
 #include <Engine/Scene/CameraManager.hpp>
 #include <Engine/Scene/Light.hpp>
-#include <Engine/Scene/SystemDisplay.hpp>
 
 #include <Core/Asset/Camera.hpp>
 #include <Gui/Viewer/Viewer.hpp>

--- a/src/Gui/Viewer/CameraManipulator.hpp
+++ b/src/Gui/Viewer/CameraManipulator.hpp
@@ -17,9 +17,6 @@
 
 namespace Ra {
 namespace Engine {
-namespace Data {
-class Camera;
-} // namespace Data
 namespace Scene {
 class Light;
 }

--- a/src/Gui/Viewer/Gizmo/Gizmo.hpp
+++ b/src/Gui/Viewer/Gizmo/Gizmo.hpp
@@ -16,7 +16,6 @@ namespace Ra {
 namespace Engine {
 
 namespace Data {
-class Camera;
 class PlainMaterial;
 class RenderObject;
 } // namespace Data


### PR DESCRIPTION
Increment over #769
