### PR TITLE
[io] Fix assimp loading point homogeneous coordinates.

### DIFF
--- a/src/IO/AssimpLoader/AssimpLightDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpLightDataLoader.cpp
@@ -83,7 +83,7 @@ std::unique_ptr<LightData> AssimpLightDataLoader::loadLightData( const aiScene* 
         builtLight->setLight(
             color,
             ( frame *
-              Core::Vector4 {light.mPosition[0], light.mPosition[1], light.mPosition[2], 0.0} )
+              Core::Vector4 {light.mPosition[0], light.mPosition[1], light.mPosition[2], 1.0} )
                 .hnormalized(),
             LightData::LightAttenuation( light.mAttenuationConstant,
                                          light.mAttenuationLinear,
@@ -97,7 +97,7 @@ std::unique_ptr<LightData> AssimpLightDataLoader::loadLightData( const aiScene* 
         builtLight->setLight(
             color,
             ( frame *
-              Core::Vector4 {light.mPosition[0], light.mPosition[1], light.mPosition[2], 0.0} )
+              Core::Vector4 {light.mPosition[0], light.mPosition[1], light.mPosition[2], 1.0} )
                 .hnormalized(),
             -( frame.transpose().inverse() * dir ).head<3>(),
             light.mAngleInnerCone,


### PR DESCRIPTION
PR #766 introduce a bug in assimp loader, where position where loaded as direction.
Here is a fix.