### PR TITLE
[core] detach observers on MultiIndexedGeometry before deletion.

### DIFF
--- a/src/Core/Geometry/IndexedGeometry.inl
+++ b/src/Core/Geometry/IndexedGeometry.inl
@@ -80,6 +80,7 @@ inline GeometryIndexLayerBase* GeometryIndexLayer<T>::clone() {
 
 // MultiIndexedGeometry
 inline MultiIndexedGeometry::~MultiIndexedGeometry() {
+    detachAll();
     clear();
 }
 


### PR DESCRIPTION
Closes #783 