### PR TITLE
Wireframe on transparent

### DIFF
--- a/src/Engine/Rendering/ForwardRenderer.cpp
+++ b/src/Engine/Rendering/ForwardRenderer.cpp
@@ -457,8 +457,7 @@ void ForwardRenderer::renderInternal( const Data::ViewingParameters& renderData 
         glBlendFuncSeparate( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ZERO );
         GL_ASSERT( glDrawBuffers( 1, buffers ) ); // Draw color texture
 
-        for ( const auto& ro : m_fancyRenderObjects )
-        {
+        auto drawWireframe = [this, &renderData]( const auto& ro ) {
             std::shared_ptr<Data::Displayable> wro;
 
             WireMap::iterator it = m_wireframes.find( ro.get() );
@@ -507,6 +506,15 @@ void ForwardRenderer::renderInternal( const Data::ViewingParameters& renderData 
                     GL_CHECK_ERROR;
                 }
             }
+        };
+
+        for ( const auto& ro : m_fancyRenderObjects )
+        {
+            drawWireframe( ro );
+        }
+        for ( const auto& ro : m_transparentRenderObjects )
+        {
+            drawWireframe( ro );
         }
     }
 


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR add wireframe rendering for transparent objects.


* **What is the current behavior?** (You can also link to an open issue here)

When rendering in wireframe, only opaque objets are drawn


* **What is the new behavior (if this is a feature change)?**

opaque and transparent objects are drawn in wireframe mode

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no
