### PR TITLE
OpenGL initialization of Viewer

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -43,5 +43,16 @@ BinPackArguments: false
 BinPackParameters: false
 #not supported yet ?
 SpaceBeforeCpp11BracedList: true
+StatementMacros: [
+'KeyMappingViewer',
+'KeyMappingGizmo',
+'KeyMappingCamera',
+'KeyMappingFlightManipulator',
+'KeyMappingRotateAroundCamera',
+'GL_ASSERT',
+'GL_CHECK_ERROR',
+'CORE_UNUSED',
+'CORE_ASSERT'
+]
 ...
 

--- a/src/Engine/Data/Texture.hpp
+++ b/src/Engine/Data/Texture.hpp
@@ -31,7 +31,7 @@ namespace Data {
  * class/function.
  *
  *  When a texture is created, no OpenGL initialisation is realized. The user must first call
- * initializeGL before being able to use this texture in an OpenGL operation. initializeGL
+ * initializeGL before being able to use this texture in an OpenGL operation.
  *
  *  MipMap representation of the texture is automatically generated as soon as the minFilter
  * parameter is something else than GL_LINEAR or GL_NEAREST

--- a/src/Engine/Rendering/Renderer.hpp
+++ b/src/Engine/Rendering/Renderer.hpp
@@ -491,6 +491,8 @@ class RA_ENGINE_API Renderer
 
     Core::Utils::Color m_backgroundColor {Core::Utils::Color::Grey( 0.0392_ra, 0_ra )};
     void preparePicking( const Data::ViewingParameters& renderData );
+
+    bool m_initialized {false};
 };
 
 } // namespace Rendering

--- a/src/Gui/Viewer/FlightCameraManipulator.cpp
+++ b/src/Gui/Viewer/FlightCameraManipulator.cpp
@@ -25,8 +25,7 @@ using FlightCameraKeyMapping = Ra::Gui::KeyMappingManageable<FlightCameraManipul
 KeyMappingFlightManipulator
 #undef KMA_VALUE
 
-    void
-    Gui::FlightCameraManipulator::configureKeyMapping_impl() {
+void Gui::FlightCameraManipulator::configureKeyMapping_impl() {
 
     FlightCameraKeyMapping::setContext(
         Gui::KeyMappingManager::getInstance()->getContext( "FlightManipulatorContext" ) );

--- a/src/Gui/Viewer/Gizmo/GizmoManager.cpp
+++ b/src/Gui/Viewer/Gizmo/GizmoManager.cpp
@@ -20,8 +20,7 @@ using GizmoMapping = KeyMappingManageable<GizmoManager>;
 KeyMappingGizmo
 #undef KMA_VALUE
 
-    void
-    GizmoManager::configureKeyMapping_impl() {
+void GizmoManager::configureKeyMapping_impl() {
     GizmoMapping::setContext( Gui::KeyMappingManager::getInstance()->getContext( "GizmoContext" ) );
     if ( GizmoMapping::getContext().isInvalid() )
     {
@@ -44,7 +43,7 @@ bool GizmoManager::isValidAction( const Gui::KeyMappingManager::KeyMappingAction
 #define KMA_VALUE( XX ) res = ( XX == action ) || res;
     KeyMappingGizmo
 #undef KMA_VALUE
-        return res;
+    return res;
 }
 
 /*

--- a/src/Gui/Viewer/TrackballCameraManipulator.cpp
+++ b/src/Gui/Viewer/TrackballCameraManipulator.cpp
@@ -28,8 +28,7 @@ namespace Gui {
 KeyMappingCamera
 #undef KMA_VALUE
 
-    void
-    TrackballCameraManipulator::configureKeyMapping_impl() {
+void TrackballCameraManipulator::configureKeyMapping_impl() {
 
     TrackballCameraMapping::setContext(
         KeyMappingManager::getInstance()->getContext( "CameraContext" ) );

--- a/src/Gui/Viewer/Viewer.cpp
+++ b/src/Gui/Viewer/Viewer.cpp
@@ -444,8 +444,9 @@ bool Viewer::initializeGL() {
 
     createGizmoManager();
 
-    emit glInitialized();
     m_glInitialized = true;
+
+    emit glInitialized();
 
     if ( m_renderers.empty() )
     {

--- a/src/Gui/Viewer/Viewer.cpp
+++ b/src/Gui/Viewer/Viewer.cpp
@@ -474,7 +474,7 @@ bool Viewer::initializeGL() {
 
     if ( m_currentRenderer == nullptr ) { changeRenderer( 0 ); }
 
-    return true;
+    return m_glInitialized;
 }
 
 void Viewer::resizeGL( QResizeEvent* event ) {

--- a/src/Gui/Viewer/Viewer.cpp
+++ b/src/Gui/Viewer/Viewer.cpp
@@ -67,10 +67,9 @@ using ViewerMapping = KeyMappingManageable<Viewer>;
 KeyMappingViewer
 #undef KMA_VALUE
 
-    // Register all keymapings related to the viewer and its managed functionalities (Trackball
-    // camera, Gizmo, ..)
-    void
-    Viewer::setupKeyMappingCallbacks() {
+// Register all keymapings related to the viewer and its managed functionalities (Trackball
+// camera, Gizmo, ..)
+void Viewer::setupKeyMappingCallbacks() {
     auto keyMappingManager = KeyMappingManager::getInstance();
 
     // Add default manipulator listener

--- a/src/Gui/Viewer/Viewer.hpp
+++ b/src/Gui/Viewer/Viewer.hpp
@@ -256,6 +256,7 @@ class RA_GUI_API Viewer : public WindowQt, public KeyMappingManageable<Viewer>
     ///\todo make the following  private:
     /// Owning pointer to the renderers.
     std::vector<std::shared_ptr<Engine::Rendering::Renderer>> m_renderers;
+    std::vector<std::shared_ptr<Engine::Rendering::Renderer>> m_pendingRenderers;
     Engine::Rendering::Renderer* m_currentRenderer;
 
     /// Owning Pointer to the feature picking manager.

--- a/src/Gui/Viewer/WindowQt.cpp
+++ b/src/Gui/Viewer/WindowQt.cpp
@@ -83,7 +83,7 @@ void WindowQt::initialize() {
     {
         makeCurrent();
 
-        m_glInitialized = initializeGL();
+        initializeGL();
 
         doneCurrent();
     }
@@ -139,7 +139,9 @@ bool WindowQt::event( QEvent* event ) {
 }*/
 
 bool WindowQt::initializeGL() {
-    return false;
+    // this simple window do not init GL
+    m_glInitialized = false;
+    return m_glInitialized;
 }
 
 void WindowQt::cleanupGL() {

--- a/src/Gui/Viewer/WindowQt.cpp
+++ b/src/Gui/Viewer/WindowQt.cpp
@@ -63,11 +63,15 @@ QOpenGLContext* WindowQt::context() {
 }
 
 void WindowQt::makeCurrent() {
-    m_context->makeCurrent( this );
+    if ( QOpenGLContext::currentContext() != m_context.get() ) { m_context->makeCurrent( this ); }
+    else
+    { ++m_contextActivationNumber; }
 }
 
 void WindowQt::doneCurrent() {
-    m_context->doneCurrent();
+    if ( m_contextActivationNumber == 0 ) { m_context->doneCurrent(); }
+    else
+    { --m_contextActivationNumber; }
 }
 
 void WindowQt::resizeEvent( QResizeEvent* event ) {
@@ -82,9 +86,7 @@ void WindowQt::initialize() {
     if ( !m_glInitialized.load() )
     {
         makeCurrent();
-
         initializeGL();
-
         doneCurrent();
     }
 }

--- a/src/Gui/Viewer/WindowQt.cpp
+++ b/src/Gui/Viewer/WindowQt.cpp
@@ -63,15 +63,20 @@ QOpenGLContext* WindowQt::context() {
 }
 
 void WindowQt::makeCurrent() {
-    if ( QOpenGLContext::currentContext() != m_context.get() ) { m_context->makeCurrent( this ); }
+    if ( QOpenGLContext::currentContext() != m_context.get() )
+    {
+        m_context->makeCurrent( this );
+        // reset counter (in case another viewer has broken our context activation counter)
+        m_contextActivationCount = 0;
+    }
     else
-    { ++m_contextActivationNumber; }
+    { ++m_contextActivationCount; }
 }
 
 void WindowQt::doneCurrent() {
-    if ( m_contextActivationNumber == 0 ) { m_context->doneCurrent(); }
+    if ( m_contextActivationCount == 0 ) { m_context->doneCurrent(); }
     else
-    { --m_contextActivationNumber; }
+    { --m_contextActivationCount; }
 }
 
 void WindowQt::resizeEvent( QResizeEvent* event ) {

--- a/src/Gui/Viewer/WindowQt.hpp
+++ b/src/Gui/Viewer/WindowQt.hpp
@@ -88,6 +88,9 @@ class RA_GUI_API WindowQt : public QWindow
   protected:
     static WindowQt* s_getProcAddressHelper;
     static glbinding::ProcAddress getProcAddress( const char* name );
+
+  private:
+    int m_contextActivationNumber {0};
 };
 
 } // namespace Gui

--- a/src/Gui/Viewer/WindowQt.hpp
+++ b/src/Gui/Viewer/WindowQt.hpp
@@ -39,13 +39,19 @@ class RA_GUI_API WindowQt : public QWindow
     virtual void leaveEvent( QEvent* event );
 
     /**
-     * Make the OpenGL context associated with the viewer the current context.
+     * Make this->context() the current context.
+     * This function is made reentrant thanks to an internal counter that count how many time the
+     * context has been asked to be activated.
+     * If the context have already been made current with a previous call to makeCurrent, this
+     * function increase an internal counter by one so that doneCurrent do not release the context.
      */
-
     void makeCurrent();
 
     /**
-     * Reset the current OpenGL context that is no more the one associated with the viewer.
+     * Release this->context().
+     * This results in no context being current in the current thread.
+     * In case a context has been made current multiple times, this function just deacrease the
+     * internal counter by one. \see makeCurrent()
      */
     void doneCurrent();
 
@@ -90,7 +96,7 @@ class RA_GUI_API WindowQt : public QWindow
     static glbinding::ProcAddress getProcAddress( const char* name );
 
   private:
-    int m_contextActivationNumber {0};
+    int m_contextActivationCount {0};
 };
 
 } // namespace Gui


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR change the OpenGL initialization procedure in the Viewer class so that, as soon as the OpenGL context is available, the OpenGL subsystem is marked as initialized. Doing that, all client applications/libraries/plugin, notified during the initialization process can use any operation requesting The OpenGL context to be bounded. 
This PR also fix a makecurrent/donecurrent problem when some methods are called with the OpenGL context bound while this method assume it should be not.
