### PR TITLE
Check compiler version in external/cmake

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -19,6 +19,9 @@ else()
   # We can use include() and find_package() for our scripts in there
   list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)
 
+  # Check compiler version
+  include(compilerVersion)
+
   # Changing the default value for CMAKE_BUILD_PARALLEL_LEVEL
   if(NOT DEFINED ENV{CMAKE_BUILD_PARALLEL_LEVEL})
       include(ProcessorCount)


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix (kind of)


* **What is the current behavior?** (You can also link to an open issue here)
It is currently possible to compile externals with an unsupported compiler.

* **What is the new behavior (if this is a feature change)?**
Check compiler version in 'external/cmake'


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No change required downstream


* **Other information**:
