### PR TITLE
Fix gizmo hover

### DIFF
--- a/src/Gui/Viewer/RotateAroundCameraManipulator.cpp
+++ b/src/Gui/Viewer/RotateAroundCameraManipulator.cpp
@@ -9,7 +9,6 @@ namespace Ra {
 namespace Gui {
 
 using namespace Ra::Core::Utils;
-using RotateAroundCameraMapping = KeyMappingManageable<RotateAroundCameraManipulator>;
 
 #define KMA_VALUE( XX ) KeyMappingManager::KeyMappingAction RotateAroundCameraManipulator::XX;
 KeyMappingRotateAroundCamera
@@ -18,8 +17,8 @@ KeyMappingRotateAroundCamera
 void RotateAroundCameraManipulator::configureKeyMapping_impl() {
     auto keyMappingManager = Gui::KeyMappingManager::getInstance();
 
-    thisKeyMapping::setContext( KeyMappingManager::getInstance()->getContext( "CameraContext" ) );
-    if ( thisKeyMapping::getContext().isInvalid() )
+    KeyMapping::setContext( KeyMappingManager::getInstance()->getContext( "CameraContext" ) );
+    if ( KeyMapping::getContext().isInvalid() )
     {
         LOG( logINFO )
             << "CameraContext not defined (maybe the configuration file do not contains it)";
@@ -27,7 +26,7 @@ void RotateAroundCameraManipulator::configureKeyMapping_impl() {
         return;
     }
 
-#define KMA_VALUE( XX ) XX = keyMappingManager->getActionIndex( thisKeyMapping::getContext(), #XX );
+#define KMA_VALUE( XX ) XX = keyMappingManager->getActionIndex( KeyMapping::getContext(), #XX );
     KeyMappingRotateAroundCamera
 #undef KMA_VALUE
 }
@@ -160,6 +159,10 @@ void RotateAroundCameraManipulator::alignOnClosestAxis() {
         m_light->setPosition( m_camera->getPosition() );
         m_light->setDirection( m_camera->getDirection() );
     }
+}
+
+KeyMappingManager::Context RotateAroundCameraManipulator::mappingContext() {
+    return KeyMapping::getContext();
 }
 
 void RotateAroundCameraManipulator::handleCameraRotate( Scalar x, Scalar y ) {

--- a/src/Gui/Viewer/RotateAroundCameraManipulator.hpp
+++ b/src/Gui/Viewer/RotateAroundCameraManipulator.hpp
@@ -11,10 +11,7 @@ class RA_GUI_API RotateAroundCameraManipulator
     friend class Ra::Gui::KeyMappingManageable<RotateAroundCameraManipulator>;
 
   public:
-    using base           = Ra::Gui::TrackballCameraManipulator;
-    using baseKeyMapping = Ra::Gui::KeyMappingManageable<base>;
-    using thisKeyMapping = Ra::Gui::KeyMappingManageable<RotateAroundCameraManipulator>;
-
+    using KeyMapping = KeyMappingManageable<RotateAroundCameraManipulator>;
     RotateAroundCameraManipulator( const CameraManipulator& cm, Ra::Gui::Viewer* viewer );
 
     /// @copydoc TrackballCameraManipulator::handleMouseMoveEvent()
@@ -33,6 +30,8 @@ class RA_GUI_API RotateAroundCameraManipulator
     /// Align the camera direction and up vector with the closest world axis.
     /// Keep m_target at the same  screen coordinates.
     void alignOnClosestAxis();
+
+    KeyMappingManager::Context mappingContext() override;
 
   protected:
     virtual void handleCameraRotate( Scalar dx, Scalar dy ) override;

--- a/src/Gui/Viewer/TrackballCameraManipulator.cpp
+++ b/src/Gui/Viewer/TrackballCameraManipulator.cpp
@@ -30,9 +30,8 @@ KeyMappingCamera
 
 void TrackballCameraManipulator::configureKeyMapping_impl() {
 
-    TrackballCameraMapping::setContext(
-        KeyMappingManager::getInstance()->getContext( "CameraContext" ) );
-    if ( TrackballCameraMapping::getContext().isInvalid() )
+    KeyMapping::setContext( KeyMappingManager::getInstance()->getContext( "CameraContext" ) );
+    if ( KeyMapping::getContext().isInvalid() )
     {
         LOG( logINFO )
             << "CameraContext not defined (maybe the configuration file do not contains it)";
@@ -40,9 +39,8 @@ void TrackballCameraManipulator::configureKeyMapping_impl() {
         return;
     }
 
-#define KMA_VALUE( XX )                                                                          \
-    XX = KeyMappingManager::getInstance()->getActionIndex( TrackballCameraMapping::getContext(), \
-                                                           #XX );
+#define KMA_VALUE( XX ) \
+    XX = KeyMappingManager::getInstance()->getActionIndex( KeyMapping::getContext(), #XX );
     KeyMappingCamera
 #undef KMA_VALUE
 }
@@ -111,6 +109,10 @@ Core::Transform::ConstTranslationPart TrackballCameraManipulator::getTrackballCe
     return m_referenceFrame.translation();
 }
 
+KeyMappingManager::Context TrackballCameraManipulator::mappingContext() {
+    return KeyMapping::getContext();
+}
+
 bool TrackballCameraManipulator::handleMousePressEvent( QMouseEvent* event,
                                                         const Qt::MouseButtons& buttons,
                                                         const Qt::KeyboardModifiers& modifiers,
@@ -119,7 +121,7 @@ bool TrackballCameraManipulator::handleMousePressEvent( QMouseEvent* event,
     m_lastMouseY    = event->pos().y();
     m_phiDir        = -Core::Math::signNZ( m_theta );
     m_currentAction = KeyMappingManager::getInstance()->getAction(
-        TrackballCameraMapping::getContext(), buttons, modifiers, key, false );
+        KeyMapping::getContext(), buttons, modifiers, key, false );
 
     return m_currentAction.isValid();
 }
@@ -166,7 +168,7 @@ bool TrackballCameraManipulator::handleWheelEvent( QWheelEvent* event,
 
 ) {
     auto action = KeyMappingManager::getInstance()->getAction(
-        TrackballCameraMapping::getContext(), buttons, modifiers, key, true );
+        KeyMapping::getContext(), buttons, modifiers, key, true );
 
     if ( action == TRACKBALLCAMERA_MOVE_FORWARD )
     {

--- a/src/Gui/Viewer/TrackballCameraManipulator.hpp
+++ b/src/Gui/Viewer/TrackballCameraManipulator.hpp
@@ -17,7 +17,7 @@ class RA_GUI_API TrackballCameraManipulator
     friend class KeyMappingManageable<TrackballCameraManipulator>;
 
   public:
-    using TrackballCameraMapping = KeyMappingManageable<TrackballCameraManipulator>;
+    using KeyMapping = KeyMappingManageable<TrackballCameraManipulator>;
 
     /// Default constructor
     TrackballCameraManipulator();
@@ -62,6 +62,8 @@ class RA_GUI_API TrackballCameraManipulator
     /// Return the trackball center.
     /// \note doesn't modify the camera.
     const Core::Transform::ConstTranslationPart getTrackballCenter() const;
+
+    KeyMappingManager::Context mappingContext() override;
 
   public slots:
     void setCameraPosition( const Core::Vector3& position ) override;

--- a/src/Gui/Viewer/Viewer.cpp
+++ b/src/Gui/Viewer/Viewer.cpp
@@ -723,7 +723,7 @@ void Viewer::handleMousePressEvent( QMouseEvent* event,
     /// currentGrabber = grabber (we need to store it for mouse move)
 
     // for now just handle one active context
-    m_activeContext = -1;
+    m_activeContext.setInvalid();
 
     auto keyMap = KeyMappingManager::getInstance();
     //! [event dispatch]
@@ -782,7 +782,7 @@ void Viewer::handleMouseReleaseEvent( QMouseEvent* event ) {
     { m_camera->handleMouseReleaseEvent( event ); }
     if ( m_activeContext == GizmoManager::getContext() )
     { m_gizmoManager->handleMouseReleaseEvent( event ); }
-    m_activeContext = -1;
+    m_activeContext.setInvalid();
 }
 
 void Viewer::handleMouseMoveEvent( QMouseEvent* event,

--- a/tests/ExampleApps/CustomCameraManipulator/main.cpp
+++ b/tests/ExampleApps/CustomCameraManipulator/main.cpp
@@ -32,7 +32,7 @@ class CameraManipulator2D : public Ra::Gui::TrackballCameraManipulator
         m_lastMouseY = event->pos().y();
 
         m_currentAction = Ra::Gui::KeyMappingManager::getInstance()->getAction(
-            Ra::Gui::TrackballCameraManipulator::TrackballCameraMapping::getContext(),
+            Ra::Gui::TrackballCameraManipulator::KeyMapping::getContext(),
             buttons,
             modifiers,
             key,

--- a/tests/ExampleApps/DrawPrimitivesApp/main.cpp
+++ b/tests/ExampleApps/DrawPrimitivesApp/main.cpp
@@ -46,7 +46,7 @@ int main( int argc, char* argv[] ) {
     auto keyMappingManager = Ra::Gui::KeyMappingManager::getInstance();
     // Add default manipulator listener
     keyMappingManager->addListener(
-        Ra::Gui::RotateAroundCameraManipulator::thisKeyMapping::configureKeyMapping );
+        Ra::Gui::RotateAroundCameraManipulator::KeyMapping::configureKeyMapping );
 
     // Start the app.
     app.m_frame_timer->start();


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix, gizmo should change color on hover, but this was not the case (don't know when it was introduced ...)

* **What is the current behavior?** (You can also link to an open issue here)
Gizmo do not change color on hover, this is due to the "camera mapping" which is by default "invalid" in CameraManipulator class, and was not overridden.


* **What is the new behavior (if this is a feature change)?**
Selected gizmo "axe" change color on hover, prior to click.

* **Other information**:
Also rename some in class using, which should change client code, to use a consistant naming.
