### PR TITLE
Fix rotate cam

### DIFF
--- a/src/Gui/Viewer/RotateAroundCameraManipulator.cpp
+++ b/src/Gui/Viewer/RotateAroundCameraManipulator.cpp
@@ -62,9 +62,6 @@ bool RotateAroundCameraManipulator::handleMouseMoveEvent(
     Scalar dx = ( event->pos().x() - m_lastMouseX ) / m_camera->getWidth();
     Scalar dy = ( event->pos().y() - m_lastMouseY ) / m_camera->getHeight();
 
-    m_lastMouseX = event->pos().x();
-    m_lastMouseY = event->pos().y();
-
     if ( m_currentAction == TRACKBALLCAMERA_ROTATE )
         handleCameraRotate( event->pos().x(), event->pos().y() );
     else if ( m_currentAction == TRACKBALLCAMERA_PAN )
@@ -74,8 +71,8 @@ bool RotateAroundCameraManipulator::handleMouseMoveEvent(
     else if ( m_currentAction == TRACKBALLCAMERA_MOVE_FORWARD )
         handleCameraMoveForward( dx, dy );
 
-    m_prevMouseX = m_lastMouseX;
-    m_prevMouseY = m_lastMouseY;
+    m_lastMouseX = event->pos().x();
+    m_lastMouseY = event->pos().y();
 
     if ( m_light != nullptr )
     {
@@ -184,8 +181,8 @@ Scalar RotateAroundCameraManipulator::projectOnBall( Scalar x, Scalar y ) {
 Ra::Core::Quaternion
 RotateAroundCameraManipulator::deformedBallQuaternion( Scalar x, Scalar y, Scalar cx, Scalar cy ) {
     // Points on the deformed ball
-    Scalar px = m_cameraSensitivity * ( m_prevMouseX - cx ) / m_camera->getWidth();
-    Scalar py = m_cameraSensitivity * ( cy - m_prevMouseY ) / m_camera->getHeight();
+    Scalar px = m_cameraSensitivity * ( m_lastMouseX - cx ) / m_camera->getWidth();
+    Scalar py = m_cameraSensitivity * ( cy - m_lastMouseY ) / m_camera->getHeight();
     Scalar dx = m_cameraSensitivity * ( x - cx ) / m_camera->getWidth();
     Scalar dy = m_cameraSensitivity * ( cy - y ) / m_camera->getHeight();
 

--- a/src/Gui/Viewer/RotateAroundCameraManipulator.hpp
+++ b/src/Gui/Viewer/RotateAroundCameraManipulator.hpp
@@ -44,8 +44,6 @@ class RA_GUI_API RotateAroundCameraManipulator
     Scalar projectOnBall( Scalar x, Scalar y );
 
   private:
-    Scalar m_prevMouseX {0.0_ra};
-    Scalar m_prevMouseY {0.0_ra};
     Ra::Core::Vector3 m_pivot {0.0_ra, 0.0_ra, 0.0_ra};
 
     Ra::Gui::Viewer* m_viewer;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
RotateAroundCameraManipulator "jumps" on first mouse move due to bug in prev/last mouse coordinates.
This was not the case before since there was a bug on camera key mapping context that do not trigger mouse press.


* **What is the new behavior (if this is a feature change)?**
Fixed