### PR TITLE
[io] Remove deprecated attribute color in GeometryData

### DIFF
--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -18,7 +18,6 @@ GeometryData::GeometryData( const std::string& name, const GeometryType& type ) 
     m_tangent(),
     m_bitangent(),
     m_texCoord(),
-    m_color(),
     m_material() {}
 
 GeometryData::~GeometryData() {}
@@ -63,7 +62,6 @@ void GeometryData::displayInfo() const {
     LOG( logINFO ) << " Tangent ?      : " << ( ( m_tangent.empty() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Bitangent ?    : " << ( ( m_bitangent.empty() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Tex.Coord. ?   : " << ( ( m_texCoord.empty() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Color ?        : " << ( ( m_color.empty() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Material ?     : " << ( ( !hasMaterial() ) ? "NO" : "YES" );
 
     if ( hasMaterial() ) { m_material->displayInfo(); }

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -169,17 +169,6 @@ class RA_CORE_API GeometryData : public AssetData
     template <typename Container>
     inline void setTextureCoordinates( const Container& texCoordList );
 
-    /// Return the list of vertex colors.
-    inline ColorArray& getColors();
-
-    /// Return the list of vertex colors.
-    inline const ColorArray& getColors() const;
-
-    /// Set the vertex colors.
-    /// \note In-place setting with getColors() is preferred.
-    template <typename Container>
-    inline void setColors( const Container& colorList );
-
     /// Return the MaterialData associated to the objet.
     inline const MaterialData& getMaterial() const;
 
@@ -236,9 +225,6 @@ class RA_CORE_API GeometryData : public AssetData
     /// Return true if the object has vertex texture coordinates.
     inline bool hasTextureCoordinates() const;
 
-    /// Return true if the object has vertex colors.
-    inline bool hasColors() const;
-
     /// Return true if the object has MaterialData.
     inline bool hasMaterial() const;
     /// \}
@@ -282,9 +268,6 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// The list of vertex texture coordinates.
     [[deprecated]] Vector3Array m_texCoord;
-
-    /// The list of vertex colors.
-    [[deprecated]] ColorArray m_color;
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -151,19 +151,6 @@ inline void GeometryData::setTextureCoordinates( const Container& texCoordList )
     internal::copyData( texCoordList, m_texCoord );
 }
 
-inline GeometryData::ColorArray& GeometryData::getColors() {
-    return m_color;
-}
-
-inline const GeometryData::ColorArray& GeometryData::getColors() const {
-    return m_color;
-}
-
-template <typename Container>
-inline void GeometryData::setColors( const Container& colorList ) {
-    internal::copyData( colorList, m_color );
-}
-
 inline const MaterialData& GeometryData::getMaterial() const {
     return *( m_material.get() );
 }
@@ -230,10 +217,6 @@ inline bool GeometryData::hasBiTangents() const {
 
 inline bool GeometryData::hasTextureCoordinates() const {
     return !m_texCoord.empty();
-}
-
-inline bool GeometryData::hasColors() const {
-    return !m_color.empty();
 }
 
 inline bool GeometryData::hasMaterial() const {

--- a/src/Engine/Data/Mesh.hpp
+++ b/src/Engine/Data/Mesh.hpp
@@ -506,11 +506,6 @@ CoreMeshType createCoreMeshFromGeometryData( const Ra::Core::Asset::GeometryData
                         data->getTexCoords() );
     }
 
-    if ( data->hasColors() )
-    {
-        mesh.addAttrib( Data::Mesh::getAttribName( Data::Mesh::VERTEX_COLOR ), data->getColors() );
-    }
-
     // add custom attribs
     // only attributs not handled before are handled by data->getAttribManager()
     // but futur plan will handle also "usual" attibutes this way

--- a/src/Engine/Scene/GeometryComponent.cpp
+++ b/src/Engine/Scene/GeometryComponent.cpp
@@ -108,11 +108,6 @@ void PointCloudComponent::generatePointCloud( const Ra::Core::Asset::GeometryDat
                         data->getTexCoords() );
     }
 
-    if ( data->hasColors() )
-    {
-        mesh.addAttrib( Data::Mesh::getAttribName( Data::Mesh::VERTEX_COLOR ), data->getColors() );
-    }
-
     // add custom attribs
     mesh.vertexAttribs().copyAllAttributes( data->getAttribManager() );
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Remove deprecated code


* **What is the current behavior?** (You can also link to an open issue here)
Loaders use deprecated attribute m_color in `Asset::GeometryData`.

* **What is the new behavior (if this is a feature change)?**
Remove this deprecated attribute and update Tinyply loader to set attributes directly


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Other loaders using this attribute will have to be updated to use the attribmanager.

* **Other information**:
Other deprecated attributes will have to be cleaned the same way, but this can be done in another PR.