### PR TITLE
Add a new signal at the end of the rendering

### DIFF
--- a/src/Gui/Viewer/Viewer.cpp
+++ b/src/Gui/Viewer/Viewer.cpp
@@ -229,6 +229,7 @@ void Viewer::startRendering( const Scalar dt ) {
 void Viewer::swapBuffers() {
     if ( isExposed() ) { m_context->swapBuffers( this ); }
     doneCurrent();
+    emit renderCompleted();
 }
 
 void Viewer::processPicking() {

--- a/src/Gui/Viewer/Viewer.hpp
+++ b/src/Gui/Viewer/Viewer.hpp
@@ -181,6 +181,8 @@ class RA_GUI_API Viewer : public WindowQt, public KeyMappingManageable<Viewer>
 
     void needUpdate();
 
+    void renderCompleted();
+
   public slots:
     /// Tell the renderer to reload all shaders.
     void reloadShaders();


### PR DESCRIPTION
_Check if you branch history is PR compatible_
- Your branch need to be up to date with origin/master AND to have linear history (i.e. no merge commit).
- Update your git repository `git fetch origin` if origin is this remote
- Check with the script provided in `scripts/is-history-pr-compatible.sh`
- You must use clang-format style
_These checks are enforced by github workflow actions_
_Please refer to the corresponding log in case of failure_

_UPDATE the form below to describe your PR._

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Create a new Qt signal emitted by a Viewer instance that indicates when the current rendering frame is completed.


* **What is the current behavior?** (You can also link to an open issue here)

The viewer does not indicate this information

* **What is the new behavior (if this is a feature change)?**

It's a small change that allow to connect new callbacks when the viewer frame is completed


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking Changes

* **Other information**:
