### PR TITLE
[engine] RenderParameter map is no more aligned due to regression in PR #809

### DIFF
--- a/src/Engine/Data/RenderParameters.hpp
+++ b/src/Engine/Data/RenderParameters.hpp
@@ -86,11 +86,14 @@ class RA_ENGINE_API RenderParameters final
      */
     template <typename T>
     class UniformBindableSet final
-        : public std::map<
-              std::string,
-              T,
-              std::less<std::string>,
-              Core::AlignedAllocator<std::pair<const std::string, T>, EIGEN_MAX_ALIGN_BYTES>>
+        : public std::
+              map<std::string, T, std::less<std::string>
+                  /*,
+                  // TODO, verify if we need an aligned allocator here as it generates a segfault
+                  // due to PR #809
+                  Core::AlignedAllocator<std::pair<const std::string, T>, EIGEN_MAX_ALIGN_BYTES>
+                  */
+                  >
     {
       public:
         /** Bind the whole parameter set to the corresponding shader uniforms


### PR DESCRIPTION
All is in the title

_Check if you branch history is PR compatible_
- Your branch need to be up to date with origin/master AND to have linear history (i.e. no merge commit).
- Update your git repository `git fetch origin` if origin is this remote
- Check with the script provided in `scripts/is-history-pr-compatible.sh`
- You must use clang-format style
_These checks are enforced by github workflow actions_
_Please refer to the corresponding log in case of failure_

_UPDATE the form below to describe your PR._

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Regression fix


* **What is the current behavior?** (You can also link to an open issue here)

segfault when adding data to a map that uses the Core::AlignedAllocator


* **What is the new behavior (if this is a feature change)?**

the renderParameter map is no more aligned and all works fine

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
