### PR TITLE
Fix issue #834 : observer/observable issue

### DIFF
--- a/src/Core/Utils/Attribs.cpp
+++ b/src/Core/Utils/Attribs.cpp
@@ -7,7 +7,7 @@ namespace Core {
 namespace Utils {
 
 AttribBase::~AttribBase() {
-    notify();
+    detachAll();
 }
 
 template <>

--- a/src/Engine/Rendering/ForwardRenderer.cpp
+++ b/src/Engine/Rendering/ForwardRenderer.cpp
@@ -254,7 +254,6 @@ void setupLineMesh( std::shared_ptr<Data::LineMesh>& disp, CoreGeometry& core ) 
         auto handle = core.template getAttribHandle<typename CoreGeometry::Point>(
             Data::Mesh::getAttribName( Data::Mesh::VERTEX_POSITION ) );
         core.vertexAttribs().getAttrib( handle ).attach( VerticesUpdater( disp, core ) );
-
         core.attach( IndicesUpdater( disp, core ) );
     }
     else


### PR DESCRIPTION
Closes #864

The bug described in #864 is due to non robust usage of observer/observable pattern.
This  bug is related to issue #783, solved by PR #786.
A discussion on observer/observable usage and limitations is opened in #788 

Description of the bug
 When building a linemesh, an observer is added for both the core geometry and the vertex attrib of the core geometry.
 When deleting the core geometry, the observer on the core geometry is notified and the vertex attrib is deleted. This make the attrib observer to be notified. 
In the current implementation of linemesh for wireframe rendering, the observer attached to the attribute try to access informations already deleted from the core geometry, which cause segfault. 

Description of the Fix 
Apply the recommandation "do not notify observers in the destructor of an observable" but detach all of them.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
