### PR TITLE
Fix headlesss install

### DIFF
--- a/tests/ExampleApps/HeadlessLibAndApp/libHeadless/CMakeLists.txt
+++ b/tests/ExampleApps/HeadlessLibAndApp/libHeadless/CMakeLists.txt
@@ -86,11 +86,18 @@ target_compile_options(${libName}
     INTERFACE
 )
 
+#configure the component "Headless" of pacakges "RadiumHeadless"
 configure_radium_library(
     TARGET ${libName}
     FILES "${${libName}_headers}"
     TARGET_DIR .
     NAMESPACE ${namespaceName}
+    PACKAGE_DIR ${CMAKE_INSTALL_PREFIX}/lib/cmake/${namespaceName}
+)
+
+# configure the package "RadiumHeadless"
+configure_radium_package(
+    NAME "Radium${libName}"
     PACKAGE_DIR ${CMAKE_INSTALL_PREFIX}/lib/cmake/${namespaceName}
     PACKAGE_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
 )

--- a/tests/ExampleApps/HeadlessLibAndApp/libHeadless/CMakeLists.txt
+++ b/tests/ExampleApps/HeadlessLibAndApp/libHeadless/CMakeLists.txt
@@ -36,6 +36,7 @@ set(CLI11_headers
     RadiumHeadless/CLI/App.hpp
     RadiumHeadless/CLI/CLI.hpp
     RadiumHeadless/CLI/Config.hpp
+    RadiumHeadless/CLI/ConfigFwd.hpp
     RadiumHeadless/CLI/Error.hpp
     RadiumHeadless/CLI/Formatter.hpp
     RadiumHeadless/CLI/FormatterFwd.hpp

--- a/tests/ExampleApps/HeadlessLibAndApp/libHeadless/Config.cmake.in
+++ b/tests/ExampleApps/HeadlessLibAndApp/libHeadless/Config.cmake.in
@@ -22,14 +22,12 @@ foreach(_comp ${RadiumHeadless_FIND_COMPONENTS})
 endforeach()
 
 #------------------------------------------------------------------------------------------------------------
-# if Radium_dir is not defined, set it to the list directory.
-# This supposes Default installation procedure for RadiumHeadless : in the same directory structure than Radium
-if ( NOT DEFINED Radium_DIR )
-    set( Radium_DIR ${CMAKE_CURRENT_LIST_DIR} )
-endif()
 
 include(CMakeFindDependencyMacro)
 if ( NOT Radium_FOUND)
+    if ( NOT DEFINED Radium_DIR )
+        set( Radium_DIR ${CMAKE_CURRENT_LIST_DIR} )
+    endif()
     find_dependency(Radium COMPONENTS Core Engine IO REQUIRED)
 endif()
 if (NOT glfw3_FOUND)

--- a/tests/ExampleApps/HeadlessLibAndApp/libHeadless/Config.cmake.in
+++ b/tests/ExampleApps/HeadlessLibAndApp/libHeadless/Config.cmake.in
@@ -22,6 +22,12 @@ foreach(_comp ${RadiumHeadless_FIND_COMPONENTS})
 endforeach()
 
 #------------------------------------------------------------------------------------------------------------
+# if Radium_dir is not defined, set it to the list directory.
+# This supposes Default installation procedure for RadiumHeadless : in the same directory structure than Radium
+if ( NOT DEFINED Radium_DIR )
+    set( Radium_DIR ${CMAKE_CURRENT_LIST_DIR} )
+endif()
+
 include(CMakeFindDependencyMacro)
 if ( NOT Radium_FOUND)
     find_dependency(Radium COMPONENTS Core Engine IO REQUIRED)


### PR DESCRIPTION

_UPDATE the form below to describe your PR._

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR make the RadiumHeadless demon library to be usable by any external client application by doing a simple `find_package(RadiumHeadless REQUIRED)`

This PR also fix RadiumHeadless missing header in the installed Bundle.


* **What is the current behavior?** (You can also link to an open issue here)
To use the Radium headless facilities, one have to do two things : 
 - `find_package(Radium REQUIRED COMPONENTS ...)` with the right set of components to access Radium base libs
 - `find_package(Headless)` to access `Radium::Headless` library.
 
This could be error-prone if some components are missing for Radium.

* **What is the new behavior (if this is a feature change)?**
To use the Radium headless facilities, one have to do only one thing : 
 - `find_package(RadiumHeadless)` to access `Radium::Headless` library and all its dependencies


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
