### PR TITLE
[script] update message according to release-candidate

### DIFF
--- a/scripts/is-history-pr-compatible.sh
+++ b/scripts/is-history-pr-compatible.sh
@@ -12,7 +12,7 @@ gitismerge () {
 }
 
 if [ `git rev-parse origin/release-candidate` != `git merge-base origin/release-candidate HEAD` ]; then
-    echo "Please rebase your branch with \"rebase origin/master\" ";
+    echo "Please rebase your branch with \"rebase origin/release-candidate\" ";
     exit 1
 else
     ko=""


### PR DESCRIPTION
CI script refer to master instead of release-candidate branch.
This PR fix the typo.