### PR TITLE
Add support to Qt6

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -40,7 +40,7 @@ with section("parse"):
                                                                     'INSTALL_LOCATION': 1,
                                                                     'TARGET': 1},
                                                         'pargs': {'flags': [], 'nargs': '*'}},
-                          'install_qt5_plugin': {'pargs': {'nargs': 3}},
+                          'install_qt_plugin': {'pargs': {'nargs': 3}},
                           'install_target_resources': { 'kwargs': { 'FILES': '+',
                                                                     'RESOURCES_DIR': 1,
                                                                     'RESOURCES_INSTALL_DIR': 1,

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -19,9 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { name: "Windows MSVC", os: windows-latest, cc: "cl.exe", cxx: "cl.exe", icon: "Windows"}
-          - { name: "Ubuntu gcc", os: ubuntu-latest, cc: "gcc-10", cxx: "g++-10", icon: "Linux" }
-          - { name: "MacOS clang", os: macos-latest, cc: "clang", cxx: "clang++", icon: "Apple" }
+          - { name: "Windows MSVC", os: windows-latest, cc: "cl.exe", cxx: "cl.exe", icon: "Windows", qtversion: "5.15.1"}
+          - { name: "Windows MSVC", os: windows-latest, cc: "cl.exe", cxx: "cl.exe", icon: "Windows", qtversion: "6.2.0"}
+          - { name: "Ubuntu gcc", os: ubuntu-latest, cc: "gcc-10", cxx: "g++-10", icon: "Linux", qtversion: "5.15.1" }
+          - { name: "Ubuntu gcc", os: ubuntu-latest, cc: "gcc-10", cxx: "g++-10", icon: "Linux", qtversion: "6.2.0" }
+          - { name: "MacOS clang", os: macos-latest, cc: "clang", cxx: "clang++", icon: "Apple", qtversion: "5.15.1" }
+          - { name: "MacOS clang", os: macos-latest, cc: "clang", cxx: "clang++", icon: "Apple", qtversion: "6.2.0" }
     steps:
       - uses: seanmiddleditch/gha-setup-ninja@master
       - name: Add msbuild to PATH
@@ -32,11 +35,12 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ../Qt
-          key: ${{ matrix.config.name }}-QtCache
+          key: ${{ matrix.config.name }}-QtCache-${{ matrix.config.qtversion }}
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          version: ${{ matrix.config.qtversion }}
       - name: Install dep Linux
         if: runner.os == 'Linux'
         run: sudo apt-get install -y libglfw3-dev

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -166,16 +166,21 @@ if(IO_FOUND)
 
 endif()
 
+# Load Radium qt functions
+if(PluginBase_FOUND OR Gui_FOUND)
+    include(${CMAKE_CURRENT_LIST_DIR}/QtFunctions.cmake)
+endif()
+
 if(PluginBase_FOUND)
-    find_dependency(Qt5 COMPONENTS Core REQUIRED)
-    get_target_property(QtCore_Dll Qt5::Core LOCATION)
+    find_qt_dependency(COMPONENTS Core REQUIRED)
+    get_target_property(QtCore_Dll Qt::Core LOCATION)
     get_filename_component(QtDlls_location "${QtCore_Dll}" DIRECTORY)
     include("${CMAKE_CURRENT_LIST_DIR}/PluginBaseTargets.cmake")
 endif()
 
 if(Gui_FOUND)
-    find_dependency(Qt5 COMPONENTS Core Widgets OpenGL Xml REQUIRED)
-    get_target_property(QtCore_Dll Qt5::Core LOCATION)
+    find_qt_dependency(COMPONENTS Core Widgets OpenGL Xml REQUIRED)
+    get_target_property(QtCore_Dll Qt::Core LOCATION)
     get_filename_component(QtDlls_location "${QtCore_Dll}" DIRECTORY)
     include("${CMAKE_CURRENT_LIST_DIR}/GuiTargets.cmake")
 endif()

--- a/cmake/QtFunctions.cmake
+++ b/cmake/QtFunctions.cmake
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.12)
+
+# Find Qt5 or Qt6 packages Parameters: COMPONENTS <component_list>: optional parameter listing the
+# Qt packages (e.g. Core, Widgets REQUIRED: optional parameter propagated to find_package
+#
+# Usage: find_qt_package(COMPONENTS Core Widgets OpenGL Xml REQUIRED) which is equivalent to:
+# find_package(Qt6 COMPONENTS Core Widgets OpenGL Xml REQUIRED) if Qt6 is available, or:
+# find_package(Qt5 COMPONENTS Core Widgets OpenGL Xml REQUIRED) otherwise.
+#
+# Qt5 and Qt6 can be retrieved using versionless targets introduced in Qt5.15:
+# https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html#versionless-targets
+macro(find_qt_package)
+    set(options REQUIRED)
+    set(oneValueArgs "")
+    set(multiValueArgs COMPONENTS)
+
+    cmake_parse_arguments(MY_OPTIONS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT MY_OPTIONS_COMPONENTS) # User didn't enter any component
+        set(MY_OPTIONS_COMPONENTS "")
+    endif()
+
+    find_package(Qt6 COMPONENTS ${MY_OPTIONS_COMPONENTS} QUIET)
+    if(NOT Qt6_FOUND)
+        if(${MY_OPTIONS_REQUIRED})
+            find_package(Qt5 5.15 COMPONENTS ${MY_OPTIONS_COMPONENTS} REQUIRED)
+        else()
+            find_package(Qt5 5.15 COMPONENTS ${MY_OPTIONS_COMPONENTS})
+        endif()
+    endif()
+endmacro()
+
+# Find Qt5 or Qt6 dependency Parameters: COMPONENTS <component_list>: optional parameter listing the
+# Qt packages (e.g. Core, Widgets REQUIRED: optional parameter propagated to find_package
+#
+# Usage example: find_package(Qt5 COMPONENTS Core Widgets OpenGL Xml REQUIRED)
+#
+# Qt5 and Qt6 can be retrieved using versionless targets introduced in Qt5.15:
+# https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html#versionless-targets
+macro(find_qt_dependency)
+    set(options REQUIRED)
+    set(oneValueArgs "")
+    set(multiValueArgs COMPONENTS)
+
+    cmake_parse_arguments(MY_OPTIONS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT MY_OPTIONS_COMPONENTS) # User didn't enter any component
+        set(MY_OPTIONS_COMPONENTS "")
+    endif()
+
+    find_package(Qt6 COMPONENTS ${MY_OPTIONS_COMPONENTS} QUIET)
+    if(NOT Qt6_FOUND)
+        if(${MY_OPTIONS_REQUIRED})
+            find_package(Qt5 5.15 COMPONENTS ${MY_OPTIONS_COMPONENTS} REQUIRED)
+        else()
+            find_package(Qt5 5.15 COMPONENTS ${MY_OPTIONS_COMPONENTS})
+        endif()
+    endif()
+endmacro()

--- a/cmake/RadiumSetupFunctions.cmake
+++ b/cmake/RadiumSetupFunctions.cmake
@@ -100,7 +100,7 @@ function(configure_cmdline_radium_app)
 endfunction()
 
 # internal Utility function to install Qt internal plugins into a macosX bundle
-macro(install_qt5_plugin _qt_plugin_name _qt_plugins_var _destination)
+macro(install_qt_plugin _qt_plugin_name _qt_plugins_var _destination)
     get_target_property(_qt_plugin_path "${_qt_plugin_name}" LOCATION)
     if(EXISTS "${_qt_plugin_path}")
         get_filename_component(_qt_plugin_file "${_qt_plugin_path}" NAME)
@@ -110,7 +110,7 @@ macro(install_qt5_plugin _qt_plugin_name _qt_plugins_var _destination)
         install(FILES "${_qt_plugin_path}" DESTINATION "${_qt_plugin_dest}")
         set(${_qt_plugins_var} "${${_qt_plugins_var}};${_qt_plugin_dest}/${_qt_plugin_file}")
     else()
-        message(FATAL_ERROR "[install_qt5_plugin] QT plugin ${_qt_plugin_name} not found")
+        message(FATAL_ERROR "[install_qt_plugin] QT plugin ${_qt_plugin_name} not found")
     endif()
 endmacro()
 
@@ -188,16 +188,16 @@ function(configure_bundled_radium_app)
     # install qtPlugins (QPA plugin name found here https://doc.qt.io/qt-5/qpa.html) needed to fixup
     # the bundle
     get_target_property(IsUsingQt ${ARGS_NAME} LINK_LIBRARIES)
-    list(FIND IsUsingQt "Qt5::Core" QTCOREIDX)
-    if(NOT QTCOREIDX EQUAL -1)
+    list(FIND IsUsingQt "Qt::Gui" QTGUIIDX)
+    if(NOT QTGUIIDX EQUAL -1)
         message(STATUS "[configure_bundled_radium_app] installing Qt plugins for ${ARGS_NAME}.")
         # Find the list of plugins needed for a macos Qt app and add them here
-        install_qt5_plugin(
-            "Qt5::QCocoaIntegrationPlugin" INSTALLED_QT_PLUGINS
+        install_qt_plugin(
+            "Qt::QCocoaIntegrationPlugin" INSTALLED_QT_PLUGINS
             "${CMAKE_INSTALL_PREFIX}/bin/${ARGS_NAME}.app/Contents/"
         )
-        install_qt5_plugin(
-            "Qt5::QMacStylePlugin" INSTALLED_QT_PLUGINS
+        install_qt_plugin(
+            "Qt::QMacStylePlugin" INSTALLED_QT_PLUGINS
             "${CMAKE_INSTALL_PREFIX}/bin/${ARGS_NAME}.app/Contents/"
         )
     endif()
@@ -635,7 +635,7 @@ function(configure_windows_radium_app)
 
     # deploy qt
     get_target_property(IsUsingQt ${ARGS_NAME} LINK_LIBRARIES)
-    list(FIND IsUsingQt "Qt5::Core" QTCOREIDX)
+    list(FIND IsUsingQt "Qt::Core" QTCOREIDX)
     if(NOT QTCOREIDX EQUAL -1)
         message(STATUS "[configure_windows_radium_app] Preparing call to WinDeployQT"
                        "for application ${ARGS_NAME}"
@@ -704,7 +704,7 @@ function(configure_radium_app)
     else()
         configure_cmdline_radium_app(${ARGN})
         get_target_property(IsUsingQt ${ARGS_NAME} LINK_LIBRARIES)
-        list(FIND IsUsingQt "Qt5::Core" QTCOREIDX)
+        list(FIND IsUsingQt "Qt::Core" QTCOREIDX)
         if(NOT QTCOREIDX EQUAL -1)
             message(
                 STATUS "[configure_radium_app] Deploying QT is not yet supported for application"

--- a/cmake/Windeployqt.cmake
+++ b/cmake/Windeployqt.cmake
@@ -20,10 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-find_package(Qt5 COMPONENTS Core REQUIRED)
+include(QtFunctions)
+find_qt_package(COMPONENTS Core REQUIRED)
 
 # Retrieve the absolute path to qmake and then use that path to find the windeployqt binary
-get_target_property(_qmake_executable Qt5::qmake IMPORTED_LOCATION)
+get_target_property(_qmake_executable Qt::qmake IMPORTED_LOCATION)
 get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
 find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${_qt_bin_dir}")
 

--- a/cmake/Windeployqt.cmake
+++ b/cmake/Windeployqt.cmake
@@ -39,6 +39,11 @@ endif()
 # Qt runtime to the specified directory
 function(windeployqt target directory)
 
+    set(QT_OPTIONS "")
+    if(Qt5_FOUND)
+        set(QT_OPTIONS ${QT_OPTIONS} --no-angle)
+    endif()
+
     # execute windeployqt in a tmp directory after build
     add_custom_command(
         TARGET ${target}
@@ -49,8 +54,8 @@ function(windeployqt target directory)
                 "${CMAKE_CURRENT_BINARY_DIR}/windeployqt-${target}"
         COMMAND
             "${WINDEPLOYQT_EXECUTABLE}" --dir "${CMAKE_CURRENT_BINARY_DIR}/windeployqt-${target}"
-            --verbose 0 --no-compiler-runtime --no-translations --no-angle --release --no-opengl-sw
-            "$<TARGET_FILE:${target}>"
+            --verbose 0 --no-compiler-runtime --no-translations --release --no-opengl-sw
+            ${QT_OPTIONS} "$<TARGET_FILE:${target}>"
         COMMENT "Run WinQTDeploy on ${target}"
         USES_TERMINAL COMMAND_EXPAND_LISTS
     )

--- a/doc/basics/compilation.md
+++ b/doc/basics/compilation.md
@@ -14,6 +14,7 @@ See also our Continuous Integration system at https://github.com/STORM-IRIT/Radi
 Minimal requirements
 * OpenGL 4.1+ / GLSL 410+
 * CMake 3.15.7+
+* Qt5 (minimal version 5.14) or Qt6 (experimental)
 
 # Build instructions
 If not already done, follow instructions at \ref dependenciesmanagement.
@@ -150,6 +151,7 @@ $ cmake .. -DQt5_DIR=........ -DCMAKE_BUILD_TYPE=.......
 $ make
 $ make install
 ~~~
+\note Qt6 support is experimental. To enable it, replace `-DQt5_DIR=path/to/qt5` by `-DQt6_DIR=path/to/qt6`.
 
 \note Running the `install` target is recommended as it will copy all the radium related library in the same place,
 generate the cmake packages and bundle applications with their dependencies (on macos and windows).
@@ -169,8 +171,7 @@ Qt 5.15+ is distributed with binaries precompiled with MSVC 2019, but Qt binarie
 
 ### Qt Dependency
 
-*Qt* distributes precompiled libraries for VS 2017 - 64 bits (tested with 5.10 and 5.12).
-If using earlier versions of Qt (5.5)  or a different toolset you may have to compile Qt yourself.
+Use precompiled libraries for VS 2017 or 2019 - 64 bits (minimal version required: 5.14).
 You will probably have to manually point cmake to the Qt folder.
 
 ### Getting started with Visual Studio
@@ -193,7 +194,7 @@ To fix it, edit `CMakeSettings.json`, such that
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "C:/Users/XXX/Dev/builds/Radium/${name}",
       "installRoot": "C:/Users/XXX/Dev/Radium-install",
-      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=C:/Qt-5.10/5.10.0/msvc2017_64 -DRADIUM_UPDATE_VERSION=OFF",
+      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=C:/Qt-5.15/5.15.0/msvc2017_64",
       "buildCommandArgs": "",
       "ctestCommandArgs": ""
     },
@@ -204,7 +205,7 @@ To fix it, edit `CMakeSettings.json`, such that
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "C:/Users/XXX/Dev/builds/Radium/${name}",
       "installRoot": "C:/Users/XXX/Dev/Radium-installdbg",
-      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=C:/Qt-5.10/5.10.0/msvc2017_64 -DRADIUM_UPDATE_VERSION=OFF",
+      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=C:/Qt-5.15/5.15.0/msvc2017_64",
       "buildCommandArgs": "",
       "ctestCommandArgs": ""
     }

--- a/doc/basics/dependencies.md
+++ b/doc/basics/dependencies.md
@@ -5,13 +5,13 @@ Radium relies on several external libraries to load files or to represent some d
 * [Core] Eigen, OpenMesh
 * [Engine] glm, globjects, glbindings
 * [IO] Assimp
-* [Gui] Qt Core, Qt Widgets and Qt OpenGL v5.5+ (5.14 recommended)
+* [Gui] Qt Core, Qt Widgets and Qt OpenGL v5.5+ (5.14 at least, Qt6 support is experimental)
 * [doc] Doxygen-awesome-css
 * stb_image
 
 We developed a series of tools to fetch and compile these dependencies easily, except for
-Qt, which needs to be installed and passed to cmake through the variable `Qt5_DIR` (see documentation at
-https://doc.qt.io/qt-5.12/cmake-manual.html#getting-started).
+Qt, which needs to be installed and passed to cmake through the variables `Qt5_DIR` OR `Qt6_DIR` (see documentation at
+https://doc.qt.io/qt-5.15/cmake-manual.html#getting-started).
 
 # Dependencies management systems
 

--- a/doc/basics/troubleshooting.md
+++ b/doc/basics/troubleshooting.md
@@ -16,8 +16,8 @@ $ cmake -DCMAKE_PREFIX_PATH=/opt/Qt/5.x/gcc_64
 
 On windows, using cmake-gui you can use the "add entry" button, adding `CMAKE_PREFIX_PATH`
 as a string to point to the Qt directory (for example in the default installation :
-`C:/Qt/5.6/msvc2015_64` )
+`C:/Qt/5.15/msvc2019_64` )
 
 # Crash when starting main application on windows
-This is usally caused by missing dlls.
+This is usually caused by missing dlls.
 With Visual Studio, you may need to copy the Qt dlls to Radium bin folder `Bundle-MSVC\bin` or `Bundle-MSVC-Debug\bin`.

--- a/doc/developer/plugin.md
+++ b/doc/developer/plugin.md
@@ -31,9 +31,10 @@ Example CMakeLists.txt setup to compile a Radium plugin:
  # Use installed Radium environment
  find_package(Radium REQUIRED Core Engine PluginBase)
 
- # Find and configure Qt environment (Radium requires Qt >= 5.1)
+ # Find and configure Qt environment using versionless targets (Radium requires Qt >= 5.15)
+ # https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html
  find_package(Qt5 COMPONENTS Core REQUIRED)
- set(Qt5_LIBRARIES Qt5::Core)
+ set(Qt5_LIBRARIES Qt::Core)
  set(CMAKE_AUTOMOC ON)
  set(CMAKE_AUTORCC ON)
 

--- a/doc/developer/plugin.md
+++ b/doc/developer/plugin.md
@@ -33,8 +33,9 @@ Example CMakeLists.txt setup to compile a Radium plugin:
 
  # Find and configure Qt environment using versionless targets (Radium requires Qt >= 5.15)
  # https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html
- find_package(Qt5 COMPONENTS Core REQUIRED)
- set(Qt5_LIBRARIES Qt::Core)
+ # find_qt_package is provided by Radium
+ find_qt_package(COMPONENTS Core REQUIRED)
+ set(Qt_LIBRARIES Qt::Core)
  set(CMAKE_AUTOMOC ON)
  set(CMAKE_AUTORCC ON)
 
@@ -52,7 +53,7 @@ Example CMakeLists.txt setup to compile a Radium plugin:
 
  target_link_libraries(${PROJECT_NAME} PUBLIC
                        Radium::Core Radium::Engine Radium::PluginBase
-                       ${Qt5_LIBRARIES} )
+                       ${Qt_LIBRARIES} )
 
  # Configure the plugin deployment using the Radium configuration tool
  configure_radium_plugin( NAME ${PROJECT_NAME} )
@@ -76,7 +77,7 @@ configure_radium_plugin(
 
 -   `NAME nameOfTheTargetOtInstall`. This parameter, mandatory, will configure how to install the target
     `nameOfTheTargetOtInstall`. This target must correspond to a configured target such the one obtained by
-    `target_link_libraries(nameOfTheTargetOtInstall PUBLIC Radium::Core Radium::Engine Radium::PluginBase ${Qt5_LIBRARIES} )`
+    `target_link_libraries(nameOfTheTargetOtInstall PUBLIC Radium::Core Radium::Engine Radium::PluginBase ${Qt_LIBRARIES} )`
 
 -   `RESOURCES ListOfResourcesDirectory`. This parameter, optional, will install several resources, needed by the plugin for its correct execution,
     so that the Radium resource locator system will be able to find them.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,7 @@ configure_radium_package(
 
 # install general scripts
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/RadiumSetupFunctions.cmake"
+              "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/QtFunctions.cmake"
         DESTINATION ${ConfigPackageLocation}
 )
 

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -5,25 +5,22 @@ project(${ra_gui_target} LANGUAGES CXX VERSION ${RADIUM_VERSION})
 
 include(filelistGui)
 
+# Qt utility functions
+include(QtFunctions)
+
 # Find packages
-find_package(Qt5 COMPONENTS Core Widgets OpenGL Xml REQUIRED)
+find_qt_package(COMPONENTS Core Widgets OpenGL Xml REQUIRED)
 find_package(OpenGL REQUIRED)
 
-if(Qt5Core_VERSION VERSION_LESS 5.5)
-    message(FATAL_ERROR "Qt5 or superior required (found ${Qt5Core_VERSION}).")
-else()
-    message(STATUS "QT ${Qt5Core_VERSION} found.")
-endif()
-
-# Qt5
-set(Qt5_LIBRARIES Qt5::Core Qt5::Widgets Qt5::OpenGL Qt5::Xml)
+# Qt
+set(Qt_LIBRARIES Qt::Core Qt::Widgets Qt::OpenGL Qt::Xml)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include_directories(${CMAKE_CURRENT_BINARY_DIR} # Moc
 )
-qt5_wrap_ui(gui_uis ${gui_uis})
+qt_wrap_ui(gui_uis ${gui_uis})
 
 add_library(
     ${ra_gui_target} SHARED ${gui_sources} ${gui_headers} ${gui_inlines} ${gui_uis}
@@ -32,7 +29,7 @@ add_library(
 
 add_dependencies(${ra_gui_target} Core Engine PluginBase IO)
 target_link_libraries(${ra_gui_target} PUBLIC Core Engine PluginBase IO)
-target_link_libraries(${ra_gui_target} PRIVATE ${Qt5_LIBRARIES} OpenGL::GL)
+target_link_libraries(${ra_gui_target} PRIVATE ${Qt_LIBRARIES} OpenGL::GL)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     target_compile_definitions(${ra_gui_target} PUBLIC GUI_IS_COMPILED_WITH_DEBUG_INFO)

--- a/src/Gui/Timeline/Timeline.cpp
+++ b/src/Gui/Timeline/Timeline.cpp
@@ -1,7 +1,6 @@
 #include "ui_Timeline.h"
 #include <Gui/Timeline/Timeline.hpp>
 
-#include <QDesktopWidget>
 #include <QEvent>
 #include <QMessageBox>
 #include <QPainter>

--- a/src/Gui/Utils/KeyMappingManager.cpp
+++ b/src/Gui/Utils/KeyMappingManager.cpp
@@ -296,7 +296,6 @@ bool KeyMappingManager::saveConfiguration( const std::string& inFilename ) {
     QXmlStreamWriter stream( &saveTo );
     stream.setAutoFormatting( true );
     stream.setAutoFormattingIndent( 4 );
-    stream.setCodec( "ISO 8859-1" );
     stream.writeStartDocument();
     stream.writeComment( "\tRadium KeyMappingManager configuration file\t" );
     stream.writeComment(
@@ -507,10 +506,7 @@ Qt::MouseButtons KeyMappingManager::getQtMouseButtonsValue( const std::string& k
     else if ( keyString == "RightButton" ) {
         key = Qt::RightButton;
     }
-    else if ( keyString == "MidButton" ) {
-        key = Qt::MidButton;
-    }
-    else if ( keyString == "MiddleButton" ) {
+    else if ( keyString == "MidButton" || keyString == "MiddleButton" ) {
         key = Qt::MiddleButton;
     }
     else if ( keyString == "XButton1" ) {

--- a/src/PluginBase/CMakeLists.txt
+++ b/src/PluginBase/CMakeLists.txt
@@ -5,17 +5,14 @@ project(${ra_pluginbase_target} LANGUAGES CXX VERSION ${RADIUM_VERSION})
 
 include(filelistPluginBase)
 
+# Qt utility functions
+include(QtFunctions)
+
 # Find packages
-find_package(Qt5 COMPONENTS Core REQUIRED)
+find_qt_package(COMPONENTS Core REQUIRED)
 
-if(Qt5Core_VERSION VERSION_LESS 5.5)
-    message(FATAL_ERROR "Qt5 or superior required (found ${Qt5Core_VERSION}).")
-else()
-    message(STATUS "QT ${Qt5Core_VERSION} found.")
-endif()
-
-# Qt5
-set(Qt5_LIBRARIES Qt5::Core)
+# Qt
+set(Qt_LIBRARIES Qt::Core)
 set(CMAKE_AUTOMOC ON)
 
 add_library(
@@ -25,7 +22,7 @@ add_library(
 
 add_dependencies(${ra_pluginbase_target} Core Engine)
 target_link_libraries(${ra_pluginbase_target} PUBLIC Core Engine)
-target_link_libraries(${ra_pluginbase_target} PRIVATE Qt5::Core)
+target_link_libraries(${ra_pluginbase_target} PRIVATE Qt::Core)
 
 target_compile_definitions(${ra_pluginbase_target} PRIVATE "-DRA_PLUGINBASE_EXPORTS")
 

--- a/tests/ExampleApps/CMakeLists.txt
+++ b/tests/ExampleApps/CMakeLists.txt
@@ -15,8 +15,8 @@ set(IN_RADIUM_BUILD_TREE TRUE)
 if(MSVC OR MSVC_IDE OR MINGW)
     # must find the Qt installation directory. This will be set by RadiumConfig.cmake after install
     # TODO : find a way to that more efficiently
-    find_dependency(Qt5 COMPONENTS Core REQUIRED)
-    add_imported_dir(FROM Qt5::Core TO QtDlls_location)
+    find_qt_dependency(COMPONENTS Core REQUIRED)
+    add_imported_dir(FROM Qt::Core TO QtDlls_location)
 endif()
 
 include(RadiumSetupFunctions)
@@ -27,14 +27,14 @@ configure_radium_app(NAME CoreExampleApp)
 add_dependencies(${PROJECT_NAME} CoreExampleApp)
 add_run_and_debug_targets(CoreExampleApp)
 
-find_package(Qt5 COMPONENTS Core Widgets OpenGL Xml REQUIRED)
+find_qt_package(COMPONENTS Core Widgets OpenGL Xml REQUIRED)
 find_package(OpenGL REQUIRED)
 set(CMAKE_AUTOMOC ON)
 add_executable(HelloRadium MACOSX_BUNDLE HelloRadium/main.cpp)
 target_include_directories(HelloRadium PRIVATE HelloRadium)
 target_link_libraries(
-    HelloRadium PUBLIC Radium::Core Radium::Engine Radium::Gui Qt5::Core Qt5::Widgets Qt5::OpenGL
-                       Qt5::Xml OpenGL::GL
+    HelloRadium PUBLIC Radium::Core Radium::Engine Radium::Gui Qt::Core Qt::Widgets Qt::OpenGL
+                       Qt::Xml OpenGL::GL
 )
 add_dependencies(${PROJECT_NAME} HelloRadium)
 message(STATUS "Installing HelloRadium into ${CMAKE_INSTALL_PREFIX}")
@@ -44,8 +44,8 @@ add_run_and_debug_targets(HelloRadium)
 add_executable(SimpleSimulationApp MACOSX_BUNDLE SimpleSimulationApp/main.cpp)
 target_include_directories(SimpleSimulationApp PRIVATE SimpleSimulationApp)
 target_link_libraries(
-    SimpleSimulationApp PUBLIC Radium::Core Radium::Engine Radium::Gui Qt5::Core Qt5::Widgets
-                               Qt5::OpenGL Qt5::Xml OpenGL::GL
+    SimpleSimulationApp PUBLIC Radium::Core Radium::Engine Radium::Gui Qt::Core Qt::Widgets
+                               Qt::OpenGL Qt::Xml OpenGL::GL
 )
 add_dependencies(${PROJECT_NAME} SimpleSimulationApp)
 message(STATUS "Installing SimpleSimulationApp into ${CMAKE_INSTALL_PREFIX}")
@@ -59,8 +59,8 @@ add_executable(
 )
 target_include_directories(DrawPrimitivesDemo PRIVATE DrawPrimitivesApp)
 target_link_libraries(
-    DrawPrimitivesDemo PUBLIC Radium::Core Radium::Engine Radium::Gui Qt5::Core Qt5::Widgets
-                              Qt5::OpenGL Qt5::Xml OpenGL::GL
+    DrawPrimitivesDemo PUBLIC Radium::Core Radium::Engine Radium::Gui Qt::Core Qt::Widgets
+                              Qt::OpenGL Qt::Xml OpenGL::GL
 )
 get_target_property(USE_ASSIMP IO IO_ASSIMP)
 if(${USE_ASSIMP})
@@ -78,8 +78,8 @@ add_run_and_debug_targets(DrawPrimitiveDemo)
 add_executable(SimpleAnimationApp MACOSX_BUNDLE SimpleAnimationApp/main.cpp)
 target_include_directories(SimpleAnimationApp PRIVATE SimpleAnimationApp)
 target_link_libraries(
-    SimpleAnimationApp PUBLIC Radium::Core Radium::Engine Radium::Gui Qt5::Core Qt5::Widgets
-                              Qt5::OpenGL Qt5::Xml OpenGL::GL
+    SimpleAnimationApp PUBLIC Radium::Core Radium::Engine Radium::Gui Qt::Core Qt::Widgets
+                              Qt::OpenGL Qt::Xml OpenGL::GL
 )
 add_dependencies(${PROJECT_NAME} SimpleAnimationApp)
 message(STATUS "Installing SimpleAnimationApp into ${CMAKE_INSTALL_PREFIX}")
@@ -88,8 +88,8 @@ add_run_and_debug_targets(SimpleAnimationApp)
 
 add_executable(RawShaderMaterial MACOSX_BUNDLE RawShaderMaterial/main.cpp)
 target_link_libraries(
-    RawShaderMaterial PUBLIC Radium::Core Radium::Engine Radium::Gui Qt5::Core Qt5::Widgets
-                             Qt5::OpenGL Qt5::Xml OpenGL::GL
+    RawShaderMaterial PUBLIC Radium::Core Radium::Engine Radium::Gui Qt::Core Qt::Widgets
+                             Qt::OpenGL Qt::Xml OpenGL::GL
 )
 add_dependencies(${PROJECT_NAME} RawShaderMaterial)
 message(STATUS "Installing RawShaderMaterial into ${CMAKE_INSTALL_PREFIX}")
@@ -98,8 +98,8 @@ add_run_and_debug_targets(RawShaderMaterial)
 
 add_executable(CustomCameraManipulator MACOSX_BUNDLE CustomCameraManipulator/main.cpp)
 target_link_libraries(
-    CustomCameraManipulator PUBLIC Radium::Core Radium::Engine Radium::Gui Qt5::Core Qt5::Widgets
-                                   Qt5::OpenGL Qt5::Xml OpenGL::GL
+    CustomCameraManipulator PUBLIC Radium::Core Radium::Engine Radium::Gui Qt::Core Qt::Widgets
+                                   Qt::OpenGL Qt::Xml OpenGL::GL
 )
 add_dependencies(${PROJECT_NAME} CustomCameraManipulator)
 message(STATUS "Installing CustomCameraManipulator into ${CMAKE_INSTALL_PREFIX}")

--- a/tests/ExampleApps/EntityAnimationDemo/CMakeLists.txt
+++ b/tests/ExampleApps/EntityAnimationDemo/CMakeLists.txt
@@ -19,8 +19,8 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 
 # ------------------------------------------------------------------------------
-find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
-set(Qt5_LIBRARIES Qt5::Core Qt5::Widgets)
+find_qt_package(COMPONENTS Core Widgets REQUIRED)
+set(Qt_LIBRARIES Qt::Core Qt::Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -35,7 +35,7 @@ set(app_sources main.cpp)
 add_executable(${PROJECT_NAME} ${app_sources})
 
 target_link_libraries(
-    ${PROJECT_NAME} PUBLIC Radium::Core Radium::Engine Radium::IO Radium::Gui ${Qt5_LIBRARIES}
+    ${PROJECT_NAME} PUBLIC Radium::Core Radium::Engine Radium::IO Radium::Gui ${Qt_LIBRARIES}
 )
 
 target_compile_options(${PROJECT_NAME} PRIVATE PUBLIC ${DEFAULT_COMPILE_OPTIONS} INTERFACE)

--- a/tests/ExampleApps/KeyEventDemoApp/CMakeLists.txt
+++ b/tests/ExampleApps/KeyEventDemoApp/CMakeLists.txt
@@ -29,8 +29,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # ///////////////////////////////
-find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
-set(Qt5_LIBRARIES Qt5::Core Qt5::Widgets)
+find_qt_package(COMPONENTS Core Widgets REQUIRED)
+
+set(Qt_LIBRARIES Qt::Core Qt::Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -43,7 +44,7 @@ set(app_sources main.cpp)
 set(app_headers)
 
 set(app_uis)
-qt5_wrap_ui(app_uis_moc ${app_uis})
+qt_wrap_ui(app_uis_moc ${app_uis})
 
 set(app_resources)
 
@@ -58,7 +59,7 @@ target_include_directories(
 )
 
 target_link_libraries(
-    ${PROJECT_NAME} PUBLIC Radium::Core Radium::Engine Radium::Gui ${Qt5_LIBRARIES}
+    ${PROJECT_NAME} PUBLIC Radium::Core Radium::Engine Radium::Gui ${Qt_LIBRARIES}
 )
 
 configure_radium_app(NAME ${PROJECT_NAME})

--- a/tests/ExampleApps/PickingDemoApp/CMakeLists.txt
+++ b/tests/ExampleApps/PickingDemoApp/CMakeLists.txt
@@ -29,8 +29,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # ///////////////////////////////
-find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
-set(Qt5_LIBRARIES Qt5::Core Qt5::Widgets)
+find_qt_package(COMPONENTS Core Widgets REQUIRED)
+set(Qt_LIBRARIES Qt::Core Qt::Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -43,7 +43,7 @@ set(app_sources main.cpp)
 set(app_headers)
 
 set(app_uis)
-qt5_wrap_ui(app_uis_moc ${app_uis})
+qt_wrap_ui(app_uis_moc ${app_uis})
 
 set(app_resources)
 
@@ -58,7 +58,7 @@ target_include_directories(
 )
 
 target_link_libraries(
-    ${PROJECT_NAME} PUBLIC Radium::Core Radium::Engine Radium::Gui Radium::IO ${Qt5_LIBRARIES}
+    ${PROJECT_NAME} PUBLIC Radium::Core Radium::Engine Radium::Gui Radium::IO ${Qt_LIBRARIES}
 )
 
 configure_radium_app(NAME ${PROJECT_NAME})

--- a/tests/ExampleApps/VolumeDemoApp/CMakeLists.txt
+++ b/tests/ExampleApps/VolumeDemoApp/CMakeLists.txt
@@ -29,8 +29,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # ///////////////////////////////
-find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
-set(Qt5_LIBRARIES Qt5::Core Qt5::Widgets)
+find_qt_package(COMPONENTS Core Widgets REQUIRED)
+set(Qt_LIBRARIES Qt::Core Qt::Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -43,7 +43,7 @@ set(app_sources main.cpp)
 set(app_headers)
 
 set(app_uis)
-qt5_wrap_ui(app_uis_moc ${app_uis})
+qt_wrap_ui(app_uis_moc ${app_uis})
 
 set(app_resources)
 
@@ -61,7 +61,7 @@ target_include_directories(
 )
 
 target_link_libraries(
-    ${PROJECT_NAME} PUBLIC Radium::Core Radium::Engine Radium::Gui Radium::IO ${Qt5_LIBRARIES}
+    ${PROJECT_NAME} PUBLIC Radium::Core Radium::Engine Radium::Gui Radium::IO ${Qt_LIBRARIES}
 )
 
 configure_radium_app(NAME ${PROJECT_NAME})

--- a/tests/ExamplePluginWithLib/Downstream/CMakeLists.txt
+++ b/tests/ExamplePluginWithLib/Downstream/CMakeLists.txt
@@ -27,8 +27,8 @@ endif()
 
 # Radium and Qt stuff
 find_package(Radium REQUIRED Core Engine PluginBase)
-find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
-set(Qt5_LIBRARIES Qt5::Core Qt5::Widgets)
+find_qt_package(COMPONENTS Core Widgets REQUIRED)
+set(Qt_LIBRARIES Qt::Core Qt::Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 include_directories(${CMAKE_CURRENT_BINARY_DIR} # Moc

--- a/tests/ExamplePluginWithLib/Downstream/Plugin/CMakeLists.txt
+++ b/tests/ExamplePluginWithLib/Downstream/Plugin/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(${PROJECT_NAME} SHARED ${sources} ${headers})
 target_compile_definitions(${PROJECT_NAME} PRIVATE ${PROJECT_NAME}_EXPORTS)
 
 target_link_libraries(
-    ${PROJECT_NAME} Radium::Core Radium::Engine Radium::PluginBase ${Qt5_LIBRARIES}
+    ${PROJECT_NAME} Radium::Core Radium::Engine Radium::PluginBase ${Qt_LIBRARIES}
     ExampleLibraryUpstream::ExampleLibraryUpstream
 )
 

--- a/tests/ExamplePluginWithLib/Downstream/README.md
+++ b/tests/ExamplePluginWithLib/Downstream/README.md
@@ -4,7 +4,7 @@ This example illustrates how to use a library shipped from another plugin (shoul
 ## Configure
 `cmake -DRadium_DIR=/pathToInstalledRadium/lib/cmake/Radium/ -DExampleLibraryUpstream_DIR=/pathToInstalledUpstreamLibrary ..`
 
-If Qt5 package is not found, add the option `-DQt5_DIR=/pathToInstalledQt5/lib/cmake/Qt5` to the cmake command.
+If Qt package is not found, add the option `-DQt5_DIR=/pathToInstalledQt5/lib/cmake/Qt5` to the cmake command.
 
 ## Compile
 ```bash

--- a/tests/ExamplePluginWithLib/Upstream/Plugin/CMakeLists.txt
+++ b/tests/ExamplePluginWithLib/Upstream/Plugin/CMakeLists.txt
@@ -25,8 +25,8 @@ endif()
 message(STATUS "Searching for package Radium")
 find_package(Radium REQUIRED Core Engine PluginBase)
 
-find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
-set(Qt5_LIBRARIES Qt5::Core Qt5::Widgets)
+find_qt_package(COMPONENTS Core Widgets REQUIRED)
+set(Qt_LIBRARIES Qt::Core Qt::Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 include_directories(${CMAKE_CURRENT_BINARY_DIR} # Moc
@@ -44,7 +44,7 @@ add_library(${PROJECT_NAME} SHARED ${sources} ${headers})
 target_compile_definitions(${PROJECT_NAME} PRIVATE ${PROJECT_NAME}_EXPORTS)
 
 target_link_libraries(
-    ${PROJECT_NAME} Radium::Core Radium::Engine Radium::PluginBase ${Qt5_LIBRARIES}
+    ${PROJECT_NAME} Radium::Core Radium::Engine Radium::PluginBase ${Qt_LIBRARIES}
     ExampleLibraryUpstream
 )
 

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -52,14 +52,14 @@ find_program(SED_EXECUTABLE sed)
 
 if(LIBXML2_XMLLINT_EXECUTABLE AND SED_EXECUTABLE)
     find_package(Filesystem COMPONENTS Final Experimental REQUIRED)
-    find_package(Qt5 COMPONENTS Core Widgets OpenGL Xml REQUIRED)
+    find_qt_package(COMPONENTS Core Widgets OpenGL Xml REQUIRED)
 
-    set(Qt5_LIBRARIES Qt5::Core Qt5::Widgets Qt5::OpenGL Qt5::Xml)
+    set(Qt_LIBRARIES Qt::Core Qt::Widgets Qt::OpenGL Qt::Xml)
 
     # KeyMappingManager saveConfiguration tests
     add_executable(integration_${INTEGRATION_TEST} ${INTEGRATION_TEST}/main.cpp)
     target_link_libraries(
-        integration_${INTEGRATION_TEST} PUBLIC Core Gui PRIVATE std::filesystem ${Qt5_LIBRARIES}
+        integration_${INTEGRATION_TEST} PUBLIC Core Gui PRIVATE std::filesystem ${Qt_LIBRARIES}
     )
     target_compile_definitions(
         integration_${INTEGRATION_TEST}
@@ -102,7 +102,7 @@ else()
 endif()
 
 find_package(Filesystem COMPONENTS Final Experimental REQUIRED)
-find_package(Qt5 COMPONENTS Core Widgets OpenGL Xml REQUIRED)
+find_qt_package(COMPONENTS Core Widgets OpenGL Xml REQUIRED)
 
 macro(generate_includes _name)
     include(filelist${_name})
@@ -123,10 +123,10 @@ configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/includes.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/includes.cpp"
 )
 
-set(Qt5_LIBRARIES Qt5::Core Qt5::Widgets Qt5::OpenGL Qt5::Xml)
+set(Qt_LIBRARIES Qt::Core Qt::Widgets Qt::OpenGL Qt::Xml)
 add_executable(integration_includes "${CMAKE_CURRENT_BINARY_DIR}/includes.cpp")
 target_link_libraries(
-    integration_includes PUBLIC Core Gui Engine PRIVATE std::filesystem ${Qt5_LIBRARIES}
+    integration_includes PUBLIC Core Gui Engine PRIVATE std::filesystem ${Qt_LIBRARIES}
 )
 target_compile_definitions(
     integration_includes

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -46,17 +46,11 @@ include(../external/Catch2/src/Catch2_download/contrib/Catch.cmake)
 catch_discover_tests(unittests WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 find_package(Filesystem COMPONENTS Final Experimental REQUIRED)
-find_package(Qt5 COMPONENTS Core Widgets OpenGL Xml REQUIRED)
+find_qt_package(COMPONENTS Core Widgets OpenGL Xml REQUIRED)
 
-if(Qt5Core_VERSION VERSION_LESS 5.5)
-    message(FATAL_ERROR "Qt5 or superior required (found ${Qt5Core_VERSION}).")
-else()
-    message(STATUS "QT ${Qt5Core_VERSION} found.")
-endif()
-
-# Qt5
-set(Qt5_LIBRARIES Qt5::Core Qt5::Widgets Qt5::OpenGL Qt5::Xml)
-target_link_libraries(unittests PRIVATE ${Qt5_LIBRARIES} PRIVATE std::filesystem)
+# Qt
+set(Qt_LIBRARIES Qt::Core Qt::Widgets Qt::OpenGL Qt::Xml)
+target_link_libraries(unittests PRIVATE ${Qt_LIBRARIES} PRIVATE std::filesystem)
 target_compile_definitions(
     unittests
     PRIVATE -DCXX_FILESYSTEM_HAVE_FS


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Radium can only be compiled using Qt5.


* **What is the new behavior (if this is a feature change)?**
Radium can now be compiled and deployed using either Qt5 or Qt6.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes: Qt is linked against versionless targets, so client applications might also need to do it.


* **Other information**:
