### PR TITLE
Fix configuration error with built-in externals

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -17,17 +17,22 @@ endif()
 # Project options
 #
 
+# define these globally, will be used for externals also.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 set(RA_DEFAULT_PROJECT_OPTIONS
     DEBUG_POSTFIX
     "d"
     POSITION_INDEPENDENT_CODE
     ON
     CXX_EXTENSIONS
-    Off
+    ${CMAKE_CXX_EXTENSIONS}
     CXX_STANDARD
-    17
+    ${CMAKE_CXX_STANDARD}
     CXX_STANDARD_REQUIRED
-    ON
+    ${CMAKE_CXX_STANDARD_REQUIRED}
     LINKER_LANGUAGE
     "CXX"
     VERSION

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -14,16 +14,16 @@ if(NOT CMAKE_PROJECT_NAME STREQUAL ${RADIUM_DEPENDENCIES_PROJECT_NAME})
 else()
     set(CMAKE_DISABLE_SOURCE_CHANGES ON)
     set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-    set(CMAKE_CXX_STANDARD 17)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-    project(${RADIUM_DEPENDENCIES_PROJECT_NAME} VERSION 1.0.0)
 
     # We can use include() and find_package() for our scripts in there
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)
 
+    # Get default options (CMAKE_CXX_*)
+    include(CompilerOptions)
     # Check compiler version
     include(CompilerVersion)
+
+    project(${RADIUM_DEPENDENCIES_PROJECT_NAME} VERSION 1.0.0)
 
     # Changing the default value for CMAKE_BUILD_PARALLEL_LEVEL
     if(NOT DEFINED ENV{CMAKE_BUILD_PARALLEL_LEVEL})

--- a/external/Core/CMakeLists.txt
+++ b/external/Core/CMakeLists.txt
@@ -27,7 +27,7 @@ if(NOT DEFINED Eigen3_DIR)
         GIT_PROGRESS TRUE
         INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
         CMAKE_ARGS ${RADIUM_EXTERNAL_CMAKE_OPTIONS} -DEIGEN_TEST_CXX11=OFF -DBUILD_TESTING=OFF
-                   "-DCMAKE_MESSAGE_INDENT=${indent_string}\;"
+                   -DEIGEN_BUILD_DOC=OFF "-DCMAKE_MESSAGE_INDENT=${indent_string}\;"
     )
     add_dependencies(CoreExternals Eigen3)
 else()


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When building the externals automatically at configure time on some platform, cmake throws an error on its doc target:
```
CMake Error at doc/examples/CMakeLists.txt:5 (add_executable):
  CXX_STANDARD is set to invalid value ''
```

* **What is the new behavior (if this is a feature change)?**
Things that have been tested (do not directly fix, but somehow try to circumvent the problem):
 - the eigen buildchain is disabled for the documentation target,
 - Eigen has been updated to latest release.

With these changes, the CI fails on Windows with similar error: 
https://github.com/STORM-IRIT/Radium-Engine/pull/852/checks#step:13:3010

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
