### PR TITLE
[tests] fix #855 epsilon so that io test work with double

### DIFF
--- a/tests/unittest/IO/volumeloader.cpp
+++ b/tests/unittest/IO/volumeloader.cpp
@@ -93,7 +93,12 @@ TEST_CASE( "IO/VolumesLoader", "[IO]" ) {
         auto binsize = volumeData->binSize();
         REQUIRE( ( Math::areApproxEqual( binsize[0], 1._ra ) &&
                    Math::areApproxEqual( binsize[1], 1._ra ) &&
-                   Math::areApproxEqual( binsize[2], 1.4_ra ) ) );
+                   // if Scalar = double, since reader use float, increase epsilon by float/double
+                   // epsilon ratio (test hack ;))
+                   Math::areApproxEqual( binsize[2],
+                                         1.4_ra,
+                                         Scalar { std::numeric_limits<float>::epsilon() /
+                                                  std::numeric_limits<double>::epsilon() } ) ) );
 
         LOG( logINFO ) << "computing gradients for data/Lobster.pvm.";
         volumeData->computeGradients();

--- a/tests/unittest/IO/volumeloader.cpp
+++ b/tests/unittest/IO/volumeloader.cpp
@@ -98,7 +98,7 @@ TEST_CASE( "IO/VolumesLoader", "[IO]" ) {
                    Math::areApproxEqual( binsize[2],
                                          1.4_ra,
                                          Scalar { std::numeric_limits<float>::epsilon() /
-                                                  std::numeric_limits<double>::epsilon() } ) ) );
+                                                  std::numeric_limits<Scalar>::epsilon() } ) ) );
 
         LOG( logINFO ) << "computing gradients for data/Lobster.pvm.";
         volumeData->computeGradients();


### PR DESCRIPTION
Increase epsilon booster so that io tests work with Scalar=double, while the reader and stored data are floats.