### PR TITLE
Set correct alpha values for Renderer exported frames

### DIFF
--- a/src/Engine/Rendering/ForwardRenderer.cpp
+++ b/src/Engine/Rendering/ForwardRenderer.cpp
@@ -272,7 +272,7 @@ void ForwardRenderer::renderInternal( const Data::ViewingParameters& renderData 
     else {
         glDisable( GL_POLYGON_OFFSET_FILL );
     }
-    static const auto clearZeros = Core::Utils::Color::Black().cast<GL_SCALAR_PLAIN>().eval();
+    static const auto clearZeros = Core::Utils::Color::Alpha().cast<GL_SCALAR_PLAIN>().eval();
     static const auto clearOnes  = Core::Utils::Color::White().cast<GL_SCALAR_PLAIN>().eval();
     static const float clearDepth { 1.0f };
 

--- a/src/Engine/Rendering/Renderer.cpp
+++ b/src/Engine/Rendering/Renderer.cpp
@@ -745,8 +745,10 @@ std::unique_ptr<uchar[]> Renderer::grabFrame( size_t& w, size_t& h ) const {
                 (uchar)std::clamp( float( pixels[in + 1] * 255.f ), float( 0 ), float( 255 ) );
             writtenPixels[ou + 2] =
                 (uchar)std::clamp( float( pixels[in + 2] * 255.f ), float( 0 ), float( 255 ) );
-            writtenPixels[ou + 3] =
-                (uchar)std::clamp( float( pixels[in + 3] * 255.f ), float( 0 ), float( 255 ) );
+            if ( pixels[in + 3] > 0.f ) { writtenPixels[ou + 3] = 255; }
+            else {
+                writtenPixels[ou + 3] = 0;
+            }
         }
     }
     w = tex->width();


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
When exporting an image captured from the Renderer, the alpha channel depends on the exported AOV and do not allow proper displaying of the picture due to alpha blending problems when some transparent objects were drawn.

This PR fix this by 
 - modifying ForwardRenderer AOV initialization (Color::Alpha, e.g. {0, 0, 0, 0} instead of Color::Black, e.g. {0, 0, 0, 1}) so that there is no background in the AOV exported picture,
 - modifying the alpha-channel of an exported frame so that any alpha value greater than 0 is set to 1 while any 0 alpha value is preserved.

These two modifications allow to export png images with no background but solid color, even for transparent objects


* **What is the current behavior?** (You can also link to an open issue here)

Exported frame has an alpha channel that depends on drawn objects


* **What is the new behavior (if this is a feature change)?**

Exported frame has alpha value of 0 in the background but 1 for all drawn pixels.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:
