### PR TITLE
[gui] fix Qt6 deprecated signal usage

### DIFF
--- a/src/Gui/Timeline/Timeline.cpp
+++ b/src/Gui/Timeline/Timeline.cpp
@@ -396,7 +396,7 @@ void Timeline::onMovingKeyFrames( size_t first, Scalar offset ) {
     }
 }
 
-void Timeline::on_comboBox_attribute_currentIndexChanged( const QString& arg1 ) {
+void Timeline::on_comboBox_attribute_currentTextChanged( const QString& arg1 ) {
     onClearKeyFrames();
     std::vector<Ra::Core::Animation::KeyFramedValueController> list;
     const QStringList names = arg1.split( "::" );

--- a/src/Gui/Timeline/Timeline.hpp
+++ b/src/Gui/Timeline/Timeline.hpp
@@ -242,9 +242,9 @@ class RA_GUI_API Timeline : public QDialog
     void onMovingKeyFrames( size_t first, Scalar offset );
 
     /*!
-     * \brief on_comboBox_attribute_currentIndexChanged set the current keyframe
+     * \brief on_comboBox_attribute_currentTextChanged set the current keyframe
      */
-    void on_comboBox_attribute_currentIndexChanged( const QString& arg1 );
+    void on_comboBox_attribute_currentTextChanged( const QString& arg1 );
 
     /*!
      * \brief on_pushButton_editAttribute_clicked make the keyframe editor pop up


### PR DESCRIPTION
Only rename a slot connected automatically by name to a Qt signal.
The actual version connect to a deprecated signal in Qt5 that is removed from Qt6. If this does not prevent to compile, there is a Qt warning at runtime resulting in deactivated UI connections when using Qt6.

This fix just rename the slot so that it could be connected automatically to the correct signal.
