### PR TITLE
[cmake] fix cmake config asking qt location.

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -173,15 +173,11 @@ endif()
 
 if(PluginBase_FOUND)
     find_qt_dependency(COMPONENTS Core REQUIRED)
-    get_target_property(QtCore_Dll Qt::Core LOCATION)
-    get_filename_component(QtDlls_location "${QtCore_Dll}" DIRECTORY)
     include("${CMAKE_CURRENT_LIST_DIR}/PluginBaseTargets.cmake")
 endif()
 
 if(Gui_FOUND)
     find_qt_dependency(COMPONENTS Core Widgets OpenGL Xml REQUIRED)
-    get_target_property(QtCore_Dll Qt::Core LOCATION)
-    get_filename_component(QtDlls_location "${QtCore_Dll}" DIRECTORY)
     include("${CMAKE_CURRENT_LIST_DIR}/GuiTargets.cmake")
 endif()
 

--- a/cmake/Windeployqt.cmake
+++ b/cmake/Windeployqt.cmake
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-include(QtFunctions)
+include(${CMAKE_CURRENT_LIST_DIR}/QtFunctions.cmake)
 find_qt_package(COMPONENTS Core REQUIRED)
 
 # Retrieve the absolute path to qmake and then use that path to find the windeployqt binary


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix, 


* **What is the current behavior?** (You can also link to an open issue here)
cmake configuration fails with new qt, when using radium as an external lib for app.
(LOCATION undef on Qt::Core, windeploy qt fails to find QtFunctions.

* **What is the new behavior (if this is a feature change)?**
seems to work
