### PR TITLE
[core] IndexLayer memory layout introspection

### DIFF
--- a/doc/main.md
+++ b/doc/main.md
@@ -6,9 +6,6 @@ Developed and maintained by the [STORM research group](https://www.irit.fr/STORM
 The source code is hosted on github: https://github.com/STORM-IRIT/Radium-Engine
 
 # Badges
-
-
-## Badges
 [![source format badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/nmellado/0e76e93f56eba8a7b28d6a0116873d85/raw/format.json)](https://github.com/STORM-IRIT/Radium-Engine/actions?query=workflow%3A%22Compile+and+Test+Radium+libraries%22)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/faf8701c9fb142f7b6215871ec40c5fe)](https://app.codacy.com/app/STORM/Radium-Engine?utm_source=github.com&utm_medium=referral&utm_content=STORM-IRIT/Radium-Engine&utm_campaign=Badge_Grade_Dashboard)
 [![codecov](https://codecov.io/gh/STORM-IRIT/Radium-Engine/branch/master/graph/badge.svg?token=MKfANkC3sd)](https://codecov.io/gh/STORM-IRIT/Radium-Engine)

--- a/src/Core/Asset/HandleData.inl
+++ b/src/Core/Asset/HandleData.inl
@@ -161,9 +161,6 @@ inline void HandleData::displayInfo() const {
     using namespace Core::Utils; // log
     std::string type;
     switch ( m_type ) {
-    case UNKNOWN:
-        type = "UNKNOWN";
-        break;
     case POINT_CLOUD:
         type = "POINT CLOUD";
         break;
@@ -172,6 +169,10 @@ inline void HandleData::displayInfo() const {
         break;
     case CAGE:
         type = "CAGE";
+        break;
+    case UNKNOWN:
+    default:
+        type = "UNKNOWN";
         break;
     }
     LOG( logINFO ) << "======== HANDLE INFO ========";

--- a/src/Core/Asset/LightData.inl
+++ b/src/Core/Asset/LightData.inl
@@ -99,9 +99,6 @@ inline void LightData::displayInfo() const {
     using namespace Core::Utils; // log
     std::string type;
     switch ( m_type ) {
-    case UNKNOWN:
-        type = "UNKNOWN";
-        break;
     case POINT_LIGHT:
         type = "POINT LIGHT";
         break;
@@ -113,6 +110,10 @@ inline void LightData::displayInfo() const {
         break;
     case AREA_LIGHT:
         type = "AREA LIGHT";
+        break;
+    case UNKNOWN:
+    default:
+        type = "UNKNOWN";
         break;
     }
     LOG( logINFO ) << "======== LIGHT INFO ========";

--- a/src/Core/Geometry/IndexedGeometry.hpp
+++ b/src/Core/Geometry/IndexedGeometry.hpp
@@ -40,7 +40,21 @@ class RA_CORE_API GeometryIndexLayerBase : public Utils::ObservableVoid,
     /// \brief Compare if two layers have the same content
     virtual inline bool operator==( const GeometryIndexLayerBase& other ) const;
     /// \return the number of index (i.e. "faces") contained in the layer.
-    virtual size_t size() = 0;
+    virtual size_t size() const = 0;
+
+    /// \return the number of components of one index (i.e. faces)
+    virtual size_t numberOfComponent() const = 0;
+
+    /// \return the size in byte of the layer container
+    virtual size_t getBufferSize() const = 0;
+
+    /// \return the stride, in bytes, from one attribute address to the next one.
+    /// \warning it's meaningful only if the attrib do not contain heap
+    /// allocated data.
+    virtual int getStride() const = 0;
+
+    /// \return a const pointer to the raw data
+    virtual const void* dataPtr() const = 0;
 
   protected:
     /// \brief Hidden constructor that must be called by inheriting classes to define the object
@@ -63,9 +77,19 @@ struct GeometryIndexLayer : public GeometryIndexLayerBase {
     /// \warning Does not account for elements permutations
     inline bool operator==( const GeometryIndexLayerBase& other ) const final;
 
-    inline size_t size() override;
+    inline size_t size() const override final;
 
-    inline GeometryIndexLayerBase* clone() override;
+    inline GeometryIndexLayerBase* clone() override final;
+
+    inline size_t numberOfComponent() const override final;
+
+    inline size_t getBufferSize() const override final;
+
+    /// \warning it's meaningful only if the attrib do not contain heap
+    /// allocated data.
+    inline int getStride() const override final;
+
+    inline const void* dataPtr() const override final;
 
   protected:
     template <class... SemanticNames>

--- a/src/Core/Geometry/IndexedGeometry.hpp
+++ b/src/Core/Geometry/IndexedGeometry.hpp
@@ -4,6 +4,7 @@
 
 #include <Core/Geometry/TriangleMesh.hpp>
 
+#include <Core/Utils/ContainerIntrospectionInterface.hpp>
 #include <Core/Utils/ObjectWithSemantic.hpp>
 #include <Core/Utils/StdMapIterators.hpp>
 
@@ -16,7 +17,8 @@ namespace Geometry {
 ///
 /// \brief Base class for index collections stored in MultiIndexedGeometry
 class RA_CORE_API GeometryIndexLayerBase : public Utils::ObservableVoid,
-                                           public Utils::ObjectWithSemantic
+                                           public Utils::ObjectWithSemantic,
+                                           public Utils::ContainerIntrospectionInterface
 {
   public:
     /// \brief Copy constructor
@@ -39,22 +41,6 @@ class RA_CORE_API GeometryIndexLayerBase : public Utils::ObservableVoid,
 
     /// \brief Compare if two layers have the same content
     virtual inline bool operator==( const GeometryIndexLayerBase& other ) const;
-    /// \return the number of index (i.e. "faces") contained in the layer.
-    virtual size_t size() const = 0;
-
-    /// \return the number of components of one index (i.e. faces)
-    virtual size_t numberOfComponent() const = 0;
-
-    /// \return the size in byte of the layer container
-    virtual size_t getBufferSize() const = 0;
-
-    /// \return the stride, in bytes, from one attribute address to the next one.
-    /// \warning it's meaningful only if the attrib do not contain heap
-    /// allocated data.
-    virtual int getStride() const = 0;
-
-    /// \return a const pointer to the raw data
-    virtual const void* dataPtr() const = 0;
 
   protected:
     /// \brief Hidden constructor that must be called by inheriting classes to define the object
@@ -77,11 +63,11 @@ struct GeometryIndexLayer : public GeometryIndexLayerBase {
     /// \warning Does not account for elements permutations
     inline bool operator==( const GeometryIndexLayerBase& other ) const final;
 
-    inline size_t size() const override final;
+    inline size_t getSize() const override final;
 
     inline GeometryIndexLayerBase* clone() override final;
 
-    inline size_t numberOfComponent() const override final;
+    inline size_t getNumberOfComponents() const override final;
 
     inline size_t getBufferSize() const override final;
 

--- a/src/Core/Geometry/IndexedGeometry.hpp
+++ b/src/Core/Geometry/IndexedGeometry.hpp
@@ -466,6 +466,7 @@ struct getType<Vector1ui> {
 
 /**
  * \brief A single layer MultiIndexedGeometry.
+ *
  * This class actually provide compatibility with old geometry with a main layer.
  * Main layer contains indices of a specific type (point, line, triangle, poly).
  * Derived classes explicit the kind of indices of the main layer.

--- a/src/Core/Geometry/IndexedGeometry.inl
+++ b/src/Core/Geometry/IndexedGeometry.inl
@@ -65,12 +65,12 @@ inline bool GeometryIndexLayer<T>::operator==( const GeometryIndexLayerBase& oth
 }
 
 template <typename T>
-inline size_t GeometryIndexLayer<T>::size() const {
+inline size_t GeometryIndexLayer<T>::getSize() const {
     return m_collection.size();
 }
 
 template <typename T>
-inline size_t GeometryIndexLayer<T>::numberOfComponent() const {
+inline size_t GeometryIndexLayer<T>::getNumberOfComponents() const {
     return IndexType::RowsAtCompileTime;
 }
 

--- a/src/Core/Geometry/IndexedGeometry.inl
+++ b/src/Core/Geometry/IndexedGeometry.inl
@@ -65,8 +65,28 @@ inline bool GeometryIndexLayer<T>::operator==( const GeometryIndexLayerBase& oth
 }
 
 template <typename T>
-inline size_t GeometryIndexLayer<T>::size() {
+inline size_t GeometryIndexLayer<T>::size() const {
     return m_collection.size();
+}
+
+template <typename T>
+inline size_t GeometryIndexLayer<T>::numberOfComponent() const {
+    return IndexType::RowsAtCompileTime;
+}
+
+template <typename T>
+inline size_t GeometryIndexLayer<T>::getBufferSize() const {
+    return m_collection.size() * sizeof( IndexType );
+}
+
+template <typename T>
+inline int GeometryIndexLayer<T>::getStride() const {
+    return sizeof( IndexType );
+}
+
+template <typename T>
+inline const void* GeometryIndexLayer<T>::dataPtr() const {
+    return m_collection.data();
 }
 
 template <typename T>

--- a/src/Core/Utils/Attribs.cpp
+++ b/src/Core/Utils/Attribs.cpp
@@ -11,12 +11,12 @@ AttribBase::~AttribBase() {
 }
 
 template <>
-size_t Attrib<float>::getElementSize() const {
+size_t Attrib<float>::getNumberOfComponents() const {
     return 1;
 }
 
 template <>
-size_t Attrib<double>::getElementSize() const {
+size_t Attrib<double>::getNumberOfComponents() const {
     return 1;
 }
 

--- a/src/Core/Utils/Attribs.hpp
+++ b/src/Core/Utils/Attribs.hpp
@@ -3,6 +3,7 @@
 
 #include <Core/Containers/VectorArray.hpp>
 #include <Core/RaCore.hpp>
+#include <Core/Utils/ContainerIntrospectionInterface.hpp>
 #include <Core/Utils/Index.hpp>
 #include <Core/Utils/Observable.hpp>
 
@@ -22,7 +23,7 @@ class Attrib;
 /**
  * AttribBase is the base class for attributes of all type.
  */
-class RA_CORE_API AttribBase : public ObservableVoid
+class RA_CORE_API AttribBase : public ObservableVoid, public ContainerIntrospectionInterface
 {
   public:
     inline explicit AttribBase( const std::string& name );
@@ -38,25 +39,6 @@ class RA_CORE_API AttribBase : public ObservableVoid
 
     /// Resize the attribute's array.
     virtual void resize( size_t s ) = 0;
-
-    /// Return the number of elements in the attribute array
-    virtual size_t getSize() const = 0;
-
-    /// Return the number of components of one element (i.e. for
-    /// glVertexAttribPointer size value)
-    /// \see https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribPointer.xhtml
-    /// \todo rename getNumberOfComponent ?
-    virtual size_t getElementSize() const = 0;
-
-    /// return the size in byte of the container
-    virtual size_t getBufferSize() const = 0;
-
-    /// Return the stride, in bytes, from one attribute address to the next one.
-    /// This is use for glVertexAttribPointer.
-    /// \warning it's meaningful only if the attrib do not contain heap
-    /// allocated data. Such attrib could not be easily sent to the GPU, and
-    /// getStride is meaningless.
-    virtual int getStride() const = 0;
 
     /// Return true if *this and \p rhs have the same name.
     bool inline operator==( const AttribBase& rhs );
@@ -80,9 +62,6 @@ class RA_CORE_API AttribBase : public ObservableVoid
 
     /// Return true if the attribute content is of Vector4 type, false otherwise.
     virtual bool isVector4() const = 0;
-
-    /// Return a void * on the attrib data
-    virtual const void* dataPtr() const = 0;
 
     /// Return true if data is locked, i.e. has been locked for write access with
     /// getDataWithlock() (defined in subclass Attrib). Double lock is prohebited, so when finished,
@@ -136,7 +115,7 @@ class Attrib : public AttribBase
 
     size_t getSize() const override;
 
-    size_t getElementSize() const override;
+    size_t getNumberOfComponents() const override;
     int getStride() const override;
     size_t getBufferSize() const override;
     bool isFloat() const override;

--- a/src/Core/Utils/Attribs.inl
+++ b/src/Core/Utils/Attribs.inl
@@ -131,12 +131,12 @@ bool Attrib<T>::isType() {
 // user wants to have a specific attrib precision, while Radium Scalar is the other precision.
 // Do we need to specialize for all floating point types ?
 template <>
-RA_CORE_API size_t Attrib<float>::getElementSize() const;
+RA_CORE_API size_t Attrib<float>::getNumberOfComponents() const;
 template <>
-RA_CORE_API size_t Attrib<double>::getElementSize() const;
+RA_CORE_API size_t Attrib<double>::getNumberOfComponents() const;
 // template specialization defined in header.
 template <typename T>
-size_t Attrib<T>::getElementSize() const {
+size_t Attrib<T>::getNumberOfComponents() const {
     return Attrib<T>::Container::Vector::RowsAtCompileTime;
 }
 

--- a/src/Core/Utils/ContainerIntrospectionInterface.hpp
+++ b/src/Core/Utils/ContainerIntrospectionInterface.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+namespace Ra {
+namespace Core {
+namespace Utils {
+
+class ContainerIntrospectionInterface
+{
+  public:
+    virtual ~ContainerIntrospectionInterface() {}
+    /// \return the number of element (i.e. faces, vector) contained in the array.
+    virtual size_t getSize() const = 0;
+
+    /// Return the number of components of one element (i.e. for
+    /// glVertexAttribPointer size value)
+    /// \see https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribPointer.xhtml
+    /// \return the number of components of one element (i.e. faces, vector)
+    virtual size_t getNumberOfComponents() const = 0;
+
+    /// \return the size in byte of container
+    virtual size_t getBufferSize() const = 0;
+
+    /// \return the stride, in bytes, from one attribute address to the next one.
+    /// \warning it's meaningful only if the attrib do not contain heap
+    /// allocated data. Such attrib could not be easily sent to the GPU, and
+    /// getStride is meaningless.
+    virtual int getStride() const = 0;
+
+    /// \return a const pointer to the raw data
+    virtual const void* dataPtr() const = 0;
+};
+
+} // namespace Utils
+} // namespace Core
+} // namespace Ra

--- a/src/Core/Utils/ContainerIntrospectionInterface.hpp
+++ b/src/Core/Utils/ContainerIntrospectionInterface.hpp
@@ -4,16 +4,21 @@ namespace Ra {
 namespace Core {
 namespace Utils {
 
+/// \brief This class defines the introspection interface a container need to implement.
+///
+/// This API allows to parse and copy contained element, or send/map to GPU buffer, given a generic
+/// pointer to the container. Typical usage are shown in Ra::Core::Utils::Attrib or
+/// Ra::Core::Geometry::IndexedGeometry This "interface" do not contain any data.
 class ContainerIntrospectionInterface
 {
   public:
+    /// only needed for correct abstract dtor call.
     virtual ~ContainerIntrospectionInterface() {}
     /// \return the number of element (i.e. faces, vector) contained in the array.
     virtual size_t getSize() const = 0;
 
-    /// Return the number of components of one element (i.e. for
-    /// glVertexAttribPointer size value)
-    /// \see https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribPointer.xhtml
+    /// Return the number of components of one element (i.e. for glVertexAttribPointer size argument
+    /// ) \see https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribPointer.xhtml
     /// \return the number of components of one element (i.e. faces, vector)
     virtual size_t getNumberOfComponents() const = 0;
 
@@ -21,9 +26,8 @@ class ContainerIntrospectionInterface
     virtual size_t getBufferSize() const = 0;
 
     /// \return the stride, in bytes, from one attribute address to the next one.
-    /// \warning it's meaningful only if the attrib do not contain heap
-    /// allocated data. Such attrib could not be easily sent to the GPU, and
-    /// getStride is meaningless.
+    /// \warning it's meaningful only if the attrib do not contain heap allocated data. Such attrib
+    /// could not be easily sent to the GPU, and getStride is meaningless.
     virtual int getStride() const = 0;
 
     /// \return a const pointer to the raw data

--- a/src/Core/Utils/ObjectWithSemantic.hpp
+++ b/src/Core/Utils/ObjectWithSemantic.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Core/RaCore.hpp>
+
 #include <cstdarg>
 #include <set>
 
@@ -21,7 +23,7 @@ class RA_CORE_API ObjectWithSemantic
     using SemanticNameCollection = std::set<SemanticName>;
 
     inline explicit ObjectWithSemantic( const ObjectWithSemantic& other ) :
-        m_names( other.m_names ) {}
+        m_names { other.m_names } {}
 
     virtual inline ~ObjectWithSemantic() = default;
 
@@ -54,9 +56,10 @@ class RA_CORE_API ObjectWithSemantic
 
   protected:
     template <class... SemanticNames>
-    inline ObjectWithSemantic( SemanticNames... names ) : m_names( { names... } ) {}
+    inline ObjectWithSemantic( SemanticNames... names ) : m_names { names... } {}
 
-    inline ObjectWithSemantic( const SemanticNameCollection& otherNames ) : m_names( otherNames ) {}
+    inline ObjectWithSemantic( const SemanticNameCollection& otherNames ) :
+        m_names { otherNames } {}
 
   private:
     SemanticNameCollection m_names;

--- a/src/Engine/Data/Mesh.inl
+++ b/src/Engine/Data/Mesh.inl
@@ -136,13 +136,13 @@ void IndexedAttribArrayDisplayable<I>::autoVertexAttribPointer( const ShaderProg
 #ifdef CORE_USE_DOUBLE
             binding->setBuffer( m_vbos[m_handleToBuffer[attribName]].get(),
                                 0,
-                                attrib->getElementSize() * sizeof( float ) );
+                                attrib->getNumberOfComponents() * sizeof( float ) );
 #else
 
             binding->setBuffer(
                 m_vbos[m_handleToBuffer[attribName]].get(), 0, attrib->getStride() );
 #endif
-            binding->setFormat( attrib->getElementSize(), GL_SCALAR );
+            binding->setFormat( attrib->getNumberOfComponents(), GL_SCALAR );
         }
         else {
             m_vao->disable( loc );
@@ -264,13 +264,13 @@ void CoreGeometryDisplayable<CoreGeometry>::autoVertexAttribPointer( const Shade
 #ifdef CORE_USE_DOUBLE
             binding->setBuffer( m_vbos[m_handleToBuffer[attribName]].get(),
                                 0,
-                                attrib->getElementSize() * sizeof( float ) );
+                                attrib->getNumberOfComponents() * sizeof( float ) );
 #else
 
             binding->setBuffer(
                 m_vbos[m_handleToBuffer[attribName]].get(), 0, attrib->getStride() );
 #endif
-            binding->setFormat( attrib->getElementSize(), GL_SCALAR );
+            binding->setFormat( attrib->getNumberOfComponents(), GL_SCALAR );
         }
         else {
             m_vao->disable( loc );
@@ -347,7 +347,7 @@ void CoreGeometryDisplayable<CoreGeometry>::updateGL() {
                 if ( !m_vbos[idx] ) { m_vbos[idx] = globjects::Buffer::create(); }
 
                 auto stride      = b->getStride();
-                auto eltSize     = b->getElementSize();
+                auto eltSize     = b->getNumberOfComponents();
                 auto size        = b->getSize();
                 auto data        = std::make_unique<float[]>( size * eltSize );
                 const void* ptr  = b->dataPtr();

--- a/src/Engine/Scene/GeometrySystem.cpp
+++ b/src/Engine/Scene/GeometrySystem.cpp
@@ -26,7 +26,6 @@ void GeometrySystem::handleAssetLoading( Entity* entity,
         Component* comp { nullptr };
         std::string componentName = "GEOM_" + entity->getName() + std::to_string( id++ );
         switch ( data->getType() ) {
-
         case Ra::Core::Asset::GeometryData::POINT_CLOUD:
             comp = new PointCloudComponent( componentName, entity, data );
             break;
@@ -43,6 +42,7 @@ void GeometrySystem::handleAssetLoading( Entity* entity,
         case Ra::Core::Asset::GeometryData::TETRA_MESH:
         case Ra::Core::Asset::GeometryData::HEX_MESH:
         case Ra::Core::Asset::GeometryData::UNKNOWN:
+        default:
             CORE_ASSERT( false, "unsupported geometry" );
         }
         registerComponent( entity, comp );

--- a/src/Gui/Viewer/Viewer.cpp
+++ b/src/Gui/Viewer/Viewer.cpp
@@ -446,7 +446,7 @@ bool Viewer::initializeGL() {
     // Register to the camera manager active camera changes
     auto cameraManager = static_cast<Ra::Engine::Scene::CameraManager*>(
         Engine::RadiumEngine::getInstance()->getSystem( "DefaultCameraManager" ) );
-    cameraManager->activeCameraObservers().attach( [this]( Core::Utils::Index idx ) {
+    cameraManager->activeCameraObservers().attach( [this]( Core::Utils::Index /*idx*/ ) {
         m_camera->updateCamera();
         m_camera->getCamera()->setViewport( width(), height() );
     } );

--- a/tests/unittest/Core/indexview.cpp
+++ b/tests/unittest/Core/indexview.cpp
@@ -208,16 +208,16 @@ TEST_CASE( "Core/Geometry/IndexedGeometry/Attributes", "[Core][Core/Geometry][In
     auto& attribM2_1 = m2.getAttrib( handle1 );
     auto& attribM2_2 = m2.getAttrib( handle2 );
     REQUIRE( attribM2_1.getSize() == 3 );
-    REQUIRE( attribM2_1.getElementSize() == 3 );
+    REQUIRE( attribM2_1.getNumberOfComponents() == 3 );
     REQUIRE( attribM2_1.getStride() == sizeof( Vector3 ) );
     REQUIRE( attribM2_1.getBufferSize() == 3 * sizeof( Vector3 ) );
     attribM2_1.resize( 10 );
     REQUIRE( attribM2_1.getSize() == 10 );
-    REQUIRE( attribM2_1.getElementSize() == 3 );
+    REQUIRE( attribM2_1.getNumberOfComponents() == 3 );
     REQUIRE( attribM2_1.getStride() == sizeof( Vector3 ) );
     REQUIRE( attribM2_1.getBufferSize() == 10 * sizeof( Vector3 ) );
     REQUIRE( attribM2_2.getSize() == 3 );
-    REQUIRE( attribM2_2.getElementSize() == 1 );
+    REQUIRE( attribM2_2.getNumberOfComponents() == 1 );
     REQUIRE( attribM2_2.getStride() == sizeof( float ) );
     REQUIRE( attribM2_2.getBufferSize() == 3 * sizeof( float ) );
 

--- a/tests/unittest/Core/observer.cpp
+++ b/tests/unittest/Core/observer.cpp
@@ -65,7 +65,10 @@ class A
   public:
     void f() { m_a++; }
     void f2( int a ) { m_a = a; }
-    void f3( int a, int b ) { m_a = a; }
+    void f3( int a, int b ) {
+        m_a = a;
+        m_b = b;
+    }
     static void g() { m_b++; }
     static void g2( int b ) { m_b = b; }
 


### PR DESCRIPTION
This PR adds access to the indexLayer of a mesh with small introspection capabilities.

This allows to use any indexLayer transparently when using low level  rendering API (e.g. OpenGL, Vulkan, embree, ...).
The way one can introspect the indexLayer is the same than any mesh attribute.