### PR TITLE
[gui] add RotateAroundCameraManipulator::fitScene.

### DIFF
--- a/src/Gui/Viewer/RotateAroundCameraManipulator.cpp
+++ b/src/Gui/Viewer/RotateAroundCameraManipulator.cpp
@@ -154,6 +154,11 @@ KeyMappingManager::Context RotateAroundCameraManipulator::mappingContext() {
     return KeyMapping::getContext();
 }
 
+void RotateAroundCameraManipulator::fitScene( const Core::Aabb& aabb ) {
+    TrackballCameraManipulator::fitScene( aabb );
+    setPivot( aabb.center() );
+}
+
 void RotateAroundCameraManipulator::handleCameraRotate( Scalar x, Scalar y ) {
     Ra::Core::Vector3 trans  = m_camera->projectToScreen( m_pivot );
     Ra::Core::Quaternion rot = deformedBallQuaternion( x, y, trans[0], trans[1] );

--- a/src/Gui/Viewer/RotateAroundCameraManipulator.hpp
+++ b/src/Gui/Viewer/RotateAroundCameraManipulator.hpp
@@ -33,6 +33,12 @@ class RA_GUI_API RotateAroundCameraManipulator
 
     KeyMappingManager::Context mappingContext() override;
 
+  public slots:
+    void fitScene( const Core::Aabb& aabb ) override {
+        TrackballCameraManipulator::fitScene( aabb );
+        setPivot( aabb.center() );
+    }
+
   protected:
     virtual void handleCameraRotate( Scalar dx, Scalar dy ) override;
     virtual void handleCameraForward( Scalar z );

--- a/src/Gui/Viewer/RotateAroundCameraManipulator.hpp
+++ b/src/Gui/Viewer/RotateAroundCameraManipulator.hpp
@@ -34,10 +34,7 @@ class RA_GUI_API RotateAroundCameraManipulator
     KeyMappingManager::Context mappingContext() override;
 
   public slots:
-    void fitScene( const Core::Aabb& aabb ) override {
-        TrackballCameraManipulator::fitScene( aabb );
-        setPivot( aabb.center() );
-    }
+    void fitScene( const Core::Aabb& aabb ) override;
 
   protected:
     virtual void handleCameraRotate( Scalar dx, Scalar dy ) override;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature.


* **What is the current behavior?** (You can also link to an open issue here)
RotateAroundCameraManipulator do not override fitScene, hence pivot point is not set to scene center. 

* **What is the new behavior (if this is a feature change)?**
fitScene use scene center as default pivot point
