### PR TITLE
[tests][headless] improve error message when OpenGL context can not be created.

### DIFF
--- a/tests/ExampleApps/HeadlessLibAndApp/libHeadless/RadiumHeadless/OpenGLContext/OpenGLContext.cpp
+++ b/tests/ExampleApps/HeadlessLibAndApp/libHeadless/RadiumHeadless/OpenGLContext/OpenGLContext.cpp
@@ -41,7 +41,11 @@ OpenGLContext::OpenGLContext( const std::array<int, 2>& size ) {
             glfwCreateWindow( size[0], size[1], "Radium CommandLine Context", nullptr, nullptr );
     }
     if ( m_glfwContext == nullptr ) {
-        std::cerr << "OpenGL context creation failed. Terminate execution.";
+        std::cerr << "OpenGL context creation failed. Terminate execution." << std::endl;
+        const char* description;
+        int code = glfwGetError( &description );
+        std::cerr << "\tError code :" << code << std::endl
+                  << "\t error string : " << description << std::endl;
         glfwTerminate();
         std::exit( -1 );
     }


### PR DESCRIPTION
A very small improvement on the error message displayed when Radium-headless is unable to create the OpenGL Context.