### PR TITLE
[github] Update ci job dependecies, to trigger doc in // of build.

### DIFF
--- a/.github/workflows/push-master-ci.yml
+++ b/.github/workflows/push-master-ci.yml
@@ -11,18 +11,18 @@ jobs:
     secrets:
       token: ${{ secrets.COMMIT_VERSION_TOKEN }}
   build:
-    needs: increase-version-number
+    needs: [increase-version-number]
     uses: ./.github/workflows/build-matrix.yml
     secrets:
       GIST_BADGES_TOKEN:  ${{ secrets.GIST_BADGES_TOKEN }}
       GIST_BADGES_SECRET: ${{ secrets.GIST_BADGES_SECRET }}
   call-deploy-doc:
-    needs: build
+    needs: [increase-version-number]
     uses: ./.github/workflows/deploy-doc.yml
     secrets:
       REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
   call-coverage:
-    needs: build
+    needs: [build]
     uses: ./.github/workflows/coverage.yml
   call-notify:
     needs: [increase-version-number]

--- a/.github/workflows/push-rc-ci.yml
+++ b/.github/workflows/push-rc-ci.yml
@@ -11,16 +11,16 @@ jobs:
     secrets:
       token: ${{ secrets.COMMIT_VERSION_TOKEN }}
   build:
-    needs: increase-version-number
+    needs: [increase-version-number]
     uses: ./.github/workflows/build-matrix.yml
     secrets:
       GIST_BADGES_TOKEN:  ${{ secrets.GIST_BADGES_TOKEN }}
       GIST_BADGES_SECRET: ${{ secrets.GIST_BADGES_SECRET }}
   call-deploy-doc:
-    needs: build
+    needs: [increase-version-number]
     uses: ./.github/workflows/deploy-doc.yml
     secrets:
       REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
   call-coverage:
-    needs: build
+    needs: [build]
     uses: ./.github/workflows/coverage.yml


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.

* **What is the current behavior?** (You can also link to an open issue here)
doc is deployed only if all builds pass. Sometimes (as last time) a build job fails due to network error. 

* **What is the new behavior (if this is a feature change)?**
Change job dependecy to deploy doc even if build fail.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope.


* **Other information**:
