### PR TITLE
Fix warnings

### DIFF
--- a/src/Engine/Rendering/Renderer.cpp
+++ b/src/Engine/Rendering/Renderer.cpp
@@ -235,10 +235,10 @@ Renderer::PickingResult Renderer::doPickingNow( const PickingQuery& query,
     renderForPicking( renderData, m_pickingShaders, m_fancyRenderObjectsPicking );
     ////////////////// added save depth //////////////////////////////////////
     float depth;
-    m_pickingFbo->readPixels( { static_cast<int>( query.m_screenCoords.x() ),
-                                static_cast<int>( query.m_screenCoords.y() ),
-                                1,
-                                1 },
+    m_pickingFbo->readPixels( { { static_cast<int>( query.m_screenCoords.x() ),
+                                  static_cast<int>( query.m_screenCoords.y() ),
+                                  1,
+                                  1 } },
                               GL_DEPTH_COMPONENT,
                               GL_FLOAT,
                               &depth );
@@ -293,10 +293,10 @@ Renderer::PickingResult Renderer::doPickingNow( const PickingQuery& query,
 
     // Now read the Picking Texture to address the Picking Requests.
     m_pickingFbo->readPixels( GL_COLOR_ATTACHMENT0,
-                              { static_cast<int>( query.m_screenCoords.x() ),
-                                static_cast<int>( query.m_screenCoords.y() ),
-                                1,
-                                1 },
+                              { { static_cast<int>( query.m_screenCoords.x() ),
+                                  static_cast<int>( query.m_screenCoords.y() ),
+                                  1,
+                                  1 } },
                               GL_RGBA_INTEGER,
                               GL_INT,
                               pick );

--- a/tests/ExampleApps/EntityAnimationDemo/main.cpp
+++ b/tests/ExampleApps/EntityAnimationDemo/main.cpp
@@ -107,8 +107,8 @@ int main( int argc, char* argv[] ) {
         //! [Creating the Cube]
 
         //! [Create a geometry component with the cube]
-        auto c = new Scene::TriangleMeshComponent(
-            "Fixed cube geometry", e, std::move( cube ), nullptr );
+        // component ownership is transfered to entity in component ctor
+        new Scene::TriangleMeshComponent( "Fixed cube geometry", e, std::move( cube ), nullptr );
         //! [Create a geometry component with the cube]
     }
     //! [Create the demo fixed entity/component]

--- a/tests/unittest/Core/observer.cpp
+++ b/tests/unittest/Core/observer.cpp
@@ -126,8 +126,8 @@ TEST_CASE( "Core/Utils/Observable", "[Core][Core/Utils][Observable]" ) {
         ///\todo add more tests with
         // using Observer2 = std::function<void( int )>;
 
-        auto bf  = std::bind( &A::f, &a );
-        auto bf2 = std::bind( &A::f2, &a, std::placeholders::_1 );
+        auto bf = std::bind( &A::f, &a );
+        std::bind( &A::f2, &a, std::placeholders::_1 );
 
         Observer obf         = bf;
         auto& observerTarget = obf.target_type();


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Remove warnings.

* **What is the current behavior?** (You can also link to an open issue here)
With gcc version 10.2.1 20210110 (Debian 10.2.1-6) 

Renderer.cpp:244:38: warning: missing braces around initializer for ‘std::__array_traits<int, 4>::_Type’ {aka ‘int [4]’} [-Wmissing-braces]
Also fixes two unused warning.

* **What is the new behavior (if this is a feature change)?**
No warning on these inits.
With my setup whole compilation produces 0 gcc warning 
there is still one "information" AutoMoc: RadiumPluginInterface.hpp:0: Note: No relevant classes found. No output generated.


* **Other information**:
Not tested on other compilers, but picking tested and seems ok.

