### PR TITLE
Generic attrib name

### DIFF
--- a/cmake/filelistCore.cmake
+++ b/cmake/filelistCore.cmake
@@ -114,6 +114,7 @@ set(core_headers
     Geometry/PolyLine.hpp
     Geometry/RayCast.hpp
     Geometry/Spline.hpp
+    Geometry/StandardAttribNames.hpp
     Geometry/TopologicalMesh.hpp
     Geometry/TriangleMesh.hpp
     Geometry/TriangleOperation.hpp

--- a/src/Core/CoreMacros.hpp
+++ b/src/Core/CoreMacros.hpp
@@ -248,7 +248,7 @@
 
 using uchar  = unsigned char;
 using ushort = unsigned short;
-using uint   =  unsigned int;
+using uint   = unsigned int;
 using ulong  = unsigned long;
 
 // Use this to use double precision for all maths

--- a/src/Core/Geometry/MeshPrimitives.cpp
+++ b/src/Core/Geometry/MeshPrimitives.cpp
@@ -1,5 +1,6 @@
 #include <Core/Containers/Grid.hpp>
 #include <Core/Geometry/MeshPrimitives.hpp>
+#include <Core/Geometry/StandardAttribNames.hpp>
 #include <Core/Math/Math.hpp> // areApproxEqual
 #include <Core/Types.hpp>
 
@@ -729,7 +730,8 @@ TriangleMesh makePlaneGrid( const uint rows,
     result.setVertices( std::move( vertices ) );
     result.setNormals( std::move( normals ) );
     result.setIndices( std::move( indices ) );
-    if ( generateTexCoord ) result.addAttrib( "in_texcoord", std::move( texCoords ) );
+    if ( generateTexCoord )
+        result.addAttrib( getAttribName( MeshAttrib::VERTEX_TEXCOORD ), std::move( texCoords ) );
     if ( bool( color ) ) result.colorize( *color );
     result.checkConsistency();
 

--- a/src/Core/Geometry/MeshPrimitives.hpp
+++ b/src/Core/Geometry/MeshPrimitives.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Core/Geometry/StandardAttribNames.hpp>
 #include <Core/Geometry/TriangleMesh.hpp>
 #include <Core/RaCore.hpp>
 #include <Core/Utils/Color.hpp>

--- a/src/Core/Geometry/MeshPrimitives.hpp
+++ b/src/Core/Geometry/MeshPrimitives.hpp
@@ -11,6 +11,34 @@ namespace Geometry {
 // Primitive construction
 //
 
+/// List of standard vertex attributes.
+/// Corresponding standard vertex attribute names are obtained with getAttribName
+/// Information which is in the mesh geometry
+enum MeshData : uint {
+    VERTEX_POSITION,   ///< Vertex positions
+    VERTEX_NORMAL,     ///< Vertex normals
+    VERTEX_TANGENT,    ///< Vertex tangent 1
+    VERTEX_BITANGENT,  ///< Vertex tangent 2
+    VERTEX_TEXCOORD,   ///< U,V  texture coords (last coordinate not used)
+    VERTEX_COLOR,      ///< RGBA color.
+    VERTEX_WEIGHTS,    ///< Skinning weights (not used)
+    VERTEX_WEIGHT_IDX, ///< Associated weight bones
+
+    MAX_DATA
+};
+
+///@{
+/// Get the name expected for a given attrib.
+static constexpr char const* getAttribName[MeshData::MAX_DATA] = { "in_position",
+                                                                   "in_normal",
+                                                                   "in_tangent",
+                                                                   "in_bitangent",
+                                                                   "in_texcoord",
+                                                                   "in_color",
+                                                                   "in_weight",
+                                                                   "in_weight_idx" };
+///@}
+
 /// Create a 2D grid mesh with given number of row and columns
 RA_CORE_API TriangleMesh makePlaneGrid( const uint rows         = 1,
                                         const uint cols         = 1,

--- a/src/Core/Geometry/MeshPrimitives.hpp
+++ b/src/Core/Geometry/MeshPrimitives.hpp
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <Core/Geometry/StandardAttribNames.hpp>
 #include <Core/Geometry/TriangleMesh.hpp>
 #include <Core/RaCore.hpp>
 #include <Core/Utils/Color.hpp>
@@ -10,34 +12,6 @@ namespace Geometry {
 //
 // Primitive construction
 //
-
-/// List of standard vertex attributes.
-/// Corresponding standard vertex attribute names are obtained with getAttribName
-/// Information which is in the mesh geometry
-enum MeshData : uint {
-    VERTEX_POSITION,   ///< Vertex positions
-    VERTEX_NORMAL,     ///< Vertex normals
-    VERTEX_TANGENT,    ///< Vertex tangent 1
-    VERTEX_BITANGENT,  ///< Vertex tangent 2
-    VERTEX_TEXCOORD,   ///< U,V  texture coords (last coordinate not used)
-    VERTEX_COLOR,      ///< RGBA color.
-    VERTEX_WEIGHTS,    ///< Skinning weights (not used)
-    VERTEX_WEIGHT_IDX, ///< Associated weight bones
-
-    MAX_DATA
-};
-
-///@{
-/// Get the name expected for a given attrib.
-static constexpr char const* getAttribName[MeshData::MAX_DATA] = { "in_position",
-                                                                   "in_normal",
-                                                                   "in_tangent",
-                                                                   "in_bitangent",
-                                                                   "in_texcoord",
-                                                                   "in_color",
-                                                                   "in_weight",
-                                                                   "in_weight_idx" };
-///@}
 
 /// Create a 2D grid mesh with given number of row and columns
 RA_CORE_API TriangleMesh makePlaneGrid( const uint rows         = 1,

--- a/src/Core/Geometry/StandardAttribNames.hpp
+++ b/src/Core/Geometry/StandardAttribNames.hpp
@@ -9,7 +9,7 @@ namespace Geometry {
 /// List of standard vertex attributes.
 /// Corresponding standard vertex attribute names are obtained with g_attribName
 /// Information which is in the mesh geometry
-enum MeshData : uint {
+enum MeshAttrib : uint {
     VERTEX_POSITION,   ///< Vertex positions
     VERTEX_NORMAL,     ///< Vertex normals
     VERTEX_TANGENT,    ///< Vertex tangent 1
@@ -24,14 +24,14 @@ enum MeshData : uint {
 
 ///@{
 /// Get the name expected for a given attrib.
-static constexpr char const* getAttribName[MeshAttibb::MAX_DATA] = { "in_position",
-                                                                     "in_normal",
-                                                                     "in_tangent",
-                                                                     "in_bitangent",
-                                                                     "in_texcoord",
-                                                                     "in_color",
-                                                                     "in_weight",
-                                                                     "in_weight_idx" };
+static constexpr char const* g_attribName[MeshAttrib::MAX_DATA] = { "in_position",
+                                                                    "in_normal",
+                                                                    "in_tangent",
+                                                                    "in_bitangent",
+                                                                    "in_texcoord",
+                                                                    "in_color",
+                                                                    "in_weight",
+                                                                    "in_weight_idx" };
 ///@}
 
 } // namespace Geometry

--- a/src/Core/Geometry/StandardAttribNames.hpp
+++ b/src/Core/Geometry/StandardAttribNames.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <Core/RaCore.hpp>
+
+namespace Ra {
+namespace Core {
+namespace Geometry {
+
+/// List of standard vertex attributes.
+/// Corresponding standard vertex attribute names are obtained with g_attribName
+/// Information which is in the mesh geometry
+enum MeshData : uint {
+    VERTEX_POSITION,   ///< Vertex positions
+    VERTEX_NORMAL,     ///< Vertex normals
+    VERTEX_TANGENT,    ///< Vertex tangent 1
+    VERTEX_BITANGENT,  ///< Vertex tangent 2
+    VERTEX_TEXCOORD,   ///< U,V  texture coords (last coordinate not used)
+    VERTEX_COLOR,      ///< RGBA color.
+    VERTEX_WEIGHTS,    ///< Skinning weights (not used)
+    VERTEX_WEIGHT_IDX, ///< Associated weight bones
+
+    MAX_DATA
+};
+
+///@{
+/// Get the name expected for a given attrib.
+static constexpr char const* getAttribName[MeshAttibb::MAX_DATA] = { "in_position",
+                                                                     "in_normal",
+                                                                     "in_tangent",
+                                                                     "in_bitangent",
+                                                                     "in_texcoord",
+                                                                     "in_color",
+                                                                     "in_weight",
+                                                                     "in_weight_idx" };
+///@}
+
+} // namespace Geometry
+} // namespace Core
+} // namespace Ra

--- a/src/Core/Geometry/StandardAttribNames.hpp
+++ b/src/Core/Geometry/StandardAttribNames.hpp
@@ -6,9 +6,8 @@ namespace Ra {
 namespace Core {
 namespace Geometry {
 
-/// List of standard vertex attributes.
-/// Corresponding standard vertex attribute names are obtained with g_attribName
-/// Information which is in the mesh geometry
+/// \brief List of standard vertex attributes.
+/// Corresponding standard vertex attribute names are obtained with #getAttribName
 enum MeshAttrib : uint {
     VERTEX_POSITION,   ///< Vertex positions
     VERTEX_NORMAL,     ///< Vertex normals

--- a/src/Core/Geometry/StandardAttribNames.hpp
+++ b/src/Core/Geometry/StandardAttribNames.hpp
@@ -22,21 +22,18 @@ enum MeshAttrib : uint {
     MAX_DATA
 };
 
-///@{
 /// Get the name expected for a given attrib.
-
-inline constexpr char const* getAttribName( MeshAttrib index ) {
-    constexpr char const* g_attribName[MeshAttrib::MAX_DATA] = { "in_position",
-                                                                 "in_normal",
-                                                                 "in_tangent",
-                                                                 "in_bitangent",
-                                                                 "in_texcoord",
-                                                                 "in_color",
-                                                                 "in_weight",
-                                                                 "in_weight_idx" };
+inline const std::string& getAttribName( MeshAttrib index ) {
+    static const std::string g_attribName[MeshAttrib::MAX_DATA] = { "in_position",
+                                                                    "in_normal",
+                                                                    "in_tangent",
+                                                                    "in_bitangent",
+                                                                    "in_texcoord",
+                                                                    "in_color",
+                                                                    "in_weight",
+                                                                    "in_weight_idx" };
     return g_attribName[index];
 }
-///@}
 
 } // namespace Geometry
 } // namespace Core

--- a/src/Core/Geometry/StandardAttribNames.hpp
+++ b/src/Core/Geometry/StandardAttribNames.hpp
@@ -24,14 +24,18 @@ enum MeshAttrib : uint {
 
 ///@{
 /// Get the name expected for a given attrib.
-static constexpr char const* g_attribName[MeshAttrib::MAX_DATA] = { "in_position",
-                                                                    "in_normal",
-                                                                    "in_tangent",
-                                                                    "in_bitangent",
-                                                                    "in_texcoord",
-                                                                    "in_color",
-                                                                    "in_weight",
-                                                                    "in_weight_idx" };
+
+inline constexpr char const* getAttribName( MeshAttrib index ) {
+    constexpr char const* g_attribName[MeshAttrib::MAX_DATA] = { "in_position",
+                                                                 "in_normal",
+                                                                 "in_tangent",
+                                                                 "in_bitangent",
+                                                                 "in_texcoord",
+                                                                 "in_color",
+                                                                 "in_weight",
+                                                                 "in_weight_idx" };
+    return g_attribName[index];
+}
 ///@}
 
 } // namespace Geometry

--- a/src/Core/Geometry/TopologicalMesh.inl
+++ b/src/Core/Geometry/TopologicalMesh.inl
@@ -5,6 +5,8 @@
 #include <typeinfo>
 #include <unordered_map>
 
+#include <Core/Geometry/StandardAttribNames.hpp>
+
 namespace Ra {
 namespace Core {
 namespace Geometry {
@@ -289,7 +291,9 @@ inline std::vector<std::string>& TopologicalMesh::WedgeCollection::getNameArray(
 }
 template <typename T>
 int TopologicalMesh::WedgeCollection::addAttribName( const std::string& name ) {
-    if ( name != std::string( "in_position" ) ) { getNameArray<T>().push_back( name ); }
+    if ( name != std::string( g_attribName[MeshAttrib::VERTEX_POSITION] ) ) {
+        getNameArray<T>().push_back( name );
+    }
     return getNameArray<T>().size() - 1;
 }
 
@@ -357,7 +361,7 @@ TopologicalMesh::InitWedgeAttribsFromMultiIndexedGeometry::operator()( AttribBas
     if ( attr->getSize() != m_triMesh.vertices().size() ) {
         LOG( logWARNING ) << "[TopologicalMesh] Skip badly sized attribute " << attr->getName();
     }
-    else if ( attr->getName() != std::string( "in_position" ) ) {
+    else if ( attr->getName() != std::string( g_attribName[MeshAttrib::VERTEX_POSITION] ) ) {
         if ( attr->isFloat() ) {
             m_topo->m_wedges.m_wedgeFloatAttribHandles.push_back(
                 m_triMesh.template getAttribHandle<Scalar>( attr->getName() ) );
@@ -611,7 +615,8 @@ void TopologicalMesh::initWithWedge(
 
     command.postProcess( *this );
     if ( hasNormals ) {
-        m_normalsIndex = m_wedges.getWedgeAttribIndex<Normal>( "in_normal" );
+        m_normalsIndex =
+            m_wedges.getWedgeAttribIndex<Normal>( g_attribName[MeshAttrib::VERTEX_NORMAL] );
 
         m_vertexFaceWedgesWithSameNormals.clear();
         m_vertexFaceWedgesWithSameNormals.resize( n_vertices() );
@@ -676,7 +681,7 @@ inline void TopologicalMesh::propagate_normal_to_wedges( VertexHandle vh ) {
     for ( VertexIHalfedgeIter vih_it = vih_iter( vh ); vih_it.is_valid(); ++vih_it ) {
         auto wd = getWedgeData( property( getWedgeIndexPph(), *vih_it ) );
 
-        m_wedges.setWedgeAttrib( wd, "in_normal", normal( vh ) );
+        m_wedges.setWedgeAttrib( wd, g_attribName[MeshAttrib::VERTEX_NORMAL], normal( vh ) );
 
         replaceWedge( *vih_it, wd );
     }

--- a/src/Core/Geometry/TopologicalMesh.inl
+++ b/src/Core/Geometry/TopologicalMesh.inl
@@ -291,7 +291,7 @@ inline std::vector<std::string>& TopologicalMesh::WedgeCollection::getNameArray(
 }
 template <typename T>
 int TopologicalMesh::WedgeCollection::addAttribName( const std::string& name ) {
-    if ( name != std::string( g_attribName[MeshAttrib::VERTEX_POSITION] ) ) {
+    if ( name != getAttribName( MeshAttrib::VERTEX_POSITION ) ) {
         getNameArray<T>().push_back( name );
     }
     return getNameArray<T>().size() - 1;
@@ -361,7 +361,7 @@ TopologicalMesh::InitWedgeAttribsFromMultiIndexedGeometry::operator()( AttribBas
     if ( attr->getSize() != m_triMesh.vertices().size() ) {
         LOG( logWARNING ) << "[TopologicalMesh] Skip badly sized attribute " << attr->getName();
     }
-    else if ( attr->getName() != std::string( g_attribName[MeshAttrib::VERTEX_POSITION] ) ) {
+    else if ( attr->getName() != getAttribName( MeshAttrib::VERTEX_POSITION ) ) {
         if ( attr->isFloat() ) {
             m_topo->m_wedges.m_wedgeFloatAttribHandles.push_back(
                 m_triMesh.template getAttribHandle<Scalar>( attr->getName() ) );
@@ -616,7 +616,7 @@ void TopologicalMesh::initWithWedge(
     command.postProcess( *this );
     if ( hasNormals ) {
         m_normalsIndex =
-            m_wedges.getWedgeAttribIndex<Normal>( g_attribName[MeshAttrib::VERTEX_NORMAL] );
+            m_wedges.getWedgeAttribIndex<Normal>( getAttribName( MeshAttrib::VERTEX_NORMAL ) );
 
         m_vertexFaceWedgesWithSameNormals.clear();
         m_vertexFaceWedgesWithSameNormals.resize( n_vertices() );
@@ -681,7 +681,7 @@ inline void TopologicalMesh::propagate_normal_to_wedges( VertexHandle vh ) {
     for ( VertexIHalfedgeIter vih_it = vih_iter( vh ); vih_it.is_valid(); ++vih_it ) {
         auto wd = getWedgeData( property( getWedgeIndexPph(), *vih_it ) );
 
-        m_wedges.setWedgeAttrib( wd, g_attribName[MeshAttrib::VERTEX_NORMAL], normal( vh ) );
+        m_wedges.setWedgeAttrib( wd, getAttribName( MeshAttrib::VERTEX_NORMAL ), normal( vh ) );
 
         replaceWedge( *vih_it, wd );
     }

--- a/src/Core/Geometry/TriangleMesh.cpp
+++ b/src/Core/Geometry/TriangleMesh.cpp
@@ -1,3 +1,4 @@
+#include <Core/Geometry/StandardAttribNames.hpp>
 #include <Core/Geometry/TriangleMesh.hpp>
 #include <Core/Types.hpp>
 
@@ -35,7 +36,7 @@ void AttribArrayGeometry::clearAttributes() {
 }
 
 void AttribArrayGeometry::colorize( const Utils::Color& color ) {
-    static const std::string colorAttribName( "in_color" );
+    static constexpr auto colorAttribName( g_attribName[MeshAttrib::VERTEX_COLOR] );
     auto colorAttribHandle = addAttrib<Core::Vector4>( colorAttribName );
     getAttrib( colorAttribHandle ).setData( Vector4Array( vertices().size(), color ) );
 }

--- a/src/Core/Geometry/TriangleMesh.cpp
+++ b/src/Core/Geometry/TriangleMesh.cpp
@@ -36,8 +36,7 @@ void AttribArrayGeometry::clearAttributes() {
 }
 
 void AttribArrayGeometry::colorize( const Utils::Color& color ) {
-    static constexpr auto colorAttribName( getAttribName( MeshAttrib::VERTEX_COLOR ) );
-    auto colorAttribHandle = addAttrib<Core::Vector4>( colorAttribName );
+    auto colorAttribHandle = addAttrib<Core::Vector4>( getAttribName( MeshAttrib::VERTEX_COLOR ) );
     getAttrib( colorAttribHandle ).setData( Vector4Array( vertices().size(), color ) );
 }
 

--- a/src/Core/Geometry/TriangleMesh.cpp
+++ b/src/Core/Geometry/TriangleMesh.cpp
@@ -36,7 +36,7 @@ void AttribArrayGeometry::clearAttributes() {
 }
 
 void AttribArrayGeometry::colorize( const Utils::Color& color ) {
-    static constexpr auto colorAttribName( g_attribName[MeshAttrib::VERTEX_COLOR] );
+    static constexpr auto colorAttribName( getAttribName( MeshAttrib::VERTEX_COLOR ) );
     auto colorAttribHandle = addAttrib<Core::Vector4>( colorAttribName );
     getAttrib( colorAttribHandle ).setData( Vector4Array( vertices().size(), color ) );
 }

--- a/src/Core/Geometry/TriangleMesh.hpp
+++ b/src/Core/Geometry/TriangleMesh.hpp
@@ -17,7 +17,7 @@ namespace Geometry {
 /// Points and Normals, defining the geometry, are always present.
 /// They can be accessed through vertices() and normals().
 /// Other attribs could be added with addAttrib() and accesssed with getAttrib().
-/// \note Attribute names "in_position" "in_normal" are reserved and pre-allocated.
+/// \note Mesh attribute VERTEX_POSITION and VERTEX_NORMAL are reserved and pre-allocated.
 class RA_CORE_API AttribArrayGeometry : public AbstractGeometry
 {
   public:

--- a/src/Core/Geometry/TriangleMesh.inl
+++ b/src/Core/Geometry/TriangleMesh.inl
@@ -200,9 +200,9 @@ inline void AttribArrayGeometry::normalsUnlock() {
 
 inline void AttribArrayGeometry::initDefaultAttribs() {
     m_verticesHandle = m_vertexAttribs.addAttrib<PointAttribHandle::value_type>(
-        g_attribName[MeshAttrib::VERTEX_POSITION] );
+        getAttribName( MeshAttrib::VERTEX_POSITION ) );
     m_normalsHandle = m_vertexAttribs.addAttrib<NormalAttribHandle::value_type>(
-        g_attribName[MeshAttrib::VERTEX_NORMAL] );
+        getAttribName( MeshAttrib::VERTEX_NORMAL ) );
     invalidateAabb();
 }
 

--- a/src/Core/Geometry/TriangleMesh.inl
+++ b/src/Core/Geometry/TriangleMesh.inl
@@ -1,5 +1,6 @@
 #pragma once
 #include "TriangleMesh.hpp"
+#include <Core/Geometry/StandardAttribNames.hpp>
 #include <Core/Geometry/TriangleOperation.hpp> // triangleArea
 
 namespace Ra {
@@ -198,8 +199,10 @@ inline void AttribArrayGeometry::normalsUnlock() {
 }
 
 inline void AttribArrayGeometry::initDefaultAttribs() {
-    m_verticesHandle = m_vertexAttribs.addAttrib<PointAttribHandle::value_type>( "in_position" );
-    m_normalsHandle  = m_vertexAttribs.addAttrib<NormalAttribHandle::value_type>( "in_normal" );
+    m_verticesHandle = m_vertexAttribs.addAttrib<PointAttribHandle::value_type>(
+        g_attribName[MeshAttrib::VERTEX_POSITION] );
+    m_normalsHandle = m_vertexAttribs.addAttrib<NormalAttribHandle::value_type>(
+        g_attribName[MeshAttrib::VERTEX_NORMAL] );
     invalidateAabb();
 }
 

--- a/src/Core/Geometry/deprecated/TopologicalMesh.inl
+++ b/src/Core/Geometry/deprecated/TopologicalMesh.inl
@@ -39,8 +39,8 @@ inline TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh,
     triMesh.vertexAttribs().for_each_attrib(
         [&triMesh, this, &vprop_float, &vprop_vec2, &vprop_vec3, &vprop_vec4]( const auto& attr ) {
             // skip builtin attribs
-            if ( attr->getName() != std::string( g_attribName[MeshAttrib::VERTEX_POSITION] ) &&
-                 attr->getName() != std::string( g_attribName[MeshAttrib::VERTEX_NORMAL] ) ) {
+            if ( attr->getName() != std::string( getAttribName( MeshAttrib::VERTEX_POSITION ) ) &&
+                 attr->getName() != std::string( getAttribName( MeshAttrib::VERTEX_NORMAL ) ) ) {
                 if ( attr->isFloat() )
                     addAttribPairToTopo( triMesh, attr, vprop_float, m_floatPph );
                 else if ( attr->isVector2() )

--- a/src/Core/Geometry/deprecated/TopologicalMesh.inl
+++ b/src/Core/Geometry/deprecated/TopologicalMesh.inl
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "TopologicalMesh.hpp"
+#include <Core/Geometry/StandardAttribNames.hpp>
 
 #include <typeinfo>
 #include <unordered_map>
@@ -38,8 +39,8 @@ inline TopologicalMesh::TopologicalMesh( const TriangleMesh& triMesh,
     triMesh.vertexAttribs().for_each_attrib(
         [&triMesh, this, &vprop_float, &vprop_vec2, &vprop_vec3, &vprop_vec4]( const auto& attr ) {
             // skip builtin attribs
-            if ( attr->getName() != std::string( "in_position" ) &&
-                 attr->getName() != std::string( "in_normal" ) ) {
+            if ( attr->getName() != std::string( g_attribName[MeshAttrib::VERTEX_POSITION] ) &&
+                 attr->getName() != std::string( g_attribName[MeshAttrib::VERTEX_NORMAL] ) ) {
                 if ( attr->isFloat() )
                     addAttribPairToTopo( triMesh, attr, vprop_float, m_floatPph );
                 else if ( attr->isVector2() )

--- a/src/Engine/Data/DrawPrimitives.cpp
+++ b/src/Engine/Data/DrawPrimitives.cpp
@@ -36,9 +36,9 @@ Rendering::RenderObject* Primitive( Scene::Component* component,
     Rendering::RenderTechnique rt;
     auto builder = Rendering::EngineRenderTechniques::getDefaultTechnique( "Plain" );
     builder.second( rt, false );
-    auto roMaterial = Core::make_shared<PlainMaterial>( "Default material" );
-    roMaterial->m_perVertexColor =
-        mesh->getAttribArrayGeometry().hasAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ) );
+    auto roMaterial              = Core::make_shared<PlainMaterial>( "Default material" );
+    roMaterial->m_perVertexColor = mesh->getAttribArrayGeometry().hasAttrib(
+        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR] );
     rt.setParametersProvider( roMaterial );
 
     auto ro = Rendering::RenderObject::createRenderObject(
@@ -57,7 +57,7 @@ LineMeshPtr Point( const Core::Vector3& point, const Core::Utils::Color& color, 
                         ( point + ( scale * Core::Vector3::UnitZ() ) ),
                         ( point - ( scale * Core::Vector3::UnitZ() ) ) } );
     geom.setIndices( { { 0, 1 }, { 2, 3 }, { 4, 5 } } );
-    geom.addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ),
+    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Point Primitive", std::move( geom ) );
@@ -68,7 +68,7 @@ Line( const Core::Vector3& a, const Core::Vector3& b, const Core::Utils::Color& 
     Geometry::LineMesh geom;
     geom.setVertices( { a, b } );
     geom.setIndices( { { 0, 1 } } );
-    geom.addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ),
+    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Line Primitive", std::move( geom ) );
@@ -90,7 +90,7 @@ Vector( const Core::Vector3& start, const Core::Vector3& v, const Core::Utils::C
                         start + ( ( 1.f - arrowFract ) * v ) + ( ( arrowFract * l ) * a ),
                         start + ( ( 1.f - arrowFract ) * v ) - ( ( arrowFract * l ) * a ) } );
     geom.setIndices( { { 0, 1 }, { 1, 2 }, { 1, 3 } } );
-    geom.addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ),
+    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Vector Primitive", std::move( geom ) );
@@ -101,7 +101,7 @@ LineMeshPtr Ray( const Core::Ray& ray, const Core::Utils::Color& color, Scalar l
     Core::Vector3 end = ray.pointAt( len );
     geom.setVertices( { ray.origin(), end } );
     geom.setIndices( { { 0, 1 } } );
-    geom.addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ),
+    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
     return make_shared<LineMesh>( "Ray Primitive", std::move( geom ) );
 }
@@ -115,16 +115,18 @@ AttribArrayDisplayablePtr Triangle( const Core::Vector3& a,
         Geometry::TriangleMesh geom;
         geom.setVertices( { a, b, c } );
         geom.setIndices( { { 0, 1, 2 } } );
-        geom.addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ),
-                        Core::Vector4Array { geom.vertices().size(), color } );
+        geom.addAttrib(
+            Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+            Core::Vector4Array { geom.vertices().size(), color } );
         return make_shared<Mesh>( "Triangle Primitive", std::move( geom ) );
     }
     else {
         Geometry::LineMesh geom;
         geom.setVertices( { a, b, c } );
         geom.setIndices( { { 0, 1 }, { 1, 2 }, { 2, 0 } } );
-        geom.addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ),
-                        Core::Vector4Array { geom.vertices().size(), color } );
+        geom.addAttrib(
+            Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+            Core::Vector4Array { geom.vertices().size(), color } );
         return make_shared<LineMesh>( "Triangle Primitive", std::move( geom ) );
     }
 }
@@ -155,7 +157,8 @@ MeshPtr QuadStrip( const Core::Vector3& a,
 
     MeshPtr mesh( new Mesh( "Quad Strip Primitive", Mesh::RM_TRIANGLE_STRIP ) );
     mesh->loadGeometry( vertices, indices );
-    mesh->getCoreGeometry().addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ), colors );
+    mesh->getCoreGeometry().addAttrib(
+        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
     return mesh;
 }
 
@@ -190,7 +193,7 @@ LineMeshPtr Circle( const Core::Vector3& center,
 
     geom.setVertices( std::move( vertices ) );
     geom.setIndices( std::move( indices ) );
-    geom.addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ),
+    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Circle Primitive", std::move( geom ) );
@@ -227,7 +230,7 @@ LineMeshPtr CircleArc( const Core::Vector3& center,
 
     geom.setVertices( std::move( vertices ) );
     geom.setIndices( std::move( indices ) );
-    geom.addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ),
+    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Arc Circle Primitive", std::move( geom ) );
@@ -242,7 +245,7 @@ MeshPtr Sphere( const Core::Vector3& center, Scalar radius, const Core::Utils::C
     std::for_each( data.begin(), data.end(), [center]( Core::Vector3& v ) { v += center; } );
     vertices.unlock();
 
-    geom.addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ),
+    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<Mesh>( "Sphere Primitive", std::move( geom ) );
@@ -282,7 +285,7 @@ MeshPtr Capsule( const Core::Vector3& p1,
     } );
     normalAttrib.unlock();
 
-    geom.addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ),
+    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<Mesh>( "Capsule Primitive", std::move( geom ) );
@@ -321,7 +324,8 @@ MeshPtr Disk( const Core::Vector3& center,
 
     MeshPtr mesh( new Mesh( "Disk Primitive", Mesh::RM_TRIANGLE_FAN ) );
     mesh->loadGeometry( vertices, indices );
-    mesh->getCoreGeometry().addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ), colors );
+    mesh->getCoreGeometry().addAttrib(
+        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
 
     return mesh;
 }
@@ -367,7 +371,7 @@ LineMeshPtr Normal( const Core::Vector3& point,
                        { 7, 4 },
                        { 4, 6 },
                        { 5, 7 } } );
-    geom.addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ),
+    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Normal Primitive", std::move( geom ) );
@@ -397,7 +401,8 @@ MeshPtr Frame( const Core::Transform& frameFromEntity, Scalar scale ) {
     MeshPtr mesh( new Mesh( "Frame Primitive", Mesh::RM_LINES ) );
 
     mesh->loadGeometry( vertices, indices );
-    mesh->getCoreGeometry().addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ), colors );
+    mesh->getCoreGeometry().addAttrib(
+        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
 
     return mesh;
 }
@@ -442,7 +447,8 @@ MeshPtr Grid( const Core::Vector3& center,
 
     MeshPtr mesh( new Mesh( "GridPrimitive", Mesh::RM_LINES ) );
     mesh->loadGeometry( vertices, indices );
-    mesh->getCoreGeometry().addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ), colors );
+    mesh->getCoreGeometry().addAttrib(
+        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
 
     return mesh;
 }
@@ -464,7 +470,8 @@ MeshPtr AABB( const Core::Aabb& aabb, const Core::Utils::Color& color ) {
 
     MeshPtr mesh( new Mesh( "AABB Primitive", Mesh::RM_LINES ) );
     mesh->loadGeometry( vertices, indices );
-    mesh->getCoreGeometry().addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ), colors );
+    mesh->getCoreGeometry().addAttrib(
+        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
 
     return mesh;
 }
@@ -486,7 +493,8 @@ MeshPtr OBB( const Obb& obb, const Core::Utils::Color& color ) {
 
     MeshPtr mesh( new Mesh( "OBB Primitive", Mesh::RM_LINES ) );
     mesh->loadGeometry( vertices, indices );
-    mesh->getCoreGeometry().addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ), colors );
+    mesh->getCoreGeometry().addAttrib(
+        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
 
     return mesh;
 }
@@ -516,7 +524,8 @@ MeshPtr Spline( const Core::Geometry::Spline<3, 3>& spline,
 
     MeshPtr mesh( new Mesh( "Spline Primitive", Mesh::RM_LINES ) );
     mesh->loadGeometry( vertices, indices );
-    mesh->getCoreGeometry().addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ), colors );
+    mesh->getCoreGeometry().addAttrib(
+        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
 
     return mesh;
 }
@@ -534,7 +543,8 @@ MeshPtr LineStrip( const Core::Vector3Array& vertices, const Core::Vector4Array&
     MeshPtr mesh( new Mesh( "Line Strip Primitive", Mesh::RM_LINE_STRIP ) );
     mesh->loadGeometry( vertices, indices );
     if ( colors.size() > 0 ) {
-        mesh->getCoreGeometry().addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ), colors );
+        mesh->getCoreGeometry().addAttrib(
+            Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
     }
     return mesh;
 }

--- a/src/Engine/Data/DrawPrimitives.cpp
+++ b/src/Engine/Data/DrawPrimitives.cpp
@@ -1,6 +1,7 @@
 #include <Engine/Data/DrawPrimitives.hpp>
 
 #include <Core/Geometry/MeshPrimitives.hpp>
+#include <Core/Geometry/StandardAttribNames.hpp>
 #include <Core/Utils/Color.hpp>
 
 #include <Engine/Data/Mesh.hpp>
@@ -38,7 +39,7 @@ Rendering::RenderObject* Primitive( Scene::Component* component,
     builder.second( rt, false );
     auto roMaterial              = Core::make_shared<PlainMaterial>( "Default material" );
     roMaterial->m_perVertexColor = mesh->getAttribArrayGeometry().hasAttrib(
-        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR] );
+        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR] );
     rt.setParametersProvider( roMaterial );
 
     auto ro = Rendering::RenderObject::createRenderObject(
@@ -57,7 +58,7 @@ LineMeshPtr Point( const Core::Vector3& point, const Core::Utils::Color& color, 
                         ( point + ( scale * Core::Vector3::UnitZ() ) ),
                         ( point - ( scale * Core::Vector3::UnitZ() ) ) } );
     geom.setIndices( { { 0, 1 }, { 2, 3 }, { 4, 5 } } );
-    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Point Primitive", std::move( geom ) );
@@ -68,7 +69,7 @@ Line( const Core::Vector3& a, const Core::Vector3& b, const Core::Utils::Color& 
     Geometry::LineMesh geom;
     geom.setVertices( { a, b } );
     geom.setIndices( { { 0, 1 } } );
-    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Line Primitive", std::move( geom ) );
@@ -90,7 +91,7 @@ Vector( const Core::Vector3& start, const Core::Vector3& v, const Core::Utils::C
                         start + ( ( 1.f - arrowFract ) * v ) + ( ( arrowFract * l ) * a ),
                         start + ( ( 1.f - arrowFract ) * v ) - ( ( arrowFract * l ) * a ) } );
     geom.setIndices( { { 0, 1 }, { 1, 2 }, { 1, 3 } } );
-    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Vector Primitive", std::move( geom ) );
@@ -101,7 +102,7 @@ LineMeshPtr Ray( const Core::Ray& ray, const Core::Utils::Color& color, Scalar l
     Core::Vector3 end = ray.pointAt( len );
     geom.setVertices( { ray.origin(), end } );
     geom.setIndices( { { 0, 1 } } );
-    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
     return make_shared<LineMesh>( "Ray Primitive", std::move( geom ) );
 }
@@ -116,7 +117,7 @@ AttribArrayDisplayablePtr Triangle( const Core::Vector3& a,
         geom.setVertices( { a, b, c } );
         geom.setIndices( { { 0, 1, 2 } } );
         geom.addAttrib(
-            Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+            Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
             Core::Vector4Array { geom.vertices().size(), color } );
         return make_shared<Mesh>( "Triangle Primitive", std::move( geom ) );
     }
@@ -125,7 +126,7 @@ AttribArrayDisplayablePtr Triangle( const Core::Vector3& a,
         geom.setVertices( { a, b, c } );
         geom.setIndices( { { 0, 1 }, { 1, 2 }, { 2, 0 } } );
         geom.addAttrib(
-            Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+            Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
             Core::Vector4Array { geom.vertices().size(), color } );
         return make_shared<LineMesh>( "Triangle Primitive", std::move( geom ) );
     }
@@ -158,7 +159,7 @@ MeshPtr QuadStrip( const Core::Vector3& a,
     MeshPtr mesh( new Mesh( "Quad Strip Primitive", Mesh::RM_TRIANGLE_STRIP ) );
     mesh->loadGeometry( vertices, indices );
     mesh->getCoreGeometry().addAttrib(
-        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
+        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR], colors );
     return mesh;
 }
 
@@ -193,7 +194,7 @@ LineMeshPtr Circle( const Core::Vector3& center,
 
     geom.setVertices( std::move( vertices ) );
     geom.setIndices( std::move( indices ) );
-    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Circle Primitive", std::move( geom ) );
@@ -230,7 +231,7 @@ LineMeshPtr CircleArc( const Core::Vector3& center,
 
     geom.setVertices( std::move( vertices ) );
     geom.setIndices( std::move( indices ) );
-    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Arc Circle Primitive", std::move( geom ) );
@@ -245,7 +246,7 @@ MeshPtr Sphere( const Core::Vector3& center, Scalar radius, const Core::Utils::C
     std::for_each( data.begin(), data.end(), [center]( Core::Vector3& v ) { v += center; } );
     vertices.unlock();
 
-    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<Mesh>( "Sphere Primitive", std::move( geom ) );
@@ -285,7 +286,7 @@ MeshPtr Capsule( const Core::Vector3& p1,
     } );
     normalAttrib.unlock();
 
-    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<Mesh>( "Capsule Primitive", std::move( geom ) );
@@ -325,7 +326,7 @@ MeshPtr Disk( const Core::Vector3& center,
     MeshPtr mesh( new Mesh( "Disk Primitive", Mesh::RM_TRIANGLE_FAN ) );
     mesh->loadGeometry( vertices, indices );
     mesh->getCoreGeometry().addAttrib(
-        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
+        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR], colors );
 
     return mesh;
 }
@@ -371,7 +372,7 @@ LineMeshPtr Normal( const Core::Vector3& point,
                        { 7, 4 },
                        { 4, 6 },
                        { 5, 7 } } );
-    geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
                     Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Normal Primitive", std::move( geom ) );
@@ -402,7 +403,7 @@ MeshPtr Frame( const Core::Transform& frameFromEntity, Scalar scale ) {
 
     mesh->loadGeometry( vertices, indices );
     mesh->getCoreGeometry().addAttrib(
-        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
+        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR], colors );
 
     return mesh;
 }
@@ -448,7 +449,7 @@ MeshPtr Grid( const Core::Vector3& center,
     MeshPtr mesh( new Mesh( "GridPrimitive", Mesh::RM_LINES ) );
     mesh->loadGeometry( vertices, indices );
     mesh->getCoreGeometry().addAttrib(
-        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
+        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR], colors );
 
     return mesh;
 }
@@ -471,7 +472,7 @@ MeshPtr AABB( const Core::Aabb& aabb, const Core::Utils::Color& color ) {
     MeshPtr mesh( new Mesh( "AABB Primitive", Mesh::RM_LINES ) );
     mesh->loadGeometry( vertices, indices );
     mesh->getCoreGeometry().addAttrib(
-        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
+        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR], colors );
 
     return mesh;
 }
@@ -494,7 +495,7 @@ MeshPtr OBB( const Obb& obb, const Core::Utils::Color& color ) {
     MeshPtr mesh( new Mesh( "OBB Primitive", Mesh::RM_LINES ) );
     mesh->loadGeometry( vertices, indices );
     mesh->getCoreGeometry().addAttrib(
-        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
+        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR], colors );
 
     return mesh;
 }
@@ -525,7 +526,7 @@ MeshPtr Spline( const Core::Geometry::Spline<3, 3>& spline,
     MeshPtr mesh( new Mesh( "Spline Primitive", Mesh::RM_LINES ) );
     mesh->loadGeometry( vertices, indices );
     mesh->getCoreGeometry().addAttrib(
-        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
+        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR], colors );
 
     return mesh;
 }
@@ -544,7 +545,8 @@ MeshPtr LineStrip( const Core::Vector3Array& vertices, const Core::Vector4Array&
     mesh->loadGeometry( vertices, indices );
     if ( colors.size() > 0 ) {
         mesh->getCoreGeometry().addAttrib(
-            Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR], colors );
+            Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
+            colors );
     }
     return mesh;
 }

--- a/src/Engine/Data/DrawPrimitives.cpp
+++ b/src/Engine/Data/DrawPrimitives.cpp
@@ -39,7 +39,7 @@ Rendering::RenderObject* Primitive( Scene::Component* component,
     builder.second( rt, false );
     auto roMaterial              = Core::make_shared<PlainMaterial>( "Default material" );
     roMaterial->m_perVertexColor = mesh->getAttribArrayGeometry().hasAttrib(
-        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR] );
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ) );
     rt.setParametersProvider( roMaterial );
 
     auto ro = Rendering::RenderObject::createRenderObject(
@@ -58,8 +58,9 @@ LineMeshPtr Point( const Core::Vector3& point, const Core::Utils::Color& color, 
                         ( point + ( scale * Core::Vector3::UnitZ() ) ),
                         ( point - ( scale * Core::Vector3::UnitZ() ) ) } );
     geom.setIndices( { { 0, 1 }, { 2, 3 }, { 4, 5 } } );
-    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
-                    Core::Vector4Array { geom.vertices().size(), color } );
+    geom.addAttrib(
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ),
+        Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Point Primitive", std::move( geom ) );
 }
@@ -69,8 +70,9 @@ Line( const Core::Vector3& a, const Core::Vector3& b, const Core::Utils::Color& 
     Geometry::LineMesh geom;
     geom.setVertices( { a, b } );
     geom.setIndices( { { 0, 1 } } );
-    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
-                    Core::Vector4Array { geom.vertices().size(), color } );
+    geom.addAttrib(
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ),
+        Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Line Primitive", std::move( geom ) );
 }
@@ -91,8 +93,9 @@ Vector( const Core::Vector3& start, const Core::Vector3& v, const Core::Utils::C
                         start + ( ( 1.f - arrowFract ) * v ) + ( ( arrowFract * l ) * a ),
                         start + ( ( 1.f - arrowFract ) * v ) - ( ( arrowFract * l ) * a ) } );
     geom.setIndices( { { 0, 1 }, { 1, 2 }, { 1, 3 } } );
-    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
-                    Core::Vector4Array { geom.vertices().size(), color } );
+    geom.addAttrib(
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ),
+        Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Vector Primitive", std::move( geom ) );
 }
@@ -102,8 +105,9 @@ LineMeshPtr Ray( const Core::Ray& ray, const Core::Utils::Color& color, Scalar l
     Core::Vector3 end = ray.pointAt( len );
     geom.setVertices( { ray.origin(), end } );
     geom.setIndices( { { 0, 1 } } );
-    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
-                    Core::Vector4Array { geom.vertices().size(), color } );
+    geom.addAttrib(
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ),
+        Core::Vector4Array { geom.vertices().size(), color } );
     return make_shared<LineMesh>( "Ray Primitive", std::move( geom ) );
 }
 
@@ -117,7 +121,7 @@ AttribArrayDisplayablePtr Triangle( const Core::Vector3& a,
         geom.setVertices( { a, b, c } );
         geom.setIndices( { { 0, 1, 2 } } );
         geom.addAttrib(
-            Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
+            Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ),
             Core::Vector4Array { geom.vertices().size(), color } );
         return make_shared<Mesh>( "Triangle Primitive", std::move( geom ) );
     }
@@ -126,7 +130,7 @@ AttribArrayDisplayablePtr Triangle( const Core::Vector3& a,
         geom.setVertices( { a, b, c } );
         geom.setIndices( { { 0, 1 }, { 1, 2 }, { 2, 0 } } );
         geom.addAttrib(
-            Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
+            Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ),
             Core::Vector4Array { geom.vertices().size(), color } );
         return make_shared<LineMesh>( "Triangle Primitive", std::move( geom ) );
     }
@@ -159,7 +163,7 @@ MeshPtr QuadStrip( const Core::Vector3& a,
     MeshPtr mesh( new Mesh( "Quad Strip Primitive", Mesh::RM_TRIANGLE_STRIP ) );
     mesh->loadGeometry( vertices, indices );
     mesh->getCoreGeometry().addAttrib(
-        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR], colors );
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ), colors );
     return mesh;
 }
 
@@ -194,8 +198,9 @@ LineMeshPtr Circle( const Core::Vector3& center,
 
     geom.setVertices( std::move( vertices ) );
     geom.setIndices( std::move( indices ) );
-    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
-                    Core::Vector4Array { geom.vertices().size(), color } );
+    geom.addAttrib(
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ),
+        Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Circle Primitive", std::move( geom ) );
 }
@@ -231,8 +236,9 @@ LineMeshPtr CircleArc( const Core::Vector3& center,
 
     geom.setVertices( std::move( vertices ) );
     geom.setIndices( std::move( indices ) );
-    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
-                    Core::Vector4Array { geom.vertices().size(), color } );
+    geom.addAttrib(
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ),
+        Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Arc Circle Primitive", std::move( geom ) );
 }
@@ -240,15 +246,16 @@ LineMeshPtr CircleArc( const Core::Vector3& center,
 MeshPtr Sphere( const Core::Vector3& center, Scalar radius, const Core::Utils::Color& color ) {
     auto geom   = makeGeodesicSphere( radius, 2 );
     auto handle = geom.getAttribHandle<TriangleMesh::Point>(
-        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_POSITION] );
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_POSITION ) );
     auto& vertices = geom.getAttrib<TriangleMesh::Point>( handle );
     auto& data     = vertices.getDataWithLock();
 
     std::for_each( data.begin(), data.end(), [center]( Core::Vector3& v ) { v += center; } );
     vertices.unlock();
 
-    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
-                    Core::Vector4Array { geom.vertices().size(), color } );
+    geom.addAttrib(
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ),
+        Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<Mesh>( "Sphere Primitive", std::move( geom ) );
 }
@@ -274,14 +281,14 @@ MeshPtr Capsule( const Core::Vector3& p1,
     Matrix3 normalMatrix = t.linear().inverse().transpose();
 
     auto vertHandle = geom.getAttribHandle<TriangleMesh::Point>(
-        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_POSITION] );
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_POSITION ) );
     auto& vertAttrib = geom.getAttrib<TriangleMesh::Point>( vertHandle );
     auto& vertData   = vertAttrib.getDataWithLock();
     std::for_each( vertData.begin(), vertData.end(), [t]( Core::Vector3& v ) { v = t * v; } );
     vertAttrib.unlock();
 
     auto normalHandle = geom.getAttribHandle<TriangleMesh::Point>(
-        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_NORMAL] );
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_NORMAL ) );
     auto& normalAttrib = geom.getAttrib<TriangleMesh::Point>( normalHandle );
     auto& normalData   = normalAttrib.getDataWithLock();
     std::for_each( normalData.begin(), normalData.end(), [normalMatrix]( Core::Vector3& n ) {
@@ -289,8 +296,9 @@ MeshPtr Capsule( const Core::Vector3& p1,
     } );
     normalAttrib.unlock();
 
-    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
-                    Core::Vector4Array { geom.vertices().size(), color } );
+    geom.addAttrib(
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ),
+        Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<Mesh>( "Capsule Primitive", std::move( geom ) );
 }
@@ -329,7 +337,7 @@ MeshPtr Disk( const Core::Vector3& center,
     MeshPtr mesh( new Mesh( "Disk Primitive", Mesh::RM_TRIANGLE_FAN ) );
     mesh->loadGeometry( vertices, indices );
     mesh->getCoreGeometry().addAttrib(
-        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR], colors );
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ), colors );
 
     return mesh;
 }
@@ -375,8 +383,9 @@ LineMeshPtr Normal( const Core::Vector3& point,
                        { 7, 4 },
                        { 4, 6 },
                        { 5, 7 } } );
-    geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
-                    Core::Vector4Array { geom.vertices().size(), color } );
+    geom.addAttrib(
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ),
+        Core::Vector4Array { geom.vertices().size(), color } );
 
     return make_shared<LineMesh>( "Normal Primitive", std::move( geom ) );
 }
@@ -406,7 +415,7 @@ MeshPtr Frame( const Core::Transform& frameFromEntity, Scalar scale ) {
 
     mesh->loadGeometry( vertices, indices );
     mesh->getCoreGeometry().addAttrib(
-        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR], colors );
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ), colors );
 
     return mesh;
 }
@@ -452,7 +461,7 @@ MeshPtr Grid( const Core::Vector3& center,
     MeshPtr mesh( new Mesh( "GridPrimitive", Mesh::RM_LINES ) );
     mesh->loadGeometry( vertices, indices );
     mesh->getCoreGeometry().addAttrib(
-        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR], colors );
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ), colors );
 
     return mesh;
 }
@@ -475,7 +484,7 @@ MeshPtr AABB( const Core::Aabb& aabb, const Core::Utils::Color& color ) {
     MeshPtr mesh( new Mesh( "AABB Primitive", Mesh::RM_LINES ) );
     mesh->loadGeometry( vertices, indices );
     mesh->getCoreGeometry().addAttrib(
-        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR], colors );
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ), colors );
 
     return mesh;
 }
@@ -498,7 +507,7 @@ MeshPtr OBB( const Obb& obb, const Core::Utils::Color& color ) {
     MeshPtr mesh( new Mesh( "OBB Primitive", Mesh::RM_LINES ) );
     mesh->loadGeometry( vertices, indices );
     mesh->getCoreGeometry().addAttrib(
-        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR], colors );
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ), colors );
 
     return mesh;
 }
@@ -529,7 +538,7 @@ MeshPtr Spline( const Core::Geometry::Spline<3, 3>& spline,
     MeshPtr mesh( new Mesh( "Spline Primitive", Mesh::RM_LINES ) );
     mesh->loadGeometry( vertices, indices );
     mesh->getCoreGeometry().addAttrib(
-        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR], colors );
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ), colors );
 
     return mesh;
 }
@@ -548,7 +557,7 @@ MeshPtr LineStrip( const Core::Vector3Array& vertices, const Core::Vector4Array&
     mesh->loadGeometry( vertices, indices );
     if ( colors.size() > 0 ) {
         mesh->getCoreGeometry().addAttrib(
-            Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
+            Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ),
             colors );
     }
     return mesh;

--- a/src/Engine/Data/DrawPrimitives.cpp
+++ b/src/Engine/Data/DrawPrimitives.cpp
@@ -238,8 +238,9 @@ LineMeshPtr CircleArc( const Core::Vector3& center,
 }
 
 MeshPtr Sphere( const Core::Vector3& center, Scalar radius, const Core::Utils::Color& color ) {
-    auto geom      = makeGeodesicSphere( radius, 2 );
-    auto handle    = geom.getAttribHandle<TriangleMesh::Point>( "in_position" );
+    auto geom   = makeGeodesicSphere( radius, 2 );
+    auto handle = geom.getAttribHandle<TriangleMesh::Point>(
+        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_POSITION] );
     auto& vertices = geom.getAttrib<TriangleMesh::Point>( handle );
     auto& data     = vertices.getDataWithLock();
 
@@ -272,13 +273,15 @@ MeshPtr Capsule( const Core::Vector3& p1,
     t.pretranslate( trans );
     Matrix3 normalMatrix = t.linear().inverse().transpose();
 
-    auto vertHandle  = geom.getAttribHandle<TriangleMesh::Point>( "in_position" );
+    auto vertHandle = geom.getAttribHandle<TriangleMesh::Point>(
+        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_POSITION] );
     auto& vertAttrib = geom.getAttrib<TriangleMesh::Point>( vertHandle );
     auto& vertData   = vertAttrib.getDataWithLock();
     std::for_each( vertData.begin(), vertData.end(), [t]( Core::Vector3& v ) { v = t * v; } );
     vertAttrib.unlock();
 
-    auto normalHandle  = geom.getAttribHandle<TriangleMesh::Point>( "in_normal" );
+    auto normalHandle = geom.getAttribHandle<TriangleMesh::Point>(
+        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_NORMAL] );
     auto& normalAttrib = geom.getAttrib<TriangleMesh::Point>( normalHandle );
     auto& normalData   = normalAttrib.getDataWithLock();
     std::for_each( normalData.begin(), normalData.end(), [normalMatrix]( Core::Vector3& n ) {

--- a/src/Engine/Data/Mesh.cpp
+++ b/src/Engine/Data/Mesh.cpp
@@ -136,8 +136,8 @@ void AttribArrayDisplayable::setDirty( unsigned int index ) {
     }
 }
 
-void AttribArrayDisplayable::setDirty( const AttribArrayDisplayable::MeshData& type ) {
-    auto name = getAttribName( type );
+void AttribArrayDisplayable::setDirty( const Ra::Core::Geometry::MeshData& type ) {
+    auto name = Core::Geometry::getAttribName[type];
     auto itr  = m_handleToBuffer.find( name );
     if ( itr == m_handleToBuffer.end() ) {
         m_handleToBuffer[name] = m_dataDirty.size();

--- a/src/Engine/Data/Mesh.cpp
+++ b/src/Engine/Data/Mesh.cpp
@@ -136,8 +136,8 @@ void AttribArrayDisplayable::setDirty( unsigned int index ) {
     }
 }
 
-void AttribArrayDisplayable::setDirty( const Ra::Core::Geometry::MeshData& type ) {
-    auto name = Core::Geometry::getAttribName[type];
+void AttribArrayDisplayable::setDirty( const Ra::Core::Geometry::MeshAttrib& type ) {
+    auto name = Core::Geometry::g_attribName[type];
     auto itr  = m_handleToBuffer.find( name );
     if ( itr == m_handleToBuffer.end() ) {
         m_handleToBuffer[name] = m_dataDirty.size();

--- a/src/Engine/Data/Mesh.cpp
+++ b/src/Engine/Data/Mesh.cpp
@@ -137,7 +137,7 @@ void AttribArrayDisplayable::setDirty( unsigned int index ) {
 }
 
 void AttribArrayDisplayable::setDirty( const Ra::Core::Geometry::MeshAttrib& type ) {
-    auto name = Core::Geometry::g_attribName[type];
+    auto name = Core::Geometry::getAttribName( type );
     auto itr  = m_handleToBuffer.find( name );
     if ( itr == m_handleToBuffer.end() ) {
         m_handleToBuffer[name] = m_dataDirty.size();

--- a/src/Engine/Data/Mesh.hpp
+++ b/src/Engine/Data/Mesh.hpp
@@ -6,6 +6,7 @@
 
 #include <Core/Asset/GeometryData.hpp>
 #include <Core/Containers/VectorArray.hpp>
+#include <Core/Geometry/MeshPrimitives.hpp>
 #include <Core/Geometry/TriangleMesh.hpp>
 #include <Core/Utils/Color.hpp>
 #include <Core/Utils/Log.hpp>
@@ -48,22 +49,6 @@ class RA_ENGINE_API Vao
 class RA_ENGINE_API AttribArrayDisplayable : public Displayable
 {
   public:
-    /// List of standard vertex attributes.
-    /// Corresponding standard vertex attribute names are obtained with getAttribName
-    /// Information which is in the mesh geometry
-    enum MeshData : uint {
-        VERTEX_POSITION,   ///< Vertex positions
-        VERTEX_NORMAL,     ///< Vertex normals
-        VERTEX_TANGENT,    ///< Vertex tangent 1
-        VERTEX_BITANGENT,  ///< Vertex tangent 2
-        VERTEX_TEXCOORD,   ///< U,V  texture coords (last coordinate not used)
-        VERTEX_COLOR,      ///< RGBA color.
-        VERTEX_WEIGHTS,    ///< Skinning weights (not used)
-        VERTEX_WEIGHT_IDX, ///< Associated weight bones
-
-        MAX_DATA
-    };
-
     /// Render mode enum used when render()/
     /// values taken from OpenGL specification
     /// @see https://www.khronos.org/registry/OpenGL/api/GL/glcorearb.h
@@ -107,7 +92,7 @@ class RA_ENGINE_API AttribArrayDisplayable : public Displayable
 
     /// Use getAttribName to find the corresponding name and call setDirty(const std::string& name).
     /// \param type: the data to set to dirty.
-    void setDirty( const MeshData& type );
+    void setDirty( const Core::Geometry::MeshData& type );
 
     /// \param name: data buffer name to set to dirty
     void setDirty( const std::string& name );
@@ -120,11 +105,6 @@ class RA_ENGINE_API AttribArrayDisplayable : public Displayable
     /// This function is called at the start of the rendering.
     /// It will update the necessary openGL buffers.
     void updateGL() override = 0;
-
-    ///@{
-    /// Get the name expected for a given attrib.
-    static inline std::string getAttribName( MeshData type );
-    ///@}
 
     ///@{
     /**  Returns the underlying CoreGeometry as an Core::Geometry::AttribArrayGeometry */
@@ -486,17 +466,17 @@ CoreMeshType createCoreMeshFromGeometryData( const Ra::Core::Asset::GeometryData
 
     // \todo remove when data will handle all the attributes in a coherent way.
     if ( data->hasTangents() ) {
-        mesh.addAttrib( Data::Mesh::getAttribName( Data::Mesh::VERTEX_TANGENT ),
+        mesh.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TANGENT],
                         data->getTangents() );
     }
 
     if ( data->hasBiTangents() ) {
-        mesh.addAttrib( Data::Mesh::getAttribName( Data::Mesh::VERTEX_BITANGENT ),
+        mesh.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_BITANGENT],
                         data->getBiTangents() );
     }
 
     if ( data->hasTextureCoordinates() ) {
-        mesh.addAttrib( Data::Mesh::getAttribName( Data::Mesh::VERTEX_TEXCOORD ),
+        mesh.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TEXCOORD],
                         data->getTexCoords() );
     }
 
@@ -506,7 +486,7 @@ CoreMeshType createCoreMeshFromGeometryData( const Ra::Core::Asset::GeometryData
     mesh.vertexAttribs().copyAllAttributes( data->getAttribManager() );
 
     // also this one will be automatically done with the futur behavior
-    //        mesh->addData( Data::Mesh::VERTEX_WEIGHTS, meshData.weights );
+    //        mesh->addData( Ra::Core::Geometry::VERTEX_WEIGHTS, meshData.weights );
 
     mesh.setIndices( std::move( indices ) );
 

--- a/src/Engine/Data/Mesh.hpp
+++ b/src/Engine/Data/Mesh.hpp
@@ -7,6 +7,7 @@
 #include <Core/Asset/GeometryData.hpp>
 #include <Core/Containers/VectorArray.hpp>
 #include <Core/Geometry/MeshPrimitives.hpp>
+#include <Core/Geometry/StandardAttribNames.hpp>
 #include <Core/Geometry/TriangleMesh.hpp>
 #include <Core/Utils/Color.hpp>
 #include <Core/Utils/Log.hpp>
@@ -90,9 +91,9 @@ class RA_ENGINE_API AttribArrayDisplayable : public Displayable
     /// Mark attrib data as dirty, forcing an update of the OpenGL buffer.
     ///@{
 
-    /// Use getAttribName to find the corresponding name and call setDirty(const std::string& name).
-    /// \param type: the data to set to dirty.
-    void setDirty( const Core::Geometry::MeshData& type );
+    /// Use g_attribName to find the corresponding name and call setDirty(const std::string& name).
+    /// \param type: the data to set to MeshAttrib
+    void setDirty( const Core::Geometry::MeshAttrib& type );
 
     /// \param name: data buffer name to set to dirty
     void setDirty( const std::string& name );
@@ -466,17 +467,17 @@ CoreMeshType createCoreMeshFromGeometryData( const Ra::Core::Asset::GeometryData
 
     // \todo remove when data will handle all the attributes in a coherent way.
     if ( data->hasTangents() ) {
-        mesh.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TANGENT],
+        mesh.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TANGENT],
                         data->getTangents() );
     }
 
     if ( data->hasBiTangents() ) {
-        mesh.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_BITANGENT],
+        mesh.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_BITANGENT],
                         data->getBiTangents() );
     }
 
     if ( data->hasTextureCoordinates() ) {
-        mesh.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TEXCOORD],
+        mesh.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TEXCOORD],
                         data->getTexCoords() );
     }
 

--- a/src/Engine/Data/Mesh.hpp
+++ b/src/Engine/Data/Mesh.hpp
@@ -467,17 +467,17 @@ CoreMeshType createCoreMeshFromGeometryData( const Ra::Core::Asset::GeometryData
 
     // \todo remove when data will handle all the attributes in a coherent way.
     if ( data->hasTangents() ) {
-        mesh.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TANGENT],
+        mesh.addAttrib( Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_TANGENT ),
                         data->getTangents() );
     }
 
     if ( data->hasBiTangents() ) {
-        mesh.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_BITANGENT],
+        mesh.addAttrib( Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_BITANGENT ),
                         data->getBiTangents() );
     }
 
     if ( data->hasTextureCoordinates() ) {
-        mesh.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TEXCOORD],
+        mesh.addAttrib( Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_TEXCOORD ),
                         data->getTexCoords() );
     }
 

--- a/src/Engine/Data/Mesh.inl
+++ b/src/Engine/Data/Mesh.inl
@@ -22,18 +22,6 @@ AttribArrayDisplayable::MeshRenderMode AttribArrayDisplayable::getRenderMode() c
     return m_renderMode;
 }
 
-std::string AttribArrayDisplayable::getAttribName( MeshData type ) {
-    if ( type == VERTEX_POSITION ) return { "in_position" };
-    if ( type == VERTEX_NORMAL ) return { "in_normal" };
-    if ( type == VERTEX_TANGENT ) return { "in_tangent" };
-    if ( type == VERTEX_BITANGENT ) return { "in_bitangent" };
-    if ( type == VERTEX_TEXCOORD ) return { "in_texcoord" };
-    if ( type == VERTEX_COLOR ) return { "in_color" };
-    if ( type == VERTEX_WEIGHTS ) return { "in_weight" };
-    if ( type == VERTEX_WEIGHT_IDX ) return { "in_weight_idx" };
-    return { "invalid mesh data attr name" };
-}
-
 ///////////////// VaoIndices  ///////////////////////
 
 void VaoIndices::setIndicesDirty() {

--- a/src/Engine/Data/VolumeObject.cpp
+++ b/src/Engine/Data/VolumeObject.cpp
@@ -45,7 +45,8 @@ void VolumeObject::loadGeometry( Core::Geometry::AbstractVolume* volume, const C
             Scalar( 0 ), Scalar( 0 ), Scalar( 1 ), Scalar( 1 ), // Left
             Scalar( 0 ), Scalar( 0 ), Scalar( 1 ), Scalar( 1 ), // Floor
             Scalar( 0 ), Scalar( 1 ), Scalar( 1 ), Scalar( 0 ); // Ceil
-        m_mesh.addAttrib( Mesh::getAttribName( Mesh::VERTEX_TEXCOORD ), tex_coords );
+        m_mesh.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TEXCOORD],
+                          tex_coords );
 
         Core::Geometry::VolumeGrid* grid = static_cast<Core::Geometry::VolumeGrid*>( volume );
         m_volume = std::unique_ptr<Core::Geometry::AbstractVolume>( volume );

--- a/src/Engine/Data/VolumeObject.cpp
+++ b/src/Engine/Data/VolumeObject.cpp
@@ -45,7 +45,7 @@ void VolumeObject::loadGeometry( Core::Geometry::AbstractVolume* volume, const C
             Scalar( 0 ), Scalar( 0 ), Scalar( 1 ), Scalar( 1 ), // Left
             Scalar( 0 ), Scalar( 0 ), Scalar( 1 ), Scalar( 1 ), // Floor
             Scalar( 0 ), Scalar( 1 ), Scalar( 1 ), Scalar( 0 ); // Ceil
-        m_mesh.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TEXCOORD],
+        m_mesh.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TEXCOORD],
                           tex_coords );
 
         Core::Geometry::VolumeGrid* grid = static_cast<Core::Geometry::VolumeGrid*>( volume );

--- a/src/Engine/Data/VolumeObject.cpp
+++ b/src/Engine/Data/VolumeObject.cpp
@@ -45,7 +45,7 @@ void VolumeObject::loadGeometry( Core::Geometry::AbstractVolume* volume, const C
             Scalar( 0 ), Scalar( 0 ), Scalar( 1 ), Scalar( 1 ), // Left
             Scalar( 0 ), Scalar( 0 ), Scalar( 1 ), Scalar( 1 ), // Floor
             Scalar( 0 ), Scalar( 1 ), Scalar( 1 ), Scalar( 0 ); // Ceil
-        m_mesh.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TEXCOORD],
+        m_mesh.addAttrib( Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_TEXCOORD ),
                           tex_coords );
 
         Core::Geometry::VolumeGrid* grid = static_cast<Core::Geometry::VolumeGrid*>( volume );

--- a/src/Engine/Rendering/DebugRender.cpp
+++ b/src/Engine/Rendering/DebugRender.cpp
@@ -166,7 +166,8 @@ void DebugRender::renderLines( const Core::Matrix4f& viewMatrix,
         Core::Geometry::LineMesh geom;
         geom.setVertices( vertices );
         geom.setIndices( std::move( indices ) );
-        geom.addAttrib( Data::Mesh::getAttribName( Data::Mesh::VERTEX_COLOR ), colors );
+        geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_COLOR],
+                        colors );
 
         Data::LineMesh mesh( "temp", std::move( geom ) );
 

--- a/src/Engine/Rendering/DebugRender.cpp
+++ b/src/Engine/Rendering/DebugRender.cpp
@@ -166,7 +166,7 @@ void DebugRender::renderLines( const Core::Matrix4f& viewMatrix,
         Core::Geometry::LineMesh geom;
         geom.setVertices( vertices );
         geom.setIndices( std::move( indices ) );
-        geom.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_COLOR],
+        geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_COLOR],
                         colors );
 
         Data::LineMesh mesh( "temp", std::move( geom ) );

--- a/src/Engine/Rendering/DebugRender.cpp
+++ b/src/Engine/Rendering/DebugRender.cpp
@@ -166,7 +166,7 @@ void DebugRender::renderLines( const Core::Matrix4f& viewMatrix,
         Core::Geometry::LineMesh geom;
         geom.setVertices( vertices );
         geom.setIndices( std::move( indices ) );
-        geom.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_COLOR],
+        geom.addAttrib( Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_COLOR ),
                         colors );
 
         Data::LineMesh mesh( "temp", std::move( geom ) );

--- a/src/Engine/Rendering/ForwardRenderer.cpp
+++ b/src/Engine/Rendering/ForwardRenderer.cpp
@@ -245,7 +245,7 @@ void setupLineMesh( std::shared_ptr<Data::LineMesh>& disp, CoreGeometry& core ) 
 
         // add observer
         auto handle = core.template getAttribHandle<typename CoreGeometry::Point>(
-            Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_POSITION] );
+            Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_POSITION] );
         core.vertexAttribs().getAttrib( handle ).attach( VerticesUpdater( disp, core ) );
         core.attach( IndicesUpdater( disp, core ) );
     }

--- a/src/Engine/Rendering/ForwardRenderer.cpp
+++ b/src/Engine/Rendering/ForwardRenderer.cpp
@@ -245,7 +245,7 @@ void setupLineMesh( std::shared_ptr<Data::LineMesh>& disp, CoreGeometry& core ) 
 
         // add observer
         auto handle = core.template getAttribHandle<typename CoreGeometry::Point>(
-            Data::Mesh::getAttribName( Data::Mesh::VERTEX_POSITION ) );
+            Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_POSITION] );
         core.vertexAttribs().getAttrib( handle ).attach( VerticesUpdater( disp, core ) );
         core.attach( IndicesUpdater( disp, core ) );
     }

--- a/src/Engine/Rendering/ForwardRenderer.cpp
+++ b/src/Engine/Rendering/ForwardRenderer.cpp
@@ -245,7 +245,7 @@ void setupLineMesh( std::shared_ptr<Data::LineMesh>& disp, CoreGeometry& core ) 
 
         // add observer
         auto handle = core.template getAttribHandle<typename CoreGeometry::Point>(
-            Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_POSITION] );
+            Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_POSITION ) );
         core.vertexAttribs().getAttrib( handle ).attach( VerticesUpdater( disp, core ) );
         core.attach( IndicesUpdater( disp, core ) );
     }

--- a/src/Engine/Scene/GeometryComponent.cpp
+++ b/src/Engine/Scene/GeometryComponent.cpp
@@ -90,17 +90,17 @@ void PointCloudComponent::generatePointCloud( const Ra::Core::Asset::GeometryDat
     mesh.setNormals( std::move( normals ) );
 
     if ( data->hasTangents() ) {
-        mesh.addAttrib( Data::Mesh::getAttribName( Data::Mesh::VERTEX_TANGENT ),
+        mesh.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TANGENT],
                         data->getTangents() );
     }
 
     if ( data->hasBiTangents() ) {
-        mesh.addAttrib( Data::Mesh::getAttribName( Data::Mesh::VERTEX_BITANGENT ),
+        mesh.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_BITANGENT],
                         data->getBiTangents() );
     }
 
     if ( data->hasTextureCoordinates() ) {
-        mesh.addAttrib( Data::Mesh::getAttribName( Data::Mesh::VERTEX_TEXCOORD ),
+        mesh.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TEXCOORD],
                         data->getTexCoords() );
     }
 
@@ -130,7 +130,7 @@ void PointCloudComponent::finalizeROFromGeometry( const Core::Asset::MaterialDat
         auto mat             = new Data::BlinnPhongMaterial( m_contentName + "_DefaultBPMaterial" );
         mat->m_renderAsSplat = m_displayMesh->getNumFaces() == 0;
         mat->m_perVertexColor = m_displayMesh->getCoreGeometry().hasAttrib(
-            Data::Mesh::getAttribName( Data::Mesh::VERTEX_COLOR ) );
+            Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_COLOR] );
         roMaterial.reset( mat );
     }
     // initialize with a default rendertechique that draws nothing

--- a/src/Engine/Scene/GeometryComponent.cpp
+++ b/src/Engine/Scene/GeometryComponent.cpp
@@ -90,17 +90,17 @@ void PointCloudComponent::generatePointCloud( const Ra::Core::Asset::GeometryDat
     mesh.setNormals( std::move( normals ) );
 
     if ( data->hasTangents() ) {
-        mesh.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TANGENT],
+        mesh.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TANGENT],
                         data->getTangents() );
     }
 
     if ( data->hasBiTangents() ) {
-        mesh.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_BITANGENT],
+        mesh.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_BITANGENT],
                         data->getBiTangents() );
     }
 
     if ( data->hasTextureCoordinates() ) {
-        mesh.addAttrib( Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TEXCOORD],
+        mesh.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TEXCOORD],
                         data->getTexCoords() );
     }
 
@@ -130,7 +130,7 @@ void PointCloudComponent::finalizeROFromGeometry( const Core::Asset::MaterialDat
         auto mat             = new Data::BlinnPhongMaterial( m_contentName + "_DefaultBPMaterial" );
         mat->m_renderAsSplat = m_displayMesh->getNumFaces() == 0;
         mat->m_perVertexColor = m_displayMesh->getCoreGeometry().hasAttrib(
-            Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_COLOR] );
+            Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_COLOR] );
         roMaterial.reset( mat );
     }
     // initialize with a default rendertechique that draws nothing

--- a/src/Engine/Scene/GeometryComponent.cpp
+++ b/src/Engine/Scene/GeometryComponent.cpp
@@ -90,17 +90,17 @@ void PointCloudComponent::generatePointCloud( const Ra::Core::Asset::GeometryDat
     mesh.setNormals( std::move( normals ) );
 
     if ( data->hasTangents() ) {
-        mesh.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TANGENT],
+        mesh.addAttrib( Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_TANGENT ),
                         data->getTangents() );
     }
 
     if ( data->hasBiTangents() ) {
-        mesh.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_BITANGENT],
+        mesh.addAttrib( Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_BITANGENT ),
                         data->getBiTangents() );
     }
 
     if ( data->hasTextureCoordinates() ) {
-        mesh.addAttrib( Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TEXCOORD],
+        mesh.addAttrib( Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_TEXCOORD ),
                         data->getTexCoords() );
     }
 
@@ -130,7 +130,7 @@ void PointCloudComponent::finalizeROFromGeometry( const Core::Asset::MaterialDat
         auto mat             = new Data::BlinnPhongMaterial( m_contentName + "_DefaultBPMaterial" );
         mat->m_renderAsSplat = m_displayMesh->getNumFaces() == 0;
         mat->m_perVertexColor = m_displayMesh->getCoreGeometry().hasAttrib(
-            Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_COLOR] );
+            Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_COLOR ) );
         roMaterial.reset( mat );
     }
     // initialize with a default rendertechique that draws nothing

--- a/src/Engine/Scene/GeometryComponent.inl
+++ b/src/Engine/Scene/GeometryComponent.inl
@@ -62,7 +62,7 @@ void SurfaceMeshComponent<CoreMeshType>::finalizeROFromGeometry(
         auto mat             = new Data::BlinnPhongMaterial( m_contentName + "_DefaultBPMaterial" );
         mat->m_renderAsSplat = m_displayMesh->getNumFaces() == 0;
         mat->m_perVertexColor = m_displayMesh->getCoreGeometry().hasAttrib(
-            Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_COLOR] );
+            Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_COLOR] );
         roMaterial.reset( mat );
     }
     // initialize with a default rendertechique that draws nothing

--- a/src/Engine/Scene/GeometryComponent.inl
+++ b/src/Engine/Scene/GeometryComponent.inl
@@ -62,7 +62,7 @@ void SurfaceMeshComponent<CoreMeshType>::finalizeROFromGeometry(
         auto mat             = new Data::BlinnPhongMaterial( m_contentName + "_DefaultBPMaterial" );
         mat->m_renderAsSplat = m_displayMesh->getNumFaces() == 0;
         mat->m_perVertexColor = m_displayMesh->getCoreGeometry().hasAttrib(
-            Data::Mesh::getAttribName( Data::Mesh::VERTEX_COLOR ) );
+            Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_COLOR] );
         roMaterial.reset( mat );
     }
     // initialize with a default rendertechique that draws nothing

--- a/src/Engine/Scene/GeometryComponent.inl
+++ b/src/Engine/Scene/GeometryComponent.inl
@@ -62,7 +62,7 @@ void SurfaceMeshComponent<CoreMeshType>::finalizeROFromGeometry(
         auto mat             = new Data::BlinnPhongMaterial( m_contentName + "_DefaultBPMaterial" );
         mat->m_renderAsSplat = m_displayMesh->getNumFaces() == 0;
         mat->m_perVertexColor = m_displayMesh->getCoreGeometry().hasAttrib(
-            Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_COLOR] );
+            Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_COLOR ) );
         roMaterial.reset( mat );
     }
     // initialize with a default rendertechique that draws nothing

--- a/src/Engine/Scene/SkinningComponent.cpp
+++ b/src/Engine/Scene/SkinningComponent.cpp
@@ -38,8 +38,10 @@ namespace Ra {
 namespace Engine {
 namespace Scene {
 
-static std::string tangentName   = Data::Mesh::getAttribName( Data::Mesh::VERTEX_TANGENT );
-static std::string bitangentName = Data::Mesh::getAttribName( Data::Mesh::VERTEX_BITANGENT );
+static std::string tangentName =
+    Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TANGENT];
+static std::string bitangentName =
+    Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_BITANGENT];
 
 TriangleMesh triangulate( const PolyMesh& polyMesh ) {
     TriangleMesh res;
@@ -156,7 +158,7 @@ void SkinningComponent::initialize() {
         m_baseMaterial = ro->getMaterial();
 
         // prepare UV
-        auto attrUV = Data::Mesh::getAttribName( Data::Mesh::VERTEX_TEXCOORD );
+        auto attrUV = Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TEXCOORD];
         AttribArrayGeometry* geom;
         if ( !m_meshIsPoly ) { geom = const_cast<TriangleMesh*>( m_triMeshWriter() ); }
         else {
@@ -382,7 +384,7 @@ const std::string& SkinningComponent::getSkeletonName() const {
 void SkinningComponent::showWeights( bool on ) {
     m_showingWeights = on;
     auto ro          = getRoMgr()->getRenderObject( *m_renderObjectReader() );
-    auto attrUV      = Data::Mesh::getAttribName( Data::Mesh::VERTEX_TEXCOORD );
+    auto attrUV      = Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TEXCOORD];
     AttribHandle<Vector3> handle;
 
     AttribArrayGeometry* geom;

--- a/src/Engine/Scene/SkinningComponent.cpp
+++ b/src/Engine/Scene/SkinningComponent.cpp
@@ -39,9 +39,9 @@ namespace Engine {
 namespace Scene {
 
 static std::string tangentName =
-    Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TANGENT];
+    Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TANGENT];
 static std::string bitangentName =
-    Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_BITANGENT];
+    Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_BITANGENT];
 
 TriangleMesh triangulate( const PolyMesh& polyMesh ) {
     TriangleMesh res;
@@ -158,7 +158,7 @@ void SkinningComponent::initialize() {
         m_baseMaterial = ro->getMaterial();
 
         // prepare UV
-        auto attrUV = Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TEXCOORD];
+        auto attrUV = Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TEXCOORD];
         AttribArrayGeometry* geom;
         if ( !m_meshIsPoly ) { geom = const_cast<TriangleMesh*>( m_triMeshWriter() ); }
         else {
@@ -384,7 +384,7 @@ const std::string& SkinningComponent::getSkeletonName() const {
 void SkinningComponent::showWeights( bool on ) {
     m_showingWeights = on;
     auto ro          = getRoMgr()->getRenderObject( *m_renderObjectReader() );
-    auto attrUV      = Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::VERTEX_TEXCOORD];
+    auto attrUV      = Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TEXCOORD];
     AttribHandle<Vector3> handle;
 
     AttribArrayGeometry* geom;

--- a/src/Engine/Scene/SkinningComponent.cpp
+++ b/src/Engine/Scene/SkinningComponent.cpp
@@ -39,9 +39,9 @@ namespace Engine {
 namespace Scene {
 
 static std::string tangentName =
-    Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TANGENT];
+    Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_TANGENT );
 static std::string bitangentName =
-    Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_BITANGENT];
+    Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_BITANGENT );
 
 TriangleMesh triangulate( const PolyMesh& polyMesh ) {
     TriangleMesh res;
@@ -158,7 +158,7 @@ void SkinningComponent::initialize() {
         m_baseMaterial = ro->getMaterial();
 
         // prepare UV
-        auto attrUV = Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TEXCOORD];
+        auto attrUV = Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_TEXCOORD );
         AttribArrayGeometry* geom;
         if ( !m_meshIsPoly ) { geom = const_cast<TriangleMesh*>( m_triMeshWriter() ); }
         else {
@@ -384,7 +384,7 @@ const std::string& SkinningComponent::getSkeletonName() const {
 void SkinningComponent::showWeights( bool on ) {
     m_showingWeights = on;
     auto ro          = getRoMgr()->getRenderObject( *m_renderObjectReader() );
-    auto attrUV      = Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::VERTEX_TEXCOORD];
+    auto attrUV      = Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_TEXCOORD );
     AttribHandle<Vector3> handle;
 
     AttribArrayGeometry* geom;

--- a/src/Engine/Scene/SkinningComponent.cpp
+++ b/src/Engine/Scene/SkinningComponent.cpp
@@ -38,9 +38,9 @@ namespace Ra {
 namespace Engine {
 namespace Scene {
 
-static std::string tangentName =
+static const std::string tangentName =
     Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_TANGENT );
-static std::string bitangentName =
+static const std::string bitangentName =
     Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_BITANGENT );
 
 TriangleMesh triangulate( const PolyMesh& polyMesh ) {

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -62,9 +62,9 @@ uint AssimpGeometryDataLoader::sceneGeometrySize( const aiScene* scene ) const {
     return mesh_size;
 }
 
-void AssimpGeometryDataLoader::loadMeshData( const aiMesh& mesh,
-                                             GeometryData& data,
-                                             std::set<std::string>& usedNames ) {
+void AssimpGeometryDataLoader::loadMeshAttrib( const aiMesh& mesh,
+                                               GeometryData& data,
+                                               std::set<std::string>& usedNames ) {
     fetchName( mesh, data, usedNames );
     fetchType( mesh, data );
     fetchVertices( mesh, data );
@@ -344,7 +344,7 @@ void AssimpGeometryDataLoader::loadGeometryData(
         aiMesh* mesh = scene->mMeshes[i];
         if ( mesh->HasPositions() ) {
             auto geometry = new GeometryData();
-            loadMeshData( *mesh, *geometry, usedNames );
+            loadMeshAttrib( *mesh, *geometry, usedNames );
             // This returns always true (see assimp documentation)
             if ( scene->HasMaterials() ) {
                 const uint matID = mesh->mMaterialIndex;

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.hpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.hpp
@@ -47,9 +47,9 @@ class RA_IO_API AssimpGeometryDataLoader : public Core::Asset::DataLoader<Core::
                            std::vector<std::unique_ptr<Core::Asset::GeometryData>>& data );
 
     /// Fill \p data with the GeometryData from \p mesh.
-    void loadMeshData( const aiMesh& mesh,
-                       Core::Asset::GeometryData& data,
-                       std::set<std::string>& usedNames );
+    void loadMeshAttrib( const aiMesh& mesh,
+                         Core::Asset::GeometryData& data,
+                         std::set<std::string>& usedNames );
 
     /// Fill \p data with the Material data from \p material.
     void loadMaterial( const aiMaterial& material, Core::Asset::GeometryData& data ) const;

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
@@ -2,6 +2,7 @@
 
 #include <Core/Asset/FileData.hpp>
 #include <Core/Containers/VectorArray.hpp>
+#include <Core/Geometry/StandardAttribNames.hpp>
 #include <Core/Utils/Attribs.hpp>
 
 #include <tinyply.h>
@@ -236,7 +237,8 @@ FileData* TinyPlyFileLoader::loadFile( const std::string& filename ) {
 
     size_t colorCount = colorBuffer ? colorBuffer->count : 0;
     if ( colorCount != 0 ) {
-        auto handle     = attribManager.addAttrib<Core::Vector4>( "in_color" );
+        auto handle = attribManager.addAttrib<Core::Vector4>(
+            Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR] );
         auto& attrib    = attribManager.getAttrib( handle );
         auto& container = attrib.getDataWithLock();
 

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
@@ -238,7 +238,7 @@ FileData* TinyPlyFileLoader::loadFile( const std::string& filename ) {
     size_t colorCount = colorBuffer ? colorBuffer->count : 0;
     if ( colorCount != 0 ) {
         auto handle = attribManager.addAttrib<Core::Vector4>(
-            Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR] );
+            Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ) );
         auto& attrib    = attribManager.getAttrib( handle );
         auto& container = attrib.getDataWithLock();
 

--- a/tests/ExampleApps/CustomCameraManipulator/main.cpp
+++ b/tests/ExampleApps/CustomCameraManipulator/main.cpp
@@ -60,7 +60,7 @@ int main( int argc, char* argv[] ) {
 
     //! [Colorize the Cube]
     cube.addAttrib(
-        "in_color",
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_COLOR ),
         Ra::Core::Vector4Array { cube.vertices().size(), Ra::Core::Utils::Color::Green() } );
     //! [Colorize the Cube]
 

--- a/tests/ExampleApps/DrawPrimitivesDemo/minimalradium.cpp
+++ b/tests/ExampleApps/DrawPrimitivesDemo/minimalradium.cpp
@@ -858,8 +858,9 @@ void MinimalComponent::initialize() {
                 Vector3 up { 0_ra, .05_ra, 0_ra };
 
                 mesh.setVertices( points );
-                mesh.addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ),
-                                Vector4Array { colors.begin(), colors.begin() + points.size() } );
+                mesh.addAttrib(
+                    Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+                    Vector4Array { colors.begin(), colors.begin() + points.size() } );
                 mesh.setIndices( indices );
                 topo = TopologicalMesh { mesh };
                 topo.mergeEqualWedges();
@@ -951,8 +952,9 @@ void MinimalComponent::initialize() {
                 Vector3 up { 0_ra, .05_ra, 0_ra };
 
                 mesh.setVertices( points );
-                mesh.addAttrib( Mesh::getAttribName( Mesh::VERTEX_COLOR ),
-                                Vector4Array { colors.begin(), colors.begin() + points.size() } );
+                mesh.addAttrib(
+                    Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+                    Vector4Array { colors.begin(), colors.begin() + points.size() } );
                 mesh.setIndices( indices );
 
                 topo = TopologicalMesh { mesh };

--- a/tests/ExampleApps/DrawPrimitivesDemo/minimalradium.cpp
+++ b/tests/ExampleApps/DrawPrimitivesDemo/minimalradium.cpp
@@ -859,7 +859,7 @@ void MinimalComponent::initialize() {
 
                 mesh.setVertices( points );
                 mesh.addAttrib(
-                    Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+                    Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
                     Vector4Array { colors.begin(), colors.begin() + points.size() } );
                 mesh.setIndices( indices );
                 topo = TopologicalMesh { mesh };
@@ -953,7 +953,7 @@ void MinimalComponent::initialize() {
 
                 mesh.setVertices( points );
                 mesh.addAttrib(
-                    Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR],
+                    Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
                     Vector4Array { colors.begin(), colors.begin() + points.size() } );
                 mesh.setIndices( indices );
 

--- a/tests/ExampleApps/DrawPrimitivesDemo/minimalradium.cpp
+++ b/tests/ExampleApps/DrawPrimitivesDemo/minimalradium.cpp
@@ -125,7 +125,8 @@ void MinimalComponent::initialize() {
         auto coord = cellSize / 8_ra;
         cube1->loadGeometry( Geometry::makeSharpBox( Vector3 { coord, coord, coord } ) );
         cube1->getCoreGeometry().addAttrib(
-            "in_color", Vector4Array { cube1->getNumVertices(), Color::Green() } );
+            Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_COLOR ),
+            Vector4Array { cube1->getNumVertices(), Color::Green() } );
 
         auto renderObject1 = RenderObject::createRenderObject(
             "Cube1", this, RenderObjectType::Geometry, cube1, {} );
@@ -137,10 +138,12 @@ void MinimalComponent::initialize() {
         std::shared_ptr<Mesh> cube2( new Mesh( "Cube" ) );
         coord = cellSize / 4_ra;
         cube2->loadGeometry( Geometry::makeSharpBox( Vector3 { coord, coord, coord } ) );
+        const std::string myColourName { "colour" };
         cube2->getCoreGeometry().addAttrib(
-            "colour", Vector4Array { cube2->getNumVertices(), Color::Red() } );
+            myColourName, Vector4Array { cube2->getNumVertices(), Color::Red() } );
 
-        cube2->setAttribNameCorrespondance( "colour", "in_color" );
+        cube2->setAttribNameCorrespondance(
+            myColourName, Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_COLOR ) );
         auto renderObject2 = RenderObject::createRenderObject(
             "CubeRO_2", this, RenderObjectType::Geometry, cube2, {} );
         coord = cellSize / 2_ra;
@@ -616,7 +619,7 @@ void MinimalComponent::initialize() {
         std::shared_ptr<Data::PolyMesh> poly1(
             new Data::PolyMesh( "Poly", std::move( polyMesh ) ) );
         poly1->getCoreGeometry().addAttrib(
-            "in_color",
+            Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_COLOR ),
             Vector4Array { poly1->getNumVertices(), colorBoost * Color { 1_ra, 0.6_ra, 0.1_ra } } );
 
         auto renderObject1 = RenderObject::createRenderObject(
@@ -633,7 +636,7 @@ void MinimalComponent::initialize() {
         auto triangulated = topo.toTriangleMesh();
         std::shared_ptr<Mesh> poly2( new Mesh( "Poly", std::move( triangulated ) ) );
         poly2->getCoreGeometry().addAttrib(
-            "in_color",
+            Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_COLOR ),
             Vector4Array { poly2->getNumVertices(), colorBoost * Color { 0_ra, 0.6_ra, 0.1_ra } } );
 
         auto renderObject2 = RenderObject::createRenderObject(

--- a/tests/ExampleApps/DrawPrimitivesDemo/minimalradium.cpp
+++ b/tests/ExampleApps/DrawPrimitivesDemo/minimalradium.cpp
@@ -858,9 +858,9 @@ void MinimalComponent::initialize() {
                 Vector3 up { 0_ra, .05_ra, 0_ra };
 
                 mesh.setVertices( points );
-                mesh.addAttrib(
-                    Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
-                    Vector4Array { colors.begin(), colors.begin() + points.size() } );
+                mesh.addAttrib( Ra::Core::Geometry::getAttribName(
+                                    Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ),
+                                Vector4Array { colors.begin(), colors.begin() + points.size() } );
                 mesh.setIndices( indices );
                 topo = TopologicalMesh { mesh };
                 topo.mergeEqualWedges();
@@ -952,9 +952,9 @@ void MinimalComponent::initialize() {
                 Vector3 up { 0_ra, .05_ra, 0_ra };
 
                 mesh.setVertices( points );
-                mesh.addAttrib(
-                    Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR],
-                    Vector4Array { colors.begin(), colors.begin() + points.size() } );
+                mesh.addAttrib( Ra::Core::Geometry::getAttribName(
+                                    Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR ),
+                                Vector4Array { colors.begin(), colors.begin() + points.size() } );
                 mesh.setIndices( indices );
 
                 topo = TopologicalMesh { mesh };

--- a/tests/ExampleApps/HelloRadium/main.cpp
+++ b/tests/ExampleApps/HelloRadium/main.cpp
@@ -22,7 +22,7 @@ int main( int argc, char* argv[] ) {
 
     //! [Colorize the Cube]
     cube.addAttrib(
-        "in_color",
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_COLOR ),
         Ra::Core::Vector4Array { cube.vertices().size(), Ra::Core::Utils::Color::Green() } );
     //! [Colorize the Cube]
 

--- a/tests/ExampleApps/KeyEventDemoApp/main.cpp
+++ b/tests/ExampleApps/KeyEventDemoApp/main.cpp
@@ -4,6 +4,7 @@
 
 // include the Engine/entity/component interface
 #include <Core/Geometry/MeshPrimitives.hpp>
+#include <Core/Geometry/StandardAttribNames.hpp>
 #include <Engine/Scene/EntityManager.hpp>
 #include <Engine/Scene/GeometryComponent.hpp>
 #include <Engine/Scene/GeometrySystem.hpp>
@@ -133,7 +134,7 @@ int main( int argc, char* argv[] ) {
 
     //! [Colorize the Cube]
     cube.addAttrib(
-        "in_color",
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_COLOR ),
         Ra::Core::Vector4Array { cube.vertices().size(), Ra::Core::Utils::Color::Green() } );
     //! [Colorize the Cube]
 

--- a/tests/ExampleApps/SimpleSimulationApp/main.cpp
+++ b/tests/ExampleApps/SimpleSimulationApp/main.cpp
@@ -16,8 +16,8 @@
 class SimpleSimulationSystem : public Ra::Engine::Scene::System
 {
     Ra::Engine::Data::PointCloud* m_cloud;
-    const std::string colorHandleName = Ra::Engine::Data::AttribArrayDisplayable::getAttribName(
-        Ra::Engine::Data::AttribArrayDisplayable::VERTEX_COLOR );
+    const std::string colorHandleName =
+        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR];
 
     Ra::Core::Utils::Attrib<Ra::Core::Vector4>& getColorAttrib() {
         auto cHandle =

--- a/tests/ExampleApps/SimpleSimulationApp/main.cpp
+++ b/tests/ExampleApps/SimpleSimulationApp/main.cpp
@@ -17,7 +17,7 @@ class SimpleSimulationSystem : public Ra::Engine::Scene::System
 {
     Ra::Engine::Data::PointCloud* m_cloud;
     const std::string colorHandleName =
-        Ra::Core::Geometry::getAttribName[Ra::Core::Geometry::MeshData::VERTEX_COLOR];
+        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR];
 
     Ra::Core::Utils::Attrib<Ra::Core::Vector4>& getColorAttrib() {
         auto cHandle =

--- a/tests/ExampleApps/SimpleSimulationApp/main.cpp
+++ b/tests/ExampleApps/SimpleSimulationApp/main.cpp
@@ -72,7 +72,7 @@ int main( int argc, char* argv[] ) {
 
     //! [Colorize the cloud]
     cloud.addAttrib(
-        "in_color",
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_COLOR ),
         Ra::Core::Vector4Array { cloud.vertices().size(), Ra::Core::Utils::Color::Green() } );
     //! [Colorize the cloud]
 

--- a/tests/ExampleApps/SimpleSimulationApp/main.cpp
+++ b/tests/ExampleApps/SimpleSimulationApp/main.cpp
@@ -17,7 +17,7 @@ class SimpleSimulationSystem : public Ra::Engine::Scene::System
 {
     Ra::Engine::Data::PointCloud* m_cloud;
     const std::string colorHandleName =
-        Ra::Core::Geometry::g_attribName[Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR];
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_COLOR );
 
     Ra::Core::Utils::Attrib<Ra::Core::Vector4>& getColorAttrib() {
         auto cHandle =

--- a/tests/ExampleApps/VolumeDemoApp/main.cpp
+++ b/tests/ExampleApps/VolumeDemoApp/main.cpp
@@ -74,7 +74,7 @@ int main( int argc, char* argv[] ) {
 
     //! [Colorize the Cube]
     cube.addAttrib(
-        "in_color",
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_COLOR ),
         Ra::Core::Vector4Array { cube.vertices().size(), Ra::Core::Utils::Color::White() } );
     //! [Colorize the Cube]
 
@@ -111,7 +111,7 @@ int main( int argc, char* argv[] ) {
 
     //! [Colorize the Cube]
     cube.addAttrib(
-        "in_color",
+        Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_COLOR ),
         Ra::Core::Vector4Array { cube.vertices().size(), Ra::Core::Utils::Color::White() } );
     //! [Colorize the Cube]
 

--- a/tests/unittest/Core/indexview.cpp
+++ b/tests/unittest/Core/indexview.cpp
@@ -1,5 +1,6 @@
 #include <Core/Geometry/IndexedGeometry.hpp>
 #include <Core/Geometry/MeshPrimitives.hpp>
+#include <Core/Geometry/StandardAttribNames.hpp>
 #include <catch2/catch.hpp>
 
 struct CustomTriangleIndexLayer : public Ra::Core::Geometry::TriangleIndexLayer {
@@ -10,11 +11,7 @@ struct CustomTriangleIndexLayer : public Ra::Core::Geometry::TriangleIndexLayer 
 
 TEST_CASE( "Core/Geometry/IndexedGeometry", "[Core][Core/Geometry][IndexedGeometry]" ) {
     using Ra::Core::Vector3;
-    using Ra::Core::Geometry::AttribArrayGeometry;
-    using Ra::Core::Geometry::MultiIndexedGeometry;
-    using Ra::Core::Geometry::PointCloudIndexLayer;
-    using Ra::Core::Geometry::TriangleIndexLayer;
-    using Ra::Core::Geometry::TriangleMesh;
+    using namespace Ra::Core::Geometry;
     using Ra::Core::Utils::ObjectWithSemantic;
 
     // Store keys of the layers that should be in the geometry
@@ -98,20 +95,16 @@ TEST_CASE( "Core/Geometry/IndexedGeometry", "[Core][Core/Geometry][IndexedGeomet
 
 TEST_CASE( "Core/Geometry/IndexedGeometry/Attributes", "[Core][Core/Geometry][IndexedGeometry]" ) {
     using Ra::Core::Vector3;
-    using Ra::Core::Geometry::AttribArrayGeometry;
-    using Ra::Core::Geometry::MultiIndexedGeometry;
-    using Ra::Core::Geometry::PointCloudIndexLayer;
-    using Ra::Core::Geometry::TriangleIndexLayer;
-    using Ra::Core::Geometry::TriangleMesh;
+    using namespace Ra::Core::Geometry;
     using Ra::Core::Utils::ObjectWithSemantic;
     using Vec3AttribHandle = AttribArrayGeometry::Vec3AttribHandle;
 
     MultiIndexedGeometry mesh( Ra::Core::Geometry::makeBox() );
 
     // base attributes are automatically added
-    auto h_pos = mesh.getAttribHandle<Vector3>( "in_position" );
+    auto h_pos = mesh.getAttribHandle<Vector3>( getAttribName( VERTEX_POSITION ) );
     REQUIRE( mesh.isValid( h_pos ) );
-    auto h_nor = mesh.getAttribHandle<Vector3>( "in_normal" );
+    auto h_nor = mesh.getAttribHandle<Vector3>( getAttribName( VERTEX_NORMAL ) );
     REQUIRE( mesh.isValid( h_nor ) );
 
     // Add/Remove attributes without filling it
@@ -254,7 +247,7 @@ TEST_CASE( "Core/Geometry/IndexedGeometry/CopyAllAttributes",
            "[Core][Core/Geometry][IndexedGeometry]" ) {
     using Ra::Core::Vector2;
     using Ra::Core::Vector3;
-    using Ra::Core::Geometry::TriangleMesh;
+    using namespace Ra::Core::Geometry;
     using Vec3AttribHandle = Ra::Core::Utils::AttribHandle<Vector3>;
     using Ra::Core::Geometry::TriangleMesh;
 

--- a/tests/unittest/Core/topomesh.cpp
+++ b/tests/unittest/Core/topomesh.cpp
@@ -1,4 +1,5 @@
 #include <Core/Geometry/MeshPrimitives.hpp>
+#include <Core/Geometry/StandardAttribNames.hpp>
 #include <Core/Geometry/TopologicalMesh.hpp>
 #include <Core/Geometry/TriangleMesh.hpp>
 #include <catch2/catch.hpp>
@@ -119,7 +120,7 @@ void copyToWedgesVector( size_t size,
         LOG( logWARNING ) << "[TopologicalMesh test] Skip badly sized attribute "
                           << attr->getName();
     }
-    else if ( attr->getName() != std::string( "in_position" ) ) {
+    else if ( attr->getName() != getAttribName( VERTEX_POSITION ) ) {
         {
             auto data = meshOne.vertices();
             for ( size_t i = 0; i < size; ++i ) {
@@ -322,7 +323,7 @@ TEST_CASE( "Core/Geometry/TopologicalMesh", "[Core][Core/Geometry][TopologicalMe
         auto topologicalMesh = TopologicalMesh( mesh );
         auto newMesh         = topologicalMesh.toTriangleMesh();
         topologicalMesh.setWedgeData(
-            TopologicalMesh::WedgeIndex { 0 }, "in_normal", Vector3( 0, 0, 0 ) );
+            TopologicalMesh::WedgeIndex { 0 }, getAttribName( VERTEX_NORMAL ), Vector3( 0, 0, 0 ) );
         auto newMeshModified = topologicalMesh.toTriangleMesh();
 
         REQUIRE( isSameMesh( mesh, newMesh ) );


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature : change the way standard attrib names are stored. Move from Engine side to Core side.


* **What is the current behavior?** (You can also link to an open issue here)
The attribute name is set by hand in the source code on core side, instead of using engine def.

For example : 
```cpp
 static const std::string colorAttribName( "in_color" );
```


* **What is the new behavior (if this is a feature change)?**
Use const array of attrib names in the Core side

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Use array according of the attribute enumeration.
The previous function getAttribName was moved from Engine to Core by this PR.

Update your code, any
```cpp
Ra::Engine::Mesh::getAttribName( Ra::Engine::Mesh::VERTEX_TEXCOORD )
```
becomes
```cpp
Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_TEXCOORD )
```

* **Other information**:
