### PR TITLE
Use m_vertexAttrib instead of deprecated attributes

### DIFF
--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -14,8 +14,7 @@ GeometryData::GeometryData( const std::string& name, const GeometryType& type ) 
     m_edge(),
     m_faces(),
     m_polyhedron(),
-    m_normal(),
-    m_tangent(),
+    m_vertexAttribs(),
     m_bitangent(),
     m_texCoord(),
     m_material() {}
@@ -51,14 +50,15 @@ void GeometryData::displayInfo() const {
         type = "HEX MESH";
         break;
     }
+
     LOG( logINFO ) << "======== MESH INFO ========";
     LOG( logINFO ) << " Name           : " << m_name;
     LOG( logINFO ) << " Type           : " << type;
     LOG( logINFO ) << " Vertex #       : " << m_vertex.size();
     LOG( logINFO ) << " Edge #         : " << m_edge.size();
     LOG( logINFO ) << " Face #         : " << m_faces.size();
-    LOG( logINFO ) << " Normal ?       : " << ( ( m_normal.empty() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Tangent ?      : " << ( ( m_tangent.empty() ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Normal ?       : " << ( ( getNormals().empty() ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Tangent ?      : " << ( ( getTangents().empty() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Bitangent ?    : " << ( ( m_bitangent.empty() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Tex.Coord. ?   : " << ( ( m_texCoord.empty() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Material ?     : " << ( ( !hasMaterial() ) ? "NO" : "YES" );

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -15,8 +15,6 @@ GeometryData::GeometryData( const std::string& name, const GeometryType& type ) 
     m_faces(),
     m_polyhedron(),
     m_vertexAttribs(),
-    m_bitangent(),
-    m_texCoord(),
     m_material() {}
 
 GeometryData::~GeometryData() {}
@@ -59,8 +57,8 @@ void GeometryData::displayInfo() const {
     LOG( logINFO ) << " Face #         : " << m_faces.size();
     LOG( logINFO ) << " Normal ?       : " << ( ( getNormals().empty() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Tangent ?      : " << ( ( getTangents().empty() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Bitangent ?    : " << ( ( m_bitangent.empty() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Tex.Coord. ?   : " << ( ( m_texCoord.empty() ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Bitangent ?    : " << ( ( getBiTangents().empty() ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Tex.Coord. ?   : " << ( ( getTexCoords().empty() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Material ?     : " << ( ( !hasMaterial() ) ? "NO" : "YES" );
 
     if ( hasMaterial() ) { m_material->displayInfo(); }

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -10,7 +10,6 @@ GeometryData::GeometryData( const std::string& name, const GeometryType& type ) 
     AssetData( name ),
     m_frame( Transform::Identity() ),
     m_type( type ),
-    m_vertex(),
     m_edge(),
     m_faces(),
     m_polyhedron(),
@@ -52,13 +51,13 @@ void GeometryData::displayInfo() const {
     LOG( logINFO ) << "======== MESH INFO ========";
     LOG( logINFO ) << " Name           : " << m_name;
     LOG( logINFO ) << " Type           : " << type;
-    LOG( logINFO ) << " Vertex #       : " << m_vertex.size();
+    LOG( logINFO ) << " Vertex #       : " << getVerticesSize();
     LOG( logINFO ) << " Edge #         : " << m_edge.size();
     LOG( logINFO ) << " Face #         : " << m_faces.size();
-    LOG( logINFO ) << " Normal ?       : " << ( ( getNormals().empty() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Tangent ?      : " << ( ( getTangents().empty() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Bitangent ?    : " << ( ( getBiTangents().empty() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Tex.Coord. ?   : " << ( ( getTexCoords().empty() ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Normal ?       : " << ( ( !hasAttribData( "normal" ) ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Tangent ?      : " << ( ( !hasAttribData( "tangent" ) ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Bitangent ?    : " << ( ( !hasAttribData( "biTangent" ) ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Tex.Coord. ?   : " << ( ( !hasAttribData( "texCoord" ) ) ? "NO" : "YES" );
     LOG( logINFO ) << " Material ?     : " << ( ( !hasMaterial() ) ? "NO" : "YES" );
 
     if ( hasMaterial() ) { m_material->displayInfo(); }

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -273,6 +273,8 @@ class RA_CORE_API GeometryData : public AssetData
 
     template <typename Container>
     inline void setVertexAttrib( std::string vertexAttribName, const Container& vertexAttribList );
+
+    inline bool hasVertexAttrib( std::string vertexAttribName ) const;
 };
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -125,7 +125,8 @@ class RA_CORE_API GeometryData : public AssetData
     template <typename Container>
     inline void setPolyhedra( const Container& polyList );
 
-    /// Return the list of vertex normals
+    /// Return the list of vertex normals.
+    /// \note This list must be unlock.
     inline Vector3Array& getNormals();
 
     /// Return the list of vertex normals.
@@ -257,11 +258,15 @@ class RA_CORE_API GeometryData : public AssetData
     /// The list of polyhedra
     VectorNuArray m_polyhedron;
 
+    /// Named attributes
+    /// \todo Move all built-in attributes to m_vertexAttribs
+    Utils::AttribManager m_vertexAttribs;
+
     /// The list of vertex normals.
-    [[deprecated]] Vector3Array m_normal;
+    //[[deprecated]] Vector3Array m_normal;
 
     /// The list of vertex tangent vectors.
-    [[deprecated]] Vector3Array m_tangent;
+    //[[deprecated]] Vector3Array m_tangent;
 
     /// The list of vertex bitangent vectors.
     [[deprecated]] Vector3Array m_bitangent;
@@ -271,10 +276,6 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;
-
-    /// Named attributes
-    /// \todo Move all built-in attributes to m_vertexAttribs
-    Utils::AttribManager m_vertexAttribs;
 };
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -318,9 +318,6 @@ class RA_CORE_API GeometryData : public AssetData
     /// The type of geometry for the object.
     GeometryType m_type;
 
-    /// The list of vertices.
-    Vector3Array m_vertex;
-
     /// The list of lines.
     Vector2uArray m_edge;
 

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -263,14 +263,14 @@ class RA_CORE_API GeometryData : public AssetData
      * done call attribDataUnlock( std :: std::string name )
      */
     template <typename Container>
-    inline Container& getAttribDataWithLock( std::string name );
+    inline Container& getAttribDataWithLock( const std::string& name );
 
     /**
      *
      * @param name
      * @brief Unlock data base on name.
      */
-    inline void attribDataUnlock( std::string name );
+    inline void attribDataUnlock( const std::string& name );
 
     /**
      *
@@ -280,7 +280,7 @@ class RA_CORE_API GeometryData : public AssetData
      * @warning There is no check on the handle validity (obtained by using name)
      */
     template <typename Container>
-    inline const Container& getAttribData( std::string name ) const;
+    inline const Container& getAttribData( const std::string& name ) const;
 
     /**
      *
@@ -292,7 +292,7 @@ class RA_CORE_API GeometryData : public AssetData
      *
      */
     template <typename Container>
-    inline void setAttribData( std::string name, const Container& attribDataList );
+    inline void setAttribData( const std::string& name, const Container& attribDataList );
 
     /**
      *
@@ -300,7 +300,7 @@ class RA_CORE_API GeometryData : public AssetData
      * @return true if the name provided correspond to an existing attribHandle.
      *
      */
-    inline bool hasAttribData( std::string name ) const;
+    inline bool hasAttribData( const std::string& name ) const;
 
     /// Print stast info to the Debug output.
     void displayInfo() const;

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -268,12 +268,45 @@ class RA_CORE_API GeometryData : public AssetData
     std::shared_ptr<MaterialData> m_material;
 
   private:
-    inline Vector3Array& getVertexAttrib( std::string vertexAttribName );
-    inline const Vector3Array& getVertexAttrib( std::string vertexAttribName ) const;
+    /**
+     *
+     * @tparam Container
+     * @param vertexAttribName
+     * @return Get container base on the given name.
+     * @warning If AttribHandle corresponding to vertexAttribName doesn't exist, it's created
+     * and return. User must use hasVertexAttrib to verify it.
+     */
+    template <typename Container>
+    inline Container& getVertexAttrib( std::string vertexAttribName );
 
+    /**
+     *
+     * @tparam Container
+     * @param vertexAttribName
+     * @return Get container base on the given name (const).
+     * @warning There is no check on the handle validity (obtained by using vertexAttribName)
+     */
+    template <typename Container>
+    inline const Container& getVertexAttrib( std::string vertexAttribName ) const;
+
+    /**
+     *
+     * @tparam Container
+     * @param vertexAttribName
+     * @param vertexAttribList
+     * @note Copy data from vertexAttribList into the attrib obtain with vertexAttribName.
+     *
+     */
     template <typename Container>
     inline void setVertexAttrib( std::string vertexAttribName, const Container& vertexAttribList );
 
+    /**
+     *
+     * @param vertexAttribName
+     * @return true if vertexAttribName provided correspond to an existing attribHandle else it
+     * return false.
+     *
+     */
     inline bool hasVertexAttrib( std::string vertexAttribName ) const;
 };
 

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -24,6 +24,8 @@ class MaterialData;
  */
 class RA_CORE_API GeometryData : public AssetData
 {
+    typedef Utils::Attrib<Eigen::Matrix<Scalar, 3, 1>>* AttribPtr;
+    AttribPtr attribPtr;
 
   public:
     using ColorArray = Vector4Array;
@@ -126,8 +128,11 @@ class RA_CORE_API GeometryData : public AssetData
     inline void setPolyhedra( const Container& polyList );
 
     /// Return the list of vertex normals.
-    /// \note This list must be unlock.
+    /// \note This list must be unlock by calling unlockData.
     inline Vector3Array& getNormals();
+
+    /// Unlock data and set to nullptr pointer associated to it
+    inline void unlockData();
 
     /// Return the list of vertex normals.
     inline const Vector3Array& getNormals() const;
@@ -261,18 +266,6 @@ class RA_CORE_API GeometryData : public AssetData
     /// Named attributes
     /// \todo Move all built-in attributes to m_vertexAttribs
     Utils::AttribManager m_vertexAttribs;
-
-    /// The list of vertex normals.
-    //[[deprecated]] Vector3Array m_normal;
-
-    /// The list of vertex tangent vectors.
-    //[[deprecated]] Vector3Array m_tangent;
-
-    /// The list of vertex bitangent vectors.
-    [[deprecated]] Vector3Array m_bitangent;
-
-    /// The list of vertex texture coordinates.
-    [[deprecated]] Vector3Array m_texCoord;
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -24,9 +24,6 @@ class MaterialData;
  */
 class RA_CORE_API GeometryData : public AssetData
 {
-    typedef Utils::Attrib<Eigen::Matrix<Scalar, 3, 1>>* AttribPtr;
-    AttribPtr attribPtr;
-
   public:
     using ColorArray = Vector4Array;
 
@@ -269,6 +266,13 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;
+
+  private:
+    inline Vector3Array& getVertexAttrib( std::string vertexAttribName );
+    inline const Vector3Array& getVertexAttrib( std::string vertexAttribName ) const;
+
+    template <typename Container>
+    inline void setVertexAttrib( std::string vertexAttribName, const Container& vertexAttribList );
 };
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -72,15 +72,19 @@ class RA_CORE_API GeometryData : public AssetData
     inline std::size_t getVerticesSize() const;
 
     /// Return the list of vertices.
-    inline Vector3Array& getVertices();
+    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    getVertices();
 
     /// Return the list of vertices.
-    inline const Vector3Array& getVertices() const;
+    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
+    getVertices() const;
 
     /// Set the mesh vertices.
     /// \note In-place setting with getVertices() is preferred.
     template <typename Container>
-    inline void setVertices( const Container& vertexList );
+    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+                  "instead." )]] inline void
+    setVertices( const Container& vertexList );
 
     /// Return the list of lines.
     /// \note For line meshes only.
@@ -125,52 +129,64 @@ class RA_CORE_API GeometryData : public AssetData
     inline void setPolyhedra( const Container& polyList );
 
     /// Return the list of vertex normals.
-    /// \note This list must be unlock by calling unlockData.
-    inline Vector3Array& getNormals();
-
-    /// Unlock data and set to nullptr pointer associated to it
-    inline void unlockData();
+    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    getNormals();
 
     /// Return the list of vertex normals.
-    inline const Vector3Array& getNormals() const;
+    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
+    getNormals() const;
 
     /// Set the vertex normals.
     /// \note In-place setting with getNormals() is preferred.
     template <typename Container>
-    inline void setNormals( const Container& normalList );
+    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+                  "instead." )]] inline void
+    setNormals( const Container& normalList );
 
     /// Return the list of vertex tangent vectors.
-    inline Vector3Array& getTangents();
+    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    getTangents();
 
     /// Return the list of vertex tangent vectors.
-    inline const Vector3Array& getTangents() const;
+    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
+    getTangents() const;
 
     /// Set the vertex tangent vectors.
     /// \note In-place setting with getTangents() is preferred.
     template <typename Container>
-    inline void setTangents( const Container& tangentList );
+    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+                  "instead." )]] inline void
+    setTangents( const Container& tangentList );
 
     /// Return the list of vertex bitangent vectors.
-    inline Vector3Array& getBiTangents();
+    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    getBiTangents();
 
     /// Return the list of vertex bitangent vectors.
-    inline const Vector3Array& getBiTangents() const;
+    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
+    getBiTangents() const;
 
     /// Set the vertex bitangent vectors.
     /// \note In-place setting with getBiTangents() is preferred.
     template <typename Container>
-    inline void setBitangents( const Container& bitangentList );
+    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+                  "instead." )]] inline void
+    setBitangents( const Container& bitangentList );
 
     /// Return the list of vertex texture coordinates.
-    inline Vector3Array& getTexCoords();
+    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    getTexCoords();
 
     /// Return the list of vertex texture coordinates.
-    inline const Vector3Array& getTexCoords() const;
+    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
+    getTexCoords() const;
 
     /// Set the vertex texture coordinates.
     /// \note In-place setting with getTexCoords() is preferred.
     template <typename Container>
-    inline void setTextureCoordinates( const Container& texCoordList );
+    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+                  "instead." )]] inline void
+    setTextureCoordinates( const Container& texCoordList );
 
     /// Return the MaterialData associated to the objet.
     inline const MaterialData& getMaterial() const;
@@ -205,7 +221,8 @@ class RA_CORE_API GeometryData : public AssetData
     inline bool isHexMesh() const;
 
     /// Return true if the object has vertices.
-    inline bool hasVertices() const;
+    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
+    hasVertices() const;
 
     /// Return true if the object has lines.
     inline bool hasEdges() const;
@@ -217,20 +234,73 @@ class RA_CORE_API GeometryData : public AssetData
     inline bool hasPolyhedra() const;
 
     /// Return true if the object has vertex normals.
-    inline bool hasNormals() const;
+    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
+    hasNormals() const;
 
     /// Return true if the object has vertex tangent vectors.
-    inline bool hasTangents() const;
+    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
+    hasTangents() const;
 
     /// Return true if the object has vertex bitangent vectors.
-    inline bool hasBiTangents() const;
+    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
+    hasBiTangents() const;
 
     /// Return true if the object has vertex texture coordinates.
-    inline bool hasTextureCoordinates() const;
+    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
+    hasTextureCoordinates() const;
 
     /// Return true if the object has MaterialData.
     inline bool hasMaterial() const;
     /// \}
+
+    /**
+     *
+     * @tparam Container
+     * @param name
+     * @return Get container base on name (lock).
+     * @warning If AttribHandle corresponding to name doesn't exist, it's created
+     * and return. By using this method, user has read-write access to data, data is lock, when
+     * done call attribDataUnlock( std :: std::string name )
+     */
+    template <typename Container>
+    inline Container& getAttribDataWithLock( std::string name );
+
+    /**
+     *
+     * @param name
+     * @brief Unlock data base on name.
+     */
+    inline void attribDataUnlock( std::string name );
+
+    /**
+     *
+     * @tparam Container
+     * @param name
+     * @return Get container base on the given name (const).
+     * @warning There is no check on the handle validity (obtained by using name)
+     */
+    template <typename Container>
+    inline const Container& getAttribData( std::string name ) const;
+
+    /**
+     *
+     * @tparam Container
+     * @param name
+     * @param attribDataList
+     * @brief Copy data from attribDataList into the attrib obtain with name.
+     * @note In-place setting with getAttribDataWithLock( std::string name ) is preferred.
+     *
+     */
+    template <typename Container>
+    inline void setAttribData( std::string name, const Container& attribDataList );
+
+    /**
+     *
+     * @param name
+     * @return true if the name provided correspond to an existing attribHandle.
+     *
+     */
+    inline bool hasAttribData( std::string name ) const;
 
     /// Print stast info to the Debug output.
     void displayInfo() const;
@@ -266,48 +336,6 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;
-
-  private:
-    /**
-     *
-     * @tparam Container
-     * @param vertexAttribName
-     * @return Get container base on the given name.
-     * @warning If AttribHandle corresponding to vertexAttribName doesn't exist, it's created
-     * and return. User must use hasVertexAttrib to verify it.
-     */
-    template <typename Container>
-    inline Container& getVertexAttrib( std::string vertexAttribName );
-
-    /**
-     *
-     * @tparam Container
-     * @param vertexAttribName
-     * @return Get container base on the given name (const).
-     * @warning There is no check on the handle validity (obtained by using vertexAttribName)
-     */
-    template <typename Container>
-    inline const Container& getVertexAttrib( std::string vertexAttribName ) const;
-
-    /**
-     *
-     * @tparam Container
-     * @param vertexAttribName
-     * @param vertexAttribList
-     * @note Copy data from vertexAttribList into the attrib obtain with vertexAttribName.
-     *
-     */
-    template <typename Container>
-    inline void setVertexAttrib( std::string vertexAttribName, const Container& vertexAttribList );
-
-    /**
-     *
-     * @param vertexAttribName
-     * @return true if vertexAttribName provided correspond to an existing attribHandle else it
-     * return false.
-     *
-     */
-    inline bool hasVertexAttrib( std::string vertexAttribName ) const;
 };
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -232,7 +232,7 @@ Utils::AttribManager& GeometryData::getAttribManager() {
 }
 
 template <typename Container>
-inline Container& GeometryData::getAttribDataWithLock( std::string name ) {
+inline Container& GeometryData::getAttribDataWithLock( const std::string& name ) {
     auto h = m_vertexAttribs.findAttrib<Vector3>( name );
     if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( name ); }
     auto attribPtr = m_vertexAttribs.getAttribPtr( h );
@@ -241,26 +241,27 @@ inline Container& GeometryData::getAttribDataWithLock( std::string name ) {
 }
 
 template <typename Container>
-inline const Container& GeometryData::getAttribData( std::string name ) const {
+inline const Container& GeometryData::getAttribData( const std::string& name ) const {
     auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( name );
     const auto& v     = m_vertexAttribs.getAttrib( attriHandler ).data();
     return v;
 }
 
 template <typename Container>
-inline void GeometryData::setAttribData( std::string name, const Container& attribDataList ) {
+inline void GeometryData::setAttribData( const std::string& name,
+                                         const Container& attribDataList ) {
     auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( name ) );
     auto& v      = attrib.getDataWithLock();
     internal::copyData( attribDataList, v );
     attrib.unlock();
 }
-bool GeometryData::hasAttribData( std::string name ) const {
+bool GeometryData::hasAttribData( const std::string& name ) const {
     auto h = m_vertexAttribs.findAttrib<Vector3>( name );
     if ( m_vertexAttribs.isValid( h ) ) { return !m_vertexAttribs.getAttrib( h ).data().empty(); }
     return false;
 }
 
-void GeometryData::attribDataUnlock( std::string name ) {
+void GeometryData::attribDataUnlock( const std::string& name ) {
     auto h = m_vertexAttribs.findAttrib<Vector3>( name );
     if ( m_vertexAttribs.isValid( h ) ) {
         auto attribPtr = m_vertexAttribs.getAttribPtr( h );

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -32,11 +32,11 @@ inline std::size_t GeometryData::getVerticesSize() const {
 }
 
 inline const Vector3Array& GeometryData::getVertices() const {
-    return m_vertex;
+    return getVertexAttrib( "vertex" );
 }
 
 inline Vector3Array& GeometryData::getVertices() {
-    return m_vertex;
+    return getVertexAttrib( "vertex" );
 }
 
 namespace internal {
@@ -57,7 +57,7 @@ inline void copyData( const InContainer& input, OutContainer& output ) {
 
 template <typename Container>
 inline void GeometryData::setVertices( const Container& vertexList ) {
-    internal::copyData( vertexList, m_vertex );
+    return setVertexAttrib( "vertex", vertexList );
 }
 
 inline Vector2uArray& GeometryData::getEdges() {
@@ -100,100 +100,55 @@ inline void GeometryData::setPolyhedra( const Container& polyList ) {
 }
 
 inline Vector3Array& GeometryData::getNormals() {
-    auto h = m_vertexAttribs.findAttrib<Vector3>( "normal" );
-    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "normal" ); }
-    auto& attrib = m_vertexAttribs.getAttrib( h );
-    auto& normal = attrib.getDataWithLock();
-    attribPtr    = &attrib;
-    return normal;
-}
-
-inline void GeometryData::unlockData() {
-    attribPtr->unlock();
-    attribPtr = nullptr;
+    return getVertexAttrib( "normal" );
 }
 
 inline const Vector3Array& GeometryData::getNormals() const {
-    auto handler = m_vertexAttribs.findAttrib<Vector3>( "normal" );
-    auto& normal = m_vertexAttribs.getAttrib( handler ).data();
-    return normal;
+    return getVertexAttrib( "normal" );
 }
 
 template <typename Container>
 inline void GeometryData::setNormals( const Container& normalList ) {
-    auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) );
-    auto& normal = attrib.getDataWithLock();
-    internal::copyData( normalList, normal );
-    attrib.unlock();
+    return setVertexAttrib( "normal", normalList );
 }
 
 inline Vector3Array& GeometryData::getTangents() {
-    auto h = m_vertexAttribs.findAttrib<Vector3>( "tangent" );
-    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "tangent" ); }
-    auto& attrib  = m_vertexAttribs.getAttrib( h );
-    auto& tangent = attrib.getDataWithLock();
-    attribPtr     = &attrib;
-    return tangent;
+    return getVertexAttrib( "tangent" );
 }
 
 inline const Vector3Array& GeometryData::getTangents() const {
-    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( "tangent" );
-    auto& tangent     = m_vertexAttribs.getAttrib( attriHandler ).data();
-    return tangent;
+    return getVertexAttrib( "tangent" );
 }
 
 template <typename Container>
 inline void GeometryData::setTangents( const Container& tangentList ) {
-    auto& attrib  = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) );
-    auto& tangent = attrib.getDataWithLock();
-    internal::copyData( tangentList, tangent );
-    attrib.unlock();
+    return setVertexAttrib( "tangent", tangentList );
 }
 
 inline Vector3Array& GeometryData::getBiTangents() {
-    auto h = m_vertexAttribs.findAttrib<Vector3>( "biTangent" );
-    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "biTangent" ); }
-    auto& attrib    = m_vertexAttribs.getAttrib( h );
-    auto& biTangent = attrib.getDataWithLock();
-    attribPtr       = &attrib;
-    return biTangent;
+    return getVertexAttrib( "biTangent" );
 }
 
 inline const Vector3Array& GeometryData::getBiTangents() const {
-    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( "biTangent" );
-    auto& biTangent   = m_vertexAttribs.getAttrib( attriHandler ).data();
-    return biTangent;
+    return getVertexAttrib( "biTangent" );
 }
 
 template <typename Container>
 inline void GeometryData::setBitangents( const Container& bitangentList ) {
-    auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "biTangent" ) );
-    auto& biTangent = attrib.getDataWithLock();
-    internal::copyData( bitangentList, biTangent );
-    attrib.unlock();
+    return setVertexAttrib( "biTangent", bitangentList );
 }
 
 inline Vector3Array& GeometryData::getTexCoords() {
-    auto h = m_vertexAttribs.findAttrib<Vector3>( "texCoord" );
-    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "texCoord" ); }
-    auto& attrib   = m_vertexAttribs.getAttrib( h );
-    auto& texCoord = attrib.getDataWithLock();
-    attribPtr      = &attrib;
-    return texCoord;
+    return getVertexAttrib( "texCoord" );
 }
 
 inline const Vector3Array& GeometryData::getTexCoords() const {
-    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( "texCoord" );
-    auto& texCoord    = m_vertexAttribs.getAttrib( attriHandler ).data();
-    return texCoord;
+    return getVertexAttrib( "texCoord" );
 }
 
 template <typename Container>
 inline void GeometryData::setTextureCoordinates( const Container& texCoordList ) {
-    auto& attrib   = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "texCoord" ) );
-    auto& texCoord = attrib.getDataWithLock();
-    internal::copyData( texCoordList, texCoord );
-    attrib.unlock();
+    return setVertexAttrib( "texCoord", texCoordList );
 }
 
 inline const MaterialData& GeometryData::getMaterial() const {
@@ -282,6 +237,33 @@ const Utils::AttribManager& GeometryData::getAttribManager() const {
 
 Utils::AttribManager& GeometryData::getAttribManager() {
     return m_vertexAttribs;
+}
+
+inline Vector3Array& GeometryData::getVertexAttrib( std::string vertexAttribName ) {
+    auto h = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
+    if ( !m_vertexAttribs.isValid( h ) ) {
+        h = m_vertexAttribs.addAttrib<Vector3>( vertexAttribName );
+    }
+    auto attribPtr = m_vertexAttribs.getAttribPtr( h );
+    if ( attribPtr->isLocked() ) { attribPtr->unlock(); }
+    auto& v = attribPtr->getDataWithLock();
+    return v;
+}
+
+inline const Vector3Array& GeometryData::getVertexAttrib( std::string vertexAttribName ) const {
+    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
+    auto& v           = m_vertexAttribs.getAttrib( attriHandler ).data();
+    return v;
+}
+
+template <typename Container>
+inline void GeometryData::setVertexAttrib( std::string vertexAttribName,
+                                           const Container& vertexAttribList ) {
+    auto& attrib =
+        m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( vertexAttribName ) );
+    auto& v = attrib.getDataWithLock();
+    internal::copyData( vertexAttribList, v );
+    attrib.unlock();
 }
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -99,30 +99,46 @@ inline void GeometryData::setPolyhedra( const Container& polyList ) {
     internal::copyData( polyList, m_polyhedron );
 }
 
+// TODO : add a shared_point or kind of to unlock attrib
 inline Vector3Array& GeometryData::getNormals() {
-    return m_normal;
+    auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) );
+    auto& normal = attrib.getDataWithLock();
+    return normal;
 }
 
 inline const Vector3Array& GeometryData::getNormals() const {
-    return m_normal;
+    auto handler = m_vertexAttribs.findAttrib<Vector3>( "normal" );
+    auto& normal = m_vertexAttribs.getAttrib( handler ).data();
+    return normal;
 }
 
 template <typename Container>
 inline void GeometryData::setNormals( const Container& normalList ) {
-    internal::copyData( normalList, m_normal );
+    auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) );
+    auto& normal = attrib.getDataWithLock();
+    internal::copyData( normalList, normal );
+    attrib.unlock();
 }
 
+// TODO : add a shared_point or kind of to unlock attrib
 inline Vector3Array& GeometryData::getTangents() {
-    return m_tangent;
+    auto& tangent = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "tangent" ) )
+                        .getDataWithLock();
+    return tangent;
 }
 
 inline const Vector3Array& GeometryData::getTangents() const {
-    return m_tangent;
+    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( "tangent" );
+    auto& tangent     = m_vertexAttribs.getAttrib( attriHandler ).data();
+    return tangent;
 }
 
 template <typename Container>
 inline void GeometryData::setTangents( const Container& tangentList ) {
-    internal::copyData( tangentList, m_tangent );
+    auto& attrib  = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) );
+    auto& tangent = attrib.getDataWithLock();
+    internal::copyData( tangentList, tangent );
+    attrib.unlock();
 }
 
 inline Vector3Array& GeometryData::getBiTangents() {
@@ -204,11 +220,15 @@ inline bool GeometryData::hasPolyhedra() const {
 }
 
 inline bool GeometryData::hasNormals() const {
-    return !m_normal.empty();
+    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) )
+                .data()
+                .empty();
 }
 
 inline bool GeometryData::hasTangents() const {
-    return !m_tangent.empty();
+    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "tangent" ) )
+                .data()
+                .empty();
 }
 
 inline bool GeometryData::hasBiTangents() const {

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -28,15 +28,15 @@ inline void GeometryData::setFrame( const Transform& frame ) {
 }
 
 inline std::size_t GeometryData::getVerticesSize() const {
-    return m_vertex.size();
+    return getAttribData<Vector3Array&>( "vertex" ).size();
 }
 
 inline const Vector3Array& GeometryData::getVertices() const {
-    return getVertexAttrib<Vector3Array&>( "vertex" );
+    return getAttribData<Vector3Array&>( "vertex" );
 }
 
 inline Vector3Array& GeometryData::getVertices() {
-    return getVertexAttrib<Vector3Array&>( "vertex" );
+    return getAttribDataWithLock<Vector3Array&>( "vertex" );
 }
 
 namespace internal {
@@ -57,7 +57,7 @@ inline void copyData( const InContainer& input, OutContainer& output ) {
 
 template <typename Container>
 inline void GeometryData::setVertices( const Container& vertexList ) {
-    return setVertexAttrib( "vertex", vertexList );
+    return setAttribData( "vertex", vertexList );
 }
 
 inline Vector2uArray& GeometryData::getEdges() {
@@ -100,55 +100,55 @@ inline void GeometryData::setPolyhedra( const Container& polyList ) {
 }
 
 inline Vector3Array& GeometryData::getNormals() {
-    return getVertexAttrib<Vector3Array&>( "normal" );
+    return getAttribDataWithLock<Vector3Array&>( "normal" );
 }
 
 inline const Vector3Array& GeometryData::getNormals() const {
-    return getVertexAttrib<Vector3Array&>( "normal" );
+    return getAttribData<Vector3Array&>( "normal" );
 }
 
 template <typename Container>
 inline void GeometryData::setNormals( const Container& normalList ) {
-    return setVertexAttrib( "normal", normalList );
+    return setAttribData( "normal", normalList );
 }
 
 inline Vector3Array& GeometryData::getTangents() {
-    return getVertexAttrib<Vector3Array&>( "tangent" );
+    return getAttribDataWithLock<Vector3Array&>( "tangent" );
 }
 
 inline const Vector3Array& GeometryData::getTangents() const {
-    return getVertexAttrib<Vector3Array&>( "tangent" );
+    return getAttribData<Vector3Array&>( "tangent" );
 }
 
 template <typename Container>
 inline void GeometryData::setTangents( const Container& tangentList ) {
-    return setVertexAttrib( "tangent", tangentList );
+    return setAttribData( "tangent", tangentList );
 }
 
 inline Vector3Array& GeometryData::getBiTangents() {
-    return getVertexAttrib<Vector3Array&>( "biTangent" );
+    return getAttribDataWithLock<Vector3Array&>( "biTangent" );
 }
 
 inline const Vector3Array& GeometryData::getBiTangents() const {
-    return getVertexAttrib<Vector3Array&>( "biTangent" );
+    return getAttribData<Vector3Array&>( "biTangent" );
 }
 
 template <typename Container>
 inline void GeometryData::setBitangents( const Container& bitangentList ) {
-    return setVertexAttrib( "biTangent", bitangentList );
+    return setAttribData( "biTangent", bitangentList );
 }
 
 inline Vector3Array& GeometryData::getTexCoords() {
-    return getVertexAttrib<Vector3Array&>( "texCoord" );
+    return getAttribDataWithLock<Vector3Array&>( "texCoord" );
 }
 
 inline const Vector3Array& GeometryData::getTexCoords() const {
-    return getVertexAttrib<Vector3Array&>( "texCoord" );
+    return getAttribData<Vector3Array&>( "texCoord" );
 }
 
 template <typename Container>
 inline void GeometryData::setTextureCoordinates( const Container& texCoordList ) {
-    return setVertexAttrib( "texCoord", texCoordList );
+    return setAttribData( "texCoord", texCoordList );
 }
 
 inline const MaterialData& GeometryData::getMaterial() const {
@@ -188,7 +188,7 @@ inline bool GeometryData::isHexMesh() const {
 }
 
 inline bool GeometryData::hasVertices() const {
-    return hasVertexAttrib( "vertex" );
+    return hasAttribData( "vertex" );
 }
 
 inline bool GeometryData::hasEdges() const {
@@ -204,19 +204,19 @@ inline bool GeometryData::hasPolyhedra() const {
 }
 
 inline bool GeometryData::hasNormals() const {
-    return hasVertexAttrib( "normal" );
+    return hasAttribData( "normal" );
 }
 
 inline bool GeometryData::hasTangents() const {
-    return hasVertexAttrib( "tangent" );
+    return hasAttribData( "tangent" );
 }
 
 inline bool GeometryData::hasBiTangents() const {
-    return hasVertexAttrib( "biTangent" );
+    return hasAttribData( "biTangent" );
 }
 
 inline bool GeometryData::hasTextureCoordinates() const {
-    return hasVertexAttrib( "texCoord" );
+    return hasAttribData( "texCoord" );
 }
 
 inline bool GeometryData::hasMaterial() const {
@@ -232,37 +232,40 @@ Utils::AttribManager& GeometryData::getAttribManager() {
 }
 
 template <typename Container>
-inline Container& GeometryData::getVertexAttrib( std::string vertexAttribName ) {
-    auto h = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
-    if ( !m_vertexAttribs.isValid( h ) ) {
-        h = m_vertexAttribs.addAttrib<Vector3>( vertexAttribName );
-    }
+inline Container& GeometryData::getAttribDataWithLock( std::string name ) {
+    auto h = m_vertexAttribs.findAttrib<Vector3>( name );
+    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( name ); }
     auto attribPtr = m_vertexAttribs.getAttribPtr( h );
-    if ( attribPtr->isLocked() ) { attribPtr->unlock(); }
-    auto& v = attribPtr->getDataWithLock();
+    auto& v        = attribPtr->getDataWithLock();
     return v;
 }
 
 template <typename Container>
-inline const Container& GeometryData::getVertexAttrib( std::string vertexAttribName ) const {
-    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
+inline const Container& GeometryData::getAttribData( std::string name ) const {
+    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( name );
     auto& v           = m_vertexAttribs.getAttrib( attriHandler ).data();
     return const_cast<VectorArray<Eigen::Matrix<float, 3, 1, 0>>&>( v );
 }
 
 template <typename Container>
-inline void GeometryData::setVertexAttrib( std::string vertexAttribName,
-                                           const Container& vertexAttribList ) {
-    auto& attrib =
-        m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( vertexAttribName ) );
-    auto& v = attrib.getDataWithLock();
-    internal::copyData( vertexAttribList, v );
+inline void GeometryData::setAttribData( std::string name, const Container& attribDataList ) {
+    auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( name ) );
+    auto& v      = attrib.getDataWithLock();
+    internal::copyData( attribDataList, v );
     attrib.unlock();
 }
-bool GeometryData::hasVertexAttrib( std::string vertexAttribName ) const {
-    auto h = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
+bool GeometryData::hasAttribData( std::string name ) const {
+    auto h = m_vertexAttribs.findAttrib<Vector3>( name );
     if ( m_vertexAttribs.isValid( h ) ) { return !m_vertexAttribs.getAttrib( h ).data().empty(); }
     return false;
+}
+
+void GeometryData::attribDataUnlock( std::string name ) {
+    auto h = m_vertexAttribs.findAttrib<Vector3>( name );
+    if ( m_vertexAttribs.isValid( h ) ) {
+        auto attribPtr = m_vertexAttribs.getAttribPtr( h );
+        if ( attribPtr->isLocked() ) { attribPtr->unlock(); }
+    }
 }
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -32,11 +32,11 @@ inline std::size_t GeometryData::getVerticesSize() const {
 }
 
 inline const Vector3Array& GeometryData::getVertices() const {
-    return getVertexAttrib( "vertex" );
+    return getVertexAttrib<Vector3Array&>( "vertex" );
 }
 
 inline Vector3Array& GeometryData::getVertices() {
-    return getVertexAttrib( "vertex" );
+    return getVertexAttrib<Vector3Array&>( "vertex" );
 }
 
 namespace internal {
@@ -100,11 +100,11 @@ inline void GeometryData::setPolyhedra( const Container& polyList ) {
 }
 
 inline Vector3Array& GeometryData::getNormals() {
-    return getVertexAttrib( "normal" );
+    return getVertexAttrib<Vector3Array&>( "normal" );
 }
 
 inline const Vector3Array& GeometryData::getNormals() const {
-    return getVertexAttrib( "normal" );
+    return getVertexAttrib<Vector3Array&>( "normal" );
 }
 
 template <typename Container>
@@ -113,11 +113,11 @@ inline void GeometryData::setNormals( const Container& normalList ) {
 }
 
 inline Vector3Array& GeometryData::getTangents() {
-    return getVertexAttrib( "tangent" );
+    return getVertexAttrib<Vector3Array&>( "tangent" );
 }
 
 inline const Vector3Array& GeometryData::getTangents() const {
-    return getVertexAttrib( "tangent" );
+    return getVertexAttrib<Vector3Array&>( "tangent" );
 }
 
 template <typename Container>
@@ -126,11 +126,11 @@ inline void GeometryData::setTangents( const Container& tangentList ) {
 }
 
 inline Vector3Array& GeometryData::getBiTangents() {
-    return getVertexAttrib( "biTangent" );
+    return getVertexAttrib<Vector3Array&>( "biTangent" );
 }
 
 inline const Vector3Array& GeometryData::getBiTangents() const {
-    return getVertexAttrib( "biTangent" );
+    return getVertexAttrib<Vector3Array&>( "biTangent" );
 }
 
 template <typename Container>
@@ -139,11 +139,11 @@ inline void GeometryData::setBitangents( const Container& bitangentList ) {
 }
 
 inline Vector3Array& GeometryData::getTexCoords() {
-    return getVertexAttrib( "texCoord" );
+    return getVertexAttrib<Vector3Array&>( "texCoord" );
 }
 
 inline const Vector3Array& GeometryData::getTexCoords() const {
-    return getVertexAttrib( "texCoord" );
+    return getVertexAttrib<Vector3Array&>( "texCoord" );
 }
 
 template <typename Container>
@@ -231,7 +231,8 @@ Utils::AttribManager& GeometryData::getAttribManager() {
     return m_vertexAttribs;
 }
 
-inline Vector3Array& GeometryData::getVertexAttrib( std::string vertexAttribName ) {
+template <typename Container>
+inline Container& GeometryData::getVertexAttrib( std::string vertexAttribName ) {
     auto h = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
     if ( !m_vertexAttribs.isValid( h ) ) {
         h = m_vertexAttribs.addAttrib<Vector3>( vertexAttribName );
@@ -242,10 +243,11 @@ inline Vector3Array& GeometryData::getVertexAttrib( std::string vertexAttribName
     return v;
 }
 
-inline const Vector3Array& GeometryData::getVertexAttrib( std::string vertexAttribName ) const {
+template <typename Container>
+inline const Container& GeometryData::getVertexAttrib( std::string vertexAttribName ) const {
     auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
     auto& v           = m_vertexAttribs.getAttrib( attriHandler ).data();
-    return v;
+    return const_cast<VectorArray<Eigen::Matrix<float, 3, 1, 0>>&>( v );
 }
 
 template <typename Container>

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -99,11 +99,18 @@ inline void GeometryData::setPolyhedra( const Container& polyList ) {
     internal::copyData( polyList, m_polyhedron );
 }
 
-// TODO : add a shared_point or kind of to unlock attrib
 inline Vector3Array& GeometryData::getNormals() {
-    auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) );
+    auto h = m_vertexAttribs.findAttrib<Vector3>( "normal" );
+    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "normal" ); }
+    auto& attrib = m_vertexAttribs.getAttrib( h );
     auto& normal = attrib.getDataWithLock();
+    attribPtr    = &attrib;
     return normal;
+}
+
+inline void GeometryData::unlockData() {
+    attribPtr->unlock();
+    attribPtr = nullptr;
 }
 
 inline const Vector3Array& GeometryData::getNormals() const {
@@ -120,10 +127,12 @@ inline void GeometryData::setNormals( const Container& normalList ) {
     attrib.unlock();
 }
 
-// TODO : add a shared_point or kind of to unlock attrib
 inline Vector3Array& GeometryData::getTangents() {
-    auto& tangent = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "tangent" ) )
-                        .getDataWithLock();
+    auto h = m_vertexAttribs.findAttrib<Vector3>( "tangent" );
+    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "tangent" ); }
+    auto& attrib  = m_vertexAttribs.getAttrib( h );
+    auto& tangent = attrib.getDataWithLock();
+    attribPtr     = &attrib;
     return tangent;
 }
 
@@ -142,29 +151,49 @@ inline void GeometryData::setTangents( const Container& tangentList ) {
 }
 
 inline Vector3Array& GeometryData::getBiTangents() {
-    return m_bitangent;
+    auto h = m_vertexAttribs.findAttrib<Vector3>( "biTangent" );
+    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "biTangent" ); }
+    auto& attrib    = m_vertexAttribs.getAttrib( h );
+    auto& biTangent = attrib.getDataWithLock();
+    attribPtr       = &attrib;
+    return biTangent;
 }
 
 inline const Vector3Array& GeometryData::getBiTangents() const {
-    return m_bitangent;
+    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( "biTangent" );
+    auto& biTangent   = m_vertexAttribs.getAttrib( attriHandler ).data();
+    return biTangent;
 }
 
 template <typename Container>
 inline void GeometryData::setBitangents( const Container& bitangentList ) {
-    internal::copyData( bitangentList, m_bitangent );
+    auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "biTangent" ) );
+    auto& biTangent = attrib.getDataWithLock();
+    internal::copyData( bitangentList, biTangent );
+    attrib.unlock();
 }
 
 inline Vector3Array& GeometryData::getTexCoords() {
-    return m_texCoord;
+    auto h = m_vertexAttribs.findAttrib<Vector3>( "texCoord" );
+    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "texCoord" ); }
+    auto& attrib   = m_vertexAttribs.getAttrib( h );
+    auto& texCoord = attrib.getDataWithLock();
+    attribPtr      = &attrib;
+    return texCoord;
 }
 
 inline const Vector3Array& GeometryData::getTexCoords() const {
-    return m_texCoord;
+    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( "texCoord" );
+    auto& texCoord    = m_vertexAttribs.getAttrib( attriHandler ).data();
+    return texCoord;
 }
 
 template <typename Container>
 inline void GeometryData::setTextureCoordinates( const Container& texCoordList ) {
-    internal::copyData( texCoordList, m_texCoord );
+    auto& attrib   = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "texCoord" ) );
+    auto& texCoord = attrib.getDataWithLock();
+    internal::copyData( texCoordList, texCoord );
+    attrib.unlock();
 }
 
 inline const MaterialData& GeometryData::getMaterial() const {
@@ -232,11 +261,15 @@ inline bool GeometryData::hasTangents() const {
 }
 
 inline bool GeometryData::hasBiTangents() const {
-    return !m_bitangent.empty();
+    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "biTangent" ) )
+                .data()
+                .empty();
 }
 
 inline bool GeometryData::hasTextureCoordinates() const {
-    return !m_texCoord.empty();
+    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "texCoord" ) )
+                .data()
+                .empty();
 }
 
 inline bool GeometryData::hasMaterial() const {

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -188,7 +188,7 @@ inline bool GeometryData::isHexMesh() const {
 }
 
 inline bool GeometryData::hasVertices() const {
-    return !m_vertex.empty();
+    return hasVertexAttrib( "vertex" );
 }
 
 inline bool GeometryData::hasEdges() const {
@@ -204,27 +204,19 @@ inline bool GeometryData::hasPolyhedra() const {
 }
 
 inline bool GeometryData::hasNormals() const {
-    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) )
-                .data()
-                .empty();
+    return hasVertexAttrib( "normal" );
 }
 
 inline bool GeometryData::hasTangents() const {
-    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "tangent" ) )
-                .data()
-                .empty();
+    return hasVertexAttrib( "tangent" );
 }
 
 inline bool GeometryData::hasBiTangents() const {
-    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "biTangent" ) )
-                .data()
-                .empty();
+    return hasVertexAttrib( "biTangent" );
 }
 
 inline bool GeometryData::hasTextureCoordinates() const {
-    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "texCoord" ) )
-                .data()
-                .empty();
+    return hasVertexAttrib( "texCoord" );
 }
 
 inline bool GeometryData::hasMaterial() const {
@@ -264,6 +256,11 @@ inline void GeometryData::setVertexAttrib( std::string vertexAttribName,
     auto& v = attrib.getDataWithLock();
     internal::copyData( vertexAttribList, v );
     attrib.unlock();
+}
+bool GeometryData::hasVertexAttrib( std::string vertexAttribName ) const {
+    auto h = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
+    if ( m_vertexAttribs.isValid( h ) ) { return !m_vertexAttribs.getAttrib( h ).data().empty(); }
+    return false;
 }
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -28,11 +28,11 @@ inline void GeometryData::setFrame( const Transform& frame ) {
 }
 
 inline std::size_t GeometryData::getVerticesSize() const {
-    return getAttribData<Vector3Array&>( "vertex" ).size();
+    return getAttribData<const Vector3Array&>( "vertex" ).size();
 }
 
 inline const Vector3Array& GeometryData::getVertices() const {
-    return getAttribData<Vector3Array&>( "vertex" );
+    return getAttribData<const Vector3Array&>( "vertex" );
 }
 
 inline Vector3Array& GeometryData::getVertices() {
@@ -104,7 +104,7 @@ inline Vector3Array& GeometryData::getNormals() {
 }
 
 inline const Vector3Array& GeometryData::getNormals() const {
-    return getAttribData<Vector3Array&>( "normal" );
+    return getAttribData<const Vector3Array&>( "normal" );
 }
 
 template <typename Container>
@@ -117,7 +117,7 @@ inline Vector3Array& GeometryData::getTangents() {
 }
 
 inline const Vector3Array& GeometryData::getTangents() const {
-    return getAttribData<Vector3Array&>( "tangent" );
+    return getAttribData<const Vector3Array&>( "tangent" );
 }
 
 template <typename Container>
@@ -130,7 +130,7 @@ inline Vector3Array& GeometryData::getBiTangents() {
 }
 
 inline const Vector3Array& GeometryData::getBiTangents() const {
-    return getAttribData<Vector3Array&>( "biTangent" );
+    return getAttribData<const Vector3Array&>( "biTangent" );
 }
 
 template <typename Container>
@@ -143,7 +143,7 @@ inline Vector3Array& GeometryData::getTexCoords() {
 }
 
 inline const Vector3Array& GeometryData::getTexCoords() const {
-    return getAttribData<Vector3Array&>( "texCoord" );
+    return getAttribData<const Vector3Array&>( "texCoord" );
 }
 
 template <typename Container>
@@ -243,8 +243,8 @@ inline Container& GeometryData::getAttribDataWithLock( std::string name ) {
 template <typename Container>
 inline const Container& GeometryData::getAttribData( std::string name ) const {
     auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( name );
-    auto& v           = m_vertexAttribs.getAttrib( attriHandler ).data();
-    return const_cast<VectorArray<Eigen::Matrix<float, 3, 1, 0>>&>( v );
+    const auto& v     = m_vertexAttribs.getAttrib( attriHandler ).data();
+    return v;
 }
 
 template <typename Container>

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -172,13 +172,14 @@ void fetchVectorData( size_t sz,
 */
 void AssimpGeometryDataLoader::fetchVertices( const aiMesh& mesh, GeometryData& data ) {
     const int size = mesh.mNumVertices;
-    auto& vertex   = data.getVertices();
+    auto& vertex   = data.getAttribDataWithLock<Core::Vector3Array&>( "vertex" );
     vertex.resize( mesh.mNumVertices );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         vertex[i] = assimpToCore( mesh.mVertices[i] );
     }
     //    fetchVectorData( mesh.mNumVertices, mesh.mVertices, vertex );
+    data.attribDataUnlock( "vertex" );
 }
 
 void AssimpGeometryDataLoader::fetchEdges( const aiMesh& mesh, GeometryData& data ) const {
@@ -209,45 +210,50 @@ void AssimpGeometryDataLoader::fetchPolyhedron( const aiMesh& mesh, GeometryData
 
 void AssimpGeometryDataLoader::fetchNormals( const aiMesh& mesh, GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    auto& normal   = data.getNormals();
+    auto& normal   = data.getAttribDataWithLock<Core::Vector3Array&>( "normal" );
     normal.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         normal[i] = assimpToCore( mesh.mNormals[i] );
         normal[i].normalize();
     }
+    data.attribDataUnlock( "normal" );
 }
 
 void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    auto& tangent  = data.getTangents();
+    auto& tangent  = data.getAttribDataWithLock<Core::Vector3Array&>( "tangent" );
     tangent.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < int( size ); ++i ) {
         tangent[i] = assimpToCore( mesh.mTangents[i] );
     }
+    data.attribDataUnlock( "tangent" );
 }
 
 void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData& data ) const {
     const int size  = mesh.mNumVertices;
-    auto& bitangent = data.getBiTangents();
+    auto& bitangent = data.getAttribDataWithLock<Core::Vector3Array&>( "biTangent" );
     bitangent.resize( mesh.mNumVertices );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         bitangent[i] = assimpToCore( mesh.mBitangents[i] );
     }
+    data.attribDataUnlock( "biTangent" );
 }
 
 void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
                                                         GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    auto& texcoord = data.getTexCoords();
+    auto& texcoord = data.getAttribDataWithLock<Core::Vector3Array&>( "texCoord" );
+    ;
     texcoord.resize( mesh.mNumVertices );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         // Radium V2 : allow to have several UV channels
         texcoord.at( i ) = assimpToCore( mesh.mTextureCoords[0][i] );
     }
+    data.attribDataUnlock( "texCoord" );
 }
 
 void AssimpGeometryDataLoader::fetchColors( const aiMesh& mesh, GeometryData& data ) const {

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -208,35 +208,26 @@ void AssimpGeometryDataLoader::fetchPolyhedron( const aiMesh& mesh, GeometryData
 }
 
 void AssimpGeometryDataLoader::fetchNormals( const aiMesh& mesh, GeometryData& data ) const {
-    const int size      = mesh.mNumVertices;
-    auto& attribManager = data.getAttribManager();
-    auto handle         = attribManager.addAttrib<Core::Vector3>( "normal" );
-    auto& attrib        = attribManager.getAttrib( handle );
-    auto& normal        = attrib.getDataWithLock();
-
+    const int size = mesh.mNumVertices;
+    auto& normal   = data.getNormals();
     normal.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         normal[i] = assimpToCore( mesh.mNormals[i] );
         normal[i].normalize();
     }
-    attrib.unlock();
+    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    // auto& tangent  = data.getTangents();
-    auto& attribManager = data.getAttribManager();
-    auto handle         = attribManager.addAttrib<Core::Vector3>( "tangent" );
-    auto& attrib        = attribManager.getAttrib( handle );
-    auto& tangent       = attrib.getDataWithLock();
-
+    auto& tangent  = data.getTangents();
     tangent.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < int( size ); ++i ) {
         tangent[i] = assimpToCore( mesh.mTangents[i] );
     }
-    attrib.unlock();
+    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData& data ) const {
@@ -247,6 +238,7 @@ void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData
     for ( int i = 0; i < size; ++i ) {
         bitangent[i] = assimpToCore( mesh.mBitangents[i] );
     }
+    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
@@ -259,6 +251,7 @@ void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
         // Radium V2 : allow to have several UV channels
         texcoord.at( i ) = assimpToCore( mesh.mTextureCoords[0][i] );
     }
+    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchColors( const aiMesh& mesh, GeometryData& data ) const {

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -216,7 +216,6 @@ void AssimpGeometryDataLoader::fetchNormals( const aiMesh& mesh, GeometryData& d
         normal[i] = assimpToCore( mesh.mNormals[i] );
         normal[i].normalize();
     }
-    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& data ) const {
@@ -227,7 +226,6 @@ void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& 
     for ( int i = 0; i < int( size ); ++i ) {
         tangent[i] = assimpToCore( mesh.mTangents[i] );
     }
-    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData& data ) const {
@@ -238,7 +236,6 @@ void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData
     for ( int i = 0; i < size; ++i ) {
         bitangent[i] = assimpToCore( mesh.mBitangents[i] );
     }
-    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
@@ -251,7 +248,6 @@ void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
         // Radium V2 : allow to have several UV channels
         texcoord.at( i ) = assimpToCore( mesh.mTextureCoords[0][i] );
     }
-    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchColors( const aiMesh& mesh, GeometryData& data ) const {

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -208,24 +208,35 @@ void AssimpGeometryDataLoader::fetchPolyhedron( const aiMesh& mesh, GeometryData
 }
 
 void AssimpGeometryDataLoader::fetchNormals( const aiMesh& mesh, GeometryData& data ) const {
-    const int size = mesh.mNumVertices;
-    auto& normal   = data.getNormals();
+    const int size      = mesh.mNumVertices;
+    auto& attribManager = data.getAttribManager();
+    auto handle         = attribManager.addAttrib<Core::Vector3>( "normal" );
+    auto& attrib        = attribManager.getAttrib( handle );
+    auto& normal        = attrib.getDataWithLock();
+
     normal.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         normal[i] = assimpToCore( mesh.mNormals[i] );
         normal[i].normalize();
     }
+    attrib.unlock();
 }
 
 void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    auto& tangent  = data.getTangents();
+    // auto& tangent  = data.getTangents();
+    auto& attribManager = data.getAttribManager();
+    auto handle         = attribManager.addAttrib<Core::Vector3>( "tangent" );
+    auto& attrib        = attribManager.getAttrib( handle );
+    auto& tangent       = attrib.getDataWithLock();
+
     tangent.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < int( size ); ++i ) {
         tangent[i] = assimpToCore( mesh.mTangents[i] );
     }
+    attrib.unlock();
 }
 
 void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData& data ) const {

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
@@ -230,6 +230,7 @@ FileData* TinyPlyFileLoader::loadFile( const std::string& filename ) {
     file.read( *file_stream );
     copyBufferToContainer( vertBuffer, geometry->getVertices() );
     copyBufferToContainer( normalBuffer, geometry->getNormals() );
+    geometry->unlockData();
 
     auto& attribManager = geometry->getAttribManager();
 

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
@@ -230,7 +230,6 @@ FileData* TinyPlyFileLoader::loadFile( const std::string& filename ) {
     file.read( *file_stream );
     copyBufferToContainer( vertBuffer, geometry->getVertices() );
     copyBufferToContainer( normalBuffer, geometry->getNormals() );
-    geometry->unlockData();
 
     auto& attribManager = geometry->getAttribManager();
 

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
@@ -228,7 +228,6 @@ FileData* TinyPlyFileLoader::loadFile( const std::string& filename ) {
 
     // read requested buffers (and only those) from file content
     file.read( *file_stream );
-
     copyBufferToContainer( vertBuffer, geometry->getVertices() );
     copyBufferToContainer( normalBuffer, geometry->getNormals() );
 

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
@@ -228,8 +228,12 @@ FileData* TinyPlyFileLoader::loadFile( const std::string& filename ) {
 
     // read requested buffers (and only those) from file content
     file.read( *file_stream );
-    copyBufferToContainer( vertBuffer, geometry->getVertices() );
-    copyBufferToContainer( normalBuffer, geometry->getNormals() );
+    copyBufferToContainer( vertBuffer,
+                           geometry->getAttribDataWithLock<Core::Vector3Array&>( "vertex" ) );
+    geometry->attribDataUnlock( "vertex" );
+    copyBufferToContainer( normalBuffer,
+                           geometry->getAttribDataWithLock<Core::Vector3Array&>( "normal" ) );
+    geometry->attribDataUnlock( "normal" );
 
     auto& attribManager = geometry->getAttribManager();
 


### PR DESCRIPTION
_Check if you branch history is PR compatible_
- Your branch need to be up to date with origin/master AND to have linear history (i.e. no merge commit).
- Update your git repository `git fetch origin` if origin is this remote
- Check with the script provided in `scripts/is-history-pr-compatible.sh`
- You must use clang-format style
_These checks are enforced by github workflow actions_
_Please refer to the corresponding log in case of failure_

_UPDATE the form below to describe your PR._

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Moving all deprecated attributes (m_normal, m_tangent, m_bitangent, m_texCoord) and m_vertex to m_vertexAttribs (which is an attribManager).


* **What is the current behavior?** (You can also link to an open issue here)
File loaders use deprecated attributes to load data.


* **What is the new behavior (if this is a feature change)?**
Now file loaders use an attribManager (m_vertexAttrib) to store this data instead of deprecated attributes, all tests passed.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
There is no breaking change.
