### PR TITLE
Scoped context

### DIFF
--- a/cmake/filelistGui.cmake
+++ b/cmake/filelistGui.cmake
@@ -74,7 +74,7 @@ set(gui_headers
     Viewer/WindowQt.hpp
 )
 
-set(gui_inlines)
+set(gui_inlines Viewer/WindowQt.inl)
 
 set(gui_uis AboutDialog/AboutDialog.ui SkeletonBasedAnimation/SkeletonBasedAnimationUI.ui
             Timeline/HelpDialog.ui Timeline/Timeline.ui

--- a/src/Gui/Viewer/WindowQt.hpp
+++ b/src/Gui/Viewer/WindowQt.hpp
@@ -118,10 +118,10 @@ class RA_GUI_API WindowQt : public QWindow
     // paintGL done by base app rendering loop
 
   protected:
-    static WindowQt* s_getProcAddressHelper;
     static glbinding::ProcAddress getProcAddress( const char* name );
 
   private:
+    static WindowQt* s_getProcAddressHelper;
     int m_contextActivationCount { 0 };
 };
 

--- a/src/Gui/Viewer/WindowQt.hpp
+++ b/src/Gui/Viewer/WindowQt.hpp
@@ -27,7 +27,7 @@ namespace Gui {
 class RA_GUI_API WindowQt : public QWindow
 {
   private:
-    class ScopedContext;
+    class ScopedGLContext;
 
   public:
     explicit WindowQt( QScreen* screen );
@@ -78,7 +78,7 @@ class RA_GUI_API WindowQt : public QWindow
      * } // block exit will first call tex dtor (with active context) then context dtor.
      * \endcode
      */
-    inline ScopedContext activateScopedContext();
+    inline ScopedGLContext activateScopedContext();
 
     /// \see https://doc.qt.io/qt-5/qglwidget.html#context
     QOpenGLContext* context();

--- a/src/Gui/Viewer/WindowQt.hpp
+++ b/src/Gui/Viewer/WindowQt.hpp
@@ -26,6 +26,9 @@ namespace Gui {
  */
 class RA_GUI_API WindowQt : public QWindow
 {
+  private:
+    class ScopedContext;
+
   public:
     explicit WindowQt( QScreen* screen );
     virtual ~WindowQt();
@@ -44,6 +47,7 @@ class RA_GUI_API WindowQt : public QWindow
      * context has been asked to be activated.
      * If the context have already been made current with a previous call to makeCurrent, this
      * function increase an internal counter by one so that doneCurrent do not release the context.
+     * \see activateScopedContext() as an alternative
      */
     void makeCurrent();
 
@@ -52,9 +56,31 @@ class RA_GUI_API WindowQt : public QWindow
      * This results in no context being current in the current thread.
      * In case a context has been made current multiple times, this function just deacrease the
      * internal counter by one. \see makeCurrent()
+     * \see activateScopedContext() as an alternative
      */
     void doneCurrent();
 
+    /**
+     * Make this->context() the current context for current block.
+     * The context is released when the return variable is destroyed. The "context object" uses
+     * this->makeCurrent() and this->doneCurrent(), hence it's compatible with enclosed scopes, and
+     * only the first created context object dtor eventually release OpenGL context.
+     *
+     * Example
+     *
+     * \code{.cpp} if(test){
+     *    auto context = viewer->activateScopedContext();
+     *     // here OpenGL context is bound
+     *     Texture tex;
+     *     // [...] do tex setup
+     *     tex->initializeGL();
+     *     // [...] use tex ...
+     * } // block exit will first call tex dtor (with active context) then context dtor.
+     * \endcode
+     */
+    inline ScopedContext activateScopedContext();
+
+    /// \see https://doc.qt.io/qt-5/qglwidget.html#context
     QOpenGLContext* context();
 
     // note when updating from globjets
@@ -101,3 +127,5 @@ class RA_GUI_API WindowQt : public QWindow
 
 } // namespace Gui
 } // namespace Ra
+
+#include "WindowQt.inl"

--- a/src/Gui/Viewer/WindowQt.inl
+++ b/src/Gui/Viewer/WindowQt.inl
@@ -4,20 +4,20 @@
 namespace Ra {
 namespace Gui {
 
-class WindowQt::ScopedContext
+class WindowQt::ScopedGLContext
 {
   public:
-    explicit ScopedContext( WindowQt* window ) : m_window( window ) { window->makeCurrent(); }
-    ~ScopedContext() { m_window->doneCurrent(); }
-    ScopedContext( const ScopedContext& ) = delete;
-    ScopedContext& operator=( ScopedContext const& ) = delete;
+    explicit ScopedGLContext( WindowQt* window ) : m_window( window ) { window->makeCurrent(); }
+    ~ScopedGLContext() { m_window->doneCurrent(); }
+    ScopedGLContext( const ScopedGLContext& ) = delete;
+    ScopedGLContext& operator=( ScopedGLContext const& ) = delete;
 
   private:
     WindowQt* m_window;
 };
 
-inline WindowQt::ScopedContext WindowQt::activateScopedContext() {
-    return ScopedContext { this };
+inline WindowQt::ScopedGLContext WindowQt::activateScopedContext() {
+    return ScopedGLContext { this };
 }
 
 } // namespace Gui

--- a/src/Gui/Viewer/WindowQt.inl
+++ b/src/Gui/Viewer/WindowQt.inl
@@ -1,0 +1,24 @@
+#pragma once
+#include <Gui/Viewer/WindowQt.hpp>
+
+namespace Ra {
+namespace Gui {
+
+class WindowQt::ScopedContext
+{
+  public:
+    explicit ScopedContext( WindowQt* window ) : m_window( window ) { window->makeCurrent(); }
+    ~ScopedContext() { m_window->doneCurrent(); }
+    ScopedContext( const ScopedContext& ) = delete;
+    ScopedContext& operator=( ScopedContext const& ) = delete;
+
+  private:
+    WindowQt* m_window;
+};
+
+inline WindowQt::ScopedContext WindowQt::activateScopedContext() {
+    return ScopedContext { this };
+}
+
+} // namespace Gui
+} // namespace Ra


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add scoped context behavior. One can ask WindowQt an OpengGLContext than is bound at variable creation, and unbound when the variable is deleted (end of scope).


* **What is the current behavior?** (You can also link to an open issue here)
Have to manage context activation with makeCurrent and doneCurrent.
In a block, some gl related variable might be deleted on block end, while the doneCurrent have to be called before block end explicitly, see #912 .


* **What is the new behavior (if this is a feature change)?**
Such block binded context are obtained as an ScopedContext object with WindowQt::createScopedContext, ScopedContext ctor calls makeCurrent, while dtor calls doneCurrent. 
Hence the "make current count" is still in use, and multiple ScopedContext can be imbricated without issues.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope, but this new behavior can replace makeCurrent/doneCurrent in a futur PR.


* **Other information**:
Also fix possible segfault on cube texture gpu allocation when no data provided