### PR TITLE
[tests] hot fix make resources available.

### DIFF
--- a/tests/ExampleApps/DrawPrimitivesDemo/CMakeLists.txt
+++ b/tests/ExampleApps/DrawPrimitivesDemo/CMakeLists.txt
@@ -52,6 +52,11 @@ add_executable(
     ${PROJECT_NAME} MACOSX_BUNDLE ${app_sources} ${app_headers} ${app_uis} ${app_resources}
 )
 
+get_target_property(USE_ASSIMP Radium::IO IO_ASSIMP)
+if(${USE_ASSIMP})
+    target_compile_definitions(${PROJECT_NAME} PRIVATE "-DIO_USE_ASSIMP")
+endif()
+
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 target_include_directories(
     ${PROJECT_NAME} PRIVATE ${RADIUM_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR} # Moc
@@ -62,4 +67,6 @@ target_link_libraries(
     ${PROJECT_NAME} PUBLIC Radium::Core Radium::Engine Radium::Gui Radium::IO ${Qt_LIBRARIES}
 )
 
-configure_radium_app(NAME ${PROJECT_NAME})
+configure_radium_app(
+    NAME ${PROJECT_NAME} RESOURCES "${CMAKE_CURRENT_SOURCE_DIR}/Assets" PREFIX "DrawPrimitivesApp"
+)

--- a/tests/ExamplePluginWithLib/CMakeLists.txt
+++ b/tests/ExamplePluginWithLib/CMakeLists.txt
@@ -43,7 +43,7 @@ add_dependencies(ExamplePluginWithLib UpstreamLibrary UpstreamPlugin)
 
 # Downstream plugin that search for the package UpstreamLibrary allow to find_package in the build
 # tree
-set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${CMAKE_CURRENT_BINARY_DIR}/Upstream/Library"})
+set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${CMAKE_CURRENT_BINARY_DIR}/Upstream/Library")
 add_subdirectory(Downstream)
 add_dependencies(ExamplePluginWithLib DownstreamPlugin)
 


### PR DESCRIPTION
hot fix for resources installation (and another cmake typo)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug in tests exampleApp asset installation, introduce in #907 cfa441a6d154bdeabf49794a68183b1bdb9aa990 


* **What is the current behavior?** (You can also link to an open issue here)
Resources are not installed anymore


* **What is the new behavior (if this is a feature change)?**
Resources dir is set for DrawPrimitiveDemo
