### PR TITLE
Viewer virtual update

### DIFF
--- a/src/Engine/Data/RenderParameters.hpp
+++ b/src/Engine/Data/RenderParameters.hpp
@@ -234,7 +234,7 @@ class RA_ENGINE_API ShaderParameterProvider
     virtual void updateGL() = 0;
 
     /**
-     * Get the list of properties the provider migh use  in a shader.
+     * Get the list of properties the provider migh use in a shader.
      * Each property will be added to the shader used for rendering under the form
      * "#define theProperty" when the provider is associated with the render technique.
      *

--- a/src/Gui/Viewer/Viewer.hpp
+++ b/src/Gui/Viewer/Viewer.hpp
@@ -115,7 +115,7 @@ class RA_GUI_API Viewer : public WindowQt, public KeyMappingManageable<Viewer>
     //  Time dependent state management
     //
     /// Update the internal viewer state to the (application) time dt
-    void update( const Scalar dt );
+    virtual void update( const Scalar dt );
     //
     // Rendering management
     //
@@ -173,11 +173,12 @@ class RA_GUI_API Viewer : public WindowQt, public KeyMappingManageable<Viewer>
     void requestEngineOpenGLInitialization();
     bool glInitialized(); //! Emitted when GL context is ready. We except call to addRenderer here
     void rendererReady(); //! Emitted when the rendered is correctly initialized
-    void rightClickPicking( const Ra::Engine::Rendering::Renderer::PickingResult& result );
-    //! Emitted when the resut of a right click picking is known (for selection)
 
-    void toggleBrushPicking(
-        bool on ); //! Emitted when the corresponding key is released (see keyReleaseEvent)
+    /// Emitted when the resut of a right click picking is known (for selection)
+    void rightClickPicking( const Ra::Engine::Rendering::Renderer::PickingResult& result );
+
+    /// Emitted when the corresponding key is released (see keyReleaseEvent)
+    void toggleBrushPicking( bool on );
 
     void needUpdate();
 


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature : make Viewer::update(dt) virtual, so that derived viewer can perform custom update. 

* **What is the current behavior?** (You can also link to an open issue here)
updates are only available with handle*event or tasks, but viewer could not update on its own.
Useful for small viewer related stuff one do not want to put on the engine side.

