### PR TITLE
Use multiIndexedLayer instead of deprecated attributes

### DIFF
--- a/src/Core/Asset/FileData.inl
+++ b/src/Core/Asset/FileData.inl
@@ -127,7 +127,7 @@ inline void FileData::displayInfo() const {
     using namespace Core::Utils; // log
     uint64_t vtxCount = 0;
     for ( const auto& geom : m_geometryData ) {
-        vtxCount += geom->getVerticesSize();
+        vtxCount += geom->getGeometry().vertices().size();
     }
     LOG( logINFO ) << "======== LOADING SUMMARY ========";
     LOG( logINFO ) << "Mesh loaded        : " << m_geometryData.size();

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -14,8 +14,7 @@ GeometryData::GeometryData( const std::string& name, const GeometryType& type ) 
     m_edge(),
     m_faces(),
     m_polyhedron(),
-    m_normal(),
-    m_tangent(),
+    m_vertexAttribs(),
     m_bitangent(),
     m_texCoord(),
     m_material() {}
@@ -51,14 +50,15 @@ void GeometryData::displayInfo() const {
         type = "HEX MESH";
         break;
     }
+
     LOG( logINFO ) << "======== MESH INFO ========";
     LOG( logINFO ) << " Name           : " << m_name;
     LOG( logINFO ) << " Type           : " << type;
     LOG( logINFO ) << " Vertex #       : " << m_vertex.size();
     LOG( logINFO ) << " Edge #         : " << m_edge.size();
     LOG( logINFO ) << " Face #         : " << m_faces.size();
-    LOG( logINFO ) << " Normal ?       : " << ( ( m_normal.empty() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Tangent ?      : " << ( ( m_tangent.empty() ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Normal ?       : " << ( ( getNormals().empty() ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Tangent ?      : " << ( ( getTangents().empty() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Bitangent ?    : " << ( ( m_bitangent.empty() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Tex.Coord. ?   : " << ( ( m_texCoord.empty() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Material ?     : " << ( ( !hasMaterial() ) ? "NO" : "YES" );

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -13,7 +13,7 @@ GeometryData::GeometryData( const std::string& name, const GeometryType& type ) 
     m_edge(),
     m_faces(),
     m_polyhedron(),
-    m_vertexAttribs(),
+    m_vertexAttribArray(),
     m_material() {}
 
 GeometryData::~GeometryData() {}

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -15,8 +15,6 @@ GeometryData::GeometryData( const std::string& name, const GeometryType& type ) 
     m_faces(),
     m_polyhedron(),
     m_vertexAttribs(),
-    m_bitangent(),
-    m_texCoord(),
     m_material() {}
 
 GeometryData::~GeometryData() {}
@@ -59,8 +57,8 @@ void GeometryData::displayInfo() const {
     LOG( logINFO ) << " Face #         : " << m_faces.size();
     LOG( logINFO ) << " Normal ?       : " << ( ( getNormals().empty() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Tangent ?      : " << ( ( getTangents().empty() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Bitangent ?    : " << ( ( m_bitangent.empty() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Tex.Coord. ?   : " << ( ( m_texCoord.empty() ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Bitangent ?    : " << ( ( getBiTangents().empty() ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Tex.Coord. ?   : " << ( ( getTexCoords().empty() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Material ?     : " << ( ( !hasMaterial() ) ? "NO" : "YES" );
 
     if ( hasMaterial() ) { m_material->displayInfo(); }

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -10,7 +10,6 @@ GeometryData::GeometryData( const std::string& name, const GeometryType& type ) 
     AssetData( name ),
     m_frame( Transform::Identity() ),
     m_type( type ),
-    m_vertex(),
     m_edge(),
     m_faces(),
     m_polyhedron(),
@@ -52,13 +51,13 @@ void GeometryData::displayInfo() const {
     LOG( logINFO ) << "======== MESH INFO ========";
     LOG( logINFO ) << " Name           : " << m_name;
     LOG( logINFO ) << " Type           : " << type;
-    LOG( logINFO ) << " Vertex #       : " << m_vertex.size();
+    LOG( logINFO ) << " Vertex #       : " << getVerticesSize();
     LOG( logINFO ) << " Edge #         : " << m_edge.size();
     LOG( logINFO ) << " Face #         : " << m_faces.size();
-    LOG( logINFO ) << " Normal ?       : " << ( ( getNormals().empty() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Tangent ?      : " << ( ( getTangents().empty() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Bitangent ?    : " << ( ( getBiTangents().empty() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Tex.Coord. ?   : " << ( ( getTexCoords().empty() ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Normal ?       : " << ( ( !hasAttribData( "normal" ) ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Tangent ?      : " << ( ( !hasAttribData( "tangent" ) ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Bitangent ?    : " << ( ( !hasAttribData( "biTangent" ) ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Tex.Coord. ?   : " << ( ( !hasAttribData( "texCoord" ) ) ? "NO" : "YES" );
     LOG( logINFO ) << " Material ?     : " << ( ( !hasMaterial() ) ? "NO" : "YES" );
 
     if ( hasMaterial() ) { m_material->displayInfo(); }

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -1,3 +1,4 @@
+#include "Core/Geometry/StandardAttribNames.hpp"
 #include <Core/Asset/GeometryData.hpp>
 
 #include <Core/Utils/Log.hpp>
@@ -46,10 +47,16 @@ void GeometryData::displayInfo() const {
         break;
     }
 
+    using namespace Geometry;
+
     LOG( logINFO ) << "======== MESH INFO ========";
     LOG( logINFO ) << " Name           : " << m_name;
     LOG( logINFO ) << " Type           : " << type;
-    LOG( logINFO ) << " Vertex #       : " << ( hasVertices() ? getVertices().size() : 0 );
+    LOG( logINFO ) << " Vertex #       : "
+                   << ( getMultiIndexedGeometry().hasAttrib(
+                            getAttribName( MeshAttrib::VERTEX_POSITION ) )
+                            ? getMultiIndexedGeometry().vertices().size()
+                            : 0 );
     LOG( logINFO ) << " Edge #         : " << ( hasEdges() ? getEdges().size() : 0 );
     LOG( logINFO ) << " Face #         : " << ( hasFaces() ? getFaces().size() : 0 );
     LOG( logINFO ) << " Normal ?       : " << ( ( !hasNormals() ) ? "NO" : "YES" );

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -48,9 +48,9 @@ void GeometryData::displayInfo() const {
     LOG( logINFO ) << "======== MESH INFO ========";
     LOG( logINFO ) << " Name           : " << m_name;
     LOG( logINFO ) << " Type           : " << type;
-    LOG( logINFO ) << " Vertex #       : " << getVerticesSize();
-    LOG( logINFO ) << " Edge #         : " << hasEdges();
-    LOG( logINFO ) << " Face #         : " << hasFaces();
+    LOG( logINFO ) << " Vertex #       : " << ( hasVertices() ? getVertices().size() : 0 );
+    LOG( logINFO ) << " Edge #         : " << ( hasEdges() ? getEdges().size() : 0 );
+    LOG( logINFO ) << " Face #         : " << ( hasFaces() ? getFaces().size() : 0 );
     LOG( logINFO ) << " Normal ?       : " << ( ( !hasNormals() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Tangent ?      : " << ( ( !hasTangents() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Bitangent ?    : " << ( ( !hasBiTangents() ) ? "NO" : "YES" );

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -10,10 +10,7 @@ GeometryData::GeometryData( const std::string& name, const GeometryType& type ) 
     AssetData( name ),
     m_frame( Transform::Identity() ),
     m_type( type ),
-    m_edge(),
-    m_faces(),
-    m_polyhedron(),
-    multiIndexedGeometry(),
+    m_multiIndexedGeometry(),
     m_material() {}
 
 GeometryData::~GeometryData() {}
@@ -52,8 +49,8 @@ void GeometryData::displayInfo() const {
     LOG( logINFO ) << " Name           : " << m_name;
     LOG( logINFO ) << " Type           : " << type;
     LOG( logINFO ) << " Vertex #       : " << getVerticesSize();
-    LOG( logINFO ) << " Edge #         : " << m_edge.size();
-    LOG( logINFO ) << " Face #         : " << m_faces.size();
+    LOG( logINFO ) << " Edge #         : " << getEdges().size();
+    LOG( logINFO ) << " Face #         : " << getFaces().size();
     LOG( logINFO ) << " Normal ?       : " << ( ( !hasNormals() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Tangent ?      : " << ( ( !hasTangents() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Bitangent ?    : " << ( ( !hasBiTangents() ) ? "NO" : "YES" );

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -54,10 +54,10 @@ void GeometryData::displayInfo() const {
     LOG( logINFO ) << " Vertex #       : " << getVerticesSize();
     LOG( logINFO ) << " Edge #         : " << m_edge.size();
     LOG( logINFO ) << " Face #         : " << m_faces.size();
-    LOG( logINFO ) << " Normal ?       : " << ( ( !hasAttribData( "normal" ) ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Tangent ?      : " << ( ( !hasAttribData( "tangent" ) ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Bitangent ?    : " << ( ( !hasAttribData( "biTangent" ) ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Tex.Coord. ?   : " << ( ( !hasAttribData( "texCoord" ) ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Normal ?       : " << ( ( !hasNormals() ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Tangent ?      : " << ( ( !hasTangents() ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Bitangent ?    : " << ( ( !hasBiTangents() ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Tex.Coord. ?   : " << ( ( !hasTextureCoordinates() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Material ?     : " << ( ( !hasMaterial() ) ? "NO" : "YES" );
 
     if ( hasMaterial() ) { m_material->displayInfo(); }

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -13,7 +13,7 @@ GeometryData::GeometryData( const std::string& name, const GeometryType& type ) 
     m_edge(),
     m_faces(),
     m_polyhedron(),
-    m_vertexAttribArray(),
+    multiIndexedGeometry(),
     m_material() {}
 
 GeometryData::~GeometryData() {}

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -60,8 +60,8 @@ void GeometryData::displayInfo() const {
     LOG( logINFO ) << "======== MESH INFO ========";
     LOG( logINFO ) << " Name           : " << m_name;
     LOG( logINFO ) << " Type           : " << type;
-    LOG( logINFO ) << " Edge #         : " << ( hasEdges() ? getPrimitiveNum() : 0 );
-    LOG( logINFO ) << " Face #         : " << ( hasFaces() ? getPrimitiveNum() : 0 );
+    LOG( logINFO ) << " Edge #         : " << ( hasEdges() ? getPrimitiveCount() : 0 );
+    LOG( logINFO ) << " Face #         : " << ( hasFaces() ? getPrimitiveCount() : 0 );
     LOG( logINFO ) << " Vertex #       : " << attribSize( MeshAttrib::VERTEX_POSITION );
     LOG( logINFO ) << " Normal ?       : " << hasAttrib( MeshAttrib::VERTEX_NORMAL );
     LOG( logINFO ) << " Tangent ?      : " << hasAttrib( MeshAttrib::VERTEX_TANGENT );

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -11,7 +11,7 @@ GeometryData::GeometryData( const std::string& name, const GeometryType& type ) 
     AssetData( name ),
     m_frame( Transform::Identity() ),
     m_type( type ),
-    m_multiIndexedGeometry(),
+    m_geometry(),
     m_material() {}
 
 GeometryData::~GeometryData() {}
@@ -47,22 +47,27 @@ void GeometryData::displayInfo() const {
         break;
     }
 
-    using namespace Geometry;
+    auto attribSize = [this]( Geometry::MeshAttrib a ) -> size_t {
+        const auto& name = getAttribName( a );
+        return getGeometry().hasAttrib( name ) ? getGeometry().getAttribBase( name )->getSize() : 0;
+    };
 
+    auto hasAttrib = [this]( Geometry::MeshAttrib a ) -> std::string {
+        return getGeometry().hasAttrib( getAttribName( a ) ) ? "YES" : "NO";
+    };
+
+    using namespace Geometry;
     LOG( logINFO ) << "======== MESH INFO ========";
     LOG( logINFO ) << " Name           : " << m_name;
     LOG( logINFO ) << " Type           : " << type;
-    LOG( logINFO ) << " Vertex #       : "
-                   << ( getMultiIndexedGeometry().hasAttrib(
-                            getAttribName( MeshAttrib::VERTEX_POSITION ) )
-                            ? getMultiIndexedGeometry().vertices().size()
-                            : 0 );
-    LOG( logINFO ) << " Edge #         : " << ( hasEdges() ? getEdges().size() : 0 );
-    LOG( logINFO ) << " Face #         : " << ( hasFaces() ? getFaces().size() : 0 );
-    LOG( logINFO ) << " Normal ?       : " << ( ( !hasNormals() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Tangent ?      : " << ( ( !hasTangents() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Bitangent ?    : " << ( ( !hasBiTangents() ) ? "NO" : "YES" );
-    LOG( logINFO ) << " Tex.Coord. ?   : " << ( ( !hasTextureCoordinates() ) ? "NO" : "YES" );
+    LOG( logINFO ) << " Edge #         : " << ( hasEdges() ? getPrimitiveNum() : 0 );
+    LOG( logINFO ) << " Face #         : " << ( hasFaces() ? getPrimitiveNum() : 0 );
+    LOG( logINFO ) << " Vertex #       : " << attribSize( MeshAttrib::VERTEX_POSITION );
+    LOG( logINFO ) << " Normal ?       : " << hasAttrib( MeshAttrib::VERTEX_NORMAL );
+    LOG( logINFO ) << " Tangent ?      : " << hasAttrib( MeshAttrib::VERTEX_TANGENT );
+    LOG( logINFO ) << " Bitangent ?    : " << hasAttrib( MeshAttrib::VERTEX_BITANGENT );
+    LOG( logINFO ) << " Tex.Coord. ?   : " << hasAttrib( MeshAttrib::VERTEX_TEXCOORD );
+    LOG( logINFO ) << " Color ?        : " << hasAttrib( MeshAttrib::VERTEX_COLOR );
     LOG( logINFO ) << " Material ?     : " << ( ( !hasMaterial() ) ? "NO" : "YES" );
 
     if ( hasMaterial() ) { m_material->displayInfo(); }

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -19,9 +19,6 @@ void GeometryData::displayInfo() const {
     using namespace Core::Utils; // log
     std::string type;
     switch ( m_type ) {
-    case UNKNOWN:
-        type = "UNKNOWN";
-        break;
     case POINT_CLOUD:
         type = "POINT CLOUD";
         break;
@@ -42,6 +39,10 @@ void GeometryData::displayInfo() const {
         break;
     case HEX_MESH:
         type = "HEX MESH";
+        break;
+    case UNKNOWN:
+    default:
+        type = "UNKNOWN";
         break;
     }
 

--- a/src/Core/Asset/GeometryData.cpp
+++ b/src/Core/Asset/GeometryData.cpp
@@ -49,8 +49,8 @@ void GeometryData::displayInfo() const {
     LOG( logINFO ) << " Name           : " << m_name;
     LOG( logINFO ) << " Type           : " << type;
     LOG( logINFO ) << " Vertex #       : " << getVerticesSize();
-    LOG( logINFO ) << " Edge #         : " << getEdges().size();
-    LOG( logINFO ) << " Face #         : " << getFaces().size();
+    LOG( logINFO ) << " Edge #         : " << hasEdges();
+    LOG( logINFO ) << " Face #         : " << hasFaces();
     LOG( logINFO ) << " Normal ?       : " << ( ( !hasNormals() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Tangent ?      : " << ( ( !hasTangents() ) ? "NO" : "YES" );
     LOG( logINFO ) << " Bitangent ?    : " << ( ( !hasBiTangents() ) ? "NO" : "YES" );

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -273,6 +273,8 @@ class RA_CORE_API GeometryData : public AssetData
 
     template <typename Container>
     inline void setVertexAttrib( std::string vertexAttribName, const Container& vertexAttribList );
+
+    inline bool hasVertexAttrib( std::string vertexAttribName ) const;
 };
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -125,7 +125,8 @@ class RA_CORE_API GeometryData : public AssetData
     template <typename Container>
     inline void setPolyhedra( const Container& polyList );
 
-    /// Return the list of vertex normals
+    /// Return the list of vertex normals.
+    /// \note This list must be unlock.
     inline Vector3Array& getNormals();
 
     /// Return the list of vertex normals.
@@ -257,11 +258,15 @@ class RA_CORE_API GeometryData : public AssetData
     /// The list of polyhedra
     VectorNuArray m_polyhedron;
 
+    /// Named attributes
+    /// \todo Move all built-in attributes to m_vertexAttribs
+    Utils::AttribManager m_vertexAttribs;
+
     /// The list of vertex normals.
-    [[deprecated]] Vector3Array m_normal;
+    //[[deprecated]] Vector3Array m_normal;
 
     /// The list of vertex tangent vectors.
-    [[deprecated]] Vector3Array m_tangent;
+    //[[deprecated]] Vector3Array m_tangent;
 
     /// The list of vertex bitangent vectors.
     [[deprecated]] Vector3Array m_bitangent;
@@ -271,10 +276,6 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;
-
-    /// Named attributes
-    /// \todo Move all built-in attributes to m_vertexAttribs
-    Utils::AttribManager m_vertexAttribs;
 };
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -318,9 +318,6 @@ class RA_CORE_API GeometryData : public AssetData
     /// The type of geometry for the object.
     GeometryType m_type;
 
-    /// The list of vertices.
-    Vector3Array m_vertex;
-
     /// The list of lines.
     Vector2uArray m_edge;
 

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -263,14 +263,14 @@ class RA_CORE_API GeometryData : public AssetData
      * done call attribDataUnlock( std :: std::string name )
      */
     template <typename Container>
-    inline Container& getAttribDataWithLock( std::string name );
+    inline Container& getAttribDataWithLock( const std::string& name );
 
     /**
      *
      * @param name
      * @brief Unlock data base on name.
      */
-    inline void attribDataUnlock( std::string name );
+    inline void attribDataUnlock( const std::string& name );
 
     /**
      *
@@ -280,7 +280,7 @@ class RA_CORE_API GeometryData : public AssetData
      * @warning There is no check on the handle validity (obtained by using name)
      */
     template <typename Container>
-    inline const Container& getAttribData( std::string name ) const;
+    inline const Container& getAttribData( const std::string& name ) const;
 
     /**
      *
@@ -292,7 +292,7 @@ class RA_CORE_API GeometryData : public AssetData
      *
      */
     template <typename Container>
-    inline void setAttribData( std::string name, const Container& attribDataList );
+    inline void setAttribData( const std::string& name, const Container& attribDataList );
 
     /**
      *
@@ -300,7 +300,7 @@ class RA_CORE_API GeometryData : public AssetData
      * @return true if the name provided correspond to an existing attribHandle.
      *
      */
-    inline bool hasAttribData( std::string name ) const;
+    inline bool hasAttribData( const std::string& name ) const;
 
     /// Print stast info to the Debug output.
     void displayInfo() const;

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -268,12 +268,45 @@ class RA_CORE_API GeometryData : public AssetData
     std::shared_ptr<MaterialData> m_material;
 
   private:
-    inline Vector3Array& getVertexAttrib( std::string vertexAttribName );
-    inline const Vector3Array& getVertexAttrib( std::string vertexAttribName ) const;
+    /**
+     *
+     * @tparam Container
+     * @param vertexAttribName
+     * @return Get container base on the given name.
+     * @warning If AttribHandle corresponding to vertexAttribName doesn't exist, it's created
+     * and return. User must use hasVertexAttrib to verify it.
+     */
+    template <typename Container>
+    inline Container& getVertexAttrib( std::string vertexAttribName );
 
+    /**
+     *
+     * @tparam Container
+     * @param vertexAttribName
+     * @return Get container base on the given name (const).
+     * @warning There is no check on the handle validity (obtained by using vertexAttribName)
+     */
+    template <typename Container>
+    inline const Container& getVertexAttrib( std::string vertexAttribName ) const;
+
+    /**
+     *
+     * @tparam Container
+     * @param vertexAttribName
+     * @param vertexAttribList
+     * @note Copy data from vertexAttribList into the attrib obtain with vertexAttribName.
+     *
+     */
     template <typename Container>
     inline void setVertexAttrib( std::string vertexAttribName, const Container& vertexAttribList );
 
+    /**
+     *
+     * @param vertexAttribName
+     * @return true if vertexAttribName provided correspond to an existing attribHandle else it
+     * return false.
+     *
+     */
     inline bool hasVertexAttrib( std::string vertexAttribName ) const;
 };
 

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -12,6 +12,7 @@
 
 #include <Core/Asset/AssetData.hpp>
 #include <Core/Asset/MaterialData.hpp>
+#include <Core/Geometry/TriangleMesh.hpp>
 
 namespace Ra {
 namespace Core {
@@ -328,8 +329,7 @@ class RA_CORE_API GeometryData : public AssetData
     VectorNuArray m_polyhedron;
 
     /// Named attributes
-    /// \todo Move all built-in attributes to m_vertexAttribs
-    Utils::AttribManager m_vertexAttribs;
+    Core::Geometry::AttribArrayGeometry m_vertexAttribArray;
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -24,6 +24,8 @@ class MaterialData;
  */
 class RA_CORE_API GeometryData : public AssetData
 {
+    typedef Utils::Attrib<Eigen::Matrix<Scalar, 3, 1>>* AttribPtr;
+    AttribPtr attribPtr;
 
   public:
     using ColorArray = Vector4Array;
@@ -126,8 +128,11 @@ class RA_CORE_API GeometryData : public AssetData
     inline void setPolyhedra( const Container& polyList );
 
     /// Return the list of vertex normals.
-    /// \note This list must be unlock.
+    /// \note This list must be unlock by calling unlockData.
     inline Vector3Array& getNormals();
+
+    /// Unlock data and set to nullptr pointer associated to it
+    inline void unlockData();
 
     /// Return the list of vertex normals.
     inline const Vector3Array& getNormals() const;
@@ -261,18 +266,6 @@ class RA_CORE_API GeometryData : public AssetData
     /// Named attributes
     /// \todo Move all built-in attributes to m_vertexAttribs
     Utils::AttribManager m_vertexAttribs;
-
-    /// The list of vertex normals.
-    //[[deprecated]] Vector3Array m_normal;
-
-    /// The list of vertex tangent vectors.
-    //[[deprecated]] Vector3Array m_tangent;
-
-    /// The list of vertex bitangent vectors.
-    [[deprecated]] Vector3Array m_bitangent;
-
-    /// The list of vertex texture coordinates.
-    [[deprecated]] Vector3Array m_texCoord;
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -24,9 +24,6 @@ class MaterialData;
  */
 class RA_CORE_API GeometryData : public AssetData
 {
-    typedef Utils::Attrib<Eigen::Matrix<Scalar, 3, 1>>* AttribPtr;
-    AttribPtr attribPtr;
-
   public:
     using ColorArray = Vector4Array;
 
@@ -269,6 +266,13 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;
+
+  private:
+    inline Vector3Array& getVertexAttrib( std::string vertexAttribName );
+    inline const Vector3Array& getVertexAttrib( std::string vertexAttribName ) const;
+
+    template <typename Container>
+    inline void setVertexAttrib( std::string vertexAttribName, const Container& vertexAttribList );
 };
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -72,15 +72,19 @@ class RA_CORE_API GeometryData : public AssetData
     inline std::size_t getVerticesSize() const;
 
     /// Return the list of vertices.
-    inline Vector3Array& getVertices();
+    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    getVertices();
 
     /// Return the list of vertices.
-    inline const Vector3Array& getVertices() const;
+    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
+    getVertices() const;
 
     /// Set the mesh vertices.
     /// \note In-place setting with getVertices() is preferred.
     template <typename Container>
-    inline void setVertices( const Container& vertexList );
+    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+                  "instead." )]] inline void
+    setVertices( const Container& vertexList );
 
     /// Return the list of lines.
     /// \note For line meshes only.
@@ -125,52 +129,64 @@ class RA_CORE_API GeometryData : public AssetData
     inline void setPolyhedra( const Container& polyList );
 
     /// Return the list of vertex normals.
-    /// \note This list must be unlock by calling unlockData.
-    inline Vector3Array& getNormals();
-
-    /// Unlock data and set to nullptr pointer associated to it
-    inline void unlockData();
+    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    getNormals();
 
     /// Return the list of vertex normals.
-    inline const Vector3Array& getNormals() const;
+    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
+    getNormals() const;
 
     /// Set the vertex normals.
     /// \note In-place setting with getNormals() is preferred.
     template <typename Container>
-    inline void setNormals( const Container& normalList );
+    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+                  "instead." )]] inline void
+    setNormals( const Container& normalList );
 
     /// Return the list of vertex tangent vectors.
-    inline Vector3Array& getTangents();
+    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    getTangents();
 
     /// Return the list of vertex tangent vectors.
-    inline const Vector3Array& getTangents() const;
+    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
+    getTangents() const;
 
     /// Set the vertex tangent vectors.
     /// \note In-place setting with getTangents() is preferred.
     template <typename Container>
-    inline void setTangents( const Container& tangentList );
+    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+                  "instead." )]] inline void
+    setTangents( const Container& tangentList );
 
     /// Return the list of vertex bitangent vectors.
-    inline Vector3Array& getBiTangents();
+    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    getBiTangents();
 
     /// Return the list of vertex bitangent vectors.
-    inline const Vector3Array& getBiTangents() const;
+    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
+    getBiTangents() const;
 
     /// Set the vertex bitangent vectors.
     /// \note In-place setting with getBiTangents() is preferred.
     template <typename Container>
-    inline void setBitangents( const Container& bitangentList );
+    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+                  "instead." )]] inline void
+    setBitangents( const Container& bitangentList );
 
     /// Return the list of vertex texture coordinates.
-    inline Vector3Array& getTexCoords();
+    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    getTexCoords();
 
     /// Return the list of vertex texture coordinates.
-    inline const Vector3Array& getTexCoords() const;
+    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
+    getTexCoords() const;
 
     /// Set the vertex texture coordinates.
     /// \note In-place setting with getTexCoords() is preferred.
     template <typename Container>
-    inline void setTextureCoordinates( const Container& texCoordList );
+    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+                  "instead." )]] inline void
+    setTextureCoordinates( const Container& texCoordList );
 
     /// Return the MaterialData associated to the objet.
     inline const MaterialData& getMaterial() const;
@@ -205,7 +221,8 @@ class RA_CORE_API GeometryData : public AssetData
     inline bool isHexMesh() const;
 
     /// Return true if the object has vertices.
-    inline bool hasVertices() const;
+    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
+    hasVertices() const;
 
     /// Return true if the object has lines.
     inline bool hasEdges() const;
@@ -217,20 +234,73 @@ class RA_CORE_API GeometryData : public AssetData
     inline bool hasPolyhedra() const;
 
     /// Return true if the object has vertex normals.
-    inline bool hasNormals() const;
+    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
+    hasNormals() const;
 
     /// Return true if the object has vertex tangent vectors.
-    inline bool hasTangents() const;
+    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
+    hasTangents() const;
 
     /// Return true if the object has vertex bitangent vectors.
-    inline bool hasBiTangents() const;
+    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
+    hasBiTangents() const;
 
     /// Return true if the object has vertex texture coordinates.
-    inline bool hasTextureCoordinates() const;
+    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
+    hasTextureCoordinates() const;
 
     /// Return true if the object has MaterialData.
     inline bool hasMaterial() const;
     /// \}
+
+    /**
+     *
+     * @tparam Container
+     * @param name
+     * @return Get container base on name (lock).
+     * @warning If AttribHandle corresponding to name doesn't exist, it's created
+     * and return. By using this method, user has read-write access to data, data is lock, when
+     * done call attribDataUnlock( std :: std::string name )
+     */
+    template <typename Container>
+    inline Container& getAttribDataWithLock( std::string name );
+
+    /**
+     *
+     * @param name
+     * @brief Unlock data base on name.
+     */
+    inline void attribDataUnlock( std::string name );
+
+    /**
+     *
+     * @tparam Container
+     * @param name
+     * @return Get container base on the given name (const).
+     * @warning There is no check on the handle validity (obtained by using name)
+     */
+    template <typename Container>
+    inline const Container& getAttribData( std::string name ) const;
+
+    /**
+     *
+     * @tparam Container
+     * @param name
+     * @param attribDataList
+     * @brief Copy data from attribDataList into the attrib obtain with name.
+     * @note In-place setting with getAttribDataWithLock( std::string name ) is preferred.
+     *
+     */
+    template <typename Container>
+    inline void setAttribData( std::string name, const Container& attribDataList );
+
+    /**
+     *
+     * @param name
+     * @return true if the name provided correspond to an existing attribHandle.
+     *
+     */
+    inline bool hasAttribData( std::string name ) const;
 
     /// Print stast info to the Debug output.
     void displayInfo() const;
@@ -266,48 +336,6 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;
-
-  private:
-    /**
-     *
-     * @tparam Container
-     * @param vertexAttribName
-     * @return Get container base on the given name.
-     * @warning If AttribHandle corresponding to vertexAttribName doesn't exist, it's created
-     * and return. User must use hasVertexAttrib to verify it.
-     */
-    template <typename Container>
-    inline Container& getVertexAttrib( std::string vertexAttribName );
-
-    /**
-     *
-     * @tparam Container
-     * @param vertexAttribName
-     * @return Get container base on the given name (const).
-     * @warning There is no check on the handle validity (obtained by using vertexAttribName)
-     */
-    template <typename Container>
-    inline const Container& getVertexAttrib( std::string vertexAttribName ) const;
-
-    /**
-     *
-     * @tparam Container
-     * @param vertexAttribName
-     * @param vertexAttribList
-     * @note Copy data from vertexAttribList into the attrib obtain with vertexAttribName.
-     *
-     */
-    template <typename Container>
-    inline void setVertexAttrib( std::string vertexAttribName, const Container& vertexAttribList );
-
-    /**
-     *
-     * @param vertexAttribName
-     * @return true if vertexAttribName provided correspond to an existing attribHandle else it
-     * return false.
-     *
-     */
-    inline bool hasVertexAttrib( std::string vertexAttribName ) const;
 };
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -77,6 +77,11 @@ class RA_CORE_API GeometryData : public AssetData
                   "instead." )]] inline Vector3Array&
     getVertices();
 
+    /// Return the (const) list of vertices.
+    [[deprecated( "Use getMultiIndexedGeometry() and related functions to obtain the "
+                  "list." )]] inline const Vector3Array&
+    getVertices() const;
+
     /// Set the mesh vertices.
     /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
@@ -86,7 +91,7 @@ class RA_CORE_API GeometryData : public AssetData
     /// Return the list of lines.
     /// \note For line meshes only.
     [[deprecated(
-        "Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
         "instead." )]] inline Vector2uArray&
     getEdges();
 
@@ -98,18 +103,18 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of lines.
     /// \note For line meshes only.
-    /// \note Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence )
+    /// \note Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence )
     /// instead.
     template <typename Container>
     [[deprecated(
-        "Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
         "instead." )]] inline void
     setEdges( const Container& edgeList );
 
     /// Return the list of faces.
     /// \note For triangle/quadrangle/polygonal meshes only.
     [[deprecated(
-        "Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
         "instead." )]] inline VectorNuArray&
     getFaces();
 
@@ -121,18 +126,18 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of faces.
     /// \note For triangle/quadrangle/polygonal meshes only.
-    /// \note Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence )
+    /// \note Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence )
     /// instead.
     template <typename Container>
     [[deprecated(
-        "Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
         "instead." )]] inline void
     setFaces( const Container& faceList );
 
     /// Return the list of polyhedra.
     /// \note For tetrahedron/hexahedron meshes only.
     [[deprecated(
-        "Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
         "instead." )]] inline VectorNuArray&
     getPolyhedra();
 
@@ -144,11 +149,11 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of polyhedra.
     /// \note For tetrahedron/hexahedron meshes only.
-    /// \note Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence )
+    /// \note Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence )
     /// instead.
     template <typename Container>
     [[deprecated(
-        "Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
         "instead." )]] inline void
     setPolyhedra( const Container& polyList );
 
@@ -156,6 +161,11 @@ class RA_CORE_API GeometryData : public AssetData
     [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) "
                   "instead." )]] inline Vector3Array&
     getNormals();
+
+    /// Return the (const) list of vertex normals.
+    [[deprecated( "Use getMultiIndexedGeometry() and related functions to obtain the "
+                  "list." )]] inline const Vector3Array&
+    getNormals() const;
 
     /// Set the vertex normals.
     /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
@@ -168,6 +178,11 @@ class RA_CORE_API GeometryData : public AssetData
                   "instead." )]] inline Vector3Array&
     getTangents();
 
+    /// Return the (const) list of vertex tangents vectors.
+    [[deprecated( "Use getMultiIndexedGeometry() and related functions to obtain the "
+                  "list." )]] inline const Vector3Array&
+    getTangents() const;
+
     /// Set the vertex tangent vectors.
     /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
@@ -179,6 +194,11 @@ class RA_CORE_API GeometryData : public AssetData
                   "instead." )]] inline Vector3Array&
     getBiTangents();
 
+    /// Return the (const) list of vertex bitangent vectors.
+    [[deprecated( "Use getMultiIndexedGeometry() and related functions to obtain the "
+                  "list." )]] inline const Vector3Array&
+    getBiTangents() const;
+
     /// Set the vertex bitangent vectors.
     /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
@@ -189,6 +209,11 @@ class RA_CORE_API GeometryData : public AssetData
     [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) "
                   "instead." )]] inline Vector3Array&
     getTexCoords();
+
+    /// Return the (const) list of vertex texture coordinates.
+    [[deprecated( "Use getMultiIndexedGeometry() and related functions to obtain the "
+                  "list." )]] inline const Vector3Array&
+    getTexCoords() const;
 
     /// Set the vertex texture coordinates.
     /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
@@ -264,11 +289,14 @@ class RA_CORE_API GeometryData : public AssetData
     /// Print stast info to the Debug output.
     void displayInfo() const;
 
-    /// Access to the attrib manager
-    inline Utils::AttribManager& getAttribManager();
-
     /// Access to the multiIndexedGeometry;
     inline Geometry::MultiIndexedGeometry& getMultiIndexedGeometry();
+
+    /// Access to the (const) multiIndexedGeometry;
+    inline const Geometry::MultiIndexedGeometry& getMultiIndexedGeometry() const;
+
+    /// Access to the attrib manager
+    inline Utils::AttribManager& getAttribManager();
 
     /// Access to the (const) attrib manager
     inline const Utils::AttribManager& getAttribManager() const;
@@ -278,19 +306,10 @@ class RA_CORE_API GeometryData : public AssetData
      * @tparam T
      * @param name
      * @return Attrib<T> from m_multiIndexedGeometry.
+     * @note This function is only to avoid redundant code of function like getNormals().
      */
     template <typename T>
     inline Utils::Attrib<T>& getAttrib( const Geometry::MeshAttrib& name );
-
-    /**
-     * @tparam V
-     * @param name
-     * @return true if the name provided correspond to an existing attribHandle.
-     * @note This function is only to avoid redundant code of function like hasNormals().
-     *
-     */
-    template <typename V>
-    inline bool hasAttribData( const Geometry::MeshAttrib& name ) const;
 
     /**
      *
@@ -305,8 +324,8 @@ class RA_CORE_API GeometryData : public AssetData
      * indexedDataUnlock ( const GeometryType& type, const std::string& name ).
      */
     template <typename V>
-    inline VectorArray<V>& addIndexedDataWithLock( const std::string& name     = "",
-                                                   const bool& firstOccurrence = true );
+    inline VectorArray<V>& findIndexedDataWithLock( const std::string& name     = "",
+                                                    const bool& firstOccurrence = true );
 
     /**
      *
@@ -374,6 +393,53 @@ class RA_CORE_API GeometryData : public AssetData
     /**
      *
      * @tparam V
+     * @param geomBase
+     * @return VectorArray<V> contains into the layerBase.
+     */
+    template <typename V>
+    inline VectorArray<V>& getDataFromLayerBase( Geometry::GeometryIndexLayerBase& geomBase );
+
+    /**
+     *
+     * @tparam V
+     * @param geomBase
+     * @return const VectorArray<V> contains into the layerBase.
+     */
+    template <typename V>
+    inline const VectorArray<V>&
+    getDataFromLayerBase( const Geometry::GeometryIndexLayerBase& geomBase ) const;
+
+    /**
+     *
+     * @tparam L
+     * @param firstOccurrence
+     * @param name
+     * @return GeometryIndexLayerBase& from the given name.
+     * @note This will try to get the first occurrence of the layer ignoring the given name for
+     * optimization. Please put firstOccurrence to false if you provide a name.
+     * @warning You must unlock the layer after using this function by using indexedDataUnlock(
+     * const GeometryType& type, const std::string& name ).
+     */
+    template <typename L>
+    inline Geometry::GeometryIndexLayerBase& getLayerBaseWithLock( const bool& firstOccurrence,
+                                                                   const std::string& name );
+
+    /**
+     *
+     * @tparam L
+     * @param firstOccurrence
+     * @param name
+     * @return const GeometryIndexLayerBase& from the given name.
+     * @note This will try to get the first occurrence of the layer ignoring the given name for
+     * optimization. Please put firstOccurrence to false if you provide a name.
+     */
+    template <typename L>
+    inline const Geometry::GeometryIndexLayerBase& getLayerBase( const bool& firstOccurrence,
+                                                                 const std::string& name ) const;
+
+    /**
+     *
+     * @tparam V
      * @tparam L
      * @param firstOccurrence
      * @param name
@@ -382,18 +448,6 @@ class RA_CORE_API GeometryData : public AssetData
     template <typename V, typename L>
     inline VectorArray<V>& getIndexedDataWithLock( const bool& firstOccurrence,
                                                    const std::string& name = "" );
-
-    /**
-     *
-     * @tparam V
-     * @tparam L
-     * @param firstOccurrence
-     * @param name
-     * @return VectorArray<V>&
-     */
-    template <typename V, typename L>
-    inline const VectorArray<V>& getIndexedData( const bool& firstOccurrence,
-                                                 const std::string& name = "" ) const;
 };
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -266,6 +266,9 @@ class RA_CORE_API GeometryData : public AssetData
     /// Access to the attrib manager
     inline Utils::AttribManager& getAttribManager();
 
+    /// Access to the multiIndexedGeometry;
+    inline Geometry::MultiIndexedGeometry& getMultiIndexedGeometry();
+
     /// Access to the (const) attrib manager
     inline const Utils::AttribManager& getAttribManager() const;
 

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -73,12 +73,14 @@ class RA_CORE_API GeometryData : public AssetData
     inline std::size_t getVerticesSize() const;
 
     /// Return the list of vertices.
-    [[deprecated( "Use verticesWithLock() "
+    [[deprecated( "Use getMultiIndexedGeometry().verticesWithLock() "
                   "instead." )]] inline Vector3Array&
     getVertices();
 
     /// Return the (const) list of vertices.
-    [[deprecated( "Use vertices() instead. " )]] inline const Vector3Array& getVertices() const;
+    [[deprecated(
+        "Use getMultiIndexedGeometry().vertices() instead. " )]] inline const Vector3Array&
+    getVertices() const;
 
     /// Set the mesh vertices.
     /// \note Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_POSITION ).setData( vertexList
@@ -152,17 +154,19 @@ class RA_CORE_API GeometryData : public AssetData
     setPolyhedra( const Container& polyList );
 
     /// Return the list of vertex normals.
-    [[deprecated( "Use normalsWithLock() instead." )]] inline Vector3Array& getNormals();
+    [[deprecated(
+        "Use getMultiIndexedGeometry().normalsWithLock() instead." )]] inline Vector3Array&
+    getNormals();
 
     /// Return the (const) list of vertex normals.
-    [[deprecated( "Use normals() instead. " )]] inline const Vector3Array& getNormals() const;
+    [[deprecated( "Use getMultiIndexedGeometry().normals() instead. " )]] inline const Vector3Array&
+    getNormals() const;
 
     /// Set the vertex normals.
     /// \note Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_NORMAL ).setData( normalList )
     /// instead.
     template <typename Container>
-    [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_NORMAL ).setData( "
-                  "normalList ) instead." )]] inline void
+    [[deprecated( "Use getMultiIndexedGeometry().setNormals( normalList  ) instead." )]] inline void
     setNormals( const Container& normalList );
 
     /// Return the list of vertex tangent vectors.

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -89,53 +89,67 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Return the list of lines.
     /// \note For line meshes only.
-    inline Vector2uArray& getEdges();
+    [[deprecated( "Use addIndexedDataWithLock( const GeometryType& type, const std::string& name ) "
+                  "instead." )]] inline Vector2uArray&
+    getEdges();
 
     /// Return the list of lines.
     /// \note For line meshes only.
-    inline const Vector2uArray& getEdges() const;
+    [[deprecated( "Use getIndexedData( const GeometryType& type, const std::string& name ) "
+                  "instead." )]] inline const Vector2uArray&
+    getEdges() const;
 
     /// Set the list of lines.
     /// \note For line meshes only.
     /// \note In-place setting with getEdges() is preferred.
     template <typename Container>
-    inline void setEdges( const Container& edgeList );
+    [[deprecated( "Use setIndexedData( const GeometryType& type, const VectorArray<V>& "
+                  "indexedDataList, const std::string& name) instead. " )]] inline void
+    setEdges( const Container& edgeList );
 
     /// Return the list of faces.
     /// \note For triangle/quadrangle/polygonal meshes only.
-    inline VectorNuArray& getFaces();
+    [[deprecated( "Use addIndexedDataWithLock( const GeometryType& type, const std::string& name ) "
+                  "instead." )]] inline VectorNuArray&
+    getFaces();
 
     /// Return the list of faces.
     /// \note For triangle/quadrangle/polygonal meshes only.
-    inline const VectorNuArray& getFaces() const;
+    [[deprecated( "Use getIndexedData( const GeometryType& type, const std::string& name ) "
+                  "instead." )]] inline const VectorNuArray&
+    getFaces() const;
 
     /// Set the list of faces.
     /// \note For triangle/quadrangle/polygonal meshes only.
     /// \note In-place setting with getFaces() is preferred.
     template <typename Container>
-    inline void setFaces( const Container& faceList );
+    [[deprecated( "Use setIndexedData( const GeometryType& type, const VectorArray<V>& "
+                  "indexedDataList, const std::string& name) instead. " )]] inline void
+    setFaces( const Container& faceList );
 
     /// Return the list of polyhedra.
     /// \note For tetrahedron/hexahedron meshes only.
-    inline VectorNuArray& getPolyhedra();
+    [[deprecated( "Use addIndexedDataWithLock( const GeometryType& type, const std::string& name ) "
+                  "instead." )]] inline VectorNuArray&
+    getPolyhedra();
 
     /// Return the list of polyhedra.
     /// \note For tetrahedron/hexahedron meshes only.
-    inline const VectorNuArray& getPolyhedra() const;
+    [[deprecated( "Use getIndexedData( const GeometryType& type, const std::string& name ) "
+                  "instead." )]] inline const VectorNuArray&
+    getPolyhedra() const;
 
     /// Set the list of polyhedra.
     /// \note For tetrahedron/hexahedron meshes only.
     /// \note In-place setting with getPolyhedra() is preferred.
     template <typename Container>
-    inline void setPolyhedra( const Container& polyList );
+    [[deprecated( "Use setIndexedData( const GeometryType& type, const VectorArray<V>& "
+                  "indexedDataList, const std::string& name) instead. " )]] inline void
+    setPolyhedra( const Container& polyList );
 
     /// Return the list of vertex normals.
     [[deprecated( "Use addAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
     getNormals();
-
-    /// Return the list of vertex normals.
-    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
-    getNormals() const;
 
     /// Set the vertex normals.
     /// \note In-place setting with getNormals() is preferred.
@@ -148,10 +162,6 @@ class RA_CORE_API GeometryData : public AssetData
     [[deprecated( "Use addAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
     getTangents();
 
-    /// Return the list of vertex tangent vectors.
-    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
-    getTangents() const;
-
     /// Set the vertex tangent vectors.
     /// \note In-place setting with getTangents() is preferred.
     template <typename Container>
@@ -163,10 +173,6 @@ class RA_CORE_API GeometryData : public AssetData
     [[deprecated( "Use addAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
     getBiTangents();
 
-    /// Return the list of vertex bitangent vectors.
-    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
-    getBiTangents() const;
-
     /// Set the vertex bitangent vectors.
     /// \note In-place setting with getBiTangents() is preferred.
     template <typename Container>
@@ -177,10 +183,6 @@ class RA_CORE_API GeometryData : public AssetData
     /// Return the list of vertex texture coordinates.
     [[deprecated( "Use addAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
     getTexCoords();
-
-    /// Return the list of vertex texture coordinates.
-    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
-    getTexCoords() const;
 
     /// Set the vertex texture coordinates.
     /// \note In-place setting with getTexCoords() is preferred.
@@ -263,18 +265,54 @@ class RA_CORE_API GeometryData : public AssetData
     /// Access to the (const) attrib manager
     inline const Utils::AttribManager& getAttribManager() const;
 
-    inline void initIndexedData( const std::string& name );
-
+    /**
+     *
+     * @tparam V
+     * @param type
+     * @param name
+     * @return Initialize (if necessary) and get a VectorArray<V> contain in layer.
+     * @note This function is only to avoid redundant code of function like getEdges().
+     * @warning This function lock the layer, user has read-write access, when done, call
+     * indexedDataUnlock ( const GeometryType& type, const std::string& name ).
+     */
     template <typename V>
-    inline VectorArray<V>& getIndexedDataWithLock( const std::string& name );
+    inline VectorArray<V>& addIndexedDataWithLock( const GeometryType& type,
+                                                   const std::string& name = "" );
 
+    /**
+     *
+     * @tparam V
+     * @param type
+     * @param name
+     * @note This function is only to avoid redundant code of function like getEdges().
+     * @return VectorArray<V>& stored in the layer.
+     */
     template <typename V>
-    inline const VectorArray<V>& getIndexedData( const std::string& name ) const;
+    inline const VectorArray<V>& getIndexedData( const GeometryType& type,
+                                                 const std::string& name = "" ) const;
 
-    inline void indexedDataUnlock( const std::string& name );
+    /**
+     *
+     * @param type
+     * @param name
+     * @warning Unlock a layer only if it was previously locked.
+     */
+    inline void indexedDataUnlock( const GeometryType& type, const std::string& name = "" );
 
+    /**
+     *
+     * @tparam V
+     * @param indexedDataList
+     * @param type
+     * @param name
+     * @brief Copy data from indexedDataList into the layer obtain with name and type.
+     * @note In-place setting with addIndexedDataWithLock( std::string name ) is preferred.
+     * This function is only to avoid redundant code of function like setEdges().
+     */
     template <typename V>
-    inline void setIndexedData( const std::string& name, const VectorArray<V>& attribDataList );
+    inline void setIndexedData( const GeometryType& type,
+                                const VectorArray<V>& indexedDataList,
+                                const std::string& name = "" );
 
   protected:
     /// The transformation of the object.
@@ -283,17 +321,8 @@ class RA_CORE_API GeometryData : public AssetData
     /// The type of geometry for the object.
     GeometryType m_type;
 
-    /// The list of lines.
-    Vector2uArray m_edge;
-
-    /// The list of faces
-    VectorNuArray m_faces;
-
-    /// The list of polyhedra
-    VectorNuArray m_polyhedron;
-
     /// Named attributes
-    Core::Geometry::MultiIndexedGeometry multiIndexedGeometry;
+    Core::Geometry::MultiIndexedGeometry m_multiIndexedGeometry;
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;
@@ -334,6 +363,35 @@ class RA_CORE_API GeometryData : public AssetData
      */
     template <typename V>
     inline bool hasAttribData( const Geometry::MeshAttrib& name ) const;
+
+    /**
+     *
+     * @tparam L
+     * @param name
+     * @return true if layer isn't initialized.
+     */
+    template <typename L>
+    inline bool initLayer( const std::string& name );
+
+    /**
+     *
+     * @tparam V
+     * @tparam L
+     * @param name
+     * @return VectorArray<V>& and lock the layer associated to it.
+     */
+    template <typename V, typename L>
+    inline VectorArray<V>& getIndexedDataWithLock( const std::string& name );
+
+    /**
+     *
+     * @tparam V
+     * @tparam L
+     * @param name
+     * @return VectorArray<V>&
+     */
+    template <typename V, typename L>
+    inline const VectorArray<V>& getIndexedData( const std::string& name ) const;
 };
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -83,19 +83,19 @@ class RA_CORE_API GeometryData : public AssetData
     /// Set the mesh vertices.
     /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) instead. " )]] inline void
+    [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_POSITION ).setData( "
+                  "vertexList ) instead. " )]] inline void
     setVertices( const Container& vertexList );
 
     /// Return the list of lines.
     /// \note For line meshes only.
-    [[deprecated(
-        "Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence ) "
-        "instead." )]] inline Vector2uArray&
+    [[deprecated( "Use findIndexDataWithLock<Vector2ui>( \"in_edge\" ) "
+                  "instead." )]] inline Vector2uArray&
     getEdges();
 
     /// Return the list of lines.
     /// \note For line meshes only.
-    [[deprecated( "Use getIndexedData( const GeometryType& type, const std::string& name ) "
+    [[deprecated( "Use getIndexedData<Vector2ui>( \"in_edge\" ) "
                   "instead." )]] inline const Vector2uArray&
     getEdges() const;
 
@@ -104,21 +104,19 @@ class RA_CORE_API GeometryData : public AssetData
     /// \note Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence )
     /// instead.
     template <typename Container>
-    [[deprecated(
-        "Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence ) "
-        "instead." )]] inline void
+    [[deprecated( "Use setIndexedData( GeometryType::LINE_MESH, edgeList, \"in_edge\" ) "
+                  "instead." )]] inline void
     setEdges( const Container& edgeList );
 
     /// Return the list of faces.
     /// \note For triangle/quadrangle/polygonal meshes only.
-    [[deprecated(
-        "Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence ) "
-        "instead." )]] inline VectorNuArray&
+    [[deprecated( "Use findIndexDataWithLock<VectorNui>( \"in_face\" ) "
+                  "instead." )]] inline VectorNuArray&
     getFaces();
 
     /// Return the list of faces.
     /// \note For triangle/quadrangle/polygonal meshes only.
-    [[deprecated( "Use getIndexedData( const GeometryType& type, const std::string& name ) "
+    [[deprecated( "Use getIndexedData<VectorNui>( \"in_face\" ) "
                   "instead." )]] inline const VectorNuArray&
     getFaces() const;
 
@@ -127,21 +125,19 @@ class RA_CORE_API GeometryData : public AssetData
     /// \note Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence )
     /// instead.
     template <typename Container>
-    [[deprecated(
-        "Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence ) "
-        "instead." )]] inline void
+    [[deprecated( "Use findIndexDataWithLock<VectorNui>( \"in_polyhedron\" ) "
+                  "instead." )]] inline void
     setFaces( const Container& faceList );
 
     /// Return the list of polyhedra.
     /// \note For tetrahedron/hexahedron meshes only.
-    [[deprecated(
-        "Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence ) "
-        "instead." )]] inline VectorNuArray&
+    [[deprecated( "Use findIndexDataWithLock<VectorNui>( \"in_polyhedron\" ) "
+                  "instead." )]] inline VectorNuArray&
     getPolyhedra();
 
     /// Return the list of polyhedra.
     /// \note For tetrahedron/hexahedron meshes only.
-    [[deprecated( "Use getIndexedData( const GeometryType& type, const std::string& name ) "
+    [[deprecated( "Use getIndexedData<VectorNui>( \"in_polyhedron\" ) "
                   "instead." )]] inline const VectorNuArray&
     getPolyhedra() const;
 
@@ -150,9 +146,8 @@ class RA_CORE_API GeometryData : public AssetData
     /// \note Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence )
     /// instead.
     template <typename Container>
-    [[deprecated(
-        "Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence ) "
-        "instead." )]] inline void
+    [[deprecated( "Use setIndexedData( GeometryType::POLY_MESH, polyList, \"in_polyhedron\" ) "
+                  "instead." )]] inline void
     setPolyhedra( const Container& polyList );
 
     /// Return the list of vertex normals.
@@ -164,55 +159,62 @@ class RA_CORE_API GeometryData : public AssetData
     /// Set the vertex normals.
     /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) instead." )]] inline void
+    [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_NORMAL ).setData( "
+                  "normalList ) instead." )]] inline void
     setNormals( const Container& normalList );
 
     /// Return the list of vertex tangent vectors.
-    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) "
-                  "instead." )]] inline Vector3Array&
+    [[deprecated(
+        "Use getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TANGENT ).getDataWithLock() "
+        "instead." )]] inline Vector3Array&
     getTangents();
 
     /// Return the (const) list of vertex tangents vectors.
-    [[deprecated( "Use getMultiIndexedGeometry() and related functions to obtain the "
-                  "list." )]] inline const Vector3Array&
+    [[deprecated( "Use getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TANGENT ).data() "
+                  "instead " )]] inline const Vector3Array&
     getTangents() const;
 
     /// Set the vertex tangent vectors.
     /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) instead." )]] inline void
+    [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_TANGENT ).setData( "
+                  "tangentList ) instead." )]] inline void
     setTangents( const Container& tangentList );
 
     /// Return the list of vertex bitangent vectors.
-    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) "
-                  "instead." )]] inline Vector3Array&
+    [[deprecated(
+        "Use getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_BITANGENT ).getDataWithLock() "
+        "instead." )]] inline Vector3Array&
     getBiTangents();
 
     /// Return the (const) list of vertex bitangent vectors.
-    [[deprecated( "Use getMultiIndexedGeometry() and related functions to obtain the "
-                  "list." )]] inline const Vector3Array&
+    [[deprecated( "Use getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_BITANGENT "
+                  ").data() " )]] inline const Vector3Array&
     getBiTangents() const;
 
     /// Set the vertex bitangent vectors.
     /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) instead." )]] inline void
+    [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_BITANGENT ).setData( "
+                  "bitangentList ) instead." )]] inline void
     setBitangents( const Container& bitangentList );
 
     /// Return the list of vertex texture coordinates.
-    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) "
-                  "instead." )]] inline Vector3Array&
+    [[deprecated(
+        "Use getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TEXCOORD ).getDataWithLock() "
+        "instead." )]] inline Vector3Array&
     getTexCoords();
 
     /// Return the (const) list of vertex texture coordinates.
-    [[deprecated( "Use getMultiIndexedGeometry() and related functions to obtain the "
-                  "list." )]] inline const Vector3Array&
+    [[deprecated( "Use getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TEXCOORD "
+                  ").data() " )]] inline const Vector3Array&
     getTexCoords() const;
 
     /// Set the vertex texture coordinates.
     /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) instead." )]] inline void
+    [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_TEXCOORD ).setData( "
+                  "texCoordList ) instead." )]] inline void
     setTextureCoordinates( const Container& texCoordList );
 
     /// Return the MaterialData associated to the objet.
@@ -300,10 +302,18 @@ class RA_CORE_API GeometryData : public AssetData
      * @tparam T
      * @param name
      * @return Attrib<T> from m_multiIndexedGeometry.
-     * @note This function is only to avoid redundant code of function like getNormals().
      */
     template <typename T>
     inline Utils::Attrib<T>& getAttrib( const Geometry::MeshAttrib& name );
+
+    /**
+     *
+     * @tparam T
+     * @param name
+     * @return Attrib<T> from m_multiIndexedGeometry.
+     */
+    template <typename T>
+    inline const Utils::Attrib<T>& getAttrib( const Geometry::MeshAttrib& name ) const;
 
     /**
      *
@@ -311,9 +321,8 @@ class RA_CORE_API GeometryData : public AssetData
      * @param name
      * @param firstOccurrence
      * @return Initialize (if necessary) and get a VectorArray<V> contain in layer.
-     * @note This function is only to avoid redundant code of function like getEdges().
-     * If firstOccurrence == true, it allow to function to be more efficient but the name isn't use
-     * to find the layer.
+     * @note If firstOccurrence == true, it allow to function to be more efficient but the name
+     * isn't use to find the layer.
      * @warning This function lock the layer, user has read-write access, when done, call
      * indexedDataUnlock ( const GeometryType& type, const std::string& name ).
      */
@@ -326,9 +335,8 @@ class RA_CORE_API GeometryData : public AssetData
      * @tparam V
      * @param name
      * @param firstOccurrence
-     * @note This function is only to avoid redundant code of function like getEdges().
-     * If firstOccurrence == true, it allow to function to be more efficient but the name isn't use
-     * to find the layer.
+     * @note If firstOccurrence == true, it allow to function to be more efficient but the name
+     * isn't use to find the layer.
      * @return VectorArray<V>& stored in the layer.
      */
     template <typename V>
@@ -363,7 +371,6 @@ class RA_CORE_API GeometryData : public AssetData
      * @param name
      * @param attribDataList
      * @brief Copy data from attribDataList into the attrib obtain with name.
-     * @note This function is only to avoid redundant code of function like setNormals().
      *
      */
     template <typename V>
@@ -377,7 +384,6 @@ class RA_CORE_API GeometryData : public AssetData
      * @param type
      * @param name
      * @brief Copy data from indexedDataList into the layer obtain with name and type.
-     * @note This function is only to avoid redundant code of function like setEdges().
      */
     template <typename V>
     inline void setIndexedData( const GeometryType& type,

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -121,10 +121,10 @@ class RA_CORE_API GeometryData : public AssetData
     inline bool hasMaterial() const;
 
     /// Used to track easily the number of primitives in the geometry data
-    inline void setPrimitiveNum( int n );
+    inline void setPrimitiveCount( int n );
 
     /// Return the number of primitives in the geometry data
-    inline int getPrimitiveNum() const;
+    inline int getPrimitiveCount() const;
 
     /// \}
 
@@ -142,7 +142,7 @@ class RA_CORE_API GeometryData : public AssetData
     Core::Geometry::MultiIndexedGeometry m_geometry;
 
     /// Simple tracking of geometric primitive number
-    int m_numPrimitives { -1 };
+    int m_primitiveCount { -1 };
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -86,8 +86,7 @@ class RA_CORE_API GeometryData : public AssetData
     /// \note Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_POSITION ).setData( vertexList
     /// ) instead.
     template <typename Container>
-    [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_POSITION ).setData( "
-                  "vertexList ) instead. " )]] inline void
+    [[deprecated( "Use getMultiIndexedGeometry().setVertices(data); instead." )]] inline void
     setVertices( const Container& vertexList );
 
     /// Return the list of lines.
@@ -166,13 +165,13 @@ class RA_CORE_API GeometryData : public AssetData
     /// \note Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_NORMAL ).setData( normalList )
     /// instead.
     template <typename Container>
-    [[deprecated( "Use getMultiIndexedGeometry().setNormals( normalList  ) instead." )]] inline void
-    setNormals( const Container& normalList );
+    [[deprecated( "Use getMultiIndexedGeometry().setNormals( data ) instead." )]] inline void
+    setNormals( const Container& );
 
     /// Return the list of vertex tangent vectors.
-    [[deprecated(
-        "Use getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TANGENT ).getDataWithLock() "
-        "instead." )]] inline Vector3Array&
+    [[deprecated( "Use getAttrib<Vector3>( getAttribName(Geometry::MeshAttrib::VERTEX_TANGENT) "
+                  ").getDataWithLock() "
+                  "instead." )]] inline Vector3Array&
     getTangents();
 
     /// Return the (const) list of vertex tangents vectors.
@@ -308,24 +307,6 @@ class RA_CORE_API GeometryData : public AssetData
 
     /**
      *
-     * @tparam T
-     * @param name
-     * @return Attrib<T> from m_multiIndexedGeometry.
-     */
-    template <typename T>
-    inline Utils::Attrib<T>& getAttrib( const Geometry::MeshAttrib& name );
-
-    /**
-     *
-     * @tparam T
-     * @param name
-     * @return Attrib<T> from m_multiIndexedGeometry.
-     */
-    template <typename T>
-    inline const Utils::Attrib<T>& getAttrib( const Geometry::MeshAttrib& name ) const;
-
-    /**
-     *
      * @tparam V
      * @param name
      * @param firstOccurrence
@@ -374,18 +355,6 @@ class RA_CORE_API GeometryData : public AssetData
     std::shared_ptr<MaterialData> m_material;
 
   private:
-    /**
-     *
-     * @tparam Container
-     * @param name
-     * @param attribDataList
-     * @brief Copy data from attribDataList into the attrib obtain with name.
-     *
-     */
-    template <typename V>
-    inline void setAttribData( const Geometry::MeshAttrib& name,
-                               const VectorArray<V>& attribDataList );
-
     /**
      *
      * @tparam V

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -73,21 +73,21 @@ class RA_CORE_API GeometryData : public AssetData
     inline std::size_t getVerticesSize() const;
 
     /// Return the list of vertices.
-    [[deprecated( "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) "
+    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) "
                   "instead." )]] inline Vector3Array&
     getVertices();
 
     /// Set the mesh vertices.
-    /// \note Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead.
+    /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated(
-        "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead. " )]] inline void
+    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) instead. " )]] inline void
     setVertices( const Container& vertexList );
 
     /// Return the list of lines.
     /// \note For line meshes only.
-    [[deprecated( "Use addIndexedDataWithLock( const GeometryType& type, const std::string& name ) "
-                  "instead." )]] inline Vector2uArray&
+    [[deprecated(
+        "Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "instead." )]] inline Vector2uArray&
     getEdges();
 
     /// Return the list of lines.
@@ -98,17 +98,19 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of lines.
     /// \note For line meshes only.
-    /// \note Use addIndexedDataWithLock( const GeometryType& type, const std::string& name )
+    /// \note Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence )
     /// instead.
     template <typename Container>
-    [[deprecated( "Use addIndexedDataWithLock( const GeometryType& type, const std::string& name ) "
-                  "instead." )]] inline void
+    [[deprecated(
+        "Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "instead." )]] inline void
     setEdges( const Container& edgeList );
 
     /// Return the list of faces.
     /// \note For triangle/quadrangle/polygonal meshes only.
-    [[deprecated( "Use addIndexedDataWithLock( const GeometryType& type, const std::string& name ) "
-                  "instead." )]] inline VectorNuArray&
+    [[deprecated(
+        "Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "instead." )]] inline VectorNuArray&
     getFaces();
 
     /// Return the list of faces.
@@ -119,17 +121,19 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of faces.
     /// \note For triangle/quadrangle/polygonal meshes only.
-    /// \note Use addIndexedDataWithLock( const GeometryType& type, const std::string& name )
+    /// \note Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence )
     /// instead.
     template <typename Container>
-    [[deprecated( "Use addIndexedDataWithLock( const GeometryType& type, const std::string& name ) "
-                  "instead." )]] inline void
+    [[deprecated(
+        "Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "instead." )]] inline void
     setFaces( const Container& faceList );
 
     /// Return the list of polyhedra.
     /// \note For tetrahedron/hexahedron meshes only.
-    [[deprecated( "Use addIndexedDataWithLock( const GeometryType& type, const std::string& name ) "
-                  "instead." )]] inline VectorNuArray&
+    [[deprecated(
+        "Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "instead." )]] inline VectorNuArray&
     getPolyhedra();
 
     /// Return the list of polyhedra.
@@ -140,59 +144,56 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of polyhedra.
     /// \note For tetrahedron/hexahedron meshes only.
-    /// \note Use addIndexedDataWithLock( const GeometryType& type, const std::string& name )
+    /// \note Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence )
     /// instead.
     template <typename Container>
-    [[deprecated( "Use addIndexedDataWithLock( const GeometryType& type, const std::string& name ) "
-                  "instead." )]] inline void
+    [[deprecated(
+        "Use addIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "instead." )]] inline void
     setPolyhedra( const Container& polyList );
 
     /// Return the list of vertex normals.
-    [[deprecated( "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) "
+    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) "
                   "instead." )]] inline Vector3Array&
     getNormals();
 
     /// Set the vertex normals.
-    /// \note Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead.
+    /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated(
-        "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead." )]] inline void
+    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) instead." )]] inline void
     setNormals( const Container& normalList );
 
     /// Return the list of vertex tangent vectors.
-    [[deprecated( "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) "
+    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) "
                   "instead." )]] inline Vector3Array&
     getTangents();
 
     /// Set the vertex tangent vectors.
-    /// \note Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead.
+    /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated(
-        "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead." )]] inline void
+    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) instead." )]] inline void
     setTangents( const Container& tangentList );
 
     /// Return the list of vertex bitangent vectors.
-    [[deprecated( "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) "
+    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) "
                   "instead." )]] inline Vector3Array&
     getBiTangents();
 
     /// Set the vertex bitangent vectors.
-    /// \note Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead.
+    /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated(
-        "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead." )]] inline void
+    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) instead." )]] inline void
     setBitangents( const Container& bitangentList );
 
     /// Return the list of vertex texture coordinates.
-    [[deprecated( "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) "
+    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) "
                   "instead." )]] inline Vector3Array&
     getTexCoords();
 
     /// Set the vertex texture coordinates.
-    /// \note Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead.
+    /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated(
-        "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead." )]] inline void
+    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) instead." )]] inline void
     setTextureCoordinates( const Container& texCoordList );
 
     /// Return the MaterialData associated to the objet.

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -274,16 +274,12 @@ class RA_CORE_API GeometryData : public AssetData
 
     /**
      *
-     * @tparam V
+     * @tparam T
      * @param name
-     * @return Get container base on name (lock).
-     * @warning If AttribHandle corresponding to name doesn't exist, it's created
-     * and return. By using this method, user has read-write access to data, data is lock, when
-     * done, user must unlock data by getting the attribManager and then get the attrib.
-     * @note This function is only to avoid redundant code of function like getNormals().
+     * @return Attrib<T> from m_multiIndexedGeometry.
      */
-    template <typename V>
-    inline VectorArray<V>& addAttribDataWithLock( const Geometry::MeshAttrib& name );
+    template <typename T>
+    inline Utils::Attrib<T>& getAttrib( const Geometry::MeshAttrib& name );
 
     /**
      * @tparam V
@@ -298,28 +294,32 @@ class RA_CORE_API GeometryData : public AssetData
     /**
      *
      * @tparam V
-     * @param type
      * @param name
+     * @param firstOccurrence
      * @return Initialize (if necessary) and get a VectorArray<V> contain in layer.
      * @note This function is only to avoid redundant code of function like getEdges().
+     * If firstOccurrence == true, it allow to function to be more efficient but the name isn't use
+     * to find the layer.
      * @warning This function lock the layer, user has read-write access, when done, call
      * indexedDataUnlock ( const GeometryType& type, const std::string& name ).
      */
     template <typename V>
-    inline VectorArray<V>& addIndexedDataWithLock( const GeometryType& type,
-                                                   const std::string& name = "" );
+    inline VectorArray<V>& addIndexedDataWithLock( const std::string& name     = "",
+                                                   const bool& firstOccurrence = true );
 
     /**
      *
      * @tparam V
-     * @param type
      * @param name
+     * @param firstOccurrence
      * @note This function is only to avoid redundant code of function like getEdges().
+     * If firstOccurrence == true, it allow to function to be more efficient but the name isn't use
+     * to find the layer.
      * @return VectorArray<V>& stored in the layer.
      */
     template <typename V>
-    inline const VectorArray<V>& getIndexedData( const GeometryType& type,
-                                                 const std::string& name = "" ) const;
+    inline const VectorArray<V>& getIndexedData( const std::string& name     = "",
+                                                 const bool& firstOccurrence = true ) const;
 
     /**
      *
@@ -372,32 +372,27 @@ class RA_CORE_API GeometryData : public AssetData
 
     /**
      *
-     * @tparam L
-     * @param name
-     * @return true if layer isn't initialized.
-     */
-    template <typename L>
-    inline bool initLayer( const std::string& name );
-
-    /**
-     *
      * @tparam V
      * @tparam L
+     * @param firstOccurrence
      * @param name
      * @return VectorArray<V>& and lock the layer associated to it.
      */
     template <typename V, typename L>
-    inline VectorArray<V>& getIndexedDataWithLock( const std::string& name );
+    inline VectorArray<V>& getIndexedDataWithLock( const bool& firstOccurrence,
+                                                   const std::string& name = "" );
 
     /**
      *
      * @tparam V
      * @tparam L
+     * @param firstOccurrence
      * @param name
      * @return VectorArray<V>&
      */
     template <typename V, typename L>
-    inline const VectorArray<V>& getIndexedData( const std::string& name ) const;
+    inline const VectorArray<V>& getIndexedData( const bool& firstOccurrence,
+                                                 const std::string& name = "" ) const;
 };
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -83,7 +83,8 @@ class RA_CORE_API GeometryData : public AssetData
     /// Set the mesh vertices.
     /// \note In-place setting with getVertices() is preferred.
     template <typename Container>
-    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+    [[deprecated( "Use setAttribData( const Geometry::MeshAttrib& name, const VectorArray<V>& "
+                  "attribDataList ) "
                   "instead." )]] inline void
     setVertices( const Container& vertexList );
 
@@ -154,7 +155,8 @@ class RA_CORE_API GeometryData : public AssetData
     /// Set the vertex normals.
     /// \note In-place setting with getNormals() is preferred.
     template <typename Container>
-    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+    [[deprecated( "Use setAttribData( const Geometry::MeshAttrib& name, const VectorArray<V>& "
+                  "attribDataList ) "
                   "instead." )]] inline void
     setNormals( const Container& normalList );
 
@@ -165,7 +167,8 @@ class RA_CORE_API GeometryData : public AssetData
     /// Set the vertex tangent vectors.
     /// \note In-place setting with getTangents() is preferred.
     template <typename Container>
-    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+    [[deprecated( "Use setAttribData( const Geometry::MeshAttrib& name, const VectorArray<V>& "
+                  "attribDataList ) "
                   "instead." )]] inline void
     setTangents( const Container& tangentList );
 
@@ -176,7 +179,8 @@ class RA_CORE_API GeometryData : public AssetData
     /// Set the vertex bitangent vectors.
     /// \note In-place setting with getBiTangents() is preferred.
     template <typename Container>
-    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+    [[deprecated( "Use setAttribData( const Geometry::MeshAttrib& name, const VectorArray<V>& "
+                  "attribDataList ) "
                   "instead." )]] inline void
     setBitangents( const Container& bitangentList );
 
@@ -187,7 +191,8 @@ class RA_CORE_API GeometryData : public AssetData
     /// Set the vertex texture coordinates.
     /// \note In-place setting with getTexCoords() is preferred.
     template <typename Container>
-    [[deprecated( "Use setAttribData( std::string name, const Container& attribDataList ) "
+    [[deprecated( "Use setAttribData( const Geometry::MeshAttrib& name, const VectorArray<V>& "
+                  "attribDataList ) "
                   "instead." )]] inline void
     setTextureCoordinates( const Container& texCoordList );
 
@@ -351,8 +356,9 @@ class RA_CORE_API GeometryData : public AssetData
      * This function is only to avoid redundant code of function like setNormals().
      *
      */
-    template <typename Container>
-    inline void setAttribData( const Geometry::MeshAttrib& name, const Container& attribDataList );
+    template <typename V>
+    inline void setAttribData( const Geometry::MeshAttrib& name,
+                               const VectorArray<V>& attribDataList );
 
     /**
      * @tparam V

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -81,7 +81,8 @@ class RA_CORE_API GeometryData : public AssetData
     [[deprecated( "Use vertices() instead. " )]] inline const Vector3Array& getVertices() const;
 
     /// Set the mesh vertices.
-    /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
+    /// \note Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_POSITION ).setData( vertexList
+    /// ) instead.
     template <typename Container>
     [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_POSITION ).setData( "
                   "vertexList ) instead. " )]] inline void
@@ -101,8 +102,8 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of lines.
     /// \note For line meshes only.
-    /// \note Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence )
-    /// instead.
+    /// \note Use findIndexDataWithLock<Vector2ui>( "in_edge" ), then modify value of the
+    /// vectorArray and unlock it. instead.
     template <typename Container>
     [[deprecated( "Use setIndexedData( GeometryType::LINE_MESH, edgeList, \"in_edge\" ) "
                   "instead." )]] inline void
@@ -122,10 +123,10 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of faces.
     /// \note For triangle/quadrangle/polygonal meshes only.
-    /// \note Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence )
-    /// instead.
+    /// \note Use findIndexDataWithLock<VectorNui>( "in_face" ), then modify value of the
+    /// vectorArray and unlock it. instead.
     template <typename Container>
-    [[deprecated( "Use findIndexDataWithLock<VectorNui>( \"in_polyhedron\" ) "
+    [[deprecated( "Use setIndexedData( GeometryType::POLY_MESH, faceList, \"in_face\" ) "
                   "instead." )]] inline void
     setFaces( const Container& faceList );
 
@@ -143,8 +144,8 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of polyhedra.
     /// \note For tetrahedron/hexahedron meshes only.
-    /// \note Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence )
-    /// instead.
+    /// \note Use findIndexDataWithLock<VectorNui>( "in_polyhedron" ), then modify value of the
+    /// vectorArray and unlock it. instead.
     template <typename Container>
     [[deprecated( "Use setIndexedData( GeometryType::POLY_MESH, polyList, \"in_polyhedron\" ) "
                   "instead." )]] inline void
@@ -157,7 +158,8 @@ class RA_CORE_API GeometryData : public AssetData
     [[deprecated( "Use normals() instead. " )]] inline const Vector3Array& getNormals() const;
 
     /// Set the vertex normals.
-    /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
+    /// \note Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_NORMAL ).setData( normalList )
+    /// instead.
     template <typename Container>
     [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_NORMAL ).setData( "
                   "normalList ) instead." )]] inline void
@@ -175,7 +177,8 @@ class RA_CORE_API GeometryData : public AssetData
     getTangents() const;
 
     /// Set the vertex tangent vectors.
-    /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
+    /// \note Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_TANGENT ).setData( tangentList
+    /// ) instead.
     template <typename Container>
     [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_TANGENT ).setData( "
                   "tangentList ) instead." )]] inline void
@@ -193,7 +196,8 @@ class RA_CORE_API GeometryData : public AssetData
     getBiTangents() const;
 
     /// Set the vertex bitangent vectors.
-    /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
+    /// \note Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_BITANGENT ).setData(
+    /// bitangentList ) instead.
     template <typename Container>
     [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_BITANGENT ).setData( "
                   "bitangentList ) instead." )]] inline void
@@ -211,7 +215,8 @@ class RA_CORE_API GeometryData : public AssetData
     getTexCoords() const;
 
     /// Set the vertex texture coordinates.
-    /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
+    /// \note Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_TEXCOORD ).setData(
+    /// texCoordList ) instead.
     template <typename Container>
     [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_TEXCOORD ).setData( "
                   "texCoordList ) instead." )]] inline void

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -91,7 +91,7 @@ class RA_CORE_API GeometryData : public AssetData
     /// Return the list of lines.
     /// \note For line meshes only.
     [[deprecated(
-        "Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence ) "
         "instead." )]] inline Vector2uArray&
     getEdges();
 
@@ -103,18 +103,18 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of lines.
     /// \note For line meshes only.
-    /// \note Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence )
+    /// \note Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence )
     /// instead.
     template <typename Container>
     [[deprecated(
-        "Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence ) "
         "instead." )]] inline void
     setEdges( const Container& edgeList );
 
     /// Return the list of faces.
     /// \note For triangle/quadrangle/polygonal meshes only.
     [[deprecated(
-        "Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence ) "
         "instead." )]] inline VectorNuArray&
     getFaces();
 
@@ -126,18 +126,18 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of faces.
     /// \note For triangle/quadrangle/polygonal meshes only.
-    /// \note Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence )
+    /// \note Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence )
     /// instead.
     template <typename Container>
     [[deprecated(
-        "Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence ) "
         "instead." )]] inline void
     setFaces( const Container& faceList );
 
     /// Return the list of polyhedra.
     /// \note For tetrahedron/hexahedron meshes only.
     [[deprecated(
-        "Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence ) "
         "instead." )]] inline VectorNuArray&
     getPolyhedra();
 
@@ -149,11 +149,11 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of polyhedra.
     /// \note For tetrahedron/hexahedron meshes only.
-    /// \note Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence )
+    /// \note Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence )
     /// instead.
     template <typename Container>
     [[deprecated(
-        "Use findIndexedDataWithLock( const std::string& name, const bool& firstOccurrence ) "
+        "Use findIndexDataWithLock( const std::string& name, const bool& firstOccurrence ) "
         "instead." )]] inline void
     setPolyhedra( const Container& polyList );
 
@@ -324,8 +324,8 @@ class RA_CORE_API GeometryData : public AssetData
      * indexedDataUnlock ( const GeometryType& type, const std::string& name ).
      */
     template <typename V>
-    inline VectorArray<V>& findIndexedDataWithLock( const std::string& name     = "",
-                                                    const bool& firstOccurrence = true );
+    inline VectorArray<V>& findIndexDataWithLock( const std::string& name     = "",
+                                                  const bool& firstOccurrence = true );
 
     /**
      *

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -69,167 +69,18 @@ class RA_CORE_API GeometryData : public AssetData
     /// Set the Transform of the object.
     inline void setFrame( const Transform& frame );
 
-    /// Return the number of vertices.
-    inline std::size_t getVerticesSize() const;
-
-    /// Return the list of vertices.
-    [[deprecated( "Use getMultiIndexedGeometry().verticesWithLock() "
-                  "instead." )]] inline Vector3Array&
-    getVertices();
-
-    /// Return the (const) list of vertices.
-    [[deprecated(
-        "Use getMultiIndexedGeometry().vertices() instead. " )]] inline const Vector3Array&
-    getVertices() const;
-
-    /// Set the mesh vertices.
-    /// \note Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_POSITION ).setData( vertexList
-    /// ) instead.
-    template <typename Container>
-    [[deprecated( "Use getMultiIndexedGeometry().setVertices(data); instead." )]] inline void
-    setVertices( const Container& vertexList );
-
-    /// Return the list of lines.
-    /// \note For line meshes only.
-    [[deprecated( "Use findIndexDataWithLock<Vector2ui>( \"in_edge\" ) "
-                  "instead." )]] inline Vector2uArray&
-    getEdges();
-
-    /// Return the list of lines.
-    /// \note For line meshes only.
-    [[deprecated( "Use getIndexedData<Vector2ui>( \"in_edge\" ) "
-                  "instead." )]] inline const Vector2uArray&
-    getEdges() const;
-
-    /// Set the list of lines.
-    /// \note For line meshes only.
-    /// \note Use findIndexDataWithLock<Vector2ui>( "in_edge" ), then modify value of the
-    /// vectorArray and unlock it. instead.
-    template <typename Container>
-    [[deprecated( "Use setIndexedData( GeometryType::LINE_MESH, edgeList, \"in_edge\" ) "
-                  "instead." )]] inline void
-    setEdges( const Container& edgeList );
-
-    /// Return the list of faces.
-    /// \note For triangle/quadrangle/polygonal meshes only.
-    [[deprecated( "Use findIndexDataWithLock<VectorNui>( \"in_face\" ) "
-                  "instead." )]] inline VectorNuArray&
-    getFaces();
-
-    /// Return the list of faces.
-    /// \note For triangle/quadrangle/polygonal meshes only.
-    [[deprecated( "Use getIndexedData<VectorNui>( \"in_face\" ) "
-                  "instead." )]] inline const VectorNuArray&
-    getFaces() const;
-
-    /// Set the list of faces.
-    /// \note For triangle/quadrangle/polygonal meshes only.
-    /// \note Use findIndexDataWithLock<VectorNui>( "in_face" ), then modify value of the
-    /// vectorArray and unlock it. instead.
-    template <typename Container>
-    [[deprecated( "Use setIndexedData( GeometryType::POLY_MESH, faceList, \"in_face\" ) "
-                  "instead." )]] inline void
-    setFaces( const Container& faceList );
-
-    /// Return the list of polyhedra.
-    /// \note For tetrahedron/hexahedron meshes only.
-    [[deprecated( "Use findIndexDataWithLock<VectorNui>( \"in_polyhedron\" ) "
-                  "instead." )]] inline VectorNuArray&
-    getPolyhedra();
-
-    /// Return the list of polyhedra.
-    /// \note For tetrahedron/hexahedron meshes only.
-    [[deprecated( "Use getIndexedData<VectorNui>( \"in_polyhedron\" ) "
-                  "instead." )]] inline const VectorNuArray&
-    getPolyhedra() const;
-
-    /// Set the list of polyhedra.
-    /// \note For tetrahedron/hexahedron meshes only.
-    /// \note Use findIndexDataWithLock<VectorNui>( "in_polyhedron" ), then modify value of the
-    /// vectorArray and unlock it. instead.
-    template <typename Container>
-    [[deprecated( "Use setIndexedData( GeometryType::POLY_MESH, polyList, \"in_polyhedron\" ) "
-                  "instead." )]] inline void
-    setPolyhedra( const Container& polyList );
-
-    /// Return the list of vertex normals.
-    [[deprecated(
-        "Use getMultiIndexedGeometry().normalsWithLock() instead." )]] inline Vector3Array&
-    getNormals();
-
-    /// Return the (const) list of vertex normals.
-    [[deprecated( "Use getMultiIndexedGeometry().normals() instead. " )]] inline const Vector3Array&
-    getNormals() const;
-
-    /// Set the vertex normals.
-    /// \note Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_NORMAL ).setData( normalList )
-    /// instead.
-    template <typename Container>
-    [[deprecated( "Use getMultiIndexedGeometry().setNormals( data ) instead." )]] inline void
-    setNormals( const Container& );
-
-    /// Return the list of vertex tangent vectors.
-    [[deprecated( "Use getAttrib<Vector3>( getAttribName(Geometry::MeshAttrib::VERTEX_TANGENT) "
-                  ").getDataWithLock() "
-                  "instead." )]] inline Vector3Array&
-    getTangents();
-
-    /// Return the (const) list of vertex tangents vectors.
-    [[deprecated( "Use getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TANGENT ).data() "
-                  "instead " )]] inline const Vector3Array&
-    getTangents() const;
-
-    /// Set the vertex tangent vectors.
-    /// \note Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_TANGENT ).setData( tangentList
-    /// ) instead.
-    template <typename Container>
-    [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_TANGENT ).setData( "
-                  "tangentList ) instead." )]] inline void
-    setTangents( const Container& tangentList );
-
-    /// Return the list of vertex bitangent vectors.
-    [[deprecated(
-        "Use getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_BITANGENT ).getDataWithLock() "
-        "instead." )]] inline Vector3Array&
-    getBiTangents();
-
-    /// Return the (const) list of vertex bitangent vectors.
-    [[deprecated( "Use getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_BITANGENT "
-                  ").data() " )]] inline const Vector3Array&
-    getBiTangents() const;
-
-    /// Set the vertex bitangent vectors.
-    /// \note Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_BITANGENT ).setData(
-    /// bitangentList ) instead.
-    template <typename Container>
-    [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_BITANGENT ).setData( "
-                  "bitangentList ) instead." )]] inline void
-    setBitangents( const Container& bitangentList );
-
-    /// Return the list of vertex texture coordinates.
-    [[deprecated(
-        "Use getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TEXCOORD ).getDataWithLock() "
-        "instead." )]] inline Vector3Array&
-    getTexCoords();
-
-    /// Return the (const) list of vertex texture coordinates.
-    [[deprecated( "Use getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TEXCOORD "
-                  ").data() " )]] inline const Vector3Array&
-    getTexCoords() const;
-
-    /// Set the vertex texture coordinates.
-    /// \note Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_TEXCOORD ).setData(
-    /// texCoordList ) instead.
-    template <typename Container>
-    [[deprecated( "Use getAttrib<Vector3ui>( Geometry::MeshAttrib::VERTEX_TEXCOORD ).setData( "
-                  "texCoordList ) instead." )]] inline void
-    setTextureCoordinates( const Container& texCoordList );
-
     /// Return the MaterialData associated to the objet.
     inline const MaterialData& getMaterial() const;
 
     /// Set the MaterialData for the object.
     inline void setMaterial( MaterialData* material );
+
+    /// Read/write access to the multiIndexedGeometry;
+    inline Geometry::MultiIndexedGeometry& getGeometry();
+
+    /// Read only access to the multiIndexedGeometry;
+    inline const Geometry::MultiIndexedGeometry& getGeometry() const;
+
     /// \}
 
     /// \name Status queries
@@ -257,10 +108,6 @@ class RA_CORE_API GeometryData : public AssetData
     /// Return true if the object is a Hexahedron Mesh.
     inline bool isHexMesh() const;
 
-    /// Return true if the object has vertices.
-    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
-    hasVertices() const;
-
     /// Return true if the object has lines.
     inline bool hasEdges() const;
 
@@ -270,76 +117,19 @@ class RA_CORE_API GeometryData : public AssetData
     /// Return true if the object has polyhedra.
     inline bool hasPolyhedra() const;
 
-    /// Return true if the object has vertex normals.
-    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
-    hasNormals() const;
-
-    /// Return true if the object has vertex tangent vectors.
-    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
-    hasTangents() const;
-
-    /// Return true if the object has vertex bitangent vectors.
-    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
-    hasBiTangents() const;
-
-    /// Return true if the object has vertex texture coordinates.
-    [[deprecated( "Use hasAttribData( std::string name ) instead." )]] inline bool
-    hasTextureCoordinates() const;
-
     /// Return true if the object has MaterialData.
     inline bool hasMaterial() const;
+
+    /// Used to track easily the number of primitives in the geometry data
+    inline void setPrimitiveNum( int n );
+
+    /// Return the number of primitives in the geometry data
+    inline int getPrimitiveNum() const;
+
     /// \}
 
     /// Print stast info to the Debug output.
     void displayInfo() const;
-
-    /// Access to the multiIndexedGeometry;
-    inline Geometry::MultiIndexedGeometry& getMultiIndexedGeometry();
-
-    /// Access to the (const) multiIndexedGeometry;
-    inline const Geometry::MultiIndexedGeometry& getMultiIndexedGeometry() const;
-
-    /// Access to the attrib manager
-    inline Utils::AttribManager& getAttribManager();
-
-    /// Access to the (const) attrib manager
-    inline const Utils::AttribManager& getAttribManager() const;
-
-    /**
-     *
-     * @tparam V
-     * @param name
-     * @param firstOccurrence
-     * @return Initialize (if necessary) and get a VectorArray<V> contain in layer.
-     * @note If firstOccurrence == true, it allow to function to be more efficient but the name
-     * isn't use to find the layer.
-     * @warning This function lock the layer, user has read-write access, when done, call
-     * indexedDataUnlock ( const GeometryType& type, const std::string& name ).
-     */
-    template <typename V>
-    inline VectorArray<V>& findIndexDataWithLock( const std::string& name     = "",
-                                                  const bool& firstOccurrence = true );
-
-    /**
-     *
-     * @tparam V
-     * @param name
-     * @param firstOccurrence
-     * @note If firstOccurrence == true, it allow to function to be more efficient but the name
-     * isn't use to find the layer.
-     * @return VectorArray<V>& stored in the layer.
-     */
-    template <typename V>
-    inline const VectorArray<V>& getIndexedData( const std::string& name     = "",
-                                                 const bool& firstOccurrence = true ) const;
-
-    /**
-     *
-     * @param type
-     * @param name
-     * @warning Unlock a layer only if it was previously locked.
-     */
-    inline void indexedDataUnlock( const GeometryType& type, const std::string& name = "" );
 
   protected:
     /// The transformation of the object.
@@ -349,83 +139,13 @@ class RA_CORE_API GeometryData : public AssetData
     GeometryType m_type;
 
     /// Named attributes
-    Core::Geometry::MultiIndexedGeometry m_multiIndexedGeometry;
+    Core::Geometry::MultiIndexedGeometry m_geometry;
+
+    /// Simple tracking of geometric primitive number
+    int m_numPrimitives { -1 };
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;
-
-  private:
-    /**
-     *
-     * @tparam V
-     * @param indexedDataList
-     * @param type
-     * @param name
-     * @brief Copy data from indexedDataList into the layer obtain with name and type.
-     */
-    template <typename V>
-    inline void setIndexedData( const GeometryType& type,
-                                const VectorArray<V>& indexedDataList,
-                                const std::string& name = "" );
-
-    /**
-     *
-     * @tparam V
-     * @param geomBase
-     * @return VectorArray<V> contains into the layerBase.
-     */
-    template <typename V>
-    inline VectorArray<V>& getDataFromLayerBase( Geometry::GeometryIndexLayerBase& geomBase );
-
-    /**
-     *
-     * @tparam V
-     * @param geomBase
-     * @return const VectorArray<V> contains into the layerBase.
-     */
-    template <typename V>
-    inline const VectorArray<V>&
-    getDataFromLayerBase( const Geometry::GeometryIndexLayerBase& geomBase ) const;
-
-    /**
-     *
-     * @tparam L
-     * @param firstOccurrence
-     * @param name
-     * @return GeometryIndexLayerBase& from the given name.
-     * @note This will try to get the first occurrence of the layer ignoring the given name for
-     * optimization. Please put firstOccurrence to false if you provide a name.
-     * @warning You must unlock the layer after using this function by using indexedDataUnlock(
-     * const GeometryType& type, const std::string& name ).
-     */
-    template <typename L>
-    inline Geometry::GeometryIndexLayerBase& getLayerBaseWithLock( const bool& firstOccurrence,
-                                                                   const std::string& name );
-
-    /**
-     *
-     * @tparam L
-     * @param firstOccurrence
-     * @param name
-     * @return const GeometryIndexLayerBase& from the given name.
-     * @note This will try to get the first occurrence of the layer ignoring the given name for
-     * optimization. Please put firstOccurrence to false if you provide a name.
-     */
-    template <typename L>
-    inline const Geometry::GeometryIndexLayerBase& getLayerBase( const bool& firstOccurrence,
-                                                                 const std::string& name ) const;
-
-    /**
-     *
-     * @tparam V
-     * @tparam L
-     * @param firstOccurrence
-     * @param name
-     * @return VectorArray<V>& and lock the layer associated to it.
-     */
-    template <typename V, typename L>
-    inline VectorArray<V>& getIndexedDataWithLock( const bool& firstOccurrence,
-                                                   const std::string& name = "" );
 };
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -311,10 +311,19 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Access to the (const) attrib manager
     inline const Utils::AttribManager& getAttribManager() const;
-    /*
-     template <typename T>
-     inline T& getIndexDataWithLock( Core::Geometry::MultiIndexedGeometry::LayerSemanticCollection&
-     semantics ,const std::string& layerName );*/
+
+    inline void initIndexedData( const std::string& name );
+
+    template <typename V>
+    inline VectorArray<V>& getIndexedDataWithLock( const std::string& name );
+
+    template <typename V>
+    inline const VectorArray<V>& getIndexedData( const std::string& name ) const;
+
+    inline void indexedDataUnlock( const std::string& name );
+
+    template <typename V>
+    inline void setIndexedData( const std::string& name, const VectorArray<V>& attribDataList );
 
   protected:
     /// The transformation of the object.

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -311,6 +311,10 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Access to the (const) attrib manager
     inline const Utils::AttribManager& getAttribManager() const;
+    /*
+     template <typename T>
+     inline T& getIndexDataWithLock( Core::Geometry::MultiIndexedGeometry::LayerSemanticCollection&
+     semantics ,const std::string& layerName );*/
 
   protected:
     /// The transformation of the object.
@@ -329,7 +333,7 @@ class RA_CORE_API GeometryData : public AssetData
     VectorNuArray m_polyhedron;
 
     /// Named attributes
-    Core::Geometry::AttribArrayGeometry m_vertexAttribArray;
+    Core::Geometry::MultiIndexedGeometry multiIndexedGeometry;
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -73,7 +73,7 @@ class RA_CORE_API GeometryData : public AssetData
     inline std::size_t getVerticesSize() const;
 
     /// Return the list of vertices.
-    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    [[deprecated( "Use addAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
     getVertices();
 
     /// Return the list of vertices.
@@ -130,7 +130,7 @@ class RA_CORE_API GeometryData : public AssetData
     inline void setPolyhedra( const Container& polyList );
 
     /// Return the list of vertex normals.
-    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    [[deprecated( "Use addAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
     getNormals();
 
     /// Return the list of vertex normals.
@@ -145,7 +145,7 @@ class RA_CORE_API GeometryData : public AssetData
     setNormals( const Container& normalList );
 
     /// Return the list of vertex tangent vectors.
-    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    [[deprecated( "Use addAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
     getTangents();
 
     /// Return the list of vertex tangent vectors.
@@ -160,7 +160,7 @@ class RA_CORE_API GeometryData : public AssetData
     setTangents( const Container& tangentList );
 
     /// Return the list of vertex bitangent vectors.
-    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    [[deprecated( "Use addAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
     getBiTangents();
 
     /// Return the list of vertex bitangent vectors.
@@ -175,7 +175,7 @@ class RA_CORE_API GeometryData : public AssetData
     setBitangents( const Container& bitangentList );
 
     /// Return the list of vertex texture coordinates.
-    [[deprecated( "Use getAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    [[deprecated( "Use addAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
     getTexCoords();
 
     /// Return the list of vertex texture coordinates.
@@ -254,55 +254,6 @@ class RA_CORE_API GeometryData : public AssetData
     inline bool hasMaterial() const;
     /// \}
 
-    /**
-     *
-     * @tparam Container
-     * @param name
-     * @return Get container base on name (lock).
-     * @warning If AttribHandle corresponding to name doesn't exist, it's created
-     * and return. By using this method, user has read-write access to data, data is lock, when
-     * done call attribDataUnlock( std :: std::string name )
-     */
-    template <typename Container>
-    inline Container& getAttribDataWithLock( const std::string& name );
-
-    /**
-     *
-     * @param name
-     * @brief Unlock data base on name.
-     */
-    inline void attribDataUnlock( const std::string& name );
-
-    /**
-     *
-     * @tparam Container
-     * @param name
-     * @return Get container base on the given name (const).
-     * @warning There is no check on the handle validity (obtained by using name)
-     */
-    template <typename Container>
-    inline const Container& getAttribData( const std::string& name ) const;
-
-    /**
-     *
-     * @tparam Container
-     * @param name
-     * @param attribDataList
-     * @brief Copy data from attribDataList into the attrib obtain with name.
-     * @note In-place setting with getAttribDataWithLock( std::string name ) is preferred.
-     *
-     */
-    template <typename Container>
-    inline void setAttribData( const std::string& name, const Container& attribDataList );
-
-    /**
-     *
-     * @param name
-     * @return true if the name provided correspond to an existing attribHandle.
-     *
-     */
-    inline bool hasAttribData( const std::string& name ) const;
-
     /// Print stast info to the Debug output.
     void displayInfo() const;
 
@@ -346,6 +297,43 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// The MaterialData for the object.
     std::shared_ptr<MaterialData> m_material;
+
+  private:
+    /**
+     *
+     * @tparam V
+     * @param name
+     * @return Get container base on name (lock).
+     * @warning If AttribHandle corresponding to name doesn't exist, it's created
+     * and return. By using this method, user has read-write access to data, data is lock, when
+     * done call attribDataUnlock( std :: std::string name )
+     * @note This function is only to avoid redundant code of function like getNormals().
+     */
+    template <typename V>
+    inline VectorArray<V>& addAttribDataWithLock( const Geometry::MeshAttrib& name );
+
+    /**
+     *
+     * @tparam Container
+     * @param name
+     * @param attribDataList
+     * @brief Copy data from attribDataList into the attrib obtain with name.
+     * @note In-place setting with addAttribDataWithLock( std::string name ) is preferred.
+     * This function is only to avoid redundant code of function like setNormals().
+     *
+     */
+    template <typename Container>
+    inline void setAttribData( const Geometry::MeshAttrib& name, const Container& attribDataList );
+
+    /**
+     * @tparam V
+     * @param name
+     * @return true if the name provided correspond to an existing attribHandle.
+     * @note This function is only to avoid redundant code of function like hasNormals().
+     *
+     */
+    template <typename V>
+    inline bool hasAttribData( const Geometry::MeshAttrib& name ) const;
 };
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -335,7 +335,7 @@ class RA_CORE_API GeometryData : public AssetData
      * @return Get container base on name (lock).
      * @warning If AttribHandle corresponding to name doesn't exist, it's created
      * and return. By using this method, user has read-write access to data, data is lock, when
-     * done call attribDataUnlock( std :: std::string name )
+     * done, user must unlock data by getting the attribManager and then get the attrib.
      * @note This function is only to avoid redundant code of function like getNormals().
      */
     template <typename V>

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -73,19 +73,15 @@ class RA_CORE_API GeometryData : public AssetData
     inline std::size_t getVerticesSize() const;
 
     /// Return the list of vertices.
-    [[deprecated( "Use addAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    [[deprecated( "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) "
+                  "instead." )]] inline Vector3Array&
     getVertices();
 
-    /// Return the list of vertices.
-    [[deprecated( "Use getAttribData( std::string name ) instead." )]] inline const Vector3Array&
-    getVertices() const;
-
     /// Set the mesh vertices.
-    /// \note In-place setting with getVertices() is preferred.
+    /// \note Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated( "Use setAttribData( const Geometry::MeshAttrib& name, const VectorArray<V>& "
-                  "attribDataList ) "
-                  "instead." )]] inline void
+    [[deprecated(
+        "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead. " )]] inline void
     setVertices( const Container& vertexList );
 
     /// Return the list of lines.
@@ -102,10 +98,11 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of lines.
     /// \note For line meshes only.
-    /// \note In-place setting with getEdges() is preferred.
+    /// \note Use addIndexedDataWithLock( const GeometryType& type, const std::string& name )
+    /// instead.
     template <typename Container>
-    [[deprecated( "Use setIndexedData( const GeometryType& type, const VectorArray<V>& "
-                  "indexedDataList, const std::string& name) instead. " )]] inline void
+    [[deprecated( "Use addIndexedDataWithLock( const GeometryType& type, const std::string& name ) "
+                  "instead." )]] inline void
     setEdges( const Container& edgeList );
 
     /// Return the list of faces.
@@ -122,10 +119,11 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of faces.
     /// \note For triangle/quadrangle/polygonal meshes only.
-    /// \note In-place setting with getFaces() is preferred.
+    /// \note Use addIndexedDataWithLock( const GeometryType& type, const std::string& name )
+    /// instead.
     template <typename Container>
-    [[deprecated( "Use setIndexedData( const GeometryType& type, const VectorArray<V>& "
-                  "indexedDataList, const std::string& name) instead. " )]] inline void
+    [[deprecated( "Use addIndexedDataWithLock( const GeometryType& type, const std::string& name ) "
+                  "instead." )]] inline void
     setFaces( const Container& faceList );
 
     /// Return the list of polyhedra.
@@ -142,58 +140,59 @@ class RA_CORE_API GeometryData : public AssetData
 
     /// Set the list of polyhedra.
     /// \note For tetrahedron/hexahedron meshes only.
-    /// \note In-place setting with getPolyhedra() is preferred.
+    /// \note Use addIndexedDataWithLock( const GeometryType& type, const std::string& name )
+    /// instead.
     template <typename Container>
-    [[deprecated( "Use setIndexedData( const GeometryType& type, const VectorArray<V>& "
-                  "indexedDataList, const std::string& name) instead. " )]] inline void
+    [[deprecated( "Use addIndexedDataWithLock( const GeometryType& type, const std::string& name ) "
+                  "instead." )]] inline void
     setPolyhedra( const Container& polyList );
 
     /// Return the list of vertex normals.
-    [[deprecated( "Use addAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    [[deprecated( "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) "
+                  "instead." )]] inline Vector3Array&
     getNormals();
 
     /// Set the vertex normals.
-    /// \note In-place setting with getNormals() is preferred.
+    /// \note Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated( "Use setAttribData( const Geometry::MeshAttrib& name, const VectorArray<V>& "
-                  "attribDataList ) "
-                  "instead." )]] inline void
+    [[deprecated(
+        "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead." )]] inline void
     setNormals( const Container& normalList );
 
     /// Return the list of vertex tangent vectors.
-    [[deprecated( "Use addAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    [[deprecated( "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) "
+                  "instead." )]] inline Vector3Array&
     getTangents();
 
     /// Set the vertex tangent vectors.
-    /// \note In-place setting with getTangents() is preferred.
+    /// \note Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated( "Use setAttribData( const Geometry::MeshAttrib& name, const VectorArray<V>& "
-                  "attribDataList ) "
-                  "instead." )]] inline void
+    [[deprecated(
+        "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead." )]] inline void
     setTangents( const Container& tangentList );
 
     /// Return the list of vertex bitangent vectors.
-    [[deprecated( "Use addAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    [[deprecated( "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) "
+                  "instead." )]] inline Vector3Array&
     getBiTangents();
 
     /// Set the vertex bitangent vectors.
-    /// \note In-place setting with getBiTangents() is preferred.
+    /// \note Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated( "Use setAttribData( const Geometry::MeshAttrib& name, const VectorArray<V>& "
-                  "attribDataList ) "
-                  "instead." )]] inline void
+    [[deprecated(
+        "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead." )]] inline void
     setBitangents( const Container& bitangentList );
 
     /// Return the list of vertex texture coordinates.
-    [[deprecated( "Use addAttribDataWithLock( std::string name ) instead." )]] inline Vector3Array&
+    [[deprecated( "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) "
+                  "instead." )]] inline Vector3Array&
     getTexCoords();
 
     /// Set the vertex texture coordinates.
-    /// \note In-place setting with getTexCoords() is preferred.
+    /// \note Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead.
     template <typename Container>
-    [[deprecated( "Use setAttribData( const Geometry::MeshAttrib& name, const VectorArray<V>& "
-                  "attribDataList ) "
-                  "instead." )]] inline void
+    [[deprecated(
+        "Use addAttribDataWithLock( const Geometry::MeshAttrib& name ) instead." )]] inline void
     setTextureCoordinates( const Container& texCoordList );
 
     /// Return the MaterialData associated to the objet.
@@ -273,6 +272,29 @@ class RA_CORE_API GeometryData : public AssetData
     /**
      *
      * @tparam V
+     * @param name
+     * @return Get container base on name (lock).
+     * @warning If AttribHandle corresponding to name doesn't exist, it's created
+     * and return. By using this method, user has read-write access to data, data is lock, when
+     * done, user must unlock data by getting the attribManager and then get the attrib.
+     * @note This function is only to avoid redundant code of function like getNormals().
+     */
+    template <typename V>
+    inline VectorArray<V>& addAttribDataWithLock( const Geometry::MeshAttrib& name );
+
+    /**
+     * @tparam V
+     * @param name
+     * @return true if the name provided correspond to an existing attribHandle.
+     * @note This function is only to avoid redundant code of function like hasNormals().
+     *
+     */
+    template <typename V>
+    inline bool hasAttribData( const Geometry::MeshAttrib& name ) const;
+
+    /**
+     *
+     * @tparam V
      * @param type
      * @param name
      * @return Initialize (if necessary) and get a VectorArray<V> contain in layer.
@@ -304,21 +326,6 @@ class RA_CORE_API GeometryData : public AssetData
      */
     inline void indexedDataUnlock( const GeometryType& type, const std::string& name = "" );
 
-    /**
-     *
-     * @tparam V
-     * @param indexedDataList
-     * @param type
-     * @param name
-     * @brief Copy data from indexedDataList into the layer obtain with name and type.
-     * @note In-place setting with addIndexedDataWithLock( std::string name ) is preferred.
-     * This function is only to avoid redundant code of function like setEdges().
-     */
-    template <typename V>
-    inline void setIndexedData( const GeometryType& type,
-                                const VectorArray<V>& indexedDataList,
-                                const std::string& name = "" );
-
   protected:
     /// The transformation of the object.
     Transform m_frame;
@@ -335,25 +342,11 @@ class RA_CORE_API GeometryData : public AssetData
   private:
     /**
      *
-     * @tparam V
-     * @param name
-     * @return Get container base on name (lock).
-     * @warning If AttribHandle corresponding to name doesn't exist, it's created
-     * and return. By using this method, user has read-write access to data, data is lock, when
-     * done, user must unlock data by getting the attribManager and then get the attrib.
-     * @note This function is only to avoid redundant code of function like getNormals().
-     */
-    template <typename V>
-    inline VectorArray<V>& addAttribDataWithLock( const Geometry::MeshAttrib& name );
-
-    /**
-     *
      * @tparam Container
      * @param name
      * @param attribDataList
      * @brief Copy data from attribDataList into the attrib obtain with name.
-     * @note In-place setting with addAttribDataWithLock( std::string name ) is preferred.
-     * This function is only to avoid redundant code of function like setNormals().
+     * @note This function is only to avoid redundant code of function like setNormals().
      *
      */
     template <typename V>
@@ -361,14 +354,18 @@ class RA_CORE_API GeometryData : public AssetData
                                const VectorArray<V>& attribDataList );
 
     /**
-     * @tparam V
-     * @param name
-     * @return true if the name provided correspond to an existing attribHandle.
-     * @note This function is only to avoid redundant code of function like hasNormals().
      *
+     * @tparam V
+     * @param indexedDataList
+     * @param type
+     * @param name
+     * @brief Copy data from indexedDataList into the layer obtain with name and type.
+     * @note This function is only to avoid redundant code of function like setEdges().
      */
     template <typename V>
-    inline bool hasAttribData( const Geometry::MeshAttrib& name ) const;
+    inline void setIndexedData( const GeometryType& type,
+                                const VectorArray<V>& indexedDataList,
+                                const std::string& name = "" );
 
     /**
      *

--- a/src/Core/Asset/GeometryData.hpp
+++ b/src/Core/Asset/GeometryData.hpp
@@ -73,14 +73,12 @@ class RA_CORE_API GeometryData : public AssetData
     inline std::size_t getVerticesSize() const;
 
     /// Return the list of vertices.
-    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) "
+    [[deprecated( "Use verticesWithLock() "
                   "instead." )]] inline Vector3Array&
     getVertices();
 
     /// Return the (const) list of vertices.
-    [[deprecated( "Use getMultiIndexedGeometry() and related functions to obtain the "
-                  "list." )]] inline const Vector3Array&
-    getVertices() const;
+    [[deprecated( "Use vertices() instead. " )]] inline const Vector3Array& getVertices() const;
 
     /// Set the mesh vertices.
     /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.
@@ -158,14 +156,10 @@ class RA_CORE_API GeometryData : public AssetData
     setPolyhedra( const Container& polyList );
 
     /// Return the list of vertex normals.
-    [[deprecated( "Use getAttrib( const Geometry::MeshAttrib& name ) "
-                  "instead." )]] inline Vector3Array&
-    getNormals();
+    [[deprecated( "Use normalsWithLock() instead." )]] inline Vector3Array& getNormals();
 
     /// Return the (const) list of vertex normals.
-    [[deprecated( "Use getMultiIndexedGeometry() and related functions to obtain the "
-                  "list." )]] inline const Vector3Array&
-    getNormals() const;
+    [[deprecated( "Use normals() instead. " )]] inline const Vector3Array& getNormals() const;
 
     /// Set the vertex normals.
     /// \note Use getAttrib( const Geometry::MeshAttrib& name ) instead.

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -232,7 +232,7 @@ Utils::AttribManager& GeometryData::getAttribManager() {
 }
 
 template <typename Container>
-inline Container& GeometryData::getAttribDataWithLock( std::string name ) {
+inline Container& GeometryData::getAttribDataWithLock( const std::string& name ) {
     auto h = m_vertexAttribs.findAttrib<Vector3>( name );
     if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( name ); }
     auto attribPtr = m_vertexAttribs.getAttribPtr( h );
@@ -241,26 +241,27 @@ inline Container& GeometryData::getAttribDataWithLock( std::string name ) {
 }
 
 template <typename Container>
-inline const Container& GeometryData::getAttribData( std::string name ) const {
+inline const Container& GeometryData::getAttribData( const std::string& name ) const {
     auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( name );
     const auto& v     = m_vertexAttribs.getAttrib( attriHandler ).data();
     return v;
 }
 
 template <typename Container>
-inline void GeometryData::setAttribData( std::string name, const Container& attribDataList ) {
+inline void GeometryData::setAttribData( const std::string& name,
+                                         const Container& attribDataList ) {
     auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( name ) );
     auto& v      = attrib.getDataWithLock();
     internal::copyData( attribDataList, v );
     attrib.unlock();
 }
-bool GeometryData::hasAttribData( std::string name ) const {
+bool GeometryData::hasAttribData( const std::string& name ) const {
     auto h = m_vertexAttribs.findAttrib<Vector3>( name );
     if ( m_vertexAttribs.isValid( h ) ) { return !m_vertexAttribs.getAttrib( h ).data().empty(); }
     return false;
 }
 
-void GeometryData::attribDataUnlock( std::string name ) {
+void GeometryData::attribDataUnlock( const std::string& name ) {
     auto h = m_vertexAttribs.findAttrib<Vector3>( name );
     if ( m_vertexAttribs.isValid( h ) ) {
         auto attribPtr = m_vertexAttribs.getAttribPtr( h );

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -32,11 +32,11 @@ inline std::size_t GeometryData::getVerticesSize() const {
 }
 
 inline const Vector3Array& GeometryData::getVertices() const {
-    return m_vertex;
+    return getVertexAttrib( "vertex" );
 }
 
 inline Vector3Array& GeometryData::getVertices() {
-    return m_vertex;
+    return getVertexAttrib( "vertex" );
 }
 
 namespace internal {
@@ -57,7 +57,7 @@ inline void copyData( const InContainer& input, OutContainer& output ) {
 
 template <typename Container>
 inline void GeometryData::setVertices( const Container& vertexList ) {
-    internal::copyData( vertexList, m_vertex );
+    return setVertexAttrib( "vertex", vertexList );
 }
 
 inline Vector2uArray& GeometryData::getEdges() {
@@ -100,100 +100,55 @@ inline void GeometryData::setPolyhedra( const Container& polyList ) {
 }
 
 inline Vector3Array& GeometryData::getNormals() {
-    auto h = m_vertexAttribs.findAttrib<Vector3>( "normal" );
-    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "normal" ); }
-    auto& attrib = m_vertexAttribs.getAttrib( h );
-    auto& normal = attrib.getDataWithLock();
-    attribPtr    = &attrib;
-    return normal;
-}
-
-inline void GeometryData::unlockData() {
-    attribPtr->unlock();
-    attribPtr = nullptr;
+    return getVertexAttrib( "normal" );
 }
 
 inline const Vector3Array& GeometryData::getNormals() const {
-    auto handler = m_vertexAttribs.findAttrib<Vector3>( "normal" );
-    auto& normal = m_vertexAttribs.getAttrib( handler ).data();
-    return normal;
+    return getVertexAttrib( "normal" );
 }
 
 template <typename Container>
 inline void GeometryData::setNormals( const Container& normalList ) {
-    auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) );
-    auto& normal = attrib.getDataWithLock();
-    internal::copyData( normalList, normal );
-    attrib.unlock();
+    return setVertexAttrib( "normal", normalList );
 }
 
 inline Vector3Array& GeometryData::getTangents() {
-    auto h = m_vertexAttribs.findAttrib<Vector3>( "tangent" );
-    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "tangent" ); }
-    auto& attrib  = m_vertexAttribs.getAttrib( h );
-    auto& tangent = attrib.getDataWithLock();
-    attribPtr     = &attrib;
-    return tangent;
+    return getVertexAttrib( "tangent" );
 }
 
 inline const Vector3Array& GeometryData::getTangents() const {
-    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( "tangent" );
-    auto& tangent     = m_vertexAttribs.getAttrib( attriHandler ).data();
-    return tangent;
+    return getVertexAttrib( "tangent" );
 }
 
 template <typename Container>
 inline void GeometryData::setTangents( const Container& tangentList ) {
-    auto& attrib  = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) );
-    auto& tangent = attrib.getDataWithLock();
-    internal::copyData( tangentList, tangent );
-    attrib.unlock();
+    return setVertexAttrib( "tangent", tangentList );
 }
 
 inline Vector3Array& GeometryData::getBiTangents() {
-    auto h = m_vertexAttribs.findAttrib<Vector3>( "biTangent" );
-    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "biTangent" ); }
-    auto& attrib    = m_vertexAttribs.getAttrib( h );
-    auto& biTangent = attrib.getDataWithLock();
-    attribPtr       = &attrib;
-    return biTangent;
+    return getVertexAttrib( "biTangent" );
 }
 
 inline const Vector3Array& GeometryData::getBiTangents() const {
-    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( "biTangent" );
-    auto& biTangent   = m_vertexAttribs.getAttrib( attriHandler ).data();
-    return biTangent;
+    return getVertexAttrib( "biTangent" );
 }
 
 template <typename Container>
 inline void GeometryData::setBitangents( const Container& bitangentList ) {
-    auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "biTangent" ) );
-    auto& biTangent = attrib.getDataWithLock();
-    internal::copyData( bitangentList, biTangent );
-    attrib.unlock();
+    return setVertexAttrib( "biTangent", bitangentList );
 }
 
 inline Vector3Array& GeometryData::getTexCoords() {
-    auto h = m_vertexAttribs.findAttrib<Vector3>( "texCoord" );
-    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "texCoord" ); }
-    auto& attrib   = m_vertexAttribs.getAttrib( h );
-    auto& texCoord = attrib.getDataWithLock();
-    attribPtr      = &attrib;
-    return texCoord;
+    return getVertexAttrib( "texCoord" );
 }
 
 inline const Vector3Array& GeometryData::getTexCoords() const {
-    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( "texCoord" );
-    auto& texCoord    = m_vertexAttribs.getAttrib( attriHandler ).data();
-    return texCoord;
+    return getVertexAttrib( "texCoord" );
 }
 
 template <typename Container>
 inline void GeometryData::setTextureCoordinates( const Container& texCoordList ) {
-    auto& attrib   = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "texCoord" ) );
-    auto& texCoord = attrib.getDataWithLock();
-    internal::copyData( texCoordList, texCoord );
-    attrib.unlock();
+    return setVertexAttrib( "texCoord", texCoordList );
 }
 
 inline const MaterialData& GeometryData::getMaterial() const {
@@ -282,6 +237,33 @@ const Utils::AttribManager& GeometryData::getAttribManager() const {
 
 Utils::AttribManager& GeometryData::getAttribManager() {
     return m_vertexAttribs;
+}
+
+inline Vector3Array& GeometryData::getVertexAttrib( std::string vertexAttribName ) {
+    auto h = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
+    if ( !m_vertexAttribs.isValid( h ) ) {
+        h = m_vertexAttribs.addAttrib<Vector3>( vertexAttribName );
+    }
+    auto attribPtr = m_vertexAttribs.getAttribPtr( h );
+    if ( attribPtr->isLocked() ) { attribPtr->unlock(); }
+    auto& v = attribPtr->getDataWithLock();
+    return v;
+}
+
+inline const Vector3Array& GeometryData::getVertexAttrib( std::string vertexAttribName ) const {
+    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
+    auto& v           = m_vertexAttribs.getAttrib( attriHandler ).data();
+    return v;
+}
+
+template <typename Container>
+inline void GeometryData::setVertexAttrib( std::string vertexAttribName,
+                                           const Container& vertexAttribList ) {
+    auto& attrib =
+        m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( vertexAttribName ) );
+    auto& v = attrib.getDataWithLock();
+    internal::copyData( vertexAttribList, v );
+    attrib.unlock();
 }
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -99,30 +99,46 @@ inline void GeometryData::setPolyhedra( const Container& polyList ) {
     internal::copyData( polyList, m_polyhedron );
 }
 
+// TODO : add a shared_point or kind of to unlock attrib
 inline Vector3Array& GeometryData::getNormals() {
-    return m_normal;
+    auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) );
+    auto& normal = attrib.getDataWithLock();
+    return normal;
 }
 
 inline const Vector3Array& GeometryData::getNormals() const {
-    return m_normal;
+    auto handler = m_vertexAttribs.findAttrib<Vector3>( "normal" );
+    auto& normal = m_vertexAttribs.getAttrib( handler ).data();
+    return normal;
 }
 
 template <typename Container>
 inline void GeometryData::setNormals( const Container& normalList ) {
-    internal::copyData( normalList, m_normal );
+    auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) );
+    auto& normal = attrib.getDataWithLock();
+    internal::copyData( normalList, normal );
+    attrib.unlock();
 }
 
+// TODO : add a shared_point or kind of to unlock attrib
 inline Vector3Array& GeometryData::getTangents() {
-    return m_tangent;
+    auto& tangent = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "tangent" ) )
+                        .getDataWithLock();
+    return tangent;
 }
 
 inline const Vector3Array& GeometryData::getTangents() const {
-    return m_tangent;
+    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( "tangent" );
+    auto& tangent     = m_vertexAttribs.getAttrib( attriHandler ).data();
+    return tangent;
 }
 
 template <typename Container>
 inline void GeometryData::setTangents( const Container& tangentList ) {
-    internal::copyData( tangentList, m_tangent );
+    auto& attrib  = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) );
+    auto& tangent = attrib.getDataWithLock();
+    internal::copyData( tangentList, tangent );
+    attrib.unlock();
 }
 
 inline Vector3Array& GeometryData::getBiTangents() {
@@ -204,11 +220,15 @@ inline bool GeometryData::hasPolyhedra() const {
 }
 
 inline bool GeometryData::hasNormals() const {
-    return !m_normal.empty();
+    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) )
+                .data()
+                .empty();
 }
 
 inline bool GeometryData::hasTangents() const {
-    return !m_tangent.empty();
+    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "tangent" ) )
+                .data()
+                .empty();
 }
 
 inline bool GeometryData::hasBiTangents() const {

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -28,15 +28,15 @@ inline void GeometryData::setFrame( const Transform& frame ) {
 }
 
 inline std::size_t GeometryData::getVerticesSize() const {
-    return m_vertex.size();
+    return getAttribData<Vector3Array&>( "vertex" ).size();
 }
 
 inline const Vector3Array& GeometryData::getVertices() const {
-    return getVertexAttrib<Vector3Array&>( "vertex" );
+    return getAttribData<Vector3Array&>( "vertex" );
 }
 
 inline Vector3Array& GeometryData::getVertices() {
-    return getVertexAttrib<Vector3Array&>( "vertex" );
+    return getAttribDataWithLock<Vector3Array&>( "vertex" );
 }
 
 namespace internal {
@@ -57,7 +57,7 @@ inline void copyData( const InContainer& input, OutContainer& output ) {
 
 template <typename Container>
 inline void GeometryData::setVertices( const Container& vertexList ) {
-    return setVertexAttrib( "vertex", vertexList );
+    return setAttribData( "vertex", vertexList );
 }
 
 inline Vector2uArray& GeometryData::getEdges() {
@@ -100,55 +100,55 @@ inline void GeometryData::setPolyhedra( const Container& polyList ) {
 }
 
 inline Vector3Array& GeometryData::getNormals() {
-    return getVertexAttrib<Vector3Array&>( "normal" );
+    return getAttribDataWithLock<Vector3Array&>( "normal" );
 }
 
 inline const Vector3Array& GeometryData::getNormals() const {
-    return getVertexAttrib<Vector3Array&>( "normal" );
+    return getAttribData<Vector3Array&>( "normal" );
 }
 
 template <typename Container>
 inline void GeometryData::setNormals( const Container& normalList ) {
-    return setVertexAttrib( "normal", normalList );
+    return setAttribData( "normal", normalList );
 }
 
 inline Vector3Array& GeometryData::getTangents() {
-    return getVertexAttrib<Vector3Array&>( "tangent" );
+    return getAttribDataWithLock<Vector3Array&>( "tangent" );
 }
 
 inline const Vector3Array& GeometryData::getTangents() const {
-    return getVertexAttrib<Vector3Array&>( "tangent" );
+    return getAttribData<Vector3Array&>( "tangent" );
 }
 
 template <typename Container>
 inline void GeometryData::setTangents( const Container& tangentList ) {
-    return setVertexAttrib( "tangent", tangentList );
+    return setAttribData( "tangent", tangentList );
 }
 
 inline Vector3Array& GeometryData::getBiTangents() {
-    return getVertexAttrib<Vector3Array&>( "biTangent" );
+    return getAttribDataWithLock<Vector3Array&>( "biTangent" );
 }
 
 inline const Vector3Array& GeometryData::getBiTangents() const {
-    return getVertexAttrib<Vector3Array&>( "biTangent" );
+    return getAttribData<Vector3Array&>( "biTangent" );
 }
 
 template <typename Container>
 inline void GeometryData::setBitangents( const Container& bitangentList ) {
-    return setVertexAttrib( "biTangent", bitangentList );
+    return setAttribData( "biTangent", bitangentList );
 }
 
 inline Vector3Array& GeometryData::getTexCoords() {
-    return getVertexAttrib<Vector3Array&>( "texCoord" );
+    return getAttribDataWithLock<Vector3Array&>( "texCoord" );
 }
 
 inline const Vector3Array& GeometryData::getTexCoords() const {
-    return getVertexAttrib<Vector3Array&>( "texCoord" );
+    return getAttribData<Vector3Array&>( "texCoord" );
 }
 
 template <typename Container>
 inline void GeometryData::setTextureCoordinates( const Container& texCoordList ) {
-    return setVertexAttrib( "texCoord", texCoordList );
+    return setAttribData( "texCoord", texCoordList );
 }
 
 inline const MaterialData& GeometryData::getMaterial() const {
@@ -188,7 +188,7 @@ inline bool GeometryData::isHexMesh() const {
 }
 
 inline bool GeometryData::hasVertices() const {
-    return hasVertexAttrib( "vertex" );
+    return hasAttribData( "vertex" );
 }
 
 inline bool GeometryData::hasEdges() const {
@@ -204,19 +204,19 @@ inline bool GeometryData::hasPolyhedra() const {
 }
 
 inline bool GeometryData::hasNormals() const {
-    return hasVertexAttrib( "normal" );
+    return hasAttribData( "normal" );
 }
 
 inline bool GeometryData::hasTangents() const {
-    return hasVertexAttrib( "tangent" );
+    return hasAttribData( "tangent" );
 }
 
 inline bool GeometryData::hasBiTangents() const {
-    return hasVertexAttrib( "biTangent" );
+    return hasAttribData( "biTangent" );
 }
 
 inline bool GeometryData::hasTextureCoordinates() const {
-    return hasVertexAttrib( "texCoord" );
+    return hasAttribData( "texCoord" );
 }
 
 inline bool GeometryData::hasMaterial() const {
@@ -232,37 +232,40 @@ Utils::AttribManager& GeometryData::getAttribManager() {
 }
 
 template <typename Container>
-inline Container& GeometryData::getVertexAttrib( std::string vertexAttribName ) {
-    auto h = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
-    if ( !m_vertexAttribs.isValid( h ) ) {
-        h = m_vertexAttribs.addAttrib<Vector3>( vertexAttribName );
-    }
+inline Container& GeometryData::getAttribDataWithLock( std::string name ) {
+    auto h = m_vertexAttribs.findAttrib<Vector3>( name );
+    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( name ); }
     auto attribPtr = m_vertexAttribs.getAttribPtr( h );
-    if ( attribPtr->isLocked() ) { attribPtr->unlock(); }
-    auto& v = attribPtr->getDataWithLock();
+    auto& v        = attribPtr->getDataWithLock();
     return v;
 }
 
 template <typename Container>
-inline const Container& GeometryData::getVertexAttrib( std::string vertexAttribName ) const {
-    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
+inline const Container& GeometryData::getAttribData( std::string name ) const {
+    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( name );
     auto& v           = m_vertexAttribs.getAttrib( attriHandler ).data();
     return const_cast<VectorArray<Eigen::Matrix<float, 3, 1, 0>>&>( v );
 }
 
 template <typename Container>
-inline void GeometryData::setVertexAttrib( std::string vertexAttribName,
-                                           const Container& vertexAttribList ) {
-    auto& attrib =
-        m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( vertexAttribName ) );
-    auto& v = attrib.getDataWithLock();
-    internal::copyData( vertexAttribList, v );
+inline void GeometryData::setAttribData( std::string name, const Container& attribDataList ) {
+    auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( name ) );
+    auto& v      = attrib.getDataWithLock();
+    internal::copyData( attribDataList, v );
     attrib.unlock();
 }
-bool GeometryData::hasVertexAttrib( std::string vertexAttribName ) const {
-    auto h = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
+bool GeometryData::hasAttribData( std::string name ) const {
+    auto h = m_vertexAttribs.findAttrib<Vector3>( name );
     if ( m_vertexAttribs.isValid( h ) ) { return !m_vertexAttribs.getAttrib( h ).data().empty(); }
     return false;
+}
+
+void GeometryData::attribDataUnlock( std::string name ) {
+    auto h = m_vertexAttribs.findAttrib<Vector3>( name );
+    if ( m_vertexAttribs.isValid( h ) ) {
+        auto attribPtr = m_vertexAttribs.getAttribPtr( h );
+        if ( attribPtr->isLocked() ) { attribPtr->unlock(); }
+    }
 }
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -32,11 +32,11 @@ inline std::size_t GeometryData::getVerticesSize() const {
 }
 
 inline const Vector3Array& GeometryData::getVertices() const {
-    return getVertexAttrib( "vertex" );
+    return getVertexAttrib<Vector3Array&>( "vertex" );
 }
 
 inline Vector3Array& GeometryData::getVertices() {
-    return getVertexAttrib( "vertex" );
+    return getVertexAttrib<Vector3Array&>( "vertex" );
 }
 
 namespace internal {
@@ -100,11 +100,11 @@ inline void GeometryData::setPolyhedra( const Container& polyList ) {
 }
 
 inline Vector3Array& GeometryData::getNormals() {
-    return getVertexAttrib( "normal" );
+    return getVertexAttrib<Vector3Array&>( "normal" );
 }
 
 inline const Vector3Array& GeometryData::getNormals() const {
-    return getVertexAttrib( "normal" );
+    return getVertexAttrib<Vector3Array&>( "normal" );
 }
 
 template <typename Container>
@@ -113,11 +113,11 @@ inline void GeometryData::setNormals( const Container& normalList ) {
 }
 
 inline Vector3Array& GeometryData::getTangents() {
-    return getVertexAttrib( "tangent" );
+    return getVertexAttrib<Vector3Array&>( "tangent" );
 }
 
 inline const Vector3Array& GeometryData::getTangents() const {
-    return getVertexAttrib( "tangent" );
+    return getVertexAttrib<Vector3Array&>( "tangent" );
 }
 
 template <typename Container>
@@ -126,11 +126,11 @@ inline void GeometryData::setTangents( const Container& tangentList ) {
 }
 
 inline Vector3Array& GeometryData::getBiTangents() {
-    return getVertexAttrib( "biTangent" );
+    return getVertexAttrib<Vector3Array&>( "biTangent" );
 }
 
 inline const Vector3Array& GeometryData::getBiTangents() const {
-    return getVertexAttrib( "biTangent" );
+    return getVertexAttrib<Vector3Array&>( "biTangent" );
 }
 
 template <typename Container>
@@ -139,11 +139,11 @@ inline void GeometryData::setBitangents( const Container& bitangentList ) {
 }
 
 inline Vector3Array& GeometryData::getTexCoords() {
-    return getVertexAttrib( "texCoord" );
+    return getVertexAttrib<Vector3Array&>( "texCoord" );
 }
 
 inline const Vector3Array& GeometryData::getTexCoords() const {
-    return getVertexAttrib( "texCoord" );
+    return getVertexAttrib<Vector3Array&>( "texCoord" );
 }
 
 template <typename Container>
@@ -231,7 +231,8 @@ Utils::AttribManager& GeometryData::getAttribManager() {
     return m_vertexAttribs;
 }
 
-inline Vector3Array& GeometryData::getVertexAttrib( std::string vertexAttribName ) {
+template <typename Container>
+inline Container& GeometryData::getVertexAttrib( std::string vertexAttribName ) {
     auto h = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
     if ( !m_vertexAttribs.isValid( h ) ) {
         h = m_vertexAttribs.addAttrib<Vector3>( vertexAttribName );
@@ -242,10 +243,11 @@ inline Vector3Array& GeometryData::getVertexAttrib( std::string vertexAttribName
     return v;
 }
 
-inline const Vector3Array& GeometryData::getVertexAttrib( std::string vertexAttribName ) const {
+template <typename Container>
+inline const Container& GeometryData::getVertexAttrib( std::string vertexAttribName ) const {
     auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
     auto& v           = m_vertexAttribs.getAttrib( attriHandler ).data();
-    return v;
+    return const_cast<VectorArray<Eigen::Matrix<float, 3, 1, 0>>&>( v );
 }
 
 template <typename Container>

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -99,11 +99,18 @@ inline void GeometryData::setPolyhedra( const Container& polyList ) {
     internal::copyData( polyList, m_polyhedron );
 }
 
-// TODO : add a shared_point or kind of to unlock attrib
 inline Vector3Array& GeometryData::getNormals() {
-    auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) );
+    auto h = m_vertexAttribs.findAttrib<Vector3>( "normal" );
+    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "normal" ); }
+    auto& attrib = m_vertexAttribs.getAttrib( h );
     auto& normal = attrib.getDataWithLock();
+    attribPtr    = &attrib;
     return normal;
+}
+
+inline void GeometryData::unlockData() {
+    attribPtr->unlock();
+    attribPtr = nullptr;
 }
 
 inline const Vector3Array& GeometryData::getNormals() const {
@@ -120,10 +127,12 @@ inline void GeometryData::setNormals( const Container& normalList ) {
     attrib.unlock();
 }
 
-// TODO : add a shared_point or kind of to unlock attrib
 inline Vector3Array& GeometryData::getTangents() {
-    auto& tangent = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "tangent" ) )
-                        .getDataWithLock();
+    auto h = m_vertexAttribs.findAttrib<Vector3>( "tangent" );
+    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "tangent" ); }
+    auto& attrib  = m_vertexAttribs.getAttrib( h );
+    auto& tangent = attrib.getDataWithLock();
+    attribPtr     = &attrib;
     return tangent;
 }
 
@@ -142,29 +151,49 @@ inline void GeometryData::setTangents( const Container& tangentList ) {
 }
 
 inline Vector3Array& GeometryData::getBiTangents() {
-    return m_bitangent;
+    auto h = m_vertexAttribs.findAttrib<Vector3>( "biTangent" );
+    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "biTangent" ); }
+    auto& attrib    = m_vertexAttribs.getAttrib( h );
+    auto& biTangent = attrib.getDataWithLock();
+    attribPtr       = &attrib;
+    return biTangent;
 }
 
 inline const Vector3Array& GeometryData::getBiTangents() const {
-    return m_bitangent;
+    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( "biTangent" );
+    auto& biTangent   = m_vertexAttribs.getAttrib( attriHandler ).data();
+    return biTangent;
 }
 
 template <typename Container>
 inline void GeometryData::setBitangents( const Container& bitangentList ) {
-    internal::copyData( bitangentList, m_bitangent );
+    auto& attrib = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "biTangent" ) );
+    auto& biTangent = attrib.getDataWithLock();
+    internal::copyData( bitangentList, biTangent );
+    attrib.unlock();
 }
 
 inline Vector3Array& GeometryData::getTexCoords() {
-    return m_texCoord;
+    auto h = m_vertexAttribs.findAttrib<Vector3>( "texCoord" );
+    if ( !m_vertexAttribs.isValid( h ) ) { h = m_vertexAttribs.addAttrib<Vector3>( "texCoord" ); }
+    auto& attrib   = m_vertexAttribs.getAttrib( h );
+    auto& texCoord = attrib.getDataWithLock();
+    attribPtr      = &attrib;
+    return texCoord;
 }
 
 inline const Vector3Array& GeometryData::getTexCoords() const {
-    return m_texCoord;
+    auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( "texCoord" );
+    auto& texCoord    = m_vertexAttribs.getAttrib( attriHandler ).data();
+    return texCoord;
 }
 
 template <typename Container>
 inline void GeometryData::setTextureCoordinates( const Container& texCoordList ) {
-    internal::copyData( texCoordList, m_texCoord );
+    auto& attrib   = m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "texCoord" ) );
+    auto& texCoord = attrib.getDataWithLock();
+    internal::copyData( texCoordList, texCoord );
+    attrib.unlock();
 }
 
 inline const MaterialData& GeometryData::getMaterial() const {
@@ -232,11 +261,15 @@ inline bool GeometryData::hasTangents() const {
 }
 
 inline bool GeometryData::hasBiTangents() const {
-    return !m_bitangent.empty();
+    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "biTangent" ) )
+                .data()
+                .empty();
 }
 
 inline bool GeometryData::hasTextureCoordinates() const {
-    return !m_texCoord.empty();
+    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "texCoord" ) )
+                .data()
+                .empty();
 }
 
 inline bool GeometryData::hasMaterial() const {

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -188,7 +188,7 @@ inline bool GeometryData::isHexMesh() const {
 }
 
 inline bool GeometryData::hasVertices() const {
-    return !m_vertex.empty();
+    return hasVertexAttrib( "vertex" );
 }
 
 inline bool GeometryData::hasEdges() const {
@@ -204,27 +204,19 @@ inline bool GeometryData::hasPolyhedra() const {
 }
 
 inline bool GeometryData::hasNormals() const {
-    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "normal" ) )
-                .data()
-                .empty();
+    return hasVertexAttrib( "normal" );
 }
 
 inline bool GeometryData::hasTangents() const {
-    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "tangent" ) )
-                .data()
-                .empty();
+    return hasVertexAttrib( "tangent" );
 }
 
 inline bool GeometryData::hasBiTangents() const {
-    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "biTangent" ) )
-                .data()
-                .empty();
+    return hasVertexAttrib( "biTangent" );
 }
 
 inline bool GeometryData::hasTextureCoordinates() const {
-    return !m_vertexAttribs.getAttrib( m_vertexAttribs.findAttrib<Vector3>( "texCoord" ) )
-                .data()
-                .empty();
+    return hasVertexAttrib( "texCoord" );
 }
 
 inline bool GeometryData::hasMaterial() const {
@@ -264,6 +256,11 @@ inline void GeometryData::setVertexAttrib( std::string vertexAttribName,
     auto& v = attrib.getDataWithLock();
     internal::copyData( vertexAttribList, v );
     attrib.unlock();
+}
+bool GeometryData::hasVertexAttrib( std::string vertexAttribName ) const {
+    auto h = m_vertexAttribs.findAttrib<Vector3>( vertexAttribName );
+    if ( m_vertexAttribs.isValid( h ) ) { return !m_vertexAttribs.getAttrib( h ).data().empty(); }
+    return false;
 }
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -28,11 +28,11 @@ inline void GeometryData::setFrame( const Transform& frame ) {
 }
 
 inline std::size_t GeometryData::getVerticesSize() const {
-    return getAttribData<Vector3Array&>( "vertex" ).size();
+    return getAttribData<const Vector3Array&>( "vertex" ).size();
 }
 
 inline const Vector3Array& GeometryData::getVertices() const {
-    return getAttribData<Vector3Array&>( "vertex" );
+    return getAttribData<const Vector3Array&>( "vertex" );
 }
 
 inline Vector3Array& GeometryData::getVertices() {
@@ -104,7 +104,7 @@ inline Vector3Array& GeometryData::getNormals() {
 }
 
 inline const Vector3Array& GeometryData::getNormals() const {
-    return getAttribData<Vector3Array&>( "normal" );
+    return getAttribData<const Vector3Array&>( "normal" );
 }
 
 template <typename Container>
@@ -117,7 +117,7 @@ inline Vector3Array& GeometryData::getTangents() {
 }
 
 inline const Vector3Array& GeometryData::getTangents() const {
-    return getAttribData<Vector3Array&>( "tangent" );
+    return getAttribData<const Vector3Array&>( "tangent" );
 }
 
 template <typename Container>
@@ -130,7 +130,7 @@ inline Vector3Array& GeometryData::getBiTangents() {
 }
 
 inline const Vector3Array& GeometryData::getBiTangents() const {
-    return getAttribData<Vector3Array&>( "biTangent" );
+    return getAttribData<const Vector3Array&>( "biTangent" );
 }
 
 template <typename Container>
@@ -143,7 +143,7 @@ inline Vector3Array& GeometryData::getTexCoords() {
 }
 
 inline const Vector3Array& GeometryData::getTexCoords() const {
-    return getAttribData<Vector3Array&>( "texCoord" );
+    return getAttribData<const Vector3Array&>( "texCoord" );
 }
 
 template <typename Container>
@@ -243,8 +243,8 @@ inline Container& GeometryData::getAttribDataWithLock( std::string name ) {
 template <typename Container>
 inline const Container& GeometryData::getAttribData( std::string name ) const {
     auto attriHandler = m_vertexAttribs.findAttrib<Vector3>( name );
-    auto& v           = m_vertexAttribs.getAttrib( attriHandler ).data();
-    return const_cast<VectorArray<Eigen::Matrix<float, 3, 1, 0>>&>( v );
+    const auto& v     = m_vertexAttribs.getAttrib( attriHandler ).data();
+    return v;
 }
 
 template <typename Container>

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -56,7 +56,7 @@ inline void copyData( const InContainer& input, OutContainer& output ) {
 
 template <typename Container>
 inline void GeometryData::setVertices( const Container& vertexList ) {
-    return setAttribData( "vertex", vertexList );
+    return setAttribData( Geometry::MeshAttrib::VERTEX_POSITION, vertexList );
 }
 
 inline Vector2uArray& GeometryData::getEdges() {
@@ -224,13 +224,12 @@ inline VectorArray<V>& GeometryData::addAttribDataWithLock( const Geometry::Mesh
     return d;
 }
 
-template <typename Container>
+template <typename V>
 inline void GeometryData::setAttribData( const Geometry::MeshAttrib& name,
-                                         const Container& attribDataList ) {
-    auto& n                     = getAttribName( name );
-    Utils::Attrib<Container>& c = m_multiIndexedGeometry.getAttribBase( n )->cast<Container>();
-    auto& v                     = c.getDataWithLock();
-    internal::copyData( attribDataList, v );
+                                         const VectorArray<V>& attribDataList ) {
+    auto& n    = getAttribName( name );
+    auto& data = addAttribDataWithLock<V>( name );
+    internal::copyData( attribDataList, data );
     m_multiIndexedGeometry.getAttribBase( n )->unlock();
 }
 

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -210,6 +210,10 @@ const Utils::AttribManager& GeometryData::getAttribManager() const {
     return m_multiIndexedGeometry.vertexAttribs();
 }
 
+inline Geometry::MultiIndexedGeometry& GeometryData::getMultiIndexedGeometry() {
+    return m_multiIndexedGeometry;
+}
+
 Utils::AttribManager& GeometryData::getAttribManager() {
     return m_multiIndexedGeometry.vertexAttribs();
 }

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -60,7 +60,7 @@ inline void copyData( const InContainer& input, OutContainer& output ) {
 
 template <typename Container>
 inline void GeometryData::setVertices( const Container& vertexList ) {
-    return setAttribData( Geometry::MeshAttrib::VERTEX_POSITION, vertexList );
+    setAttribData( Geometry::MeshAttrib::VERTEX_POSITION, vertexList );
 }
 
 inline Vector2uArray& GeometryData::getEdges() {

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -197,40 +197,38 @@ inline bool GeometryData::isHexMesh() const {
 }
 
 inline bool GeometryData::hasVertices() const {
-    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_POSITION );
-    return m_multiIndexedGeometry.hasAttribData( name );
+    return m_multiIndexedGeometry.vertexAttribs().contains( "in_position" );
 }
 
 inline bool GeometryData::hasEdges() const {
-    return !getIndexedData<Vector2ui>( "in_edge" ).empty();
+    return m_multiIndexedGeometry.containsLayer( { Geometry::LineIndexLayer::staticSemanticName },
+                                                 "in_edge" );
 }
 
 inline bool GeometryData::hasFaces() const {
-    return !getIndexedData<VectorNui>( "in_face" ).empty();
+    return m_multiIndexedGeometry.containsLayer( { Geometry::PolyIndexLayer::staticSemanticName },
+                                                 "in_face" );
 }
 
 inline bool GeometryData::hasPolyhedra() const {
-    return !getIndexedData<VectorNui>( "in_polyhedron" ).empty();
+    return m_multiIndexedGeometry.containsLayer( { Geometry::PolyIndexLayer::staticSemanticName },
+                                                 "in_polyhedron" );
 }
 
 inline bool GeometryData::hasNormals() const {
-    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_NORMAL );
-    return m_multiIndexedGeometry.hasAttribData( name );
+    return m_multiIndexedGeometry.vertexAttribs().contains( "in_normal" );
 }
 
 inline bool GeometryData::hasTangents() const {
-    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_TANGENT );
-    return m_multiIndexedGeometry.hasAttribData( name );
+    return m_multiIndexedGeometry.vertexAttribs().contains( "in_tangent" );
 }
 
 inline bool GeometryData::hasBiTangents() const {
-    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_BITANGENT );
-    return m_multiIndexedGeometry.hasAttribData( name );
+    return m_multiIndexedGeometry.vertexAttribs().contains( "in_bitangent" );
 }
 
 inline bool GeometryData::hasTextureCoordinates() const {
-    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_TEXCOORD );
-    return m_multiIndexedGeometry.hasAttribData( name );
+    return m_multiIndexedGeometry.vertexAttribs().contains( "in_texcoord" );
 }
 
 inline bool GeometryData::hasMaterial() const {

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -29,8 +29,8 @@ inline void GeometryData::setFrame( const Transform& frame ) {
 
 inline std::size_t GeometryData::getVerticesSize() const {
     auto& n      = getAttribName( Geometry::MeshAttrib::VERTEX_POSITION );
-    auto h       = multiIndexedGeometry.getAttribHandle<Vector3>( n );
-    auto& attrib = multiIndexedGeometry.getAttrib( h );
+    auto h       = m_multiIndexedGeometry.getAttribHandle<Vector3>( n );
+    auto& attrib = m_multiIndexedGeometry.getAttrib( h );
     return attrib.data().size();
 }
 
@@ -60,42 +60,42 @@ inline void GeometryData::setVertices( const Container& vertexList ) {
 }
 
 inline Vector2uArray& GeometryData::getEdges() {
-    return getIndexedDataWithLock<Vector2ui>( "edge" );
+    return addIndexedDataWithLock<Vector2ui>( GeometryType::LINE_MESH, "in_edge" );
 }
 
 inline const Vector2uArray& GeometryData::getEdges() const {
-    return getIndexedData<Vector2ui>( "edge" );
+    return getIndexedData<Vector2ui>( GeometryType::LINE_MESH, "in_edge" );
 }
 
 template <typename Container>
 inline void GeometryData::setEdges( const Container& edgeList ) {
-    setIndexedData( "edge", edgeList );
+    setIndexedData( GeometryType::LINE_MESH, edgeList, "in_edge" );
 }
 
 inline const VectorNuArray& GeometryData::getFaces() const {
-    return getIndexedData<VectorNui>( "face" );
+    return getIndexedData<VectorNui>( GeometryType::POLY_MESH, "in_face" );
 }
 
 inline VectorNuArray& GeometryData::getFaces() {
-    return getIndexedDataWithLock<VectorNui>( "face" );
+    return addIndexedDataWithLock<VectorNui>( GeometryType::POLY_MESH, "in_face" );
 }
 
 template <typename Container>
 inline void GeometryData::setFaces( const Container& faceList ) {
-    setIndexedData( "face", faceList );
+    setIndexedData( GeometryType::POLY_MESH, faceList, "in_face" );
 }
 
 inline VectorNuArray& GeometryData::getPolyhedra() {
-    return getIndexedDataWithLock<VectorNui>( "polyhedron" );
+    return addIndexedDataWithLock<VectorNui>( GeometryType::POLY_MESH, "in_polyhedron" );
 }
 
 inline const VectorNuArray& GeometryData::getPolyhedra() const {
-    return getIndexedData<VectorNui>( "polyhedron" );
+    return getIndexedData<VectorNui>( GeometryType::POLY_MESH, "in_polyhedron" );
 }
 
 template <typename Container>
 inline void GeometryData::setPolyhedra( const Container& polyList ) {
-    setIndexedData( "polyhedron", polyList );
+    setIndexedData( GeometryType::POLY_MESH, polyList, "in_polyhedron" );
 }
 
 inline Vector3Array& GeometryData::getNormals() {
@@ -175,15 +175,15 @@ inline bool GeometryData::hasVertices() const {
 }
 
 inline bool GeometryData::hasEdges() const {
-    return !getIndexedData<Vector2ui>( "edge" ).empty();
+    return !getIndexedData<Vector2ui>( GeometryType::LINE_MESH, "in_edge" ).empty();
 }
 
 inline bool GeometryData::hasFaces() const {
-    return !getIndexedData<VectorNui>( "face" ).empty();
+    return !getIndexedData<VectorNui>( GeometryType::POLY_MESH, "in_face" ).empty();
 }
 
 inline bool GeometryData::hasPolyhedra() const {
-    return !getIndexedData<VectorNui>( "polyhedron" ).empty();
+    return !getIndexedData<VectorNui>( GeometryType::POLY_MESH, "in_polyhedron" ).empty();
 }
 
 inline bool GeometryData::hasNormals() const {
@@ -207,19 +207,19 @@ inline bool GeometryData::hasMaterial() const {
 }
 
 const Utils::AttribManager& GeometryData::getAttribManager() const {
-    return multiIndexedGeometry.vertexAttribs();
+    return m_multiIndexedGeometry.vertexAttribs();
 }
 
 Utils::AttribManager& GeometryData::getAttribManager() {
-    return multiIndexedGeometry.vertexAttribs();
+    return m_multiIndexedGeometry.vertexAttribs();
 }
 
 template <typename V>
 inline VectorArray<V>& GeometryData::addAttribDataWithLock( const Geometry::MeshAttrib& name ) {
     auto& n = getAttribName( name );
-    auto h  = multiIndexedGeometry.getAttribHandle<V>( n );
-    if ( !multiIndexedGeometry.isValid( h ) ) { h = multiIndexedGeometry.addAttrib<V>( n ); }
-    auto& attrib = multiIndexedGeometry.getAttrib( h );
+    auto h  = m_multiIndexedGeometry.getAttribHandle<V>( n );
+    if ( !m_multiIndexedGeometry.isValid( h ) ) { h = m_multiIndexedGeometry.addAttrib<V>( n ); }
+    auto& attrib = m_multiIndexedGeometry.getAttrib( h );
     auto& d      = attrib.getDataWithLock();
     return d;
 }
@@ -228,97 +228,106 @@ template <typename Container>
 inline void GeometryData::setAttribData( const Geometry::MeshAttrib& name,
                                          const Container& attribDataList ) {
     auto& n                     = getAttribName( name );
-    Utils::Attrib<Container>& c = multiIndexedGeometry.getAttribBase( n )->cast<Container>();
+    Utils::Attrib<Container>& c = m_multiIndexedGeometry.getAttribBase( n )->cast<Container>();
     auto& v                     = c.getDataWithLock();
     internal::copyData( attribDataList, v );
-    multiIndexedGeometry.getAttribBase( n )->unlock();
+    m_multiIndexedGeometry.getAttribBase( n )->unlock();
 }
 
 template <typename V>
 inline bool GeometryData::hasAttribData( const Geometry::MeshAttrib& name ) const {
     auto& n = getAttribName( name );
-    auto h  = multiIndexedGeometry.getAttribHandle<V>( n );
-    if ( multiIndexedGeometry.isValid( h ) ) {
-        return !multiIndexedGeometry.getAttrib( h ).data().empty();
+    auto h  = m_multiIndexedGeometry.getAttribHandle<V>( n );
+    if ( m_multiIndexedGeometry.isValid( h ) ) {
+        return !m_multiIndexedGeometry.getAttrib( h ).data().empty();
     }
     return false;
 }
 
-inline void GeometryData::initIndexedData( const std::string& name ) {
-    if ( name == "edge" ) {
-        auto pil = std::make_unique<Core::Geometry::LineIndexLayer>();
-        bool a   = multiIndexedGeometry.addLayer( std::move( pil ), "edge" );
-        std::cout << name << a << std::endl;
+template <typename L>
+inline bool GeometryData::initLayer( const std::string& name ) {
+    if ( !m_multiIndexedGeometry.containsLayer( { L::staticSemanticName }, name ) ) {
+        auto pil = std::make_unique<L>();
+        return m_multiIndexedGeometry.addLayer( std::move( pil ), name );
     }
-    else {
-        auto pil1 = std::make_unique<Core::Geometry::PolyIndexLayer>();
-        bool b    = multiIndexedGeometry.addLayer( std::move( pil1 ), name );
-        std::cout << name << b << std::endl;
-    }
+    return false;
 }
 
-template <typename V>
+template <typename V, typename L>
 inline VectorArray<V>& GeometryData::getIndexedDataWithLock( const std::string& name ) {
-    if ( name == "edge" && !multiIndexedGeometry.containsLayer(
-                               { Core::Geometry::LineIndexLayer::staticSemanticName }, name ) ) {
-        auto pil = std::make_unique<Core::Geometry::LineIndexLayer>();
-        multiIndexedGeometry.addLayer( std::move( pil ), "edge" );
-    }
-    else if ( name != "edge" &&
-              !multiIndexedGeometry.containsLayer(
-                  { Core::Geometry::PolyIndexLayer::staticSemanticName }, name ) ) {
-        auto pil1 = std::make_unique<Core::Geometry::PolyIndexLayer>();
-        multiIndexedGeometry.addLayer( std::move( pil1 ), name );
-    }
-
-    if ( name == "edge" ) {
-        auto& d = multiIndexedGeometry.getLayerWithLock(
-            { Core::Geometry::LineIndexLayer::staticSemanticName }, name );
-        auto& v    = dynamic_cast<Geometry::GeometryIndexLayer<V>&>( d );
-        auto& data = v.collection();
-        return data;
-    }
-    else {
-        auto& d = multiIndexedGeometry.getLayerWithLock(
-            { Core::Geometry::PolyIndexLayer::staticSemanticName }, name );
-        auto& v    = dynamic_cast<Geometry::GeometryIndexLayer<V>&>( d );
-        auto& data = v.collection();
-        return data;
-    }
-}
-
-template <typename V>
-inline const VectorArray<V>& GeometryData::getIndexedData( const std::string& name ) const {
-    std::set<std::string> semantics;
-    for ( const auto& k : multiIndexedGeometry.layerKeys() ) {
-        if ( k.second == name ) {
-            semantics = k.first;
-            break;
-        }
-    }
-
-    const auto& d = multiIndexedGeometry.getFirstLayerOccurrence( semantics );
-    const auto& v = dynamic_cast<const Geometry::GeometryIndexLayer<V>&>( d.second );
-    auto& data    = v.collection();
+    auto& d    = m_multiIndexedGeometry.getLayerWithLock( { L::staticSemanticName }, name );
+    auto& v    = dynamic_cast<Geometry::GeometryIndexLayer<V>&>( d );
+    auto& data = v.collection();
     return data;
 }
 
-inline void GeometryData::indexedDataUnlock( const std::string& name ) {
-    std::set<std::string> semantics;
-    for ( const auto& k : multiIndexedGeometry.layerKeys() ) {
-        if ( k.second == name ) {
-            semantics = k.first;
-            break;
-        }
+template <typename V>
+inline VectorArray<V>& GeometryData::addIndexedDataWithLock( const GeometryType& type,
+                                                             const std::string& name ) {
+    switch ( type ) {
+    case GeometryType::LINE_MESH:
+        initLayer<Geometry::LineIndexLayer>( name );
+        return getIndexedDataWithLock<V, Geometry::LineIndexLayer>( name );
+    case GeometryType::TRI_MESH:
+        // initLayer<Geometry::TriangleIndexLayer>( name );
+        // return getIndexedDataWithLock<V, Geometry::TriangleIndexLayer>( name );
+    case GeometryType::QUAD_MESH:
+        // initLayer<Geometry::QuadIndexLayer>( name );
+        // return getIndexedDataWithLock<V, Geometry::QuadIndexLayer>( name );
+    default:
+        initLayer<Geometry::PolyIndexLayer>( name );
+        return getIndexedDataWithLock<V, Geometry::PolyIndexLayer>( name );
     }
-    multiIndexedGeometry.unlockLayer( semantics, name );
+}
+
+template <typename V, typename L>
+inline const VectorArray<V>& GeometryData::getIndexedData( const std::string& name ) const {
+    auto& d    = m_multiIndexedGeometry.getLayer( { L::staticSemanticName }, name );
+    auto& v    = dynamic_cast<const Geometry::GeometryIndexLayer<V>&>( d );
+    auto& data = v.collection();
+    return data;
 }
 
 template <typename V>
-inline void GeometryData::setIndexedData( const std::string& name,
-                                          const VectorArray<V>& attribDataList ) {
-    internal::copyData( attribDataList, getIndexedDataWithLock<V>( name ) );
-    indexedDataUnlock( name );
+inline const VectorArray<V>& GeometryData::getIndexedData( const GeometryType& type,
+                                                           const std::string& name ) const {
+    switch ( type ) {
+    case GeometryType::LINE_MESH:
+        return getIndexedData<V, Geometry::LineIndexLayer>( name );
+    case GeometryType::TRI_MESH:
+        // return getIndexedDataWithLock<V, Geometry::TriangleIndexLayer>( name );
+    case GeometryType::QUAD_MESH:
+        // return getIndexedDataWithLock<V, Geometry::QuadIndexLayer>( name );
+    default:
+        return getIndexedData<V, Geometry::PolyIndexLayer>( name );
+    }
+}
+
+inline void GeometryData::indexedDataUnlock( const GeometryType& type, const std::string& name ) {
+    switch ( type ) {
+    case GeometryType::LINE_MESH:
+        m_multiIndexedGeometry.unlockLayer( { Core::Geometry::LineIndexLayer::staticSemanticName },
+                                            name );
+        break;
+    case GeometryType::TRI_MESH:
+        // m_multiIndexedGeometry.unlockLayer( {
+        // Core::Geometry::TriangleIndexLayer::staticSemanticName }, name ); break;
+    case GeometryType::QUAD_MESH:
+        // m_multiIndexedGeometry.unlockLayer( { Core::Geometry::QuadIndexLayer::staticSemanticName
+        // }, name ); break;
+    default:
+        m_multiIndexedGeometry.unlockLayer( { Core::Geometry::PolyIndexLayer::staticSemanticName },
+                                            name );
+        break;
+    }
+}
+
+template <typename V>
+inline void GeometryData::setIndexedData( const GeometryType& type,
+                                          const VectorArray<V>& indexedDataList,
+                                          const std::string& name ) {
+    internal::copyData( indexedDataList, addIndexedDataWithLock<V>( type, name ) );
+    indexedDataUnlock( type, name );
 }
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -120,9 +120,7 @@ inline Vector3Array& GeometryData::getTangents() {
 }
 
 inline const Vector3Array& GeometryData::getTangents() const {
-    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_TANGENT );
-    auto h     = m_multiIndexedGeometry.getAttribHandle<Vector3>( name );
-    return m_multiIndexedGeometry.getAttrib( h ).data();
+    return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TANGENT ).data();
 }
 
 template <typename Container>
@@ -135,9 +133,7 @@ inline Vector3Array& GeometryData::getBiTangents() {
 }
 
 inline const Vector3Array& GeometryData::getBiTangents() const {
-    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_BITANGENT );
-    auto h     = m_multiIndexedGeometry.getAttribHandle<Vector3>( name );
-    return m_multiIndexedGeometry.getAttrib( h ).data();
+    return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_BITANGENT ).data();
 }
 
 template <typename Container>
@@ -150,9 +146,7 @@ inline Vector3Array& GeometryData::getTexCoords() {
 }
 
 inline const Vector3Array& GeometryData::getTexCoords() const {
-    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_TEXCOORD );
-    auto h     = m_multiIndexedGeometry.getAttribHandle<Vector3>( name );
-    return m_multiIndexedGeometry.getAttrib( h ).data();
+    return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TEXCOORD ).data();
 }
 
 template <typename Container>
@@ -255,6 +249,14 @@ template <typename T>
 inline Utils::Attrib<T>& GeometryData::getAttrib( const Geometry::MeshAttrib& name ) {
     const auto& n = getAttribName( name );
     auto h        = m_multiIndexedGeometry.addAttrib<T>( n );
+    auto& attrib  = m_multiIndexedGeometry.getAttrib( h );
+    return attrib;
+}
+
+template <typename T>
+const inline Utils::Attrib<T>& GeometryData::getAttrib( const Geometry::MeshAttrib& name ) const {
+    const auto& n = getAttribName( name );
+    auto h        = m_multiIndexedGeometry.getAttribHandle<T>( n );
     auto& attrib  = m_multiIndexedGeometry.getAttrib( h );
     return attrib;
 }

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -64,7 +64,7 @@ inline void GeometryData::setVertices( const Container& vertexList ) {
 }
 
 inline Vector2uArray& GeometryData::getEdges() {
-    return findIndexedDataWithLock<Vector2ui>( "in_edge" );
+    return findIndexDataWithLock<Vector2ui>( "in_edge" );
 }
 
 inline const Vector2uArray& GeometryData::getEdges() const {
@@ -81,7 +81,7 @@ inline const VectorNuArray& GeometryData::getFaces() const {
 }
 
 inline VectorNuArray& GeometryData::getFaces() {
-    return findIndexedDataWithLock<VectorNui>( "in_face" );
+    return findIndexDataWithLock<VectorNui>( "in_face" );
 }
 
 template <typename Container>
@@ -90,7 +90,7 @@ inline void GeometryData::setFaces( const Container& faceList ) {
 }
 
 inline VectorNuArray& GeometryData::getPolyhedra() {
-    return findIndexedDataWithLock<VectorNui>( "in_polyhedron" );
+    return findIndexDataWithLock<VectorNui>( "in_polyhedron" );
 }
 
 inline const VectorNuArray& GeometryData::getPolyhedra() const {
@@ -320,8 +320,8 @@ inline VectorArray<V>& GeometryData::getIndexedDataWithLock( const bool& firstOc
 }
 
 template <typename V>
-inline VectorArray<V>& GeometryData::findIndexedDataWithLock( const std::string& name,
-                                                              const bool& firstOccurrence ) {
+inline VectorArray<V>& GeometryData::findIndexDataWithLock( const std::string& name,
+                                                            const bool& firstOccurrence ) {
     if ( std::is_same<V, Vector2ui>::value ) {
         return getIndexedDataWithLock<V, Geometry::LineIndexLayer>( firstOccurrence, name );
     }
@@ -380,7 +380,7 @@ template <typename V>
 inline void GeometryData::setIndexedData( const GeometryType& type,
                                           const VectorArray<V>& indexedDataList,
                                           const std::string& name ) {
-    internal::copyData( indexedDataList, findIndexedDataWithLock<V>( name ) );
+    internal::copyData( indexedDataList, findIndexDataWithLock<V>( name ) );
     indexedDataUnlock( type, name );
 }
 

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -102,11 +102,11 @@ Geometry::MultiIndexedGeometry& GeometryData::getGeometry() {
     return m_geometry;
 }
 
-inline void GeometryData::setPrimitiveNum( int n ) {
-    m_numPrimitives = n;
+inline void GeometryData::setPrimitiveCount( int n ) {
+    m_primitiveCount = n;
 }
-inline int GeometryData::getPrimitiveNum() const {
-    return m_numPrimitives;
+inline int GeometryData::getPrimitiveCount() const {
+    return m_primitiveCount;
 }
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -28,148 +28,6 @@ inline void GeometryData::setFrame( const Transform& frame ) {
     m_frame = frame;
 }
 
-inline std::size_t GeometryData::getVerticesSize() const {
-    return m_multiIndexedGeometry.vertices().size();
-}
-
-inline Vector3Array& GeometryData::getVertices() {
-    return m_multiIndexedGeometry.verticesWithLock();
-}
-
-inline const Vector3Array& GeometryData::getVertices() const {
-    return m_multiIndexedGeometry.vertices();
-}
-
-namespace internal {
-
-template <typename InContainer, typename OutContainer>
-inline void copyData( const InContainer& input, OutContainer& output ) {
-    using OutValueType  = typename OutContainer::value_type;
-    using OutScalarType = typename OutValueType::Scalar;
-    std::transform( std::begin( input ),
-                    std::end( input ),
-                    std::back_inserter( output ),
-                    []( const typename InContainer::value_type& v ) -> OutValueType {
-                        return v.template cast<OutScalarType>();
-                    } );
-}
-
-} // namespace internal
-
-template <typename Container>
-inline void GeometryData::setVertices( const Container& data ) {
-    getMultiIndexedGeometry().setVertices( data );
-}
-
-inline Vector2uArray& GeometryData::getEdges() {
-    return findIndexDataWithLock<Vector2ui>( "in_edge" );
-}
-
-inline const Vector2uArray& GeometryData::getEdges() const {
-    return getIndexedData<Vector2ui>( "in_edge" );
-}
-
-template <typename Container>
-inline void GeometryData::setEdges( const Container& edgeList ) {
-    setIndexedData( GeometryType::LINE_MESH, edgeList, "in_edge" );
-}
-
-inline const VectorNuArray& GeometryData::getFaces() const {
-    return getIndexedData<VectorNui>( "in_face" );
-}
-
-inline VectorNuArray& GeometryData::getFaces() {
-    return findIndexDataWithLock<VectorNui>( "in_face" );
-}
-
-template <typename Container>
-inline void GeometryData::setFaces( const Container& faceList ) {
-    setIndexedData( GeometryType::POLY_MESH, faceList, "in_face" );
-}
-
-inline VectorNuArray& GeometryData::getPolyhedra() {
-    return findIndexDataWithLock<VectorNui>( "in_polyhedron" );
-}
-
-inline const VectorNuArray& GeometryData::getPolyhedra() const {
-    return getIndexedData<VectorNui>( "in_polyhedron" );
-}
-
-template <typename Container>
-inline void GeometryData::setPolyhedra( const Container& polyList ) {
-    setIndexedData( GeometryType::POLY_MESH, polyList, "in_polyhedron" );
-}
-
-inline Vector3Array& GeometryData::getNormals() {
-    return m_multiIndexedGeometry.normalsWithLock();
-}
-
-inline const Vector3Array& GeometryData::getNormals() const {
-    return m_multiIndexedGeometry.normals();
-}
-
-template <typename Container>
-inline void GeometryData::setNormals( const Container& data ) {
-    getMultiIndexedGeometry().setNormals( data );
-}
-
-inline Vector3Array& GeometryData::getTangents() {
-    return m_multiIndexedGeometry.vertexAttribs()
-        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_TANGENT ) )
-        .getDataWithLock();
-}
-
-inline const Vector3Array& GeometryData::getTangents() const {
-    return m_multiIndexedGeometry.vertexAttribs()
-        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_TANGENT ) )
-        .data();
-}
-
-template <typename Container>
-inline void GeometryData::setTangents( const Container& data ) {
-    m_multiIndexedGeometry
-        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_TANGENT ) )
-        .setData( data );
-}
-
-inline Vector3Array& GeometryData::getBiTangents() {
-    return m_multiIndexedGeometry
-        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_BITANGENT ) )
-        .getDataWithLock();
-}
-
-inline const Vector3Array& GeometryData::getBiTangents() const {
-    return m_multiIndexedGeometry
-        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_BITANGENT ) )
-        .data();
-}
-
-template <typename Container>
-inline void GeometryData::setBitangents( const Container& data ) {
-    m_multiIndexedGeometry
-        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_BITANGENT ) )
-        .setData( data );
-}
-
-inline Vector3Array& GeometryData::getTexCoords() {
-    return m_multiIndexedGeometry
-        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_TEXCOORD ) )
-        .getDataWithLock();
-}
-
-inline const Vector3Array& GeometryData::getTexCoords() const {
-    return m_multiIndexedGeometry
-        .getAttrib<Vector3>( Geometry::getAttribName( Geometry::MeshAttrib::VERTEX_TEXCOORD ) )
-        .data();
-}
-
-template <typename Container>
-inline void GeometryData::setTextureCoordinates( const Container& data ) {
-    m_multiIndexedGeometry
-        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_TEXCOORD ) )
-        .setData( data );
-}
-
 inline const MaterialData& GeometryData::getMaterial() const {
     return *( m_material.get() );
 }
@@ -206,148 +64,49 @@ inline bool GeometryData::isHexMesh() const {
     return ( m_type == HEX_MESH );
 }
 
-inline bool GeometryData::hasVertices() const {
-    return m_multiIndexedGeometry.vertexAttribs().contains( "in_position" );
-}
-
 inline bool GeometryData::hasEdges() const {
-    return m_multiIndexedGeometry.containsLayer( { Geometry::LineIndexLayer::staticSemanticName },
-                                                 "in_edge" );
+    return m_geometry.containsLayer( { Geometry::LineIndexLayer::staticSemanticName }, "indices" );
 }
 
 inline bool GeometryData::hasFaces() const {
-    return m_multiIndexedGeometry.containsLayer( { Geometry::PolyIndexLayer::staticSemanticName },
-                                                 "in_face" );
+    std::string layerSemanticName;
+    switch ( m_type ) {
+    case TRI_MESH:
+        layerSemanticName = std::string( Geometry::TriangleIndexLayer::staticSemanticName );
+        break;
+    case QUAD_MESH:
+        layerSemanticName = std::string( Geometry::QuadIndexLayer::staticSemanticName );
+        break;
+    case POLY_MESH:
+        layerSemanticName = std::string( Geometry::PolyIndexLayer::staticSemanticName );
+        break;
+    default:
+        return false;
+    }
+    return m_geometry.containsLayer( { layerSemanticName }, "indices" );
 }
 
 inline bool GeometryData::hasPolyhedra() const {
-    return m_multiIndexedGeometry.containsLayer( { Geometry::PolyIndexLayer::staticSemanticName },
-                                                 "in_polyhedron" );
-}
-
-inline bool GeometryData::hasNormals() const {
-    return m_multiIndexedGeometry.vertexAttribs().contains( "in_normal" );
-}
-
-inline bool GeometryData::hasTangents() const {
-    return m_multiIndexedGeometry.vertexAttribs().contains( "in_tangent" );
-}
-
-inline bool GeometryData::hasBiTangents() const {
-    return m_multiIndexedGeometry.vertexAttribs().contains( "in_bitangent" );
-}
-
-inline bool GeometryData::hasTextureCoordinates() const {
-    return m_multiIndexedGeometry.vertexAttribs().contains( "in_texcoord" );
+    return m_geometry.containsLayer( { Geometry::PolyIndexLayer::staticSemanticName }, "indices" );
 }
 
 inline bool GeometryData::hasMaterial() const {
     return m_material != nullptr;
 }
 
-const Geometry::MultiIndexedGeometry& GeometryData::getMultiIndexedGeometry() const {
-    return m_multiIndexedGeometry;
+const Geometry::MultiIndexedGeometry& GeometryData::getGeometry() const {
+    return m_geometry;
 }
 
-Geometry::MultiIndexedGeometry& GeometryData::getMultiIndexedGeometry() {
-    return m_multiIndexedGeometry;
+Geometry::MultiIndexedGeometry& GeometryData::getGeometry() {
+    return m_geometry;
 }
 
-const Utils::AttribManager& GeometryData::getAttribManager() const {
-    return m_multiIndexedGeometry.vertexAttribs();
+inline void GeometryData::setPrimitiveNum( int n ) {
+    m_numPrimitives = n;
 }
-
-Utils::AttribManager& GeometryData::getAttribManager() {
-    return m_multiIndexedGeometry.vertexAttribs();
-}
-
-template <typename V>
-inline VectorArray<V>&
-GeometryData::getDataFromLayerBase( Geometry::GeometryIndexLayerBase& geomBase ) {
-    return static_cast<Geometry::GeometryIndexLayer<V>&>( geomBase ).collection();
-}
-
-template <typename V>
-inline const VectorArray<V>&
-GeometryData::getDataFromLayerBase( const Geometry::GeometryIndexLayerBase& geomBase ) const {
-    return static_cast<const Geometry::GeometryIndexLayer<V>&>( geomBase ).collection();
-}
-
-template <typename L>
-inline Geometry::GeometryIndexLayerBase&
-GeometryData::getLayerBaseWithLock( const bool& firstOccurrence, const std::string& name ) {
-    return ( firstOccurrence )
-               ? m_multiIndexedGeometry.getFirstLayerOccurrenceWithLock( L::staticSemanticName )
-                     .second
-               : m_multiIndexedGeometry.getLayerWithLock( { L::staticSemanticName }, name );
-}
-
-template <typename L>
-inline const Geometry::GeometryIndexLayerBase&
-GeometryData::getLayerBase( const bool& firstOccurrence, const std::string& name ) const {
-    return ( firstOccurrence )
-               ? m_multiIndexedGeometry.getFirstLayerOccurrence( L::staticSemanticName ).second
-               : m_multiIndexedGeometry.getLayer( { L::staticSemanticName }, name );
-}
-
-template <typename V, typename L>
-inline VectorArray<V>& GeometryData::getIndexedDataWithLock( const bool& firstOccurrence,
-                                                             const std::string& name ) {
-    if ( m_multiIndexedGeometry.containsLayer( { L::staticSemanticName }, name ) ) {
-        auto& geomBaseFound = getLayerBaseWithLock<L>( firstOccurrence, name );
-        return getDataFromLayerBase<V>( geomBaseFound );
-    }
-    else {
-        auto pil = std::make_unique<L>();
-        auto& geomBaseCreated =
-            m_multiIndexedGeometry.addLayer( std::move( pil ), true, name ).second;
-        return getDataFromLayerBase<V>( geomBaseCreated );
-    }
-}
-
-template <typename V>
-inline VectorArray<V>& GeometryData::findIndexDataWithLock( const std::string& name,
-                                                            const bool& firstOccurrence ) {
-    if ( std::is_same<V, Vector2ui>::value ) {
-        return getIndexedDataWithLock<V, Geometry::LineIndexLayer>( firstOccurrence, name );
-    }
-    else {
-        return getIndexedDataWithLock<V, Geometry::PolyIndexLayer>( firstOccurrence, name );
-    }
-}
-
-template <typename V>
-inline const VectorArray<V>& GeometryData::getIndexedData( const std::string& name,
-                                                           const bool& firstOccurrence ) const {
-    if ( std::is_same<V, Vector2ui>::value ) {
-        auto& geomBase = getLayerBase<Geometry::LineIndexLayer>( firstOccurrence, name );
-        return getDataFromLayerBase<V>( geomBase );
-    }
-    else {
-        auto& geomBase = getLayerBase<Geometry::PolyIndexLayer>( firstOccurrence, name );
-        return getDataFromLayerBase<V>( geomBase );
-    }
-}
-
-inline void GeometryData::indexedDataUnlock( const GeometryType& type, const std::string& name ) {
-    switch ( type ) {
-    case GeometryType::LINE_MESH:
-        m_multiIndexedGeometry.unlockLayer(
-            { { Core::Geometry::LineIndexLayer::staticSemanticName }, name } );
-        break;
-    default:
-        m_multiIndexedGeometry.unlockLayer(
-            { { Core::Geometry::PolyIndexLayer::staticSemanticName }, name } );
-        break;
-    }
-}
-
-template <typename V>
-inline void GeometryData::setIndexedData( const GeometryType& type,
-                                          const VectorArray<V>& indexedDataList,
-                                          const std::string& name ) {
-    internal::copyData( indexedDataList, findIndexDataWithLock<V>( name ) );
-    indexedDataUnlock( type, name );
+inline int GeometryData::getPrimitiveNum() const {
+    return m_numPrimitives;
 }
 
 } // namespace Asset

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -28,14 +28,14 @@ inline void GeometryData::setFrame( const Transform& frame ) {
 }
 
 inline std::size_t GeometryData::getVerticesSize() const {
-    auto& n      = getAttribName( Geometry::MeshAttrib::VERTEX_POSITION );
+    const auto& n      = getAttribName( Geometry::MeshAttrib::VERTEX_POSITION );
     auto h       = m_multiIndexedGeometry.getAttribHandle<Vector3>( n );
-    auto& attrib = m_multiIndexedGeometry.getAttrib( h );
+    const auto& attrib = m_multiIndexedGeometry.getAttrib( h );
     return attrib.data().size();
 }
 
 inline Vector3Array& GeometryData::getVertices() {
-    return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_POSITION ).getDataWithLock();
+    return m_multiIndexedGeometry.verticesWithLock();
 }
 
 inline const Vector3Array& GeometryData::getVertices() const {
@@ -262,10 +262,7 @@ inline Utils::Attrib<T>& GeometryData::getAttrib( const Geometry::MeshAttrib& na
 template <typename V>
 inline void GeometryData::setAttribData( const Geometry::MeshAttrib& name,
                                          const VectorArray<V>& attribDataList ) {
-    auto& attrib = getAttrib<V>( name );
-    auto& data   = attrib.getDataWithLock();
-    internal::copyData( attribDataList, data );
-    attrib.unlock();
+    getAttrib<V>( name ).setData(attribDataList);
 }
 
 template <typename V>

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -112,7 +112,7 @@ inline const Vector3Array& GeometryData::getNormals() const {
 
 template <typename Container>
 inline void GeometryData::setNormals( const Container& normalList ) {
-    return setAttribData( Geometry::MeshAttrib::VERTEX_NORMAL, normalList );
+    setAttribData( Geometry::MeshAttrib::VERTEX_NORMAL, normalList );
 }
 
 inline Vector3Array& GeometryData::getTangents() {
@@ -127,7 +127,7 @@ inline const Vector3Array& GeometryData::getTangents() const {
 
 template <typename Container>
 inline void GeometryData::setTangents( const Container& tangentList ) {
-    return setAttribData( Geometry::MeshAttrib::VERTEX_TANGENT, tangentList );
+    setAttribData( Geometry::MeshAttrib::VERTEX_TANGENT, tangentList );
 }
 
 inline Vector3Array& GeometryData::getBiTangents() {
@@ -142,7 +142,7 @@ inline const Vector3Array& GeometryData::getBiTangents() const {
 
 template <typename Container>
 inline void GeometryData::setBitangents( const Container& bitangentList ) {
-    return setAttribData( Geometry::MeshAttrib::VERTEX_BITANGENT, bitangentList );
+    setAttribData( Geometry::MeshAttrib::VERTEX_BITANGENT, bitangentList );
 }
 
 inline Vector3Array& GeometryData::getTexCoords() {
@@ -157,7 +157,7 @@ inline const Vector3Array& GeometryData::getTexCoords() const {
 
 template <typename Container>
 inline void GeometryData::setTextureCoordinates( const Container& texCoordList ) {
-    return setAttribData( Geometry::MeshAttrib::VERTEX_TEXCOORD, texCoordList );
+    setAttribData( Geometry::MeshAttrib::VERTEX_TEXCOORD, texCoordList );
 }
 
 inline const MaterialData& GeometryData::getMaterial() const {

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -38,6 +38,10 @@ inline Vector3Array& GeometryData::getVertices() {
     return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_POSITION ).getDataWithLock();
 }
 
+inline const Vector3Array& GeometryData::getVertices() const {
+    return m_multiIndexedGeometry.vertices();
+}
+
 namespace internal {
 
 template <typename InContainer, typename OutContainer>
@@ -60,7 +64,7 @@ inline void GeometryData::setVertices( const Container& vertexList ) {
 }
 
 inline Vector2uArray& GeometryData::getEdges() {
-    return addIndexedDataWithLock<Vector2ui>( "in_edge" );
+    return findIndexedDataWithLock<Vector2ui>( "in_edge" );
 }
 
 inline const Vector2uArray& GeometryData::getEdges() const {
@@ -77,7 +81,7 @@ inline const VectorNuArray& GeometryData::getFaces() const {
 }
 
 inline VectorNuArray& GeometryData::getFaces() {
-    return addIndexedDataWithLock<VectorNui>( "in_face" );
+    return findIndexedDataWithLock<VectorNui>( "in_face" );
 }
 
 template <typename Container>
@@ -86,7 +90,7 @@ inline void GeometryData::setFaces( const Container& faceList ) {
 }
 
 inline VectorNuArray& GeometryData::getPolyhedra() {
-    return addIndexedDataWithLock<VectorNui>( "in_polyhedron" );
+    return findIndexedDataWithLock<VectorNui>( "in_polyhedron" );
 }
 
 inline const VectorNuArray& GeometryData::getPolyhedra() const {
@@ -102,6 +106,10 @@ inline Vector3Array& GeometryData::getNormals() {
     return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_NORMAL ).getDataWithLock();
 }
 
+inline const Vector3Array& GeometryData::getNormals() const {
+    return m_multiIndexedGeometry.normals();
+}
+
 template <typename Container>
 inline void GeometryData::setNormals( const Container& normalList ) {
     return setAttribData( Geometry::MeshAttrib::VERTEX_NORMAL, normalList );
@@ -109,6 +117,12 @@ inline void GeometryData::setNormals( const Container& normalList ) {
 
 inline Vector3Array& GeometryData::getTangents() {
     return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TANGENT ).getDataWithLock();
+}
+
+inline const Vector3Array& GeometryData::getTangents() const {
+    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_TANGENT );
+    auto h     = m_multiIndexedGeometry.getAttribHandle<Vector3>( name );
+    return m_multiIndexedGeometry.getAttrib( h ).data();
 }
 
 template <typename Container>
@@ -120,6 +134,12 @@ inline Vector3Array& GeometryData::getBiTangents() {
     return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_BITANGENT ).getDataWithLock();
 }
 
+inline const Vector3Array& GeometryData::getBiTangents() const {
+    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_BITANGENT );
+    auto h     = m_multiIndexedGeometry.getAttribHandle<Vector3>( name );
+    return m_multiIndexedGeometry.getAttrib( h ).data();
+}
+
 template <typename Container>
 inline void GeometryData::setBitangents( const Container& bitangentList ) {
     return setAttribData( Geometry::MeshAttrib::VERTEX_BITANGENT, bitangentList );
@@ -127,6 +147,12 @@ inline void GeometryData::setBitangents( const Container& bitangentList ) {
 
 inline Vector3Array& GeometryData::getTexCoords() {
     return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TEXCOORD ).getDataWithLock();
+}
+
+inline const Vector3Array& GeometryData::getTexCoords() const {
+    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_TEXCOORD );
+    auto h     = m_multiIndexedGeometry.getAttribHandle<Vector3>( name );
+    return m_multiIndexedGeometry.getAttrib( h ).data();
 }
 
 template <typename Container>
@@ -171,7 +197,8 @@ inline bool GeometryData::isHexMesh() const {
 }
 
 inline bool GeometryData::hasVertices() const {
-    return hasAttribData<Vector3>( Geometry::MeshAttrib::VERTEX_POSITION );
+    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_POSITION );
+    return m_multiIndexedGeometry.hasAttribData( name );
 }
 
 inline bool GeometryData::hasEdges() const {
@@ -187,31 +214,39 @@ inline bool GeometryData::hasPolyhedra() const {
 }
 
 inline bool GeometryData::hasNormals() const {
-    return hasAttribData<Vector3>( Geometry::MeshAttrib::VERTEX_NORMAL );
+    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_NORMAL );
+    return m_multiIndexedGeometry.hasAttribData( name );
 }
 
 inline bool GeometryData::hasTangents() const {
-    return hasAttribData<Vector3>( Geometry::MeshAttrib::VERTEX_TANGENT );
+    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_TANGENT );
+    return m_multiIndexedGeometry.hasAttribData( name );
 }
 
 inline bool GeometryData::hasBiTangents() const {
-    return hasAttribData<Vector3>( Geometry::MeshAttrib::VERTEX_BITANGENT );
+    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_BITANGENT );
+    return m_multiIndexedGeometry.hasAttribData( name );
 }
 
 inline bool GeometryData::hasTextureCoordinates() const {
-    return hasAttribData<Vector3>( Geometry::MeshAttrib::VERTEX_TEXCOORD );
+    auto& name = getAttribName( Geometry::MeshAttrib::VERTEX_TEXCOORD );
+    return m_multiIndexedGeometry.hasAttribData( name );
 }
 
 inline bool GeometryData::hasMaterial() const {
     return m_material != nullptr;
 }
 
-const Utils::AttribManager& GeometryData::getAttribManager() const {
-    return m_multiIndexedGeometry.vertexAttribs();
+const Geometry::MultiIndexedGeometry& GeometryData::getMultiIndexedGeometry() const {
+    return m_multiIndexedGeometry;
 }
 
-inline Geometry::MultiIndexedGeometry& GeometryData::getMultiIndexedGeometry() {
+Geometry::MultiIndexedGeometry& GeometryData::getMultiIndexedGeometry() {
     return m_multiIndexedGeometry;
+}
+
+const Utils::AttribManager& GeometryData::getAttribManager() const {
+    return m_multiIndexedGeometry.vertexAttribs();
 }
 
 Utils::AttribManager& GeometryData::getAttribManager() {
@@ -221,14 +256,8 @@ Utils::AttribManager& GeometryData::getAttribManager() {
 template <typename T>
 inline Utils::Attrib<T>& GeometryData::getAttrib( const Geometry::MeshAttrib& name ) {
     const auto& n = getAttribName( name );
-    Utils::AttribHandle<T> h;
-    if ( m_multiIndexedGeometry.vertexAttribs().contains( n ) ) {
-        h = m_multiIndexedGeometry.getAttribHandle<T>( n );
-    }
-    else {
-        h = m_multiIndexedGeometry.addAttrib<T>( n );
-    }
-    auto& attrib = m_multiIndexedGeometry.getAttrib( h );
+    auto h        = m_multiIndexedGeometry.addAttrib<T>( n );
+    auto& attrib  = m_multiIndexedGeometry.getAttrib( h );
     return attrib;
 }
 
@@ -242,77 +271,91 @@ inline void GeometryData::setAttribData( const Geometry::MeshAttrib& name,
 }
 
 template <typename V>
-inline bool GeometryData::hasAttribData( const Geometry::MeshAttrib& name ) const {
-    auto& n = getAttribName( name );
-    auto h  = m_multiIndexedGeometry.getAttribHandle<V>( n );
-    if ( m_multiIndexedGeometry.isValid( h ) ) {
-        return !m_multiIndexedGeometry.getAttrib( h ).data().empty();
-    }
-    return false;
+inline VectorArray<V>&
+GeometryData::getDataFromLayerBase( Geometry::GeometryIndexLayerBase& geomBase ) {
+    auto& v    = dynamic_cast<Geometry::GeometryIndexLayer<V>&>( geomBase );
+    auto& data = v.collection();
+    return data;
+}
+
+template <typename V>
+inline const VectorArray<V>&
+GeometryData::getDataFromLayerBase( const Geometry::GeometryIndexLayerBase& geomBase ) const {
+    const auto& v    = dynamic_cast<const Geometry::GeometryIndexLayer<V>&>( geomBase );
+    const auto& data = v.collection();
+    return data;
+}
+
+template <typename L>
+inline Geometry::GeometryIndexLayerBase&
+GeometryData::getLayerBaseWithLock( const bool& firstOccurrence, const std::string& name ) {
+    auto& geomBase =
+        ( firstOccurrence )
+            ? m_multiIndexedGeometry.getFirstLayerOccurrenceWithLock( L::staticSemanticName ).second
+            : m_multiIndexedGeometry.getLayerWithLock( { L::staticSemanticName }, name );
+    return geomBase;
+}
+
+template <typename L>
+inline const Geometry::GeometryIndexLayerBase&
+GeometryData::getLayerBase( const bool& firstOccurrence, const std::string& name ) const {
+    const auto& geomBase =
+        ( firstOccurrence )
+            ? m_multiIndexedGeometry.getFirstLayerOccurrence( L::staticSemanticName ).second
+            : m_multiIndexedGeometry.getLayer( { L::staticSemanticName }, name );
+    return geomBase;
 }
 
 template <typename V, typename L>
 inline VectorArray<V>& GeometryData::getIndexedDataWithLock( const bool& firstOccurrence,
                                                              const std::string& name ) {
-    try {
-        auto& geomBase =
-            ( firstOccurrence )
-                ? m_multiIndexedGeometry.getFirstLayerOccurrenceWithLock( L::staticSemanticName )
-                      .second
-                : m_multiIndexedGeometry.getLayerWithLock( { L::staticSemanticName }, name );
-        auto& v    = dynamic_cast<Geometry::GeometryIndexLayer<V>&>( geomBase );
-        auto& data = v.collection();
-        return data;
+    if ( m_multiIndexedGeometry.containsLayer( { L::staticSemanticName }, name ) ) {
+        auto& geomBaseFound = getLayerBaseWithLock<L>( firstOccurrence, name );
+        return getDataFromLayerBase<V>( geomBaseFound );
     }
-    catch ( const std::out_of_range& e ) {
+    else {
         auto pil = std::make_unique<L>();
-        m_multiIndexedGeometry.addLayer( std::move( pil ), name );
-        return getIndexedDataWithLock<V, L>( firstOccurrence, name );
+        auto& geomBaseCreated =
+            m_multiIndexedGeometry.addLayer( std::move( pil ), true, name ).second;
+        return getDataFromLayerBase<V>( geomBaseCreated );
     }
 }
 
 template <typename V>
-inline VectorArray<V>& GeometryData::addIndexedDataWithLock( const std::string& name,
-                                                             const bool& firstOccurrence ) {
+inline VectorArray<V>& GeometryData::findIndexedDataWithLock( const std::string& name,
+                                                              const bool& firstOccurrence ) {
     if ( std::is_same<V, Vector2ui>::value ) {
         return getIndexedDataWithLock<V, Geometry::LineIndexLayer>( firstOccurrence, name );
     }
-    /*else if (std::is_same<V, Vector3ui>::value){
+    /* else if (std::is_same<V, Vector3ui>::value){
         return getIndexedDataWithLock<V, Geometry::TriangleIndexLayer>( firstOccurrence, name );
     }
     else if (std::is_same<V, Vector4ui>::value){
         return getIndexedDataWithLock<V, Geometry::QuadIndexLayer>( firstOccurrence, name );
-    }*/
+    } */
     else {
         return getIndexedDataWithLock<V, Geometry::PolyIndexLayer>( firstOccurrence, name );
     }
-}
-
-template <typename V, typename L>
-inline const VectorArray<V>& GeometryData::getIndexedData( const bool& firstOccurrence,
-                                                           const std::string& name ) const {
-    auto& g    = ( firstOccurrence )
-                     ? m_multiIndexedGeometry.getFirstLayerOccurrence( L::staticSemanticName ).second
-                     : m_multiIndexedGeometry.getLayer( { L::staticSemanticName }, name );
-    auto& v    = dynamic_cast<const Geometry::GeometryIndexLayer<V>&>( g );
-    auto& data = v.collection();
-    return data;
 }
 
 template <typename V>
 inline const VectorArray<V>& GeometryData::getIndexedData( const std::string& name,
                                                            const bool& firstOccurrence ) const {
     if ( std::is_same<V, Vector2ui>::value ) {
-        return getIndexedData<V, Geometry::LineIndexLayer>( firstOccurrence, name );
+        auto& geomBase = getLayerBase<Geometry::LineIndexLayer>( firstOccurrence, name );
+        return getDataFromLayerBase<V>( geomBase );
     }
     /*else if (std::is_same<V, Vector3ui>::value){
-        return getIndexedData<V, Geometry::TriangleIndexLayer>( firstOccurrence, name );
+        auto& geomBase = getLayerBase<Geometry::TriangleIndexLayer>( firstOccurrence, name );
+        return getDataFromLayerBase<V>( geomBase );
     }
     else if (std::is_same<V, Vector4ui>::value){
-        return getIndexedData<V, Geometry::QuadIndexLayer>( firstOccurrence, name );
+        auto& geomBase = getLayerBase<Geometry::QuadIndexLayer>( firstOccurrence, name );
+        return getDataFromLayerBase<V>( geomBase );
     }*/
     else {
-        return getIndexedData<V, Geometry::PolyIndexLayer>( firstOccurrence, name );
+        auto& geomBase = getLayerBase<Geometry::PolyIndexLayer>( firstOccurrence, name );
+        return getDataFromLayerBase<V>( geomBase );
     }
 }
 
@@ -339,7 +382,7 @@ template <typename V>
 inline void GeometryData::setIndexedData( const GeometryType& type,
                                           const VectorArray<V>& indexedDataList,
                                           const std::string& name ) {
-    internal::copyData( indexedDataList, addIndexedDataWithLock<V>( name ) );
+    internal::copyData( indexedDataList, findIndexedDataWithLock<V>( name ) );
     indexedDataUnlock( type, name );
 }
 

--- a/src/Core/Asset/GeometryData.inl
+++ b/src/Core/Asset/GeometryData.inl
@@ -1,4 +1,5 @@
 #pragma once
+#include "Core/Geometry/StandardAttribNames.hpp"
 #include <Core/Asset/GeometryData.hpp>
 
 #include <algorithm> //std::transform
@@ -28,10 +29,7 @@ inline void GeometryData::setFrame( const Transform& frame ) {
 }
 
 inline std::size_t GeometryData::getVerticesSize() const {
-    const auto& n      = getAttribName( Geometry::MeshAttrib::VERTEX_POSITION );
-    auto h             = m_multiIndexedGeometry.getAttribHandle<Vector3>( n );
-    const auto& attrib = m_multiIndexedGeometry.getAttrib( h );
-    return attrib.data().size();
+    return m_multiIndexedGeometry.vertices().size();
 }
 
 inline Vector3Array& GeometryData::getVertices() {
@@ -59,8 +57,8 @@ inline void copyData( const InContainer& input, OutContainer& output ) {
 } // namespace internal
 
 template <typename Container>
-inline void GeometryData::setVertices( const Container& vertexList ) {
-    setAttribData( Geometry::MeshAttrib::VERTEX_POSITION, vertexList );
+inline void GeometryData::setVertices( const Container& data ) {
+    getMultiIndexedGeometry().setVertices( data );
 }
 
 inline Vector2uArray& GeometryData::getEdges() {
@@ -111,47 +109,65 @@ inline const Vector3Array& GeometryData::getNormals() const {
 }
 
 template <typename Container>
-inline void GeometryData::setNormals( const Container& normalList ) {
-    setAttribData( Geometry::MeshAttrib::VERTEX_NORMAL, normalList );
+inline void GeometryData::setNormals( const Container& data ) {
+    getMultiIndexedGeometry().setNormals( data );
 }
 
 inline Vector3Array& GeometryData::getTangents() {
-    return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TANGENT ).getDataWithLock();
+    return m_multiIndexedGeometry.vertexAttribs()
+        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_TANGENT ) )
+        .getDataWithLock();
 }
 
 inline const Vector3Array& GeometryData::getTangents() const {
-    return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TANGENT ).data();
+    return m_multiIndexedGeometry.vertexAttribs()
+        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_TANGENT ) )
+        .data();
 }
 
 template <typename Container>
-inline void GeometryData::setTangents( const Container& tangentList ) {
-    setAttribData( Geometry::MeshAttrib::VERTEX_TANGENT, tangentList );
+inline void GeometryData::setTangents( const Container& data ) {
+    m_multiIndexedGeometry
+        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_TANGENT ) )
+        .setData( data );
 }
 
 inline Vector3Array& GeometryData::getBiTangents() {
-    return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_BITANGENT ).getDataWithLock();
+    return m_multiIndexedGeometry
+        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_BITANGENT ) )
+        .getDataWithLock();
 }
 
 inline const Vector3Array& GeometryData::getBiTangents() const {
-    return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_BITANGENT ).data();
+    return m_multiIndexedGeometry
+        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_BITANGENT ) )
+        .data();
 }
 
 template <typename Container>
-inline void GeometryData::setBitangents( const Container& bitangentList ) {
-    setAttribData( Geometry::MeshAttrib::VERTEX_BITANGENT, bitangentList );
+inline void GeometryData::setBitangents( const Container& data ) {
+    m_multiIndexedGeometry
+        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_BITANGENT ) )
+        .setData( data );
 }
 
 inline Vector3Array& GeometryData::getTexCoords() {
-    return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TEXCOORD ).getDataWithLock();
+    return m_multiIndexedGeometry
+        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_TEXCOORD ) )
+        .getDataWithLock();
 }
 
 inline const Vector3Array& GeometryData::getTexCoords() const {
-    return getAttrib<Vector3>( Geometry::MeshAttrib::VERTEX_TEXCOORD ).data();
+    return m_multiIndexedGeometry
+        .getAttrib<Vector3>( Geometry::getAttribName( Geometry::MeshAttrib::VERTEX_TEXCOORD ) )
+        .data();
 }
 
 template <typename Container>
-inline void GeometryData::setTextureCoordinates( const Container& texCoordList ) {
-    setAttribData( Geometry::MeshAttrib::VERTEX_TEXCOORD, texCoordList );
+inline void GeometryData::setTextureCoordinates( const Container& data ) {
+    m_multiIndexedGeometry
+        .getAttrib<Vector3>( getAttribName( Geometry::MeshAttrib::VERTEX_TEXCOORD ) )
+        .setData( data );
 }
 
 inline const MaterialData& GeometryData::getMaterial() const {
@@ -243,28 +259,6 @@ const Utils::AttribManager& GeometryData::getAttribManager() const {
 
 Utils::AttribManager& GeometryData::getAttribManager() {
     return m_multiIndexedGeometry.vertexAttribs();
-}
-
-template <typename T>
-inline Utils::Attrib<T>& GeometryData::getAttrib( const Geometry::MeshAttrib& name ) {
-    const auto& n = getAttribName( name );
-    auto h        = m_multiIndexedGeometry.addAttrib<T>( n );
-    auto& attrib  = m_multiIndexedGeometry.getAttrib( h );
-    return attrib;
-}
-
-template <typename T>
-const inline Utils::Attrib<T>& GeometryData::getAttrib( const Geometry::MeshAttrib& name ) const {
-    const auto& n = getAttribName( name );
-    auto h        = m_multiIndexedGeometry.getAttribHandle<T>( n );
-    auto& attrib  = m_multiIndexedGeometry.getAttrib( h );
-    return attrib;
-}
-
-template <typename V>
-inline void GeometryData::setAttribData( const Geometry::MeshAttrib& name,
-                                         const VectorArray<V>& attribDataList ) {
-    getAttrib<V>( name ).setData( attribDataList );
 }
 
 template <typename V>

--- a/src/Core/Geometry/IndexedGeometry.cpp
+++ b/src/Core/Geometry/IndexedGeometry.cpp
@@ -221,8 +221,8 @@ MultiIndexedGeometry::addLayer( std::unique_ptr<GeometryIndexLayerBase>&& layer,
         CORE_ASSERT( !pos->second.first, "try to get already locked layer" );
         pos->second.first = true;
     }
-    /// TODO What happens to the unique ptr when it is not inserted ? (The problem was the same in
-    /// the previous version).
+    /// If not inserted, the pointer is deleted. So the caller must ensure this possible deletion
+    /// is safe before calling this method.
 
     return { inserted, *( pos->second.second ) };
 }

--- a/src/Core/Geometry/IndexedGeometry.cpp
+++ b/src/Core/Geometry/IndexedGeometry.cpp
@@ -200,7 +200,7 @@ void MultiIndexedGeometry::unlockFirstLayerOccurrence( const LayerSemanticCollec
 void MultiIndexedGeometry::unlockLayer( const LayerKeyType& layerKey ) {
     auto& p = m_indices.at( layerKey );
     CORE_ASSERT( p.first, "try to release unlocked layer" );
-    p.first = true;
+    p.first = false;
     notify();
 }
 

--- a/src/Core/Geometry/IndexedGeometry.hpp
+++ b/src/Core/Geometry/IndexedGeometry.hpp
@@ -64,7 +64,7 @@ struct GeometryIndexLayer : public GeometryIndexLayerBase {
 
     inline size_t getSize() const override final;
 
-    inline GeometryIndexLayerBase* clone() override final;
+    inline std::unique_ptr<GeometryIndexLayerBase> clone() override final;
 
     inline size_t getNumberOfComponents() const override final;
 
@@ -237,6 +237,7 @@ class RA_CORE_API MultiIndexedGeometry : public AttribArrayGeometry, public Util
     /// \complexity \f$ O(n) \f$, with \f$ n \f$ the number of layers in the collection
     /// \throws std::out_of_range
     inline const GeometryIndexLayerBase& getLayer( const LayerKeyType& layerKey ) const;
+
     /// \copybrief getLayer( const LayerKeyType& ) const
     ///
     /// Convenience function.
@@ -289,6 +290,7 @@ class RA_CORE_API MultiIndexedGeometry : public AttribArrayGeometry, public Util
     /// \throws std::out_of_range
     inline GeometryIndexLayerBase& getLayerWithLock( const LayerSemanticCollection& semantics,
                                                      const std::string& layerName );
+
     /// \copybrief getLayerWithLock( const LayerKeyType& )
     ///
     /// Convenience function.
@@ -321,6 +323,7 @@ class RA_CORE_API MultiIndexedGeometry : public AttribArrayGeometry, public Util
     /// \complexity \f$ O(n) \f$, with \f$ n \f$ the number of layers in the collection
     /// \throws std::out_of_range
     void unlockLayer( const LayerKeyType& layerKey );
+    void unlockLayer2( const LayerKeyType& layerKey );
 
     /// \copybrief unlockLayer( const LayerKeyType& )
     ///
@@ -384,7 +387,8 @@ class RA_CORE_API MultiIndexedGeometry : public AttribArrayGeometry, public Util
 
     /// Note: we cannot store unique_ptr here has unordered_map needs its
     /// elements to be copy-constructible
-    using EntryType = std::pair<bool, GeometryIndexLayerBase*>;
+    using EntryType = std::pair<bool, std::unique_ptr<GeometryIndexLayerBase>>;
+
     struct RA_CORE_API KeyHash {
         std::size_t operator()( const LayerKeyType& k ) const;
     };

--- a/src/Core/Geometry/IndexedGeometry.hpp
+++ b/src/Core/Geometry/IndexedGeometry.hpp
@@ -385,8 +385,6 @@ class RA_CORE_API MultiIndexedGeometry : public AttribArrayGeometry, public Util
     /// \brief Clear attributes stored as pointers
     void deepClear();
 
-    /// Note: we cannot store unique_ptr here has unordered_map needs its
-    /// elements to be copy-constructible
     using EntryType = std::pair<bool, std::unique_ptr<GeometryIndexLayerBase>>;
 
     struct RA_CORE_API KeyHash {

--- a/src/Core/Geometry/IndexedGeometry.hpp
+++ b/src/Core/Geometry/IndexedGeometry.hpp
@@ -32,7 +32,7 @@ class RA_CORE_API GeometryIndexLayerBase : public Utils::ObservableVoid,
     virtual ~GeometryIndexLayerBase();
 
     /// \brief Create new layer with duplicated content
-    virtual GeometryIndexLayerBase* clone() = 0;
+    virtual std::unique_ptr<GeometryIndexLayerBase> clone() = 0;
 
     /// \brief Append content from another layer
     /// \return false if data cannot be appended, e.g., different semantics

--- a/src/Core/Geometry/IndexedGeometry.hpp
+++ b/src/Core/Geometry/IndexedGeometry.hpp
@@ -410,7 +410,7 @@ struct RA_CORE_API PointCloudIndexLayer : public GeometryIndexLayer<Vector1ui> {
 
     /// \brief Constructor of an index layer with linearly spaced indices ranging from \f$0\f$ to
     /// \f$n-1\f$
-    inline PointCloudIndexLayer( size_t n );
+    inline explicit PointCloudIndexLayer( size_t n );
 
     /// \brief Generate linearly spaced indices with same size as \p attr vertex buffer
     void linearIndices( const AttribArrayGeometry& attr );
@@ -430,7 +430,7 @@ struct RA_CORE_API TriangleIndexLayer : public GeometryIndexLayer<Vector3ui> {
 
   protected:
     template <class... SemanticNames>
-    inline TriangleIndexLayer( SemanticNames... names );
+    inline explicit TriangleIndexLayer( SemanticNames... names );
 };
 
 /// \brief Index layer for quadrilateral mesh.
@@ -441,7 +441,7 @@ struct RA_CORE_API QuadIndexLayer : public GeometryIndexLayer<Vector4ui> {
 
   protected:
     template <class... SemanticNames>
-    inline QuadIndexLayer( SemanticNames... names );
+    inline explicit QuadIndexLayer( SemanticNames... names );
 };
 
 /// \brief Index layer for polygonal mesh.
@@ -453,7 +453,7 @@ struct RA_CORE_API PolyIndexLayer : public GeometryIndexLayer<VectorNui> {
 
   protected:
     template <class... SemanticNames>
-    inline PolyIndexLayer( SemanticNames... names );
+    inline explicit PolyIndexLayer( SemanticNames... names );
 };
 
 /// \brief Index layer for line mesh.
@@ -464,7 +464,7 @@ struct RA_CORE_API LineIndexLayer : public GeometryIndexLayer<Vector2ui> {
 
   protected:
     template <class... SemanticNames>
-    inline LineIndexLayer( SemanticNames... names );
+    inline explicit LineIndexLayer( SemanticNames... names );
 };
 
 /// \}

--- a/src/Core/Geometry/IndexedGeometry.hpp
+++ b/src/Core/Geometry/IndexedGeometry.hpp
@@ -365,8 +365,10 @@ class RA_CORE_API MultiIndexedGeometry : public AttribArrayGeometry, public Util
     ///
     /// \warning Takes the ownership of the layer
     ///
-    bool addLayer( std::unique_ptr<GeometryIndexLayerBase>&& layer,
-                   const std::string& layerName = "" );
+    std::pair<bool, GeometryIndexLayerBase&>
+    addLayer( std::unique_ptr<GeometryIndexLayerBase>&& layer,
+              const bool withLock          = false,
+              const std::string& layerName = "" );
 
     /// \brief Range on layer keys (read-only)
     ///

--- a/src/Core/Geometry/IndexedGeometry.hpp
+++ b/src/Core/Geometry/IndexedGeometry.hpp
@@ -14,7 +14,6 @@ namespace Ra {
 namespace Core {
 namespace Geometry {
 
-///
 /// \brief Base class for index collections stored in MultiIndexedGeometry
 class RA_CORE_API GeometryIndexLayerBase : public Utils::ObservableVoid,
                                            public Utils::ObjectWithSemantic,
@@ -398,8 +397,18 @@ class RA_CORE_API MultiIndexedGeometry : public AttribArrayGeometry, public Util
     std::unordered_map<LayerKeyType, EntryType, KeyHash> m_indices;
 };
 
+/// \name Predefined index layers
+/// The use of these layers helps in generic management of geometries
+/// \{
+
+/// \brief Index layer for a point cloud
 struct RA_CORE_API PointCloudIndexLayer : public GeometryIndexLayer<Vector1ui> {
+    /// \brief Constructor of an empty layer
     inline PointCloudIndexLayer();
+
+    /// \brief Constructor of an index layer with linearly spaced indices ranging from \f$0\f$ to
+    /// \f$n-1\f$
+    inline PointCloudIndexLayer( size_t n );
 
     /// \brief Generate linearly spaced indices with same size as \p attr vertex buffer
     void linearIndices( const AttribArrayGeometry& attr );
@@ -411,6 +420,8 @@ struct RA_CORE_API PointCloudIndexLayer : public GeometryIndexLayer<Vector1ui> {
     inline PointCloudIndexLayer( SemanticNames... names );
 };
 
+/// \brief Index layer for triangle mesh.
+/// \note, This layer ensures that all faces have exactly 3 vertices
 struct RA_CORE_API TriangleIndexLayer : public GeometryIndexLayer<Vector3ui> {
     inline TriangleIndexLayer();
     static constexpr const char* staticSemanticName = "TriangleMesh";
@@ -420,6 +431,20 @@ struct RA_CORE_API TriangleIndexLayer : public GeometryIndexLayer<Vector3ui> {
     inline TriangleIndexLayer( SemanticNames... names );
 };
 
+/// \brief Index layer for quadrilateral mesh.
+/// \note, This layer ensures that all faces have exactly 4 vertices
+struct RA_CORE_API QuadIndexLayer : public GeometryIndexLayer<Vector4ui> {
+    inline QuadIndexLayer();
+    static constexpr const char* staticSemanticName = "QuadMesh";
+
+  protected:
+    template <class... SemanticNames>
+    inline QuadIndexLayer( SemanticNames... names );
+};
+
+/// \brief Index layer for polygonal mesh.
+/// \note, Using this layer, all faces might have more than 4 vertices or have different number of
+/// vertices.
 struct RA_CORE_API PolyIndexLayer : public GeometryIndexLayer<VectorNui> {
     inline PolyIndexLayer();
     static constexpr const char* staticSemanticName = "PolyMesh";
@@ -429,6 +454,8 @@ struct RA_CORE_API PolyIndexLayer : public GeometryIndexLayer<VectorNui> {
     inline PolyIndexLayer( SemanticNames... names );
 };
 
+/// \brief Index layer for line mesh.
+/// \note, This layer ensures that all faces have exactly 2 vertices
 struct RA_CORE_API LineIndexLayer : public GeometryIndexLayer<Vector2ui> {
     inline LineIndexLayer();
     static constexpr const char* staticSemanticName = "LineMesh";
@@ -437,6 +464,8 @@ struct RA_CORE_API LineIndexLayer : public GeometryIndexLayer<Vector2ui> {
     template <class... SemanticNames>
     inline LineIndexLayer( SemanticNames... names );
 };
+
+/// \}
 
 /// Temporary class providing the old API for TriangleMesh, LineMesh and PolyMesh
 /// This class will be marked as deprecated soon.
@@ -452,6 +481,11 @@ struct getType<Vector2ui> {
 template <>
 struct getType<Vector3ui> {
     using Type = Ra::Core::Geometry::TriangleIndexLayer;
+};
+
+template <>
+struct getType<Vector4ui> {
+    using Type = Ra::Core::Geometry::QuadIndexLayer;
 };
 
 template <>
@@ -512,6 +546,9 @@ class RA_CORE_API IndexedPointCloud : public IndexedGeometry<Vector1ui>
 {};
 
 class RA_CORE_API TriangleMesh : public IndexedGeometry<Vector3ui>
+{};
+
+class RA_CORE_API QuadMesh : public IndexedGeometry<Vector4ui>
 {};
 
 class RA_CORE_API PolyMesh : public IndexedGeometry<VectorNui>

--- a/src/Core/Geometry/IndexedGeometry.inl
+++ b/src/Core/Geometry/IndexedGeometry.inl
@@ -154,6 +154,11 @@ MultiIndexedGeometry::unlockLayer( const MultiIndexedGeometry::LayerSemanticColl
 // PointCloudIndexLayer
 inline PointCloudIndexLayer::PointCloudIndexLayer() :
     GeometryIndexLayer( PointCloudIndexLayer::staticSemanticName ) {}
+inline PointCloudIndexLayer::PointCloudIndexLayer( size_t n ) :
+    GeometryIndexLayer( PointCloudIndexLayer::staticSemanticName ) {
+    collection().resize( n );
+    collection().getMap() = IndexContainerType::Matrix::LinSpaced( n, 0, n - 1 );
+}
 template <class... SemanticNames>
 inline PointCloudIndexLayer::PointCloudIndexLayer( SemanticNames... names ) :
     GeometryIndexLayer( PointCloudIndexLayer::staticSemanticName, names... ) {}
@@ -163,6 +168,12 @@ inline TriangleIndexLayer::TriangleIndexLayer() :
 template <class... SemanticNames>
 inline TriangleIndexLayer::TriangleIndexLayer( SemanticNames... names ) :
     GeometryIndexLayer( TriangleIndexLayer::staticSemanticName, names... ) {}
+// QuadIndexLayer
+inline QuadIndexLayer::QuadIndexLayer() :
+    GeometryIndexLayer( QuadIndexLayer::staticSemanticName ) {}
+template <class... SemanticNames>
+inline QuadIndexLayer::QuadIndexLayer( SemanticNames... names ) :
+    GeometryIndexLayer( QuadIndexLayer::staticSemanticName, names... ) {}
 // PolyIndexLayer
 inline PolyIndexLayer::PolyIndexLayer() :
     GeometryIndexLayer( PolyIndexLayer::staticSemanticName ) {}

--- a/src/Core/Geometry/IndexedGeometry.inl
+++ b/src/Core/Geometry/IndexedGeometry.inl
@@ -91,8 +91,8 @@ inline const void* GeometryIndexLayer<T>::dataPtr() const {
 }
 
 template <typename T>
-inline GeometryIndexLayerBase* GeometryIndexLayer<T>::clone() {
-    auto copy          = new GeometryIndexLayer<T>( *this );
+inline std::unique_ptr<GeometryIndexLayerBase> GeometryIndexLayer<T>::clone() {
+    auto copy          = std::make_unique<GeometryIndexLayer<T>>( *this );
     copy->m_collection = m_collection;
     return copy;
 }

--- a/src/Core/Geometry/IndexedGeometry.inl
+++ b/src/Core/Geometry/IndexedGeometry.inl
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Core/Geometry/IndexedGeometry.hpp>
+#include <memory>
 
 namespace Ra {
 namespace Core {
@@ -126,13 +127,7 @@ MultiIndexedGeometry::countLayers( const MultiIndexedGeometry::LayerSemanticColl
 
 inline const GeometryIndexLayerBase&
 MultiIndexedGeometry::getLayer( const MultiIndexedGeometry::LayerKeyType& layerKey ) const {
-    return *( m_indices.at( layerKey ).second );
-}
-
-inline const GeometryIndexLayerBase&
-MultiIndexedGeometry::getLayer( const MultiIndexedGeometry::LayerSemanticCollection& semantics,
-                                const std::string& layerName ) const {
-    return getLayer( { semantics, layerName } );
+    return *( m_indices.at( layerKey ).second.get() );
 }
 
 inline GeometryIndexLayerBase& MultiIndexedGeometry::getLayerWithLock(

--- a/src/Core/Geometry/TopologicalMesh.inl
+++ b/src/Core/Geometry/TopologicalMesh.inl
@@ -447,6 +447,7 @@ void TopologicalMesh::initWithWedge(
     const auto& abstractLayer = mesh.getLayer( layerKey );
 
     if ( !abstractLayer.hasSemantic( TriangleIndexLayer::staticSemanticName ) &&
+         !abstractLayer.hasSemantic( QuadIndexLayer::staticSemanticName ) &&
          !abstractLayer.hasSemantic( PolyIndexLayer::staticSemanticName ) ) {
         LOG( logWARNING ) << "TopologicalMesh: mesh does not contains faces. Aborting conversion";
         return;
@@ -454,12 +455,8 @@ void TopologicalMesh::initWithWedge(
 
     clean();
 
-    LOG( logINFO )
-        << "TopologicalMesh: load mesh with "
-        << ( abstractLayer.hasSemantic( TriangleIndexLayer::staticSemanticName )
-                 ? static_cast<const TriangleIndexLayer&>( abstractLayer ).collection().size()
-                 : static_cast<const PolyIndexLayer&>( abstractLayer ).collection().size() )
-        << " faces and " << mesh.vertices().size() << " vertices.";
+    LOG( logINFO ) << "TopologicalMesh: load mesh with " << abstractLayer.getSize() << " faces and "
+                   << mesh.vertices().size() << " vertices.";
     // use a hashmap for fast search of existing vertex position
     using VertexMap = std::unordered_map<Vector3, TopologicalMesh::VertexHandle, hash_vec>;
     VertexMap vertexHandles;

--- a/src/Core/Geometry/TriangleMesh.hpp
+++ b/src/Core/Geometry/TriangleMesh.hpp
@@ -111,6 +111,9 @@ class RA_CORE_API AttribArrayGeometry : public AbstractGeometry
     /// \see AttribManager::contains for more info.
     inline bool hasAttrib( const std::string& name );
 
+    /// Check if data in an attribute is empty or not with the given name.
+    inline bool hasAttribData( const std::string& name ) const;
+
     ///@{
     /// Add attribute with the given name.
     /// \see AttribManager::addAttrib() for more info.

--- a/src/Core/Geometry/TriangleMesh.hpp
+++ b/src/Core/Geometry/TriangleMesh.hpp
@@ -111,9 +111,6 @@ class RA_CORE_API AttribArrayGeometry : public AbstractGeometry
     /// \see AttribManager::contains for more info.
     inline bool hasAttrib( const std::string& name );
 
-    /// Check if data in an attribute is empty or not with the given name.
-    inline bool hasAttribData( const std::string& name ) const;
-
     ///@{
     /// Add attribute with the given name.
     /// \see AttribManager::addAttrib() for more info.

--- a/src/Core/Geometry/TriangleMesh.hpp
+++ b/src/Core/Geometry/TriangleMesh.hpp
@@ -12,6 +12,9 @@ namespace Ra {
 namespace Core {
 namespace Geometry {
 
+/// \brief This class represents vertex + attributes per vertex. Toplogy is handled in
+/// MultiIndexedGeometry subclass.
+///
 /// Attributes are unique per vertex, so that same position with different
 /// normals are two vertices.
 /// Points and Normals, defining the geometry, are always present.
@@ -88,28 +91,39 @@ class RA_CORE_API AttribArrayGeometry : public AbstractGeometry
     template <typename T>
     inline bool isValid( const Utils::AttribHandle<T>& h ) const;
 
-    /// Get attribute by handle.
-    /// \see AttribManager::getAttrib() for more info.
+    /// @name Wrappers to Utils::AttribManager.
+    /// @{
+
+    /// \see Utils::AttribManager::getAttrib
     template <typename T>
     inline Utils::Attrib<T>& getAttrib( const Utils::AttribHandle<T>& h );
-
-    /// Get attribute by handle.
-    /// \see AttribManager::getAttrib() for more info.
-    template <typename T>
-    inline Utils::Attrib<T>* getAttribPtr( const Utils::AttribHandle<T>& h );
-
-    /// Get attribute by handle (const).
-    /// \see AttribManager::getAttrib() for more info.
+    ///  \see Utils::AttribManager::getAttrib
     template <typename T>
     inline const Utils::Attrib<T>& getAttrib( const Utils::AttribHandle<T>& h ) const;
 
-    /// Get attribute by handle (const).
-    /// \see AttribManager::getAttrib() for more info.
+    /// \see Utils::AttribManager::getAttrib
+    template <typename T>
+    inline Utils::Attrib<T>& getAttrib( const std::string& name );
+    /// \see Utils::AttribManager::getAttrib
+    template <typename T>
+    inline const Utils::Attrib<T>& getAttrib( const std::string& name ) const;
+
+    /// \see Utils::AttribManager::getAttribPtr
+    template <typename T>
+    inline Utils::Attrib<T>* getAttribPtr( const Utils::AttribHandle<T>& h );
+    /// \see Utils::AttribManager::getAttribPtr
+    template <typename T>
+    inline const Utils::Attrib<T>* getAttribPtr( const Utils::AttribHandle<T>& h ) const;
+
+    /// \see Utils::AttribManager::getAttribBase
     inline Utils::AttribBase* getAttribBase( const std::string& name );
+    /// \see Utils::AttribManager::getAttribBase
+    inline const Utils::AttribBase* getAttribBase( const std::string& name ) const;
+    ///@}
 
     /// Check if an attribute exists with the given name.
     /// \see AttribManager::contains for more info.
-    inline bool hasAttrib( const std::string& name );
+    inline bool hasAttrib( const std::string& name ) const;
 
     ///@{
     /// Add attribute with the given name.
@@ -172,6 +186,7 @@ class RA_CORE_API AttribArrayGeometry : public AbstractGeometry
 
     /// Return the vertexAttribs manager. In case you want to have direct access
     /// to Utils::AttribManager functionality.
+    /// \todo rename to getAttribManager ?
     inline Utils::AttribManager& vertexAttribs();
 
     /// Return the vertexAttribs manager. In case you want to have direct access

--- a/src/Core/Geometry/TriangleMesh.inl
+++ b/src/Core/Geometry/TriangleMesh.inl
@@ -142,12 +142,6 @@ inline bool AttribArrayGeometry::hasAttrib( const std::string& name ) {
     return m_vertexAttribs.contains( name );
 }
 
-inline bool AttribArrayGeometry::hasAttribData( const std::string& name ) const {
-    auto h = getAttribHandle<Vector3>( name );
-    if ( isValid( h ) ) { return !getAttrib( h ).data().empty(); }
-    return false;
-}
-
 template <typename T>
 inline Utils::AttribHandle<T> AttribArrayGeometry::addAttrib( const std::string& name ) {
     invalidateAabb();

--- a/src/Core/Geometry/TriangleMesh.inl
+++ b/src/Core/Geometry/TriangleMesh.inl
@@ -142,6 +142,12 @@ inline bool AttribArrayGeometry::hasAttrib( const std::string& name ) {
     return m_vertexAttribs.contains( name );
 }
 
+inline bool AttribArrayGeometry::hasAttribData( const std::string& name ) const {
+    auto h = getAttribHandle<Vector3>( name );
+    if ( isValid( h ) ) { return !getAttrib( h ).data().empty(); }
+    return false;
+}
+
 template <typename T>
 inline Utils::AttribHandle<T> AttribArrayGeometry::addAttrib( const std::string& name ) {
     invalidateAabb();

--- a/src/Core/Geometry/TriangleMesh.inl
+++ b/src/Core/Geometry/TriangleMesh.inl
@@ -138,7 +138,22 @@ inline Utils::AttribBase* AttribArrayGeometry::getAttribBase( const std::string&
     return m_vertexAttribs.getAttribBase( name );
 }
 
-inline bool AttribArrayGeometry::hasAttrib( const std::string& name ) {
+inline const Utils::AttribBase*
+AttribArrayGeometry::getAttribBase( const std::string& name ) const {
+    return m_vertexAttribs.getAttribBase( name );
+}
+
+template <typename T>
+inline const Utils::Attrib<T>& AttribArrayGeometry::getAttrib( const std::string& name ) const {
+    return m_vertexAttribs.getAttrib<T>( name );
+}
+
+template <typename T>
+inline Utils::Attrib<T>& AttribArrayGeometry::getAttrib( const std::string& name ) {
+    return m_vertexAttribs.getAttrib<T>( name );
+}
+
+inline bool AttribArrayGeometry::hasAttrib( const std::string& name ) const {
     return m_vertexAttribs.contains( name );
 }
 

--- a/src/Core/Utils/Attribs.hpp
+++ b/src/Core/Utils/Attribs.hpp
@@ -330,11 +330,25 @@ class RA_CORE_API AttribManager : public Observable<const std::string&>
          * @param a
          * @brief Constructor, save statement of all attribs from attribManager ( isLocked() )
          */
-        explicit Unlocker( AttribManager* a ) : n_a { a } {
-            for ( const auto& attr : n_a->m_attribs ) {
-                if ( attr == nullptr ) break;
-                v.push_back( std::make_pair( attr.get(), attr->isLocked() ) );
-            }
+        /// \code{.cpp}
+        /// auto geometry = new GeometryData();
+        /// geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_TANGENT ).getDataWithLock();
+        //  REQUIRE (geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT
+        //  )->isLocked() );
+        //  {
+        //      auto unlocker = geometry->getAttribManager().getUnlocker();
+        //      geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_BITANGENT
+        //      ).getDataWithLock(); REQUIRE( geometry->getAttribManager().getAttribBase(
+        //      MeshAttrib::VERTEX_BITANGENT )->isLocked() );
+        //  }
+        //      REQUIRE(geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT
+        //      )->isLocked() ); REQUIRE( !geometry->getAttribManager().getAttribBase(
+        //      MeshAttrib::VERTEX_BITANGENT )->isLocked() );
+
+        explicit Unlocker( AttribManager* a ) : m_a { a } {
+            a->for_each_attrib( [this]( const auto& attr ) {
+                return ( v.push_back( std::make_pair( attr, attr->isLocked() ) ) );
+            } );
         }
         /**
          * @brief Destructor, unlock all attribs from attribManager which have been locked after the
@@ -347,7 +361,7 @@ class RA_CORE_API AttribManager : public Observable<const std::string&>
         }
 
       private:
-        AttribManager* n_a;
+        AttribManager* m_a;
         std::vector<std::pair<AttribBase*, bool>> v;
     };
 

--- a/src/Core/Utils/Attribs.hpp
+++ b/src/Core/Utils/Attribs.hpp
@@ -320,8 +320,8 @@ class RA_CORE_API AttribManager : public Observable<const std::string&>
     /// Return the number of attributes
     inline int getNumAttribs() const;
 
-    /// Unlocker class, unlock all attribs (which are locked after create the unlocker object) after
-    /// destruct.
+    /// Unlocker class, unlock all attribs (which are locked after the creation of the unlocker
+    /// object) after destruct.
     class Unlocker
     {
       public:
@@ -331,19 +331,28 @@ class RA_CORE_API AttribManager : public Observable<const std::string&>
          * @brief Constructor, save statement of all attribs from attribManager ( isLocked() )
          */
         /// \code{.cpp}
-        /// auto geometry = new GeometryData();
-        /// geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_TANGENT ).getDataWithLock();
-        //  REQUIRE (geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT
-        //  )->isLocked() );
-        //  {
-        //      auto unlocker = geometry->getAttribManager().getUnlocker();
-        //      geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_BITANGENT
-        //      ).getDataWithLock(); REQUIRE( geometry->getAttribManager().getAttribBase(
-        //      MeshAttrib::VERTEX_BITANGENT )->isLocked() );
-        //  }
-        //      REQUIRE(geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT
-        //      )->isLocked() ); REQUIRE( !geometry->getAttribManager().getAttribBase(
-        //      MeshAttrib::VERTEX_BITANGENT )->isLocked() );
+        /*
+        {
+        auto geometry = new GeometryData();
+        // get write access. The attrib must be explicitly unlocked after usage
+        auto tgt = geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_TANGENT
+        ).getDataWithLock();
+        // ... write to tgt
+
+        // enable auto-unlock for next write access
+        auto unlocker = geometry->getAttribManager().getUnlocker();
+        // get write access to several attribs attribs
+        auto txc = geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_TEXCOORD
+        ).getDataWithLock();
+        // ... write to txc
+        auto btg = geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_BITANGENT
+        ).getDataWithLock();
+        // ... write to btg
+
+        // tgt is still locked as it was locked outside of the unlocker scope. You must unlock it.
+        tgt.unlock();
+        // txc and btg are automatically unlocked as the unlocker get out of scope
+        } */
 
         explicit Unlocker( AttribManager* a ) : m_a { a } {
             a->for_each_attrib( [this]( const auto& attr ) {

--- a/src/Core/Utils/Attribs.hpp
+++ b/src/Core/Utils/Attribs.hpp
@@ -327,32 +327,35 @@ class RA_CORE_API AttribManager : public Observable<const std::string&>
       public:
         /**
          *
-         * @param a
-         * @brief Constructor, save statement of all attribs from attribManager ( isLocked() )
+         * @param a the AttribManager on which locking will be supervised
+         * @brief Constructor, save lock state of all attribs from attribManager
+         * \code{.cpp}
+         * {
+         * auto geometry = new GeometryData();
+         *
+         * // get write access. The attrib must be explicitly unlocked after usage
+         * auto tgt = geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_TANGENT
+         * ).getDataWithLock();
+         * // ... write to tgt
+         *
+         * // enable auto-unlock for all folowing write access requests
+         * auto unlocker = geometry->getAttribManager().getUnlocker();
+         *
+         * // get write access to several attribs
+         * auto txc = geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_TEXCOORD
+         * ).getDataWithLock();
+         * // ... write to txc
+         * auto btg = geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_BITANGENT
+         * ).getDataWithLock();
+         * // ... write to btg
+         *
+         * // tgt is still locked as it was locked outside of the unlocker scope.
+         * // Must be explicitly unlocked.
+         * tgt.unlock();
+         *
+         * // txc and btg are automatically unlocked when the unlocker's dtor is called (i.e. gets out of scope)
+         * }
          */
-        /// \code{.cpp}
-        /*
-        {
-        auto geometry = new GeometryData();
-        // get write access. The attrib must be explicitly unlocked after usage
-        auto tgt = geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_TANGENT
-        ).getDataWithLock();
-        // ... write to tgt
-
-        // enable auto-unlock for next write access
-        auto unlocker = geometry->getAttribManager().getUnlocker();
-        // get write access to several attribs attribs
-        auto txc = geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_TEXCOORD
-        ).getDataWithLock();
-        // ... write to txc
-        auto btg = geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_BITANGENT
-        ).getDataWithLock();
-        // ... write to btg
-
-        // tgt is still locked as it was locked outside of the unlocker scope. You must unlock it.
-        tgt.unlock();
-        // txc and btg are automatically unlocked as the unlocker get out of scope
-        } */
 
         explicit Unlocker( AttribManager* a ) : m_a { a } {
             a->for_each_attrib( [this]( const auto& attr ) {

--- a/src/Core/Utils/Attribs.hpp
+++ b/src/Core/Utils/Attribs.hpp
@@ -251,26 +251,38 @@ class RA_CORE_API AttribManager : public Observable<const std::string&>
     ///@{
     /// Get attribute by handle.
     /// \complexity \f$ O(1) \f$
-    /// \warning There is no check on the handle validity.
+    /// \warning There is no check on the handle validity. Attrib is statically cast to T without
+    /// other checks.
+    ///
     template <typename T>
     inline Attrib<T>& getAttrib( const AttribHandle<T>& h );
-
-    template <typename T>
-    inline Attrib<T>* getAttribPtr( const AttribHandle<T>& h );
-
-    /// Get attribute by handle (const).
-    /// \complexity \f$ O(1) \f$
-    /// \warning There is no check on the handle validity.
     template <typename T>
     inline const Attrib<T>& getAttrib( const AttribHandle<T>& h ) const;
+    template <typename T>
+    inline Attrib<T>* getAttribPtr( const AttribHandle<T>& h );
+    template <typename T>
+    inline const Attrib<T>* getAttribPtr( const AttribHandle<T>& h ) const;
+    ///@}
 
+    ///@{
+    /// Get attribute by name.
+    /// First search name to index correpondance \complexity \f$ O(getNumAttribs()) \f$
+    /// \warning There is no check on the name validity. Attrib is statically cast to T without
+    /// other checks.
+    template <typename T>
+    inline Attrib<T>& getAttrib( const std::string& name );
+    template <typename T>
+    inline const Attrib<T>& getAttrib( const std::string& name ) const;
+    ///@}
+
+    ///@{
     /// Return a AttribBase ptr to the attrib identified by name.
     /// to give access to AttribBase method, regardless of the type of element
     /// stored in the attrib.
     inline AttribBase* getAttribBase( const std::string& name );
-
-    /// \see getAttribBase( const std::string& name );
+    inline const AttribBase* getAttribBase( const std::string& name ) const;
     inline AttribBase* getAttribBase( const Index& idx );
+    inline const AttribBase* getAttribBase( const Index& idx ) const;
     ///@}
 
     ///@{
@@ -353,7 +365,8 @@ class RA_CORE_API AttribManager : public Observable<const std::string&>
          * // Must be explicitly unlocked.
          * tgt.unlock();
          *
-         * // txc and btg are automatically unlocked when the unlocker's dtor is called (i.e. gets out of scope)
+         * // txc and btg are automatically unlocked when the unlocker's dtor is called (i.e. gets
+         * out of scope)
          * }
          */
 

--- a/src/Core/Utils/Attribs.hpp
+++ b/src/Core/Utils/Attribs.hpp
@@ -320,6 +320,39 @@ class RA_CORE_API AttribManager : public Observable<const std::string&>
     /// Return the number of attributes
     inline int getNumAttribs() const;
 
+    /// Unlocker class, unlock all attribs (which are locked after create the unlocker object) after
+    /// destruct.
+    class Unlocker
+    {
+      public:
+        /**
+         *
+         * @param a
+         * @brief Constructor, save statement of all attribs from attribManager ( isLocked() )
+         */
+        explicit Unlocker( AttribManager* a ) : n_a { a } {
+            for ( const auto& attr : n_a->m_attribs ) {
+                if ( attr == nullptr ) break;
+                v.push_back( std::make_pair( attr.get(), attr->isLocked() ) );
+            }
+        }
+        /**
+         * @brief Destructor, unlock all attribs from attribManager which have been locked after the
+         * initialization of the Unlocker.
+         */
+        ~Unlocker() {
+            for ( auto& p : v ) {
+                if ( !p.second && p.first->isLocked() ) { p.first->unlock(); }
+            }
+        }
+
+      private:
+        AttribManager* n_a;
+        std::vector<std::pair<AttribBase*, bool>> v;
+    };
+
+    Unlocker getUnlocker() { return Unlocker { this }; }
+
   private:
     /// Attrib list, better using attribs() to go through.
     Container m_attribs;

--- a/src/Core/Utils/Attribs.inl
+++ b/src/Core/Utils/Attribs.inl
@@ -198,6 +198,21 @@ inline AttribHandle<T> AttribManager::findAttrib( const std::string& name ) cons
 }
 
 template <typename T>
+typename Attrib<T>::Container& AttribManager::getDataWithLock( const AttribHandle<T>& h ) {
+    return static_cast<Attrib<T>*>( m_attribs.at( h.m_idx ).get() )->getDataWithLock();
+}
+
+template <typename T>
+const typename Attrib<T>::Container& AttribManager::getData( const AttribHandle<T>& h ) {
+    return static_cast<Attrib<T>*>( m_attribs.at( h.m_idx ).get() )->data();
+}
+
+template <typename T>
+void AttribManager::unlock( const AttribHandle<T>& h ) {
+    static_cast<Attrib<T>*>( m_attribs.at( h.m_idx ).get() )->unlock();
+}
+
+template <typename T>
 inline Attrib<T>& AttribManager::getAttrib( const AttribHandle<T>& h ) {
     return *static_cast<Attrib<T>*>( m_attribs.at( h.m_idx ).get() );
 }

--- a/src/Core/Utils/Attribs.inl
+++ b/src/Core/Utils/Attribs.inl
@@ -203,7 +203,26 @@ inline Attrib<T>& AttribManager::getAttrib( const AttribHandle<T>& h ) {
 }
 
 template <typename T>
+inline const Attrib<T>& AttribManager::getAttrib( const AttribHandle<T>& h ) const {
+    return *static_cast<Attrib<T>*>( m_attribs.at( h.m_idx ).get() );
+}
+template <typename T>
+inline Attrib<T>& AttribManager::getAttrib( const std::string& name ) {
+    return getAttrib( findAttrib<T>( name ) );
+}
+
+template <typename T>
+inline const Attrib<T>& AttribManager::getAttrib( const std::string& name ) const {
+    return getAttrib( findAttrib<T>( name ) );
+}
+
+template <typename T>
 inline Attrib<T>* AttribManager::getAttribPtr( const AttribHandle<T>& h ) {
+    return static_cast<Attrib<T>*>( m_attribs.at( h.m_idx ).get() );
+}
+
+template <typename T>
+inline const Attrib<T>* AttribManager::getAttribPtr( const AttribHandle<T>& h ) const {
     return static_cast<Attrib<T>*>( m_attribs.at( h.m_idx ).get() );
 }
 
@@ -219,22 +238,25 @@ inline void AttribManager::setAttrib( const AttribHandle<T>& h,
     static_cast<Attrib<T>*>( m_attribs.at( h.m_idx ).get() )->setData( data );
 }
 
-template <typename T>
-inline const Attrib<T>& AttribManager::getAttrib( const AttribHandle<T>& h ) const {
-    return *static_cast<Attrib<T>*>( m_attribs.at( h.m_idx ).get() );
-}
-
-AttribBase* AttribManager::getAttribBase( const std::string& name ) {
+inline AttribBase* AttribManager::getAttribBase( const std::string& name ) {
     auto c = m_attribsIndex.find( name );
     if ( c != m_attribsIndex.end() ) return m_attribs[c->second].get();
-
     return nullptr;
 }
 
-AttribBase* AttribManager::getAttribBase( const Index& idx ) {
+inline const AttribBase* AttribManager::getAttribBase( const std::string& name ) const {
+    auto c = m_attribsIndex.find( name );
+    if ( c != m_attribsIndex.end() ) return m_attribs[c->second].get();
+    return nullptr;
+}
 
+inline AttribBase* AttribManager::getAttribBase( const Index& idx ) {
     if ( idx.isValid() ) return m_attribs[idx].get();
+    return nullptr;
+}
 
+inline const AttribBase* AttribManager::getAttribBase( const Index& idx ) const {
+    if ( idx.isValid() ) return m_attribs[idx].get();
     return nullptr;
 }
 

--- a/src/Engine/Data/EnvironmentTexture.cpp
+++ b/src/Engine/Data/EnvironmentTexture.cpp
@@ -608,7 +608,7 @@ Ra::Engine::Data::Texture* EnvironmentTexture::getSHImage() {
             Ra::Core::Utils::Color color {
                 Ra::Core::Utils::Color::linearRGBTosRGB( lcolor * 0.05_ra ) };
 
-            auto clpfnct = []( Scalar x ) { return std::clamp( x, 0_ra, 1_ra ); };
+            auto clpfnct = []( Scalar value ) { return std::clamp( value, 0_ra, 1_ra ); };
 
             color.unaryExpr( clpfnct );
             thepixels[4 * ( j * ambientWidth + i ) + 0] =

--- a/src/Engine/Data/Mesh.hpp
+++ b/src/Engine/Data/Mesh.hpp
@@ -445,41 +445,11 @@ class RA_ENGINE_API PolyMesh : public IndexedGeometry<Core::Geometry::PolyMesh>
 template <typename CoreMeshType>
 CoreMeshType createCoreMeshFromGeometryData( const Ra::Core::Asset::GeometryData* data ) {
     CoreMeshType mesh;
-    typename CoreMeshType::PointAttribHandle::Container vertices;
-    typename CoreMeshType::NormalAttribHandle::Container normals;
     typename CoreMeshType::IndexContainerType indices;
-
-    vertices.reserve( data->getVerticesSize() );
-    std::copy(
-        data->getVertices().begin(), data->getVertices().end(), std::back_inserter( vertices ) );
-
-    if ( data->hasNormals() ) {
-        normals.reserve( data->getVerticesSize() );
-        std::copy(
-            data->getNormals().begin(), data->getNormals().end(), std::back_inserter( normals ) );
-    }
 
     const auto& faces = data->getFaces();
     indices.reserve( faces.size() );
     std::copy( faces.begin(), faces.end(), std::back_inserter( indices ) );
-    mesh.setVertices( std::move( vertices ) );
-    mesh.setNormals( std::move( normals ) );
-
-    // \todo remove when data will handle all the attributes in a coherent way.
-    if ( data->hasTangents() ) {
-        mesh.addAttrib( Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_TANGENT ),
-                        data->getTangents() );
-    }
-
-    if ( data->hasBiTangents() ) {
-        mesh.addAttrib( Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_BITANGENT ),
-                        data->getBiTangents() );
-    }
-
-    if ( data->hasTextureCoordinates() ) {
-        mesh.addAttrib( Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_TEXCOORD ),
-                        data->getTexCoords() );
-    }
 
     // add custom attribs
     // only attributs not handled before are handled by data->getAttribManager()

--- a/src/Engine/Data/Mesh.hpp
+++ b/src/Engine/Data/Mesh.hpp
@@ -447,9 +447,11 @@ CoreMeshType createCoreMeshFromGeometryData( const Ra::Core::Asset::GeometryData
     CoreMeshType mesh;
     typename CoreMeshType::IndexContainerType indices;
 
-    const auto& faces = data->getFaces();
-    indices.reserve( faces.size() );
-    std::copy( faces.begin(), faces.end(), std::back_inserter( indices ) );
+    if ( !data->isLineMesh() ) {
+        const auto& faces = data->getFaces();
+        indices.reserve( faces.size() );
+        std::copy( faces.begin(), faces.end(), std::back_inserter( indices ) );
+    }
 
     // add custom attribs
     // only attributs not handled before are handled by data->getAttribManager()

--- a/src/Engine/Data/Mesh.hpp
+++ b/src/Engine/Data/Mesh.hpp
@@ -453,12 +453,14 @@ CoreMeshType createCoreMeshFromGeometryData( const Ra::Core::Asset::GeometryData
         std::copy( faces.begin(), faces.end(), std::back_inserter( indices ) );
     }
     // Create a degenerated triangle to handle edges case.
-    /*
     else {
         const auto& edges = data->getEdges();
         indices.reserve( edges.size() );
-        std::transform();
-    } */
+        std::transform(
+            edges.begin(), edges.end(), std::back_inserter( indices ), []( Ra::Core::Vector2ui v ) {
+                return ( Ra::Core::Vector3ui { v( 0 ), v( 1 ), v( 1 ) } );
+            } );
+    }
 
     // add custom attribs
     // only attributs not handled before are handled by data->getAttribManager()

--- a/src/Engine/Data/Mesh.hpp
+++ b/src/Engine/Data/Mesh.hpp
@@ -452,11 +452,13 @@ CoreMeshType createCoreMeshFromGeometryData( const Ra::Core::Asset::GeometryData
         indices.reserve( faces.size() );
         std::copy( faces.begin(), faces.end(), std::back_inserter( indices ) );
     }
+    // Create a degenerated triangle to handle edges case.
+    /*
     else {
         const auto& edges = data->getEdges();
         indices.reserve( edges.size() );
-        // std::transform()
-    }
+        std::transform();
+    } */
 
     // add custom attribs
     // only attributs not handled before are handled by data->getAttribManager()

--- a/src/Engine/Data/Mesh.hpp
+++ b/src/Engine/Data/Mesh.hpp
@@ -420,13 +420,14 @@ class RA_ENGINE_API Mesh : public IndexedGeometry<Core::Geometry::TriangleMesh>
   private:
 };
 
-/// PolyMesh, own a Core::Geometry::PolyMesh
+/// GeneralMesh, own a Mesh of type T ( e.g. Core::Geometry::PolyMesh or Core::Geometry::QuadMesh)
 /// This class handle the GPU representation of a polyhedron mesh.
 /// Each face of the polyhedron (typically quads) are assume to be planar and convex.
 /// Simple triangulation is performed on the fly before sending data to the GPU.
-class RA_ENGINE_API PolyMesh : public IndexedGeometry<Core::Geometry::PolyMesh>
+template <typename T>
+class RA_ENGINE_API GeneralMesh : public IndexedGeometry<T>
 {
-    using base      = IndexedGeometry<Core::Geometry::PolyMesh>;
+    using base      = IndexedGeometry<T>;
     using IndexType = Core::Vector3ui;
 
   public:
@@ -441,36 +442,45 @@ class RA_ENGINE_API PolyMesh : public IndexedGeometry<Core::Geometry::PolyMesh>
     Core::AlignedStdVector<IndexType> m_triangleIndices;
 };
 
+using PolyMesh = GeneralMesh<Core::Geometry::PolyMesh>;
+using QuadMesh = GeneralMesh<Core::Geometry::QuadMesh>;
+
 /// create a TriangleMesh, PolyMesh or other Core::*Mesh from GeometryData
+/// \todo replace the copy of all geometry data by reference to original data.
 template <typename CoreMeshType>
 CoreMeshType createCoreMeshFromGeometryData( const Ra::Core::Asset::GeometryData* data ) {
     CoreMeshType mesh;
     typename CoreMeshType::IndexContainerType indices;
 
     if ( !data->isLineMesh() ) {
-        const auto& faces = data->getFaces();
+        auto& geo = data->getGeometry();
+        const auto& [layerKeyType, layerBase] =
+            geo.getFirstLayerOccurrence( mesh.getLayerKey().first );
+        const auto& layer = static_cast<
+            const Core::Geometry::GeometryIndexLayer<typename CoreMeshType::IndexType>&>(
+            layerBase );
+        const auto& faces = layer.collection();
         indices.reserve( faces.size() );
         std::copy( faces.begin(), faces.end(), std::back_inserter( indices ) );
     }
+#if 0
+    // TODO manage line meshes in a "usual" way, i.e. as an indexed geometry with specific
+    //  rendering properties (i.e. shader, as it is the case for point clouds)
     // Create a degenerated triangle to handle edges case.
     else {
-        const auto& edges = data->getEdges();
+        const auto& edges = ... access the LineIndexLayer
         indices.reserve( edges.size() );
         std::transform(
             edges.begin(), edges.end(), std::back_inserter( indices ), []( Ra::Core::Vector2ui v ) {
                 return ( Ra::Core::Vector3ui { v( 0 ), v( 1 ), v( 1 ) } );
             } );
     }
-
-    // add custom attribs
-    // only attributs not handled before are handled by data->getAttribManager()
-    // but futur plan will handle also "usual" attibutes this way
-    mesh.vertexAttribs().copyAllAttributes( data->getAttribManager() );
-
-    // also this one will be automatically done with the futur behavior
-    //        mesh->addData( Ra::Core::Geometry::VERTEX_WEIGHTS, meshData.weights );
+#endif
 
     mesh.setIndices( std::move( indices ) );
+
+    // This copy only "usual" attributes. See Core::Geometry::AttribManager::copyAllAttributes
+    mesh.vertexAttribs().copyAllAttributes( data->getGeometry().vertexAttribs() );
 
     return mesh;
 }
@@ -491,6 +501,11 @@ struct getType<Ra::Core::Geometry::TriangleMesh> {
 };
 
 template <>
+struct getType<Ra::Core::Geometry::QuadMesh> {
+    using Type = Ra::Engine::Data::QuadMesh;
+};
+
+template <>
 struct getType<Ra::Core::Geometry::PolyMesh> {
     using Type = Ra::Engine::Data::PolyMesh;
 };
@@ -502,7 +517,7 @@ typename RenderMeshType::getType<CoreMeshType>::Type*
 createMeshFromGeometryData( const std::string& name, const Ra::Core::Asset::GeometryData* data ) {
     using MeshType = typename RenderMeshType::getType<CoreMeshType>::Type;
 
-    CoreMeshType mesh = createCoreMeshFromGeometryData<CoreMeshType>( data );
+    auto mesh = createCoreMeshFromGeometryData<CoreMeshType>( data );
 
     MeshType* ret = new MeshType { name };
     ret->loadGeometry( std::move( mesh ) );

--- a/src/Engine/Data/Mesh.hpp
+++ b/src/Engine/Data/Mesh.hpp
@@ -452,6 +452,11 @@ CoreMeshType createCoreMeshFromGeometryData( const Ra::Core::Asset::GeometryData
         indices.reserve( faces.size() );
         std::copy( faces.begin(), faces.end(), std::back_inserter( indices ) );
     }
+    else {
+        const auto& edges = data->getEdges();
+        indices.reserve( edges.size() );
+        // std::transform()
+    }
 
     // add custom attribs
     // only attributs not handled before are handled by data->getAttribManager()

--- a/src/Engine/Data/Mesh.inl
+++ b/src/Engine/Data/Mesh.inl
@@ -567,37 +567,40 @@ LineMesh::LineMesh( const std::string& name, typename base::MeshRenderMode rende
 
 /////////  PolyMesh ///////////
 
-size_t PolyMesh::getNumFaces() const {
-    return getCoreGeometry().getIndices().size();
+template <typename T>
+size_t GeneralMesh<T>::getNumFaces() const {
+    return this->getCoreGeometry().getIndices().size();
 }
 
-void PolyMesh::updateGL_specific_impl() {
-    if ( !m_indices ) {
-        m_indices      = globjects::Buffer::create();
-        m_indicesDirty = true;
+template <typename T>
+void GeneralMesh<T>::updateGL_specific_impl() {
+    if ( !this->m_indices ) {
+        this->m_indices      = globjects::Buffer::create();
+        this->m_indicesDirty = true;
     }
-    if ( m_indicesDirty ) {
+    if ( this->m_indicesDirty ) {
         triangulate();
         /// this one do not work since m_indices is not a std::vector
         // m_indices->setData( m_mesh.m_indices, GL_DYNAMIC_DRAW );
-        m_numElements = m_triangleIndices.size() * PolyMesh::IndexType::RowsAtCompileTime;
+        this->m_numElements = m_triangleIndices.size() * GeneralMesh::IndexType::RowsAtCompileTime;
 
-        m_indices->setData(
-            static_cast<gl::GLsizeiptr>( m_triangleIndices.size() * sizeof( PolyMesh::IndexType ) ),
-            m_triangleIndices.data(),
-            GL_STATIC_DRAW );
-        m_indicesDirty = false;
+        this->m_indices->setData( static_cast<gl::GLsizeiptr>( m_triangleIndices.size() *
+                                                               sizeof( GeneralMesh::IndexType ) ),
+                                  m_triangleIndices.data(),
+                                  GL_STATIC_DRAW );
+        this->m_indicesDirty = false;
     }
     if ( !base::m_vao ) { base::m_vao = globjects::VertexArray::create(); }
     base::m_vao->bind();
-    base::m_vao->bindElementBuffer( m_indices.get() );
+    base::m_vao->bindElementBuffer( this->m_indices.get() );
     base::m_vao->unbind();
 }
 
-void PolyMesh::triangulate() {
+template <typename T>
+void GeneralMesh<T>::triangulate() {
     m_triangleIndices.clear();
-    m_triangleIndices.reserve( m_mesh.getIndices().size() );
-    for ( const auto& face : m_mesh.getIndices() ) {
+    m_triangleIndices.reserve( this->m_mesh.getIndices().size() );
+    for ( const auto& face : this->m_mesh.getIndices() ) {
         if ( face.size() == 3 ) { m_triangleIndices.push_back( face ); }
         else {
             /// simple sew triangulation
@@ -614,6 +617,17 @@ void PolyMesh::triangulate() {
                 }
             }
         }
+    }
+}
+
+template <>
+inline void GeneralMesh<Core::Geometry::QuadMesh>::triangulate() {
+    m_triangleIndices.clear();
+    m_triangleIndices.reserve( 2 * this->m_mesh.getIndices().size() );
+    // assume quads are convex
+    for ( const auto& face : this->m_mesh.getIndices() ) {
+        m_triangleIndices.emplace_back( face[0], face[1], face[2] );
+        m_triangleIndices.emplace_back( face[0], face[2], face[3] );
     }
 }
 

--- a/src/Engine/Rendering/ForwardRenderer.cpp
+++ b/src/Engine/Rendering/ForwardRenderer.cpp
@@ -452,10 +452,12 @@ void ForwardRenderer::renderInternal( const Data::ViewingParameters& renderData 
 
                 using trimesh = Ra::Engine::Data::IndexedGeometry<Ra::Core::Geometry::TriangleMesh>;
                 using polymesh = Ra::Engine::Data::IndexedGeometry<Ra::Core::Geometry::PolyMesh>;
+                using quadmesh = Ra::Engine::Data::IndexedGeometry<Ra::Core::Geometry::QuadMesh>;
 
                 auto displayable = ro->getMesh();
                 auto tm          = std::dynamic_pointer_cast<trimesh>( displayable );
                 auto tp          = std::dynamic_pointer_cast<polymesh>( displayable );
+                auto tq          = std::dynamic_pointer_cast<quadmesh>( displayable );
 
                 auto processLineMesh = []( auto cm, std::shared_ptr<Data::LineMesh>& lm ) {
                     if ( cm->getRenderMode() ==
@@ -465,6 +467,7 @@ void ForwardRenderer::renderInternal( const Data::ViewingParameters& renderData 
                 };
                 if ( tm ) { processLineMesh( tm, disp ); }
                 if ( tp ) { processLineMesh( tp, disp ); }
+                if ( tq ) { processLineMesh( tq, disp ); }
 
                 m_wireframes[ro.get()] = disp;
                 wro                    = disp;

--- a/src/Engine/Scene/GeometryComponent.cpp
+++ b/src/Engine/Scene/GeometryComponent.cpp
@@ -75,10 +75,7 @@ void PointCloudComponent::generatePointCloud( const Ra::Core::Asset::GeometryDat
     Ra::Core::Geometry::PointCloud mesh;
 
     // add custom attribs
-    mesh.vertexAttribs().copyAllAttributes( data->getAttribManager() );
-
-    // To be discussed: Should not weights be part of the geometry ?
-    //        mesh->addData( Data::Mesh::VERTEX_WEIGHTS, meshData.weights );
+    mesh.vertexAttribs().copyAllAttributes( data->getGeometry().vertexAttribs() );
 
     m_displayMesh->loadGeometry( std::move( mesh ) );
 

--- a/src/Engine/Scene/GeometryComponent.cpp
+++ b/src/Engine/Scene/GeometryComponent.cpp
@@ -73,36 +73,6 @@ void PointCloudComponent::generatePointCloud( const Ra::Core::Asset::GeometryDat
     m_displayMesh->setRenderMode( Data::AttribArrayDisplayable::RM_POINTS );
 
     Ra::Core::Geometry::PointCloud mesh;
-    Ra::Core::Geometry::PointCloud::PointAttribHandle::Container vertices;
-    Ra::Core::Geometry::PointCloud::NormalAttribHandle::Container normals;
-
-    vertices.reserve( data->getVerticesSize() );
-    std::copy(
-        data->getVertices().begin(), data->getVertices().end(), std::back_inserter( vertices ) );
-
-    if ( data->hasNormals() ) {
-        normals.reserve( data->getVerticesSize() );
-        std::copy(
-            data->getNormals().begin(), data->getNormals().end(), std::back_inserter( normals ) );
-    }
-
-    mesh.setVertices( std::move( vertices ) );
-    mesh.setNormals( std::move( normals ) );
-
-    if ( data->hasTangents() ) {
-        mesh.addAttrib( Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_TANGENT ),
-                        data->getTangents() );
-    }
-
-    if ( data->hasBiTangents() ) {
-        mesh.addAttrib( Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_BITANGENT ),
-                        data->getBiTangents() );
-    }
-
-    if ( data->hasTextureCoordinates() ) {
-        mesh.addAttrib( Ra::Core::Geometry::getAttribName( Ra::Core::Geometry::VERTEX_TEXCOORD ),
-                        data->getTexCoords() );
-    }
 
     // add custom attribs
     mesh.vertexAttribs().copyAllAttributes( data->getAttribManager() );

--- a/src/Engine/Scene/GeometryComponent.hpp
+++ b/src/Engine/Scene/GeometryComponent.hpp
@@ -99,6 +99,7 @@ class SurfaceMeshComponent : public GeometryComponent
 };
 
 using TriangleMeshComponent = SurfaceMeshComponent<Ra::Core::Geometry::TriangleMesh>;
+using QuadMeshComponent     = SurfaceMeshComponent<Ra::Core::Geometry::QuadMesh>;
 using PolyMeshComponent     = SurfaceMeshComponent<Ra::Core::Geometry::PolyMesh>;
 
 /// \warning, WIP

--- a/src/Engine/Scene/GeometrySystem.cpp
+++ b/src/Engine/Scene/GeometrySystem.cpp
@@ -36,6 +36,8 @@ void GeometrySystem::handleAssetLoading( Entity* entity,
             comp = new TriangleMeshComponent( componentName, entity, data );
             break;
         case Ra::Core::Asset::GeometryData::QUAD_MESH:
+            comp = new QuadMeshComponent( componentName, entity, data );
+            break;
         case Ra::Core::Asset::GeometryData::POLY_MESH:
             comp = new PolyMeshComponent( componentName, entity, data );
             break;

--- a/src/Engine/Scene/SkinningComponent.hpp
+++ b/src/Engine/Scene/SkinningComponent.hpp
@@ -188,11 +188,17 @@ class RA_ENGINE_API SkinningComponent : public Component
     /// Whether the skinned mesh is a TriangleMesh or a PolyMesh.
     bool m_meshIsPoly { false };
 
+    /// Whether the skinned mesh is a TriangleMesh or a PolyMesh.
+    bool m_meshIsQuad { false };
+
     /// Getter/Setter to the skinned mesh, in case it is a TriangleMesh.
     ReadWrite<Core::Geometry::TriangleMesh> m_triMeshWriter;
 
     /// Getter/Setter to the skinned mesh, in case it is a PolyMesh.
     ReadWrite<Core::Geometry::PolyMesh> m_polyMeshWriter;
+
+    /// Getter/Setter to the skinned mesh, in case it is a QuadMesh.
+    ReadWrite<Core::Geometry::QuadMesh> m_quadMeshWriter;
 
     /// The Topological mesh used to geometrically recompute the normals.
     Core::Geometry::TopologicalMesh m_topoMesh;

--- a/src/Gui/SkeletonBasedAnimation/SkeletonBasedAnimationUI.cpp
+++ b/src/Gui/SkeletonBasedAnimation/SkeletonBasedAnimationUI.cpp
@@ -133,8 +133,9 @@ QAction* SkeletonBasedAnimationUI::getAction( int i ) {
         return ui->actionSTBSLBS;
     case 5:
         return ui->actionSTBSDQS;
+    default:
+        return nullptr;
     }
-    return nullptr;
 }
 
 void SkeletonBasedAnimationUI::postLoadFile( Engine::Scene::Entity* entity ) {

--- a/src/IO/AssimpLoader/AssimpFileLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpFileLoader.cpp
@@ -44,7 +44,9 @@ bool AssimpFileLoader::handleFileExtension( const std::string& extension ) const
 }
 
 FileData* AssimpFileLoader::loadFile( const std::string& filename ) {
+
     auto fileData = new FileData( filename );
+    // fileData->setVerbose( true );
 
     if ( !fileData->isInitialized() ) { return nullptr; }
 

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -172,13 +172,14 @@ void fetchVectorData( size_t sz,
 */
 void AssimpGeometryDataLoader::fetchVertices( const aiMesh& mesh, GeometryData& data ) {
     const int size = mesh.mNumVertices;
-    auto& vertex   = data.getVertices();
+    auto& vertex   = data.getAttribDataWithLock<Core::Vector3Array&>( "vertex" );
     vertex.resize( mesh.mNumVertices );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         vertex[i] = assimpToCore( mesh.mVertices[i] );
     }
     //    fetchVectorData( mesh.mNumVertices, mesh.mVertices, vertex );
+    data.attribDataUnlock( "vertex" );
 }
 
 void AssimpGeometryDataLoader::fetchEdges( const aiMesh& mesh, GeometryData& data ) const {
@@ -209,45 +210,50 @@ void AssimpGeometryDataLoader::fetchPolyhedron( const aiMesh& mesh, GeometryData
 
 void AssimpGeometryDataLoader::fetchNormals( const aiMesh& mesh, GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    auto& normal   = data.getNormals();
+    auto& normal   = data.getAttribDataWithLock<Core::Vector3Array&>( "normal" );
     normal.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         normal[i] = assimpToCore( mesh.mNormals[i] );
         normal[i].normalize();
     }
+    data.attribDataUnlock( "normal" );
 }
 
 void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    auto& tangent  = data.getTangents();
+    auto& tangent  = data.getAttribDataWithLock<Core::Vector3Array&>( "tangent" );
     tangent.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < int( size ); ++i ) {
         tangent[i] = assimpToCore( mesh.mTangents[i] );
     }
+    data.attribDataUnlock( "tangent" );
 }
 
 void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData& data ) const {
     const int size  = mesh.mNumVertices;
-    auto& bitangent = data.getBiTangents();
+    auto& bitangent = data.getAttribDataWithLock<Core::Vector3Array&>( "biTangent" );
     bitangent.resize( mesh.mNumVertices );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         bitangent[i] = assimpToCore( mesh.mBitangents[i] );
     }
+    data.attribDataUnlock( "biTangent" );
 }
 
 void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
                                                         GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    auto& texcoord = data.getTexCoords();
+    auto& texcoord = data.getAttribDataWithLock<Core::Vector3Array&>( "texCoord" );
+    ;
     texcoord.resize( mesh.mNumVertices );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         // Radium V2 : allow to have several UV channels
         texcoord.at( i ) = assimpToCore( mesh.mTextureCoords[0][i] );
     }
+    data.attribDataUnlock( "texCoord" );
 }
 
 void AssimpGeometryDataLoader::fetchColors( const aiMesh& mesh, GeometryData& data ) const {

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -208,35 +208,26 @@ void AssimpGeometryDataLoader::fetchPolyhedron( const aiMesh& mesh, GeometryData
 }
 
 void AssimpGeometryDataLoader::fetchNormals( const aiMesh& mesh, GeometryData& data ) const {
-    const int size      = mesh.mNumVertices;
-    auto& attribManager = data.getAttribManager();
-    auto handle         = attribManager.addAttrib<Core::Vector3>( "normal" );
-    auto& attrib        = attribManager.getAttrib( handle );
-    auto& normal        = attrib.getDataWithLock();
-
+    const int size = mesh.mNumVertices;
+    auto& normal   = data.getNormals();
     normal.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         normal[i] = assimpToCore( mesh.mNormals[i] );
         normal[i].normalize();
     }
-    attrib.unlock();
+    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    // auto& tangent  = data.getTangents();
-    auto& attribManager = data.getAttribManager();
-    auto handle         = attribManager.addAttrib<Core::Vector3>( "tangent" );
-    auto& attrib        = attribManager.getAttrib( handle );
-    auto& tangent       = attrib.getDataWithLock();
-
+    auto& tangent  = data.getTangents();
     tangent.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < int( size ); ++i ) {
         tangent[i] = assimpToCore( mesh.mTangents[i] );
     }
-    attrib.unlock();
+    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData& data ) const {
@@ -247,6 +238,7 @@ void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData
     for ( int i = 0; i < size; ++i ) {
         bitangent[i] = assimpToCore( mesh.mBitangents[i] );
     }
+    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
@@ -259,6 +251,7 @@ void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
         // Radium V2 : allow to have several UV channels
         texcoord.at( i ) = assimpToCore( mesh.mTextureCoords[0][i] );
     }
+    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchColors( const aiMesh& mesh, GeometryData& data ) const {

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -216,7 +216,6 @@ void AssimpGeometryDataLoader::fetchNormals( const aiMesh& mesh, GeometryData& d
         normal[i] = assimpToCore( mesh.mNormals[i] );
         normal[i].normalize();
     }
-    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& data ) const {
@@ -227,7 +226,6 @@ void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& 
     for ( int i = 0; i < int( size ); ++i ) {
         tangent[i] = assimpToCore( mesh.mTangents[i] );
     }
-    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData& data ) const {
@@ -238,7 +236,6 @@ void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData
     for ( int i = 0; i < size; ++i ) {
         bitangent[i] = assimpToCore( mesh.mBitangents[i] );
     }
-    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
@@ -251,7 +248,6 @@ void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
         // Radium V2 : allow to have several UV channels
         texcoord.at( i ) = assimpToCore( mesh.mTextureCoords[0][i] );
     }
-    data.unlockData();
 }
 
 void AssimpGeometryDataLoader::fetchColors( const aiMesh& mesh, GeometryData& data ) const {

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -208,24 +208,35 @@ void AssimpGeometryDataLoader::fetchPolyhedron( const aiMesh& mesh, GeometryData
 }
 
 void AssimpGeometryDataLoader::fetchNormals( const aiMesh& mesh, GeometryData& data ) const {
-    const int size = mesh.mNumVertices;
-    auto& normal   = data.getNormals();
+    const int size      = mesh.mNumVertices;
+    auto& attribManager = data.getAttribManager();
+    auto handle         = attribManager.addAttrib<Core::Vector3>( "normal" );
+    auto& attrib        = attribManager.getAttrib( handle );
+    auto& normal        = attrib.getDataWithLock();
+
     normal.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         normal[i] = assimpToCore( mesh.mNormals[i] );
         normal[i].normalize();
     }
+    attrib.unlock();
 }
 
 void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    auto& tangent  = data.getTangents();
+    // auto& tangent  = data.getTangents();
+    auto& attribManager = data.getAttribManager();
+    auto handle         = attribManager.addAttrib<Core::Vector3>( "tangent" );
+    auto& attrib        = attribManager.getAttrib( handle );
+    auto& tangent       = attrib.getDataWithLock();
+
     tangent.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < int( size ); ++i ) {
         tangent[i] = assimpToCore( mesh.mTangents[i] );
     }
+    attrib.unlock();
 }
 
 void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData& data ) const {

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -109,7 +109,7 @@ void AssimpGeometryDataLoader::loadMeshAttrib( const aiMesh& mesh,
     }
 
     // Translate mesh topology
-    data.setPrimitiveNum( mesh.mNumFaces );
+    data.setPrimitiveCount( mesh.mNumFaces );
     switch ( data.getType() ) {
     case GeometryData::GeometryType::LINE_MESH:
         fetchIndexLayer<Core::Geometry::LineIndexLayer>( mesh.mFaces, mesh.mNumFaces, geo );
@@ -128,7 +128,7 @@ void AssimpGeometryDataLoader::loadMeshAttrib( const aiMesh& mesh,
         auto pil =
             std::make_unique<Core::Geometry::PointCloudIndexLayer>( size_t( mesh.mNumVertices ) );
         geo.addLayer( std::move( pil ) );
-        data.setPrimitiveNum( mesh.mNumVertices );
+        data.setPrimitiveCount( mesh.mNumVertices );
     } break;
     }
     // TODO : Polyhedrons are not supported yet in Radium core geometry

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -190,7 +190,7 @@ void AssimpGeometryDataLoader::fetchEdges( const aiMesh& mesh, GeometryData& dat
     for ( int i = 0; i < size; ++i ) {
         edge[i] = assimpToCore( mesh.mFaces[i].mIndices, mesh.mFaces[i].mNumIndices ).cast<uint>();
     }
-    data.indexedDataUnlock( "edge" );
+    data.indexedDataUnlock( GeometryData::GeometryType::LINE_MESH, "in_edge" );
 }
 
 void AssimpGeometryDataLoader::fetchFaces( const aiMesh& mesh, GeometryData& data ) const {
@@ -201,7 +201,7 @@ void AssimpGeometryDataLoader::fetchFaces( const aiMesh& mesh, GeometryData& dat
     for ( int i = 0; i < size; ++i ) {
         face[i] = assimpToCore( mesh.mFaces[i].mIndices, mesh.mFaces[i].mNumIndices ).cast<uint>();
     }
-    data.indexedDataUnlock( "face" );
+    data.indexedDataUnlock( GeometryData::GeometryType::POLY_MESH, "in_face" );
 }
 
 void AssimpGeometryDataLoader::fetchPolyhedron( const aiMesh& mesh, GeometryData& data ) const {

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -190,6 +190,7 @@ void AssimpGeometryDataLoader::fetchEdges( const aiMesh& mesh, GeometryData& dat
     for ( int i = 0; i < size; ++i ) {
         edge[i] = assimpToCore( mesh.mFaces[i].mIndices, mesh.mFaces[i].mNumIndices ).cast<uint>();
     }
+    data.indexedDataUnlock( "edge" );
 }
 
 void AssimpGeometryDataLoader::fetchFaces( const aiMesh& mesh, GeometryData& data ) const {
@@ -200,6 +201,7 @@ void AssimpGeometryDataLoader::fetchFaces( const aiMesh& mesh, GeometryData& dat
     for ( int i = 0; i < size; ++i ) {
         face[i] = assimpToCore( mesh.mFaces[i].mIndices, mesh.mFaces[i].mNumIndices ).cast<uint>();
     }
+    data.indexedDataUnlock( "face" );
 }
 
 void AssimpGeometryDataLoader::fetchPolyhedron( const aiMesh& mesh, GeometryData& data ) const {

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -172,14 +172,14 @@ void fetchVectorData( size_t sz,
 */
 void AssimpGeometryDataLoader::fetchVertices( const aiMesh& mesh, GeometryData& data ) {
     const int size = mesh.mNumVertices;
-    auto& vertex   = data.getAttribDataWithLock<Core::Vector3Array&>( "vertex" );
+    auto& vertex   = data.getVertices();
     vertex.resize( mesh.mNumVertices );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         vertex[i] = assimpToCore( mesh.mVertices[i] );
     }
     //    fetchVectorData( mesh.mNumVertices, mesh.mVertices, vertex );
-    data.attribDataUnlock( "vertex" );
+    data.getAttribManager().getAttribBase( Core::Geometry::MeshAttrib::VERTEX_POSITION )->unlock();
 }
 
 void AssimpGeometryDataLoader::fetchEdges( const aiMesh& mesh, GeometryData& data ) const {
@@ -212,42 +212,42 @@ void AssimpGeometryDataLoader::fetchPolyhedron( const aiMesh& mesh, GeometryData
 
 void AssimpGeometryDataLoader::fetchNormals( const aiMesh& mesh, GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    auto& normal   = data.getAttribDataWithLock<Core::Vector3Array&>( "normal" );
+    auto& normal   = data.getNormals();
     normal.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         normal[i] = assimpToCore( mesh.mNormals[i] );
         normal[i].normalize();
     }
-    data.attribDataUnlock( "normal" );
+    data.getAttribManager().getAttribBase( Core::Geometry::MeshAttrib::VERTEX_NORMAL )->unlock();
 }
 
 void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    auto& tangent  = data.getAttribDataWithLock<Core::Vector3Array&>( "tangent" );
+    auto& tangent  = data.getTangents();
     tangent.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < int( size ); ++i ) {
         tangent[i] = assimpToCore( mesh.mTangents[i] );
     }
-    data.attribDataUnlock( "tangent" );
+    data.getAttribManager().getAttribBase( Core::Geometry::MeshAttrib::VERTEX_TANGENT )->unlock();
 }
 
 void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData& data ) const {
     const int size  = mesh.mNumVertices;
-    auto& bitangent = data.getAttribDataWithLock<Core::Vector3Array&>( "biTangent" );
+    auto& bitangent = data.getBiTangents();
     bitangent.resize( mesh.mNumVertices );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
         bitangent[i] = assimpToCore( mesh.mBitangents[i] );
     }
-    data.attribDataUnlock( "biTangent" );
+    data.getAttribManager().getAttribBase( Core::Geometry::MeshAttrib::VERTEX_BITANGENT )->unlock();
 }
 
 void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
                                                         GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    auto& texcoord = data.getAttribDataWithLock<Core::Vector3Array&>( "texCoord" );
+    auto& texcoord = data.getTexCoords();
     ;
     texcoord.resize( mesh.mNumVertices );
 #pragma omp parallel for
@@ -255,7 +255,7 @@ void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
         // Radium V2 : allow to have several UV channels
         texcoord.at( i ) = assimpToCore( mesh.mTextureCoords[0][i] );
     }
-    data.attribDataUnlock( "texCoord" );
+    data.getAttribManager().getAttribBase( Core::Geometry::MeshAttrib::VERTEX_TEXCOORD )->unlock();
 }
 
 void AssimpGeometryDataLoader::fetchColors( const aiMesh& mesh, GeometryData& data ) const {

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -179,7 +179,6 @@ void AssimpGeometryDataLoader::fetchVertices( const aiMesh& mesh, GeometryData& 
         vertex[i] = assimpToCore( mesh.mVertices[i] );
     }
     //    fetchVectorData( mesh.mNumVertices, mesh.mVertices, vertex );
-    data.getAttribManager().getAttribBase( Core::Geometry::MeshAttrib::VERTEX_POSITION )->unlock();
 }
 
 void AssimpGeometryDataLoader::fetchEdges( const aiMesh& mesh, GeometryData& data ) const {
@@ -219,7 +218,6 @@ void AssimpGeometryDataLoader::fetchNormals( const aiMesh& mesh, GeometryData& d
         normal[i] = assimpToCore( mesh.mNormals[i] );
         normal[i].normalize();
     }
-    data.getAttribManager().getAttribBase( Core::Geometry::MeshAttrib::VERTEX_NORMAL )->unlock();
 }
 
 void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& data ) const {
@@ -230,7 +228,6 @@ void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& 
     for ( int i = 0; i < int( size ); ++i ) {
         tangent[i] = assimpToCore( mesh.mTangents[i] );
     }
-    data.getAttribManager().getAttribBase( Core::Geometry::MeshAttrib::VERTEX_TANGENT )->unlock();
 }
 
 void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData& data ) const {
@@ -241,7 +238,6 @@ void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData
     for ( int i = 0; i < size; ++i ) {
         bitangent[i] = assimpToCore( mesh.mBitangents[i] );
     }
-    data.getAttribManager().getAttribBase( Core::Geometry::MeshAttrib::VERTEX_BITANGENT )->unlock();
 }
 
 void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
@@ -255,7 +251,6 @@ void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
         // Radium V2 : allow to have several UV channels
         texcoord.at( i ) = assimpToCore( mesh.mTextureCoords[0][i] );
     }
-    data.getAttribManager().getAttribBase( Core::Geometry::MeshAttrib::VERTEX_TEXCOORD )->unlock();
 }
 
 void AssimpGeometryDataLoader::fetchColors( const aiMesh& mesh, GeometryData& data ) const {
@@ -352,7 +347,9 @@ void AssimpGeometryDataLoader::loadGeometryData(
         aiMesh* mesh = scene->mMeshes[i];
         if ( mesh->HasPositions() ) {
             auto geometry = new GeometryData();
+            auto unlocker = geometry->getAttribManager().getUnlocker();
             loadMeshAttrib( *mesh, *geometry, usedNames );
+
             // This returns always true (see assimp documentation)
             if ( scene->HasMaterials() ) {
                 const uint matID = mesh->mMaterialIndex;

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.cpp
@@ -172,8 +172,9 @@ void fetchVectorData( size_t sz,
 */
 void AssimpGeometryDataLoader::fetchVertices( const aiMesh& mesh, GeometryData& data ) {
     const int size = mesh.mNumVertices;
-    auto& attrib   = data.getAttrib<Core::Vector3>( Core::Geometry::MeshAttrib::VERTEX_POSITION );
-    auto& vertex   = attrib.getDataWithLock();
+    auto& attrib   = data.getMultiIndexedGeometry().getAttrib<Core::Vector3>(
+        getAttribName( Core::Geometry::MeshAttrib::VERTEX_POSITION ) );
+    auto& vertex = attrib.getDataWithLock();
     vertex.resize( mesh.mNumVertices );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
@@ -213,8 +214,9 @@ void AssimpGeometryDataLoader::fetchPolyhedron( const aiMesh& mesh, GeometryData
 
 void AssimpGeometryDataLoader::fetchNormals( const aiMesh& mesh, GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    auto& attrib   = data.getAttrib<Core::Vector3>( Core::Geometry::MeshAttrib::VERTEX_NORMAL );
-    auto& normal   = attrib.getDataWithLock();
+    auto& attrib   = data.getMultiIndexedGeometry().getAttrib<Core::Vector3>(
+        getAttribName( Core::Geometry::MeshAttrib::VERTEX_NORMAL ) );
+    auto& normal = attrib.getDataWithLock();
     normal.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < size; ++i ) {
@@ -225,9 +227,11 @@ void AssimpGeometryDataLoader::fetchNormals( const aiMesh& mesh, GeometryData& d
 }
 
 void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& data ) const {
-    const int size = mesh.mNumVertices;
-    auto& attrib   = data.getAttrib<Core::Vector3>( Core::Geometry::MeshAttrib::VERTEX_TANGENT );
-    auto& tangent  = attrib.getDataWithLock();
+    const int size    = mesh.mNumVertices;
+    auto attribHandle = data.getMultiIndexedGeometry().addAttrib<Core::Vector3>(
+        getAttribName( Core::Geometry::MeshAttrib::VERTEX_TANGENT ) );
+    auto& attrib  = data.getMultiIndexedGeometry().getAttrib( attribHandle );
+    auto& tangent = attrib.getDataWithLock();
     tangent.resize( mesh.mNumVertices, Core::Vector3::Zero() );
 #pragma omp parallel for
     for ( int i = 0; i < int( size ); ++i ) {
@@ -237,8 +241,9 @@ void AssimpGeometryDataLoader::fetchTangents( const aiMesh& mesh, GeometryData& 
 }
 
 void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData& data ) const {
-    const int size  = mesh.mNumVertices;
-    auto& attrib    = data.getAttrib<Core::Vector3>( Core::Geometry::MeshAttrib::VERTEX_BITANGENT );
+    const int size = mesh.mNumVertices;
+    auto& attrib   = data.getMultiIndexedGeometry().getAttrib<Core::Vector3>(
+        getAttribName( Core::Geometry::MeshAttrib::VERTEX_BITANGENT ) );
     auto& bitangent = attrib.getDataWithLock();
     bitangent.resize( mesh.mNumVertices );
 #pragma omp parallel for
@@ -251,7 +256,8 @@ void AssimpGeometryDataLoader::fetchBitangents( const aiMesh& mesh, GeometryData
 void AssimpGeometryDataLoader::fetchTextureCoordinates( const aiMesh& mesh,
                                                         GeometryData& data ) const {
     const int size = mesh.mNumVertices;
-    auto& attrib   = data.getAttrib<Core::Vector3>( Core::Geometry::MeshAttrib::VERTEX_TEXCOORD );
+    auto& attrib   = data.getMultiIndexedGeometry().getAttrib<Core::Vector3>(
+        getAttribName( Core::Geometry::MeshAttrib::VERTEX_TEXCOORD ) );
     auto& texcoord = attrib.getDataWithLock();
     texcoord.resize( mesh.mNumVertices );
 #pragma omp parallel for

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.hpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.hpp
@@ -70,9 +70,6 @@ class RA_IO_API AssimpGeometryDataLoader : public Core::Asset::DataLoader<Core::
     void fetchType( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
 
     /// Fill \p data with the vertices from \p mesh.
-    /// @warning This function lock the vertices attrib, you must unlock the attrib with unlock()
-    /// using getAttribManager() and getAttribBase( const Index &idx ) or by using an getUnlocker().
-    /// @see Unlocker
     void fetchVertices( const aiMesh& mesh, Core::Asset::GeometryData& data );
 
     /// Fill \p data with the lines from \p mesh.
@@ -85,27 +82,15 @@ class RA_IO_API AssimpGeometryDataLoader : public Core::Asset::DataLoader<Core::
     void fetchPolyhedron( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
 
     /// Fill \p data with the vertex normals from \p mesh.
-    /// @warning This function lock the normals attrib, you must unlock the attrib with unlock()
-    /// using getAttribManager() and getAttribBase( const Index &idx ) or by using an getUnlocker().
-    /// @see Unlocker
     void fetchNormals( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
 
     /// Fill \p data with the vertex tangent vectors from \p mesh.
-    /// @warning This function lock the tangents attrib, you must unlock the attrib with unlock()
-    /// using getAttribManager() and getAttribBase( const Index &idx ) or by using an getUnlocker().
-    /// @see Unlocker
     void fetchTangents( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
 
     /// Fill \p data with the vertex bitangent vectors from \p mesh.
-    /// @warning This function lock the biTangents attrib, you must unlock the attrib with unlock()
-    /// using getAttribManager() and getAttribBase( const Index &idx ) or by using an getUnlocker().
-    /// @see Unlocker
     void fetchBitangents( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
 
     /// Fill \p data with the vertex texture coordinates from \p mesh.
-    /// @warning This function lock the texCoords attrib, you must unlock the attrib with unlock()
-    /// using getAttribManager() and getAttribBase( const Index &idx ) or by using an getUnlocker().
-    /// @see Unlocker
     void fetchTextureCoordinates( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
 
     /// Fill \p data with the vertex colors from \p mesh.

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.hpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.hpp
@@ -70,6 +70,9 @@ class RA_IO_API AssimpGeometryDataLoader : public Core::Asset::DataLoader<Core::
     void fetchType( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
 
     /// Fill \p data with the vertices from \p mesh.
+    /// @warning This function lock the vertices attrib, you must unlock the attrib with unlock()
+    /// using getAttribManager() and getAttribBase( const Index &idx ) or by using an getUnlocker().
+    /// @see Unlocker
     void fetchVertices( const aiMesh& mesh, Core::Asset::GeometryData& data );
 
     /// Fill \p data with the lines from \p mesh.
@@ -82,15 +85,27 @@ class RA_IO_API AssimpGeometryDataLoader : public Core::Asset::DataLoader<Core::
     void fetchPolyhedron( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
 
     /// Fill \p data with the vertex normals from \p mesh.
+    /// @warning This function lock the normals attrib, you must unlock the attrib with unlock()
+    /// using getAttribManager() and getAttribBase( const Index &idx ) or by using an getUnlocker().
+    /// @see Unlocker
     void fetchNormals( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
 
     /// Fill \p data with the vertex tangent vectors from \p mesh.
+    /// @warning This function lock the tangents attrib, you must unlock the attrib with unlock()
+    /// using getAttribManager() and getAttribBase( const Index &idx ) or by using an getUnlocker().
+    /// @see Unlocker
     void fetchTangents( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
 
     /// Fill \p data with the vertex bitangent vectors from \p mesh.
+    /// @warning This function lock the biTangents attrib, you must unlock the attrib with unlock()
+    /// using getAttribManager() and getAttribBase( const Index &idx ) or by using an getUnlocker().
+    /// @see Unlocker
     void fetchBitangents( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
 
     /// Fill \p data with the vertex texture coordinates from \p mesh.
+    /// @warning This function lock the texCoords attrib, you must unlock the attrib with unlock()
+    /// using getAttribManager() and getAttribBase( const Index &idx ) or by using an getUnlocker().
+    /// @see Unlocker
     void fetchTextureCoordinates( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
 
     /// Fill \p data with the vertex colors from \p mesh.

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.hpp
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Core/Asset/DataLoader.hpp>
+#include <Core/Asset/GeometryData.hpp>
+#include <Core/Geometry/StandardAttribNames.hpp>
 #include <Core/Types.hpp>
 #include <IO/RaIO.hpp>
 
@@ -9,6 +11,7 @@
 
 struct aiScene;
 struct aiMesh;
+struct aiFace;
 struct aiNode;
 struct aiMaterial;
 
@@ -46,11 +49,6 @@ class RA_IO_API AssimpGeometryDataLoader : public Core::Asset::DataLoader<Core::
     void loadGeometryData( const aiScene* scene,
                            std::vector<std::unique_ptr<Core::Asset::GeometryData>>& data );
 
-    /// Fill \p data with the GeometryData from \p mesh.
-    void loadMeshAttrib( const aiMesh& mesh,
-                         Core::Asset::GeometryData& data,
-                         std::set<std::string>& usedNames );
-
     /// Fill \p data with the Material data from \p material.
     void loadMaterial( const aiMaterial& material, Core::Asset::GeometryData& data ) const;
 
@@ -59,6 +57,12 @@ class RA_IO_API AssimpGeometryDataLoader : public Core::Asset::DataLoader<Core::
                         const Core::Transform& parentFrame,
                         const std::map<uint, size_t>& indexTable,
                         std::vector<std::unique_ptr<Core::Asset::GeometryData>>& data ) const;
+
+  private:
+    /// Fill \p data with the GeometryData from \p mesh.
+    void loadMeshAttrib( const aiMesh& mesh,
+                         Core::Asset::GeometryData& data,
+                         std::set<std::string>& usedNames );
 
     /// Fill \p data with the name from \p mesh.
     /// \note If the name is already in use, then appends as much "_" as needed.
@@ -69,37 +73,27 @@ class RA_IO_API AssimpGeometryDataLoader : public Core::Asset::DataLoader<Core::
     /// Fill \p data with the GeometryType from \p mesh.
     void fetchType( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
 
-    /// Fill \p data with the vertices from \p mesh.
-    void fetchVertices( const aiMesh& mesh, Core::Asset::GeometryData& data );
-
-    /// Fill \p data with the lines from \p mesh.
-    void fetchEdges( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
-
-    /// Fill \p data with the faces from \p mesh.
-    void fetchFaces( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
-
     /// Fill \p data with the polyhedra from \p mesh.
     void fetchPolyhedron( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
 
-    /// Fill \p data with the vertex normals from \p mesh.
-    void fetchNormals( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
+    /// Fill the Radium geometry attribute \p a of \p data from assimp data \p aiData
+    template <typename T>
+    void fetchAttribute( T* aiData,
+                         int size,
+                         Core::Geometry::MultiIndexedGeometry& data,
+                         Core::Geometry::MeshAttrib a ) const;
 
-    /// Fill \p data with the vertex tangent vectors from \p mesh.
-    void fetchTangents( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
+    /// Fill the index layer using ai mesh topology
+    template <typename T>
+    void fetchIndexLayer( aiFace* faces,
+                          int numFaces,
+                          Core::Geometry::MultiIndexedGeometry& data ) const;
 
-    /// Fill \p data with the vertex bitangent vectors from \p mesh.
-    void fetchBitangents( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
-
-    /// Fill \p data with the vertex texture coordinates from \p mesh.
-    void fetchTextureCoordinates( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
-
-    /// Fill \p data with the vertex colors from \p mesh.
-    void fetchColors( const aiMesh& mesh, Core::Asset::GeometryData& data ) const;
-
-  private:
     /// The loaded file path (used to retrieve material texture files).
     std::string m_filepath;
 };
 
 } // namespace IO
 } // namespace Ra
+
+#include <IO/AssimpLoader/AssimpGeometryDataLoader.inl>

--- a/src/IO/AssimpLoader/AssimpGeometryDataLoader.inl
+++ b/src/IO/AssimpLoader/AssimpGeometryDataLoader.inl
@@ -1,0 +1,39 @@
+#include <IO/AssimpLoader/AssimpGeometryDataLoader.hpp>
+
+#include <IO/AssimpLoader/AssimpWrapper.hpp>
+#include <assimp/mesh.h>
+
+namespace Ra {
+namespace IO {
+
+template <typename T>
+void AssimpGeometryDataLoader::fetchAttribute( T* aiData,
+                                               int size,
+                                               Core::Geometry::MultiIndexedGeometry& data,
+                                               Core::Geometry::MeshAttrib a ) const {
+    auto attribHandle = data.addAttrib<typename AssimpTypeWrapper<T>::Type>( getAttribName( a ) );
+    auto& attribData  = data.vertexAttribs().getDataWithLock( attribHandle );
+    attribData.resize( size );
+#pragma omp parallel for
+    for ( int i = 0; i < size; ++i ) {
+        attribData.at( i ) = assimpToCore( aiData[i] );
+    }
+    data.vertexAttribs().unlock( attribHandle );
+}
+
+template <typename T>
+void AssimpGeometryDataLoader::fetchIndexLayer( aiFace* faces,
+                                                int numFaces,
+                                                Core::Geometry::MultiIndexedGeometry& data ) const {
+    auto layer    = std::make_unique<T>();
+    auto& indices = layer->collection();
+    indices.resize( numFaces );
+#pragma omp parallel for
+    for ( int i = 0; i < numFaces; ++i ) {
+        indices[i] = assimpToCore<typename T::IndexType>( faces[i].mIndices, faces[i].mNumIndices );
+    }
+    data.addLayer( std::move( layer ), false, "indices" );
+}
+
+} // namespace IO
+} // namespace Ra

--- a/src/IO/AssimpLoader/AssimpWrapper.hpp
+++ b/src/IO/AssimpLoader/AssimpWrapper.hpp
@@ -12,6 +12,39 @@
 namespace Ra {
 namespace IO {
 
+template <typename T>
+struct AssimpTypeWrapper {};
+
+template <>
+struct AssimpTypeWrapper<aiVector3D> {
+    using Type = Core::Vector3;
+};
+
+template <>
+struct AssimpTypeWrapper<aiQuaternion> {
+    using Type = Core::Quaternion;
+};
+
+template <>
+struct AssimpTypeWrapper<aiMatrix4x4> {
+    using Type = Core::Transform;
+};
+
+template <>
+struct AssimpTypeWrapper<aiColor3D> {
+    using Type = Core::Utils::Color;
+};
+
+template <>
+struct AssimpTypeWrapper<aiColor4D> {
+    using Type = Core::Utils::Color;
+};
+
+template <>
+struct AssimpTypeWrapper<aiString> {
+    using Type = std::string;
+};
+
 inline Core::Vector3 assimpToCore( const aiVector3D& v ) {
     return Core::Vector3( v.x, v.y, v.z );
 }
@@ -61,12 +94,21 @@ inline std::string assimpToCore( const aiString& string ) {
     return result.empty() ? "default" : result;
 }
 
-inline Core::VectorNi assimpToCore( const uint* index, const uint size ) {
-    Core::VectorNi v( size );
+inline Core::VectorNui assimpToCore( const uint* index, const uint size ) {
+    Core::VectorNui v( size );
     for ( uint i = 0; i < size; ++i ) {
         v[i] = index[i];
     }
 
+    return v;
+}
+
+template <typename T>
+inline T assimpToCore( const uint* index, const uint size ) {
+    T v;
+    for ( uint i = 0; i < size; ++i ) {
+        v[i] = index[i];
+    }
     return v;
 }
 

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
@@ -229,8 +229,12 @@ FileData* TinyPlyFileLoader::loadFile( const std::string& filename ) {
 
     // read requested buffers (and only those) from file content
     file.read( *file_stream );
-    copyBufferToContainer( vertBuffer, geometry->getVertices() );
-    copyBufferToContainer( normalBuffer, geometry->getNormals() );
+    copyBufferToContainer( vertBuffer,
+                           geometry->getAttribDataWithLock<Core::Vector3Array&>( "vertex" ) );
+    geometry->attribDataUnlock( "vertex" );
+    copyBufferToContainer( normalBuffer,
+                           geometry->getAttribDataWithLock<Core::Vector3Array&>( "normal" ) );
+    geometry->attribDataUnlock( "normal" );
 
     auto& attribManager = geometry->getAttribManager();
 

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
@@ -230,7 +230,7 @@ FileData* TinyPlyFileLoader::loadFile( const std::string& filename ) {
     // read requested buffers (and only those) from file content
     file.read( *file_stream );
     {
-        auto unlocker = geomData->getGeometry().vertexAttribs().getUnlocker();
+        auto unlocker = geomData->getGeometry().vertexAttribs().getScopedLockState();
         copyBufferToContainer( vertBuffer, geomData->getGeometry().verticesWithLock() );
         copyBufferToContainer( normalBuffer, geomData->getGeometry().normalsWithLock() );
     }

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
@@ -229,14 +229,11 @@ FileData* TinyPlyFileLoader::loadFile( const std::string& filename ) {
 
     // read requested buffers (and only those) from file content
     file.read( *file_stream );
-    copyBufferToContainer( vertBuffer, geometry->getVertices() );
-    geometry->getAttribManager()
-        .getAttribBase( Core::Geometry::MeshAttrib::VERTEX_POSITION )
-        ->unlock();
-    copyBufferToContainer( normalBuffer, geometry->getNormals() );
-    geometry->getAttribManager()
-        .getAttribBase( Core::Geometry::MeshAttrib::VERTEX_NORMAL )
-        ->unlock();
+    {
+        auto unlocker = geometry->getAttribManager().getUnlocker();
+        copyBufferToContainer( vertBuffer, geometry->getVertices() );
+        copyBufferToContainer( normalBuffer, geometry->getNormals() );
+    }
 
     auto& attribManager = geometry->getAttribManager();
 

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
@@ -229,12 +229,14 @@ FileData* TinyPlyFileLoader::loadFile( const std::string& filename ) {
 
     // read requested buffers (and only those) from file content
     file.read( *file_stream );
-    copyBufferToContainer( vertBuffer,
-                           geometry->getAttribDataWithLock<Core::Vector3Array&>( "vertex" ) );
-    geometry->attribDataUnlock( "vertex" );
-    copyBufferToContainer( normalBuffer,
-                           geometry->getAttribDataWithLock<Core::Vector3Array&>( "normal" ) );
-    geometry->attribDataUnlock( "normal" );
+    copyBufferToContainer( vertBuffer, geometry->getVertices() );
+    geometry->getAttribManager()
+        .getAttribBase( Core::Geometry::MeshAttrib::VERTEX_POSITION )
+        ->unlock();
+    copyBufferToContainer( normalBuffer, geometry->getNormals() );
+    geometry->getAttribManager()
+        .getAttribBase( Core::Geometry::MeshAttrib::VERTEX_NORMAL )
+        ->unlock();
 
     auto& attribManager = geometry->getAttribManager();
 

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
@@ -231,7 +231,6 @@ FileData* TinyPlyFileLoader::loadFile( const std::string& filename ) {
     file.read( *file_stream );
     copyBufferToContainer( vertBuffer, geometry->getVertices() );
     copyBufferToContainer( normalBuffer, geometry->getNormals() );
-    geometry->unlockData();
 
     auto& attribManager = geometry->getAttribManager();
 

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
@@ -231,6 +231,7 @@ FileData* TinyPlyFileLoader::loadFile( const std::string& filename ) {
     file.read( *file_stream );
     copyBufferToContainer( vertBuffer, geometry->getVertices() );
     copyBufferToContainer( normalBuffer, geometry->getNormals() );
+    geometry->unlockData();
 
     auto& attribManager = geometry->getAttribManager();
 

--- a/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
+++ b/src/IO/TinyPlyLoader/TinyPlyFileLoader.cpp
@@ -229,7 +229,6 @@ FileData* TinyPlyFileLoader::loadFile( const std::string& filename ) {
 
     // read requested buffers (and only those) from file content
     file.read( *file_stream );
-
     copyBufferToContainer( vertBuffer, geometry->getVertices() );
     copyBufferToContainer( normalBuffer, geometry->getNormals() );
 

--- a/src/IO/VolumesLoader/VolumeLoader.cpp
+++ b/src/IO/VolumesLoader/VolumeLoader.cpp
@@ -145,7 +145,7 @@ Ra::Core::Asset::FileData* VolumeLoader::loadPvmFile( const std::string& filenam
         auto fillRadiumVolume = []( auto container, auto densityData ) {
             std::generate( container->data().begin(), container->data().end(), [&densityData]() {
                 auto d = *densityData++;
-                return Scalar( d ) / std::numeric_limits<decltype( d )>::max();
+                return Scalar( d ) / Scalar( std::numeric_limits<decltype( d )>::max() );
             } );
         };
         Ra::Core::Vector3 binSize { Scalar( scalex ), Scalar( scaley ), Scalar( scalez ) };

--- a/src/IO/filelist.cmake
+++ b/src/IO/filelist.cmake
@@ -45,6 +45,8 @@ if(RADIUM_IO_ASSIMP)
         AssimpLoader/AssimpWrapper.hpp
     )
 
+    list(APPEND io_inlines AssimpLoader/AssimpGeometryDataLoader.inl)
+
 endif(RADIUM_IO_ASSIMP)
 
 if(RADIUM_IO_TINYPLY)

--- a/tests/ExampleApps/DrawPrimitivesDemo/minimalradium.cpp
+++ b/tests/ExampleApps/DrawPrimitivesDemo/minimalradium.cpp
@@ -710,6 +710,9 @@ void MinimalComponent::initialize() {
                         createMeshFromGeometryData<Geometry::TriangleMesh>( "logo", gd ) };
                     break;
                 case Ra::Core::Asset::GeometryData::QUAD_MESH:
+                    mesh = std::shared_ptr<Data::QuadMesh> {
+                        createMeshFromGeometryData<Geometry::QuadMesh>( "logo", gd ) };
+                    break;
                 case Ra::Core::Asset::GeometryData::POLY_MESH:
                     mesh = std::shared_ptr<Data::PolyMesh> {
                         createMeshFromGeometryData<Geometry::PolyMesh>( "logo", gd ) };

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -27,6 +27,7 @@ set(test_src
     Engine/signalmanager.cpp
     Engine/renderparameters.cpp
     Gui/keymapping.cpp
+    Core/geometryData.cpp
 )
 
 get_target_property(HAS_VOLUMES IO RADIUM_IO_HAS_VOLUMES)

--- a/tests/unittest/Core/geometryData.cpp
+++ b/tests/unittest/Core/geometryData.cpp
@@ -145,12 +145,13 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
         REQUIRE( attribTexCoords.data().size() == 1 );
         REQUIRE( attribTexCoords.data()[0] == saveTexCoords );
 
-        geometry->addAttribDataWithLock<Ra::Core::Vector3>( MeshAttrib::VERTEX_TANGENT );
+        geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_TANGENT ).getDataWithLock();
         REQUIRE(
             geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT )->isLocked() );
         {
             auto unlocker = geometry->getAttribManager().getUnlocker();
-            geometry->addAttribDataWithLock<Ra::Core::Vector3>( MeshAttrib::VERTEX_BITANGENT );
+            geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_BITANGENT )
+                .getDataWithLock();
             REQUIRE( geometry->getAttribManager()
                          .getAttribBase( MeshAttrib::VERTEX_BITANGENT )
                          ->isLocked() );
@@ -173,8 +174,7 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
         geometry.indexedDataUnlock( GeometryData::GeometryType::LINE_MESH, "in_edge" );
         REQUIRE( geometry.hasEdges() );
 
-        const auto& data = geometry.getIndexedData<Ra::Core::Vector2ui>(
-            GeometryData::GeometryType::LINE_MESH, "in_edge" );
+        const auto& data = geometry.getIndexedData<Ra::Core::Vector2ui>( "in_edge" );
         REQUIRE( save == data[0] );
 
         auto geometry2 = GeometryData();
@@ -195,8 +195,7 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
         geometry.indexedDataUnlock( GeometryData::GeometryType::POLY_MESH, "in_face" );
         REQUIRE( geometry.hasFaces() );
 
-        const auto& data = geometry.getIndexedData<Ra::Core::VectorNui>(
-            GeometryData::GeometryType::POLY_MESH, "in_face" );
+        const auto& data = geometry.getIndexedData<Ra::Core::VectorNui>( "in_face" );
         REQUIRE( save == data[0] );
 
         auto geometry2 = GeometryData();
@@ -217,8 +216,7 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
         geometry.indexedDataUnlock( GeometryData::GeometryType::POLY_MESH, "in_polyhedron" );
         REQUIRE( geometry.hasPolyhedra() );
 
-        const auto& data = geometry.getIndexedData<Ra::Core::VectorNui>(
-            GeometryData::GeometryType::POLY_MESH, "in_polyhedron" );
+        const auto& data = geometry.getIndexedData<Ra::Core::VectorNui>( "in_polyhedron" );
         REQUIRE( save == data[0] );
 
         auto geometry2 = GeometryData();

--- a/tests/unittest/Core/geometryData.cpp
+++ b/tests/unittest/Core/geometryData.cpp
@@ -144,6 +144,22 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
             geoTexCoordsTest->getAttribManager().getAttrib( attribHandlerTexCoords2 );
         REQUIRE( attribTexCoords.data().size() == 1 );
         REQUIRE( attribTexCoords.data()[0] == saveTexCoords );
+
+        geometry->addAttribDataWithLock<Ra::Core::Vector3>( MeshAttrib::VERTEX_TANGENT );
+        REQUIRE(
+            geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT )->isLocked() );
+        {
+            auto unlocker = geometry->getAttribManager().getUnlocker();
+            geometry->addAttribDataWithLock<Ra::Core::Vector3>( MeshAttrib::VERTEX_BITANGENT );
+            REQUIRE( geometry->getAttribManager()
+                         .getAttribBase( MeshAttrib::VERTEX_BITANGENT )
+                         ->isLocked() );
+        }
+        REQUIRE(
+            geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT )->isLocked() );
+        REQUIRE( !geometry->getAttribManager()
+                      .getAttribBase( MeshAttrib::VERTEX_BITANGENT )
+                      ->isLocked() );
     }
 
     SECTION( "Edges test " ) {

--- a/tests/unittest/Core/geometryData.cpp
+++ b/tests/unittest/Core/geometryData.cpp
@@ -1,3 +1,4 @@
+#include "Core/Geometry/StandardAttribNames.hpp"
 #include <Core/Asset/GeometryData.hpp>
 #include <catch2/catch.hpp>
 
@@ -9,25 +10,25 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
     SECTION( "Normal test" ) {
         auto geometry = new GeometryData();
         auto& normal  = geometry->getNormals();
+        auto& name    = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_NORMAL );
+
         REQUIRE( normal.empty() );
-        REQUIRE(
-            geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_NORMAL )->isLocked() );
+        REQUIRE( geometry->getAttribManager().getAttribBase( name )->isLocked() );
 
         normal.resize( 1, Ra::Core::Vector3::Zero() );
         normal[0] = Ra::Core::Vector3().setRandom();
         auto save = normal[0];
-        geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_NORMAL )->unlock();
+        geometry->getAttribManager().getAttribBase( name )->unlock();
         REQUIRE( !normal.empty() );
+        REQUIRE( !geometry->getAttribManager().getAttribBase( name )->isLocked() );
 
-        auto& name        = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_NORMAL );
         auto attriHandler = geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( name );
         const auto& data  = geometry->getAttribManager().getAttrib( attriHandler ).data();
         REQUIRE( save == data[0] );
 
         auto geometry2 = new GeometryData();
         geometry2->setNormals( normal );
-        auto& name2        = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_NORMAL );
-        auto attriHandler2 = geometry2->getAttribManager().findAttrib<Ra::Core::Vector3>( name2 );
+        auto attriHandler2 = geometry2->getAttribManager().findAttrib<Ra::Core::Vector3>( name );
         const auto& attrib = geometry2->getAttribManager().getAttrib( attriHandler2 );
         REQUIRE( attrib.data().size() == 1 );
         REQUIRE( attrib.data()[0] == save );
@@ -45,122 +46,147 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
         auto save = vertex[0];
         geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_POSITION )->unlock();
         REQUIRE( !vertex.empty() );
+        REQUIRE( !geometry->getAttribManager()
+                      .getAttribBase( MeshAttrib::VERTEX_POSITION )
+                      ->isLocked() );
 
-        auto& name        = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_POSITION );
-        auto attriHandler = geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( name );
-        const auto& data  = geometry->getAttribManager().getAttrib( attriHandler ).data();
+        auto& name       = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_POSITION );
+        auto attriHandle = geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( name );
+        const auto& data = geometry->getAttribManager().getAttrib( attriHandle ).data();
         REQUIRE( save == data[0] );
 
         auto geometry2 = new GeometryData();
-        geometry2->setVertices( vertex );
-        auto& name2        = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_POSITION );
-        auto attriHandler2 = geometry2->getAttribManager().findAttrib<Ra::Core::Vector3>( name2 );
-        const auto& attrib = geometry2->getAttribManager().getAttrib( attriHandler2 );
+        geometry2->getMultiIndexedGeometry().setVertices(
+            geometry->getMultiIndexedGeometry().vertices() );
+        auto attriHandle2  = geometry2->getAttribManager().findAttrib<Ra::Core::Vector3>( name );
+        const auto& attrib = geometry2->getAttribManager().getAttrib( attriHandle2 );
         REQUIRE( attrib.data().size() == 1 );
         REQUIRE( attrib.data()[0] == save );
     }
 
     SECTION( "Tangent, BiTangent, TexCoord tests" ) {
-        auto geometry = new GeometryData();
+        auto geom               = new GeometryData();
+        auto& tangentAttribName = getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_TANGENT );
+        auto tangentAttribHandle =
+            geom->getMultiIndexedGeometry().addAttrib<Ra::Core::Vector3>( tangentAttribName );
+        auto& tangents =
+            geom->getMultiIndexedGeometry().getAttrib( tangentAttribHandle ).getDataWithLock();
 
-        // Tangent test
-        auto& tangents = geometry->getTangents();
         REQUIRE( tangents.empty() );
-        REQUIRE(
-            geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT )->isLocked() );
+        REQUIRE( geom->getAttribManager().getAttribBase( tangentAttribName )->isLocked() );
 
         tangents.resize( 1, Ra::Core::Vector3::Zero() );
         tangents[0]  = Ra::Core::Vector3().setRandom();
         auto saveTan = tangents[0];
-        geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT )->unlock();
-        REQUIRE( !tangents.empty() );
+        geom->getAttribManager().getAttribBase( tangentAttribName )->unlock();
 
-        auto& nameTan = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_TANGENT );
-        auto attribHandlerTan =
-            geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( nameTan );
-        const auto& dataTan = geometry->getAttribManager().getAttrib( attribHandlerTan ).data();
+        REQUIRE( !tangents.empty() );
+        REQUIRE( !geom->getAttribManager().getAttribBase( tangentAttribName )->isLocked() );
+
+        auto tangentAttribHandle2 =
+            geom->getAttribManager().findAttrib<Ra::Core::Vector3>( tangentAttribName );
+        const auto& dataTan = geom->getAttribManager().getAttrib( tangentAttribHandle2 ).data();
         REQUIRE( saveTan == dataTan[0] );
 
-        auto geoTanTest = new GeometryData();
-        geoTanTest->setTangents( tangents );
-        auto attribHandlerTan2 =
-            geoTanTest->getAttribManager().findAttrib<Ra::Core::Vector3>( nameTan );
-        const auto& attribTan = geoTanTest->getAttribManager().getAttrib( attribHandlerTan2 );
-        REQUIRE( attribTan.data().size() == 1 );
-        REQUIRE( attribTan.data()[0] == saveTan );
+        auto geom2 = new GeometryData();
+        auto geom2TangentAttribHandle2 =
+            geom2->getMultiIndexedGeometry().addAttrib<Ra::Core::Vector3>( tangentAttribName );
+        geom2->getMultiIndexedGeometry()
+            .getAttrib<Ra::Core::Vector3>( tangentAttribHandle2 )
+            .setData( dataTan );
 
-        // BiTangent test
-        auto& biTangents = geometry->getBiTangents();
-        REQUIRE( biTangents.empty() );
-        REQUIRE( geometry->getAttribManager()
-                     .getAttribBase( MeshAttrib::VERTEX_BITANGENT )
-                     ->isLocked() );
+        auto tangentAttribHandle3 =
+            geom2->getAttribManager().findAttrib<Ra::Core::Vector3>( tangentAttribName );
 
-        biTangents.resize( 1, Ra::Core::Vector3::Zero() );
-        biTangents[0]  = Ra::Core::Vector3().setRandom();
-        auto saveBiTan = biTangents[0];
-        geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_BITANGENT )->unlock();
-        REQUIRE( !biTangents.empty() );
+        const auto& tangents2 = geom2->getAttribManager().getAttrib( tangentAttribHandle3 );
 
-        auto& nameBiTan = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_BITANGENT );
-        auto attribHandlerBiTan =
-            geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( nameBiTan );
-        const auto& dataBiTan = geometry->getAttribManager().getAttrib( attribHandlerBiTan ).data();
-        REQUIRE( saveBiTan == dataBiTan[0] );
+        REQUIRE( tangents2.data().size() == 1 );
+        REQUIRE( tangents2.data()[0] == saveTan );
+        /// \todo to be continued
+        /*
 
-        auto geoBiTanTest = new GeometryData();
-        geoBiTanTest->setBitangents( biTangents );
-        auto attribHandlerBiTan2 =
-            geoBiTanTest->getAttribManager().findAttrib<Ra::Core::Vector3>( nameBiTan );
-        const auto& attribBiTan = geoBiTanTest->getAttribManager().getAttrib( attribHandlerBiTan2 );
+                // BiTangent test
+                auto& biTangents = geometry->getBiTangents();
+                auto& biTangentAttribName =
+                    Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_BITANGENT );
+                REQUIRE( biTangents.empty() );
+                REQUIRE( geometry->getAttribManager().getAttribBase( biTangentAttribName
+           )->isLocked() );
 
-        REQUIRE( attribBiTan.data().size() == 1 );
-        REQUIRE( attribBiTan.data()[0] == saveBiTan );
+                biTangents.resize( 1, Ra::Core::Vector3::Zero() );
+                biTangents[0]  = Ra::Core::Vector3().setRandom();
+                auto saveBiTan = biTangents[0];
+                geometry->getAttribManager().getAttribBase( biTangentAttribName )->unlock();
+                REQUIRE( !biTangents.empty() );
 
-        // TexCoords test
-        auto& texCoords = geometry->getTexCoords();
-        REQUIRE( texCoords.empty() );
-        REQUIRE(
-            geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TEXCOORD )->isLocked() );
 
-        texCoords.resize( 1, Ra::Core::Vector3::Zero() );
-        texCoords[0]       = Ra::Core::Vector3().setRandom();
-        auto saveTexCoords = texCoords[0];
-        geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TEXCOORD )->unlock();
-        REQUIRE( !texCoords.empty() );
+                        auto attribHandlerBiTan =
+                            geometry->getAttribManager().findAttrib<Ra::Core::Vector3>(
+           biTangentAttribName
+                ); const auto& dataBiTan = geometry->getAttribManager().getAttrib(
+           attribHandlerBiTan
+                ).data(); REQUIRE( saveBiTan == dataBiTan[0] );
 
-        auto& nameTexCoords = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_TEXCOORD );
-        auto attribHandlerTexCoords =
-            geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( nameTexCoords );
-        const auto& dataTexCoords =
-            geometry->getAttribManager().getAttrib( attribHandlerTexCoords ).data();
-        REQUIRE( saveTexCoords == dataTexCoords[0] );
+                        auto geoBiTanTest = new GeometryData();
+                        geoBiTanTest->setBitangents( biTangents );
+                        auto attribHandlerBiTan2 =
+                            geoBiTanTest->getAttribManager().findAttrib<Ra::Core::Vector3>(
+                biTangentAttribName ); const auto& attribBiTan =
+           geoBiTanTest->getAttribManager().getAttrib( attribHandlerBiTan2 );
 
-        auto geoTexCoordsTest = new GeometryData();
-        geoTexCoordsTest->setTextureCoordinates( texCoords );
-        auto attribHandlerTexCoords2 =
-            geoTexCoordsTest->getAttribManager().findAttrib<Ra::Core::Vector3>( nameTexCoords );
-        const auto& attribTexCoords =
-            geoTexCoordsTest->getAttribManager().getAttrib( attribHandlerTexCoords2 );
-        REQUIRE( attribTexCoords.data().size() == 1 );
-        REQUIRE( attribTexCoords.data()[0] == saveTexCoords );
+                        REQUIRE( attribBiTan.data().size() == 1 );
+                        REQUIRE( attribBiTan.data()[0] == saveBiTan );
 
-        geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_TANGENT ).getDataWithLock();
-        REQUIRE(
-            geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT )->isLocked() );
-        {
-            auto unlocker = geometry->getAttribManager().getUnlocker();
-            geometry->getAttrib<Ra::Core::Vector3>( MeshAttrib::VERTEX_BITANGENT )
-                .getDataWithLock();
-            REQUIRE( geometry->getAttribManager()
-                         .getAttribBase( MeshAttrib::VERTEX_BITANGENT )
-                         ->isLocked() );
-        }
-        REQUIRE(
-            geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT )->isLocked() );
-        REQUIRE( !geometry->getAttribManager()
-                      .getAttribBase( MeshAttrib::VERTEX_BITANGENT )
-                      ->isLocked() );
+                        // TexCoords test
+                        auto& texCoords = geometry->getTexCoords();
+                        REQUIRE( texCoords.empty() );
+                        REQUIRE(
+                            geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TEXCOORD
+                )->isLocked() );
+
+                        texCoords.resize( 1, Ra::Core::Vector3::Zero() );
+                        texCoords[0]       = Ra::Core::Vector3().setRandom();
+                        auto saveTexCoords = texCoords[0];
+                        geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TEXCOORD
+           )->unlock(); REQUIRE( !texCoords.empty() );
+
+                        auto& nameTexCoords = Ra::Core::Geometry::getAttribName(
+           MeshAttrib::VERTEX_TEXCOORD
+                ); auto attribHandlerTexCoords =
+           geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( nameTexCoords ); const auto&
+           dataTexCoords = geometry->getAttribManager().getAttrib( attribHandlerTexCoords ).data();
+           REQUIRE( saveTexCoords == dataTexCoords[0] );
+
+                        auto geoTexCoordsTest = new GeometryData();
+                        geoTexCoordsTest->setTextureCoordinates( texCoords );
+                        auto attribHandlerTexCoords2 =
+                            geoTexCoordsTest->getAttribManager().findAttrib<Ra::Core::Vector3>(
+                nameTexCoords ); const auto& attribTexCoords =
+                            geoTexCoordsTest->getAttribManager().getAttrib( attribHandlerTexCoords2
+           ); REQUIRE( attribTexCoords.data().size() == 1 ); REQUIRE( attribTexCoords.data()[0] ==
+           saveTexCoords );
+
+                        geometry->getMultiIndexedGeometry()
+                            .getAttrib<Ra::Core::Vector3>( tangentAttribName )
+                            .getDataWithLock();
+                        REQUIRE( geometry->getAttribManager().getAttribBase( tangentAttribName
+           )->isLocked()
+                );
+                        {
+                            auto unlocker = geometry->getAttribManager().getUnlocker();
+                            geometry->getMultiIndexedGeometry()
+                                .getAttrib<Ra::Core::Vector3>( getAttribName(
+           MeshAttrib::VERTEX_BITANGENT ) ) .getDataWithLock(); REQUIRE(
+           geometry->getAttribManager() .getAttribBase( getAttribName( MeshAttrib::VERTEX_BITANGENT
+           ) )
+                                         ->isLocked() );
+                        }
+                        REQUIRE( geometry->getAttribManager().getAttribBase( tangentAttribName
+           )->isLocked()
+                ); REQUIRE( !geometry->getAttribManager().getAttribBase( biTangentAttribName
+           )->isLocked()
+                );
+                */
     }
 
     SECTION( "Edges test " ) {
@@ -200,7 +226,8 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
 
         auto geometry2 = GeometryData();
         geometry2.setFaces( faces );
-        // geometry2.setIndexedData(GeometryData::GeometryType::POLY_MESH, faces, "in_face");
+        //        geometry2.setIndexedData( GeometryData::GeometryType::POLY_MESH, faces, "in_face"
+        //        );
         REQUIRE( geometry2.getFaces().size() == 1 );
         REQUIRE( geometry.getFaces()[0] == save );
     }

--- a/tests/unittest/Core/geometryData.cpp
+++ b/tests/unittest/Core/geometryData.cpp
@@ -8,250 +8,97 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
     using namespace Ra::Core::Geometry;
 
     SECTION( "Normal test" ) {
-        auto geometry = new GeometryData();
-        auto& normal  = geometry->getNormals();
-        auto& name    = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_NORMAL );
+        auto geom      = new GeometryData();
+        auto& coreGeom = geom->getGeometry();
+        auto& normal   = coreGeom.normalsWithLock();
+        auto& name     = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_NORMAL );
 
         REQUIRE( normal.empty() );
-        REQUIRE( geometry->getAttribManager().getAttribBase( name )->isLocked() );
+        REQUIRE( coreGeom.vertexAttribs().getAttribBase( name )->isLocked() );
 
         normal.resize( 1, Ra::Core::Vector3::Zero() );
         normal[0] = Ra::Core::Vector3().setRandom();
         auto save = normal[0];
-        geometry->getAttribManager().getAttribBase( name )->unlock();
-        REQUIRE( !normal.empty() );
-        REQUIRE( !geometry->getAttribManager().getAttribBase( name )->isLocked() );
+        coreGeom.normalsUnlock();
 
-        auto attriHandler = geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( name );
-        const auto& data  = geometry->getAttribManager().getAttrib( attriHandler ).data();
+        REQUIRE( !normal.empty() );
+        REQUIRE( !coreGeom.vertexAttribs().getAttribBase( name )->isLocked() );
+
+        auto attriHandler = coreGeom.vertexAttribs().findAttrib<Ra::Core::Vector3>( name );
+        const auto& data  = coreGeom.vertexAttribs().getData( attriHandler );
         REQUIRE( save == data[0] );
 
-        auto geometry2 = new GeometryData();
-        geometry2->setNormals( normal );
-        auto attriHandler2 = geometry2->getAttribManager().findAttrib<Ra::Core::Vector3>( name );
-        const auto& attrib = geometry2->getAttribManager().getAttrib( attriHandler2 );
-        REQUIRE( attrib.data().size() == 1 );
-        REQUIRE( attrib.data()[0] == save );
+        auto geometry2  = new GeometryData();
+        auto& coreGeom2 = geometry2->getGeometry();
+        coreGeom2.setNormals( normal );
+        auto attriHandler2 = coreGeom2.vertexAttribs().findAttrib<Ra::Core::Vector3>( name );
+        const auto& d      = coreGeom2.vertexAttribs().getData( attriHandler2 );
+        REQUIRE( d.size() == 1 );
+        REQUIRE( d[0] == save );
     }
 
     SECTION( "Vertices test" ) {
-        auto geometry = new GeometryData();
-        auto& vertex  = geometry->getVertices();
+        auto geom      = new GeometryData();
+        auto& coreGeom = geom->getGeometry();
+        auto& vertex   = coreGeom.verticesWithLock();
+        auto& name     = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_POSITION );
+
         REQUIRE( vertex.empty() );
-        REQUIRE(
-            geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_POSITION )->isLocked() );
+        REQUIRE( coreGeom.vertexAttribs().getAttribBase( name )->isLocked() );
 
         vertex.resize( 1, Ra::Core::Vector3::Zero() );
         vertex[0] = Ra::Core::Vector3().setRandom();
         auto save = vertex[0];
-        geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_POSITION )->unlock();
-        REQUIRE( !vertex.empty() );
-        REQUIRE( !geometry->getAttribManager()
-                      .getAttribBase( MeshAttrib::VERTEX_POSITION )
-                      ->isLocked() );
+        coreGeom.verticesUnlock();
 
-        auto& name       = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_POSITION );
-        auto attriHandle = geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( name );
-        const auto& data = geometry->getAttribManager().getAttrib( attriHandle ).data();
+        REQUIRE( !vertex.empty() );
+        REQUIRE( !coreGeom.vertexAttribs().getAttribBase( name )->isLocked() );
+
+        auto attriHandle = coreGeom.vertexAttribs().findAttrib<Ra::Core::Vector3>( name );
+        const auto& data = coreGeom.vertexAttribs().getData( attriHandle );
         REQUIRE( save == data[0] );
 
-        auto geometry2 = new GeometryData();
-        geometry2->getMultiIndexedGeometry().setVertices(
-            geometry->getMultiIndexedGeometry().vertices() );
-        auto attriHandle2  = geometry2->getAttribManager().findAttrib<Ra::Core::Vector3>( name );
-        const auto& attrib = geometry2->getAttribManager().getAttrib( attriHandle2 );
-        REQUIRE( attrib.data().size() == 1 );
-        REQUIRE( attrib.data()[0] == save );
+        auto geom2      = new GeometryData();
+        auto& coreGeom2 = geom2->getGeometry();
+        coreGeom2.setVertices( geom->getGeometry().vertices() );
+        auto attriHandle2 = coreGeom2.vertexAttribs().findAttrib<Ra::Core::Vector3>( name );
+        const auto& d     = coreGeom2.vertexAttribs().getData( attriHandle2 );
+        REQUIRE( d.size() == 1 );
+        REQUIRE( d[0] == save );
     }
 
     SECTION( "Tangent, BiTangent, TexCoord tests" ) {
-        auto geom               = new GeometryData();
-        auto& tangentAttribName = getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_TANGENT );
-        auto tangentAttribHandle =
-            geom->getMultiIndexedGeometry().addAttrib<Ra::Core::Vector3>( tangentAttribName );
-        auto& tangents =
-            geom->getMultiIndexedGeometry().getAttrib( tangentAttribHandle ).getDataWithLock();
+        auto geom         = new GeometryData();
+        auto& coreGeom    = geom->getGeometry();
+        auto& name        = getAttribName( Ra::Core::Geometry::MeshAttrib::VERTEX_TANGENT );
+        auto attribHandle = coreGeom.addAttrib<Ra::Core::Vector3>( name );
+        auto& attribData  = coreGeom.vertexAttribs().getDataWithLock( attribHandle );
 
-        REQUIRE( tangents.empty() );
-        REQUIRE( geom->getAttribManager().getAttribBase( tangentAttribName )->isLocked() );
+        REQUIRE( attribData.empty() );
+        REQUIRE( coreGeom.vertexAttribs().getAttribBase( name )->isLocked() );
 
-        tangents.resize( 1, Ra::Core::Vector3::Zero() );
-        tangents[0]  = Ra::Core::Vector3().setRandom();
-        auto saveTan = tangents[0];
-        geom->getAttribManager().getAttribBase( tangentAttribName )->unlock();
+        attribData.resize( 1, Ra::Core::Vector3::Zero() );
+        attribData[0] = Ra::Core::Vector3().setRandom();
+        auto saveTan  = attribData[0];
+        coreGeom.vertexAttribs().getAttribBase( name )->unlock();
 
-        REQUIRE( !tangents.empty() );
-        REQUIRE( !geom->getAttribManager().getAttribBase( tangentAttribName )->isLocked() );
+        REQUIRE( !attribData.empty() );
+        REQUIRE( !coreGeom.vertexAttribs().getAttribBase( name )->isLocked() );
 
-        auto tangentAttribHandle2 =
-            geom->getAttribManager().findAttrib<Ra::Core::Vector3>( tangentAttribName );
-        const auto& dataTan = geom->getAttribManager().getAttrib( tangentAttribHandle2 ).data();
+        auto tangentAttribHandle2 = coreGeom.vertexAttribs().findAttrib<Ra::Core::Vector3>( name );
+        const auto& dataTan       = coreGeom.vertexAttribs().getData( tangentAttribHandle2 );
         REQUIRE( saveTan == dataTan[0] );
 
-        auto geom2 = new GeometryData();
-        auto geom2TangentAttribHandle2 =
-            geom2->getMultiIndexedGeometry().addAttrib<Ra::Core::Vector3>( tangentAttribName );
-        geom2->getMultiIndexedGeometry()
-            .getAttrib<Ra::Core::Vector3>( tangentAttribHandle2 )
-            .setData( dataTan );
+        auto geom2         = new GeometryData();
+        auto& coreGeom2    = geom2->getGeometry();
+        auto attribHandle2 = coreGeom2.addAttrib<Ra::Core::Vector3>( name );
+        coreGeom2.getAttrib<Ra::Core::Vector3>( attribHandle2 ).setData( dataTan );
 
-        auto tangentAttribHandle3 =
-            geom2->getAttribManager().findAttrib<Ra::Core::Vector3>( tangentAttribName );
+        auto attribHandle3 = coreGeom2.vertexAttribs().findAttrib<Ra::Core::Vector3>( name );
+        const auto& d      = coreGeom2.vertexAttribs().getData( attribHandle3 );
 
-        const auto& tangents2 = geom2->getAttribManager().getAttrib( tangentAttribHandle3 );
-
-        REQUIRE( tangents2.data().size() == 1 );
-        REQUIRE( tangents2.data()[0] == saveTan );
-        /// \todo to be continued
-        /*
-
-                // BiTangent test
-                auto& biTangents = geometry->getBiTangents();
-                auto& biTangentAttribName =
-                    Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_BITANGENT );
-                REQUIRE( biTangents.empty() );
-                REQUIRE( geometry->getAttribManager().getAttribBase( biTangentAttribName
-           )->isLocked() );
-
-                biTangents.resize( 1, Ra::Core::Vector3::Zero() );
-                biTangents[0]  = Ra::Core::Vector3().setRandom();
-                auto saveBiTan = biTangents[0];
-                geometry->getAttribManager().getAttribBase( biTangentAttribName )->unlock();
-                REQUIRE( !biTangents.empty() );
-
-
-                        auto attribHandlerBiTan =
-                            geometry->getAttribManager().findAttrib<Ra::Core::Vector3>(
-           biTangentAttribName
-                ); const auto& dataBiTan = geometry->getAttribManager().getAttrib(
-           attribHandlerBiTan
-                ).data(); REQUIRE( saveBiTan == dataBiTan[0] );
-
-                        auto geoBiTanTest = new GeometryData();
-                        geoBiTanTest->setBitangents( biTangents );
-                        auto attribHandlerBiTan2 =
-                            geoBiTanTest->getAttribManager().findAttrib<Ra::Core::Vector3>(
-                biTangentAttribName ); const auto& attribBiTan =
-           geoBiTanTest->getAttribManager().getAttrib( attribHandlerBiTan2 );
-
-                        REQUIRE( attribBiTan.data().size() == 1 );
-                        REQUIRE( attribBiTan.data()[0] == saveBiTan );
-
-                        // TexCoords test
-                        auto& texCoords = geometry->getTexCoords();
-                        REQUIRE( texCoords.empty() );
-                        REQUIRE(
-                            geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TEXCOORD
-                )->isLocked() );
-
-                        texCoords.resize( 1, Ra::Core::Vector3::Zero() );
-                        texCoords[0]       = Ra::Core::Vector3().setRandom();
-                        auto saveTexCoords = texCoords[0];
-                        geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TEXCOORD
-           )->unlock(); REQUIRE( !texCoords.empty() );
-
-                        auto& nameTexCoords = Ra::Core::Geometry::getAttribName(
-           MeshAttrib::VERTEX_TEXCOORD
-                ); auto attribHandlerTexCoords =
-           geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( nameTexCoords ); const auto&
-           dataTexCoords = geometry->getAttribManager().getAttrib( attribHandlerTexCoords ).data();
-           REQUIRE( saveTexCoords == dataTexCoords[0] );
-
-                        auto geoTexCoordsTest = new GeometryData();
-                        geoTexCoordsTest->setTextureCoordinates( texCoords );
-                        auto attribHandlerTexCoords2 =
-                            geoTexCoordsTest->getAttribManager().findAttrib<Ra::Core::Vector3>(
-                nameTexCoords ); const auto& attribTexCoords =
-                            geoTexCoordsTest->getAttribManager().getAttrib( attribHandlerTexCoords2
-           ); REQUIRE( attribTexCoords.data().size() == 1 ); REQUIRE( attribTexCoords.data()[0] ==
-           saveTexCoords );
-
-                        geometry->getMultiIndexedGeometry()
-                            .getAttrib<Ra::Core::Vector3>( tangentAttribName )
-                            .getDataWithLock();
-                        REQUIRE( geometry->getAttribManager().getAttribBase( tangentAttribName
-           )->isLocked()
-                );
-                        {
-                            auto unlocker = geometry->getAttribManager().getUnlocker();
-                            geometry->getMultiIndexedGeometry()
-                                .getAttrib<Ra::Core::Vector3>( getAttribName(
-           MeshAttrib::VERTEX_BITANGENT ) ) .getDataWithLock(); REQUIRE(
-           geometry->getAttribManager() .getAttribBase( getAttribName( MeshAttrib::VERTEX_BITANGENT
-           ) )
-                                         ->isLocked() );
-                        }
-                        REQUIRE( geometry->getAttribManager().getAttribBase( tangentAttribName
-           )->isLocked()
-                ); REQUIRE( !geometry->getAttribManager().getAttribBase( biTangentAttribName
-           )->isLocked()
-                );
-                */
-    }
-
-    SECTION( "Edges test " ) {
-        auto geometry = GeometryData();
-        auto& edges   = geometry.getEdges();
-        REQUIRE( edges.empty() );
-
-        edges.resize( 1 );
-        edges[0]  = Ra::Core::Vector2ui().setRandom();
-        auto save = edges[0];
-        geometry.indexedDataUnlock( GeometryData::GeometryType::LINE_MESH, "in_edge" );
-        REQUIRE( !edges.empty() );
-
-        const auto& data = geometry.getIndexedData<Ra::Core::Vector2ui>( "in_edge" );
-        REQUIRE( save == data[0] );
-
-        auto geometry2 = GeometryData();
-        geometry2.setEdges( edges );
-        // geometry2.setIndexedData(GeometryData::GeometryType::LINE_MESH, edges, "in_edge");
-        REQUIRE( geometry2.getEdges().size() == 1 );
-        REQUIRE( geometry.getEdges()[0] == save );
-    }
-
-    SECTION( "Faces test " ) {
-        auto geometry = GeometryData();
-        auto& faces   = geometry.getFaces();
-        REQUIRE( faces.empty() );
-
-        faces.resize( 1 );
-        faces[0]  = Ra::Core::VectorNui().setRandom();
-        auto save = faces[0];
-        geometry.indexedDataUnlock( GeometryData::GeometryType::POLY_MESH, "in_face" );
-        REQUIRE( !faces.empty() );
-
-        const auto& data = geometry.getIndexedData<Ra::Core::VectorNui>( "in_face" );
-        REQUIRE( save == data[0] );
-
-        auto geometry2 = GeometryData();
-        geometry2.setFaces( faces );
-        //        geometry2.setIndexedData( GeometryData::GeometryType::POLY_MESH, faces, "in_face"
-        //        );
-        REQUIRE( geometry2.getFaces().size() == 1 );
-        REQUIRE( geometry.getFaces()[0] == save );
-    }
-
-    SECTION( "Polyhedron test " ) {
-        auto geometry     = GeometryData();
-        auto& polyhedrons = geometry.getPolyhedra();
-        REQUIRE( polyhedrons.empty() );
-
-        polyhedrons.resize( 1 );
-        polyhedrons[0] = Ra::Core::VectorNui().setRandom();
-        auto save      = polyhedrons[0];
-        geometry.indexedDataUnlock( GeometryData::GeometryType::POLY_MESH, "in_polyhedron" );
-        REQUIRE( !polyhedrons.empty() );
-
-        const auto& data = geometry.getIndexedData<Ra::Core::VectorNui>( "in_polyhedron" );
-        REQUIRE( save == data[0] );
-
-        auto geometry2 = GeometryData();
-        geometry2.setPolyhedra( polyhedrons );
-        // geometry2.setIndexedData(GeometryData::GeometryType::POLY_MESH, polyhedrons,
-        // "in_polyhedron");
-        REQUIRE( geometry2.getPolyhedra().size() == 1 );
-        REQUIRE( geometry.getPolyhedra()[0] == save );
+        REQUIRE( d.size() == 1 );
+        REQUIRE( d[0] == saveTan );
     }
 
     SECTION( "Type test " ) {

--- a/tests/unittest/Core/geometryData.cpp
+++ b/tests/unittest/Core/geometryData.cpp
@@ -1,0 +1,249 @@
+#include <Core/Asset/GeometryData.hpp>
+#include <catch2/catch.hpp>
+
+TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
+
+    using namespace Ra::Core::Asset;
+    using namespace Ra::Core::Geometry;
+
+    SECTION( "Normal test" ) {
+        auto geometry = new GeometryData();
+        auto& normal  = geometry->getNormals();
+        REQUIRE( !geometry->hasNormals() );
+        REQUIRE(
+            geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_NORMAL )->isLocked() );
+
+        normal.resize( 1, Ra::Core::Vector3::Zero() );
+        normal[0] = Ra::Core::Vector3().setRandom();
+        auto save = normal[0];
+        geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_NORMAL )->unlock();
+        REQUIRE( geometry->hasNormals() );
+
+        auto& name        = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_NORMAL );
+        auto attriHandler = geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( name );
+        const auto& data  = geometry->getAttribManager().getAttrib( attriHandler ).data();
+        REQUIRE( save == data[0] );
+
+        auto geometry2 = new GeometryData();
+        geometry2->setNormals( normal );
+        auto& name2        = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_NORMAL );
+        auto attriHandler2 = geometry2->getAttribManager().findAttrib<Ra::Core::Vector3>( name2 );
+        const auto& attrib = geometry2->getAttribManager().getAttrib( attriHandler2 );
+        REQUIRE( attrib.data().size() == 1 );
+        REQUIRE( attrib.data()[0] == save );
+    }
+
+    SECTION( "Vertices test" ) {
+        auto geometry = new GeometryData();
+        auto& vertex  = geometry->getVertices();
+        REQUIRE( !geometry->hasVertices() );
+        REQUIRE(
+            geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_POSITION )->isLocked() );
+
+        vertex.resize( 1, Ra::Core::Vector3::Zero() );
+        vertex[0] = Ra::Core::Vector3().setRandom();
+        auto save = vertex[0];
+        geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_POSITION )->unlock();
+        REQUIRE( geometry->hasVertices() );
+
+        auto& name        = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_POSITION );
+        auto attriHandler = geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( name );
+        const auto& data  = geometry->getAttribManager().getAttrib( attriHandler ).data();
+        REQUIRE( save == data[0] );
+
+        auto geometry2 = new GeometryData();
+        geometry2->setVertices( vertex );
+        auto& name2        = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_POSITION );
+        auto attriHandler2 = geometry2->getAttribManager().findAttrib<Ra::Core::Vector3>( name2 );
+        const auto& attrib = geometry2->getAttribManager().getAttrib( attriHandler2 );
+        REQUIRE( attrib.data().size() == 1 );
+        REQUIRE( attrib.data()[0] == save );
+    }
+
+    SECTION( "Tangent, BiTangent, TexCoord tests" ) {
+        auto geometry = new GeometryData();
+
+        // Tangent test
+        auto& tangents = geometry->getTangents();
+        REQUIRE( !geometry->hasTangents() );
+        REQUIRE(
+            geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT )->isLocked() );
+
+        tangents.resize( 1, Ra::Core::Vector3::Zero() );
+        tangents[0]  = Ra::Core::Vector3().setRandom();
+        auto saveTan = tangents[0];
+        geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT )->unlock();
+        REQUIRE( geometry->hasTangents() );
+
+        auto& nameTan = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_TANGENT );
+        auto attribHandlerTan =
+            geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( nameTan );
+        const auto& dataTan = geometry->getAttribManager().getAttrib( attribHandlerTan ).data();
+        REQUIRE( saveTan == dataTan[0] );
+
+        auto geoTanTest = new GeometryData();
+        geoTanTest->setTangents( tangents );
+        auto attribHandlerTan2 =
+            geoTanTest->getAttribManager().findAttrib<Ra::Core::Vector3>( nameTan );
+        const auto& attribTan = geoTanTest->getAttribManager().getAttrib( attribHandlerTan2 );
+        REQUIRE( attribTan.data().size() == 1 );
+        REQUIRE( attribTan.data()[0] == saveTan );
+
+        // BiTangent test
+        auto& biTangents = geometry->getBiTangents();
+        REQUIRE( !geometry->hasBiTangents() );
+        REQUIRE( geometry->getAttribManager()
+                     .getAttribBase( MeshAttrib::VERTEX_BITANGENT )
+                     ->isLocked() );
+
+        biTangents.resize( 1, Ra::Core::Vector3::Zero() );
+        biTangents[0]  = Ra::Core::Vector3().setRandom();
+        auto saveBiTan = biTangents[0];
+        geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_BITANGENT )->unlock();
+        REQUIRE( geometry->hasBiTangents() );
+
+        auto& nameBiTan = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_BITANGENT );
+        auto attribHandlerBiTan =
+            geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( nameBiTan );
+        const auto& dataBiTan = geometry->getAttribManager().getAttrib( attribHandlerBiTan ).data();
+        REQUIRE( saveBiTan == dataBiTan[0] );
+
+        auto geoBiTanTest = new GeometryData();
+        geoBiTanTest->setBitangents( biTangents );
+        auto attribHandlerBiTan2 =
+            geoBiTanTest->getAttribManager().findAttrib<Ra::Core::Vector3>( nameBiTan );
+        const auto& attribBiTan = geoBiTanTest->getAttribManager().getAttrib( attribHandlerBiTan2 );
+
+        REQUIRE( attribBiTan.data().size() == 1 );
+        REQUIRE( attribBiTan.data()[0] == saveBiTan );
+
+        // TexCoords test
+        auto& texCoords = geometry->getTexCoords();
+        REQUIRE( !geometry->hasTextureCoordinates() );
+        REQUIRE(
+            geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TEXCOORD )->isLocked() );
+
+        texCoords.resize( 1, Ra::Core::Vector3::Zero() );
+        texCoords[0]       = Ra::Core::Vector3().setRandom();
+        auto saveTexCoords = texCoords[0];
+        geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TEXCOORD )->unlock();
+        REQUIRE( geometry->hasTextureCoordinates() );
+
+        auto& nameTexCoords = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_TEXCOORD );
+        auto attribHandlerTexCoords =
+            geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( nameTexCoords );
+        const auto& dataTexCoords =
+            geometry->getAttribManager().getAttrib( attribHandlerTexCoords ).data();
+        REQUIRE( saveTexCoords == dataTexCoords[0] );
+
+        auto geoTexCoordsTest = new GeometryData();
+        geoTexCoordsTest->setTextureCoordinates( texCoords );
+        auto attribHandlerTexCoords2 =
+            geoTexCoordsTest->getAttribManager().findAttrib<Ra::Core::Vector3>( nameTexCoords );
+        const auto& attribTexCoords =
+            geoTexCoordsTest->getAttribManager().getAttrib( attribHandlerTexCoords2 );
+        REQUIRE( attribTexCoords.data().size() == 1 );
+        REQUIRE( attribTexCoords.data()[0] == saveTexCoords );
+    }
+
+    SECTION( "Edges test " ) {
+        auto geometry = GeometryData();
+        auto& edges   = geometry.getEdges();
+        REQUIRE( !geometry.hasEdges() );
+
+        edges.resize( 1 );
+        edges[0]  = Ra::Core::Vector2ui().setRandom();
+        auto save = edges[0];
+        geometry.indexedDataUnlock( GeometryData::GeometryType::LINE_MESH, "in_edge" );
+        REQUIRE( geometry.hasEdges() );
+
+        const auto& data = geometry.getIndexedData<Ra::Core::Vector2ui>(
+            GeometryData::GeometryType::LINE_MESH, "in_edge" );
+        REQUIRE( save == data[0] );
+
+        auto geometry2 = GeometryData();
+        geometry2.setEdges( edges );
+        // geometry2.setIndexedData(GeometryData::GeometryType::LINE_MESH, edges, "in_edge");
+        REQUIRE( geometry2.getEdges().size() == 1 );
+        REQUIRE( geometry.getEdges()[0] == save );
+    }
+
+    SECTION( "Faces test " ) {
+        auto geometry = GeometryData();
+        auto& faces   = geometry.getFaces();
+        REQUIRE( !geometry.hasFaces() );
+
+        faces.resize( 1 );
+        faces[0]  = Ra::Core::VectorNui().setRandom();
+        auto save = faces[0];
+        geometry.indexedDataUnlock( GeometryData::GeometryType::POLY_MESH, "in_face" );
+        REQUIRE( geometry.hasFaces() );
+
+        const auto& data = geometry.getIndexedData<Ra::Core::VectorNui>(
+            GeometryData::GeometryType::POLY_MESH, "in_face" );
+        REQUIRE( save == data[0] );
+
+        auto geometry2 = GeometryData();
+        geometry2.setFaces( faces );
+        // geometry2.setIndexedData(GeometryData::GeometryType::POLY_MESH, faces, "in_face");
+        REQUIRE( geometry2.getFaces().size() == 1 );
+        REQUIRE( geometry.getFaces()[0] == save );
+    }
+
+    SECTION( "Polyhedron test " ) {
+        auto geometry     = GeometryData();
+        auto& polyhedrons = geometry.getPolyhedra();
+        REQUIRE( !geometry.hasPolyhedra() );
+
+        polyhedrons.resize( 1 );
+        polyhedrons[0] = Ra::Core::VectorNui().setRandom();
+        auto save      = polyhedrons[0];
+        geometry.indexedDataUnlock( GeometryData::GeometryType::POLY_MESH, "in_polyhedron" );
+        REQUIRE( geometry.hasPolyhedra() );
+
+        const auto& data = geometry.getIndexedData<Ra::Core::VectorNui>(
+            GeometryData::GeometryType::POLY_MESH, "in_polyhedron" );
+        REQUIRE( save == data[0] );
+
+        auto geometry2 = GeometryData();
+        geometry2.setPolyhedra( polyhedrons );
+        // geometry2.setIndexedData(GeometryData::GeometryType::POLY_MESH, polyhedrons,
+        // "in_polyhedron");
+        REQUIRE( geometry2.getPolyhedra().size() == 1 );
+        REQUIRE( geometry.getPolyhedra()[0] == save );
+    }
+
+    SECTION( "Type test " ) {
+        auto geometry = GeometryData();
+
+        geometry.setType( GeometryData::GeometryType::LINE_MESH );
+        REQUIRE( geometry.isLineMesh() );
+
+        geometry.setType( GeometryData::GeometryType::TRI_MESH );
+        REQUIRE( geometry.isTriMesh() );
+
+        geometry.setType( GeometryData::GeometryType::QUAD_MESH );
+        REQUIRE( geometry.isQuadMesh() );
+
+        geometry.setType( GeometryData::GeometryType::POLY_MESH );
+        REQUIRE( geometry.isPolyMesh() );
+
+        geometry.setType( GeometryData::GeometryType::HEX_MESH );
+        REQUIRE( geometry.isHexMesh() );
+
+        geometry.setType( GeometryData::GeometryType::TETRA_MESH );
+        REQUIRE( geometry.isTetraMesh() );
+
+        geometry.setType( GeometryData::GeometryType::POINT_CLOUD );
+        REQUIRE( geometry.isPointCloud() );
+
+        geometry.setType( GeometryData::GeometryType::UNKNOWN );
+        REQUIRE( !geometry.isLineMesh() );
+        REQUIRE( !geometry.isTriMesh() );
+        REQUIRE( !geometry.isQuadMesh() );
+        REQUIRE( !geometry.isPolyMesh() );
+        REQUIRE( !geometry.isHexMesh() );
+        REQUIRE( !geometry.isTetraMesh() );
+        REQUIRE( !geometry.isPointCloud() );
+    }
+}

--- a/tests/unittest/Core/geometryData.cpp
+++ b/tests/unittest/Core/geometryData.cpp
@@ -9,7 +9,7 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
     SECTION( "Normal test" ) {
         auto geometry = new GeometryData();
         auto& normal  = geometry->getNormals();
-        REQUIRE( !geometry->hasNormals() );
+        REQUIRE( normal.empty() );
         REQUIRE(
             geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_NORMAL )->isLocked() );
 
@@ -17,7 +17,7 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
         normal[0] = Ra::Core::Vector3().setRandom();
         auto save = normal[0];
         geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_NORMAL )->unlock();
-        REQUIRE( geometry->hasNormals() );
+        REQUIRE( !normal.empty() );
 
         auto& name        = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_NORMAL );
         auto attriHandler = geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( name );
@@ -36,7 +36,7 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
     SECTION( "Vertices test" ) {
         auto geometry = new GeometryData();
         auto& vertex  = geometry->getVertices();
-        REQUIRE( !geometry->hasVertices() );
+        REQUIRE( vertex.empty() );
         REQUIRE(
             geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_POSITION )->isLocked() );
 
@@ -44,7 +44,7 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
         vertex[0] = Ra::Core::Vector3().setRandom();
         auto save = vertex[0];
         geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_POSITION )->unlock();
-        REQUIRE( geometry->hasVertices() );
+        REQUIRE( !vertex.empty() );
 
         auto& name        = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_POSITION );
         auto attriHandler = geometry->getAttribManager().findAttrib<Ra::Core::Vector3>( name );
@@ -65,7 +65,7 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
 
         // Tangent test
         auto& tangents = geometry->getTangents();
-        REQUIRE( !geometry->hasTangents() );
+        REQUIRE( tangents.empty() );
         REQUIRE(
             geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT )->isLocked() );
 
@@ -73,7 +73,7 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
         tangents[0]  = Ra::Core::Vector3().setRandom();
         auto saveTan = tangents[0];
         geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TANGENT )->unlock();
-        REQUIRE( geometry->hasTangents() );
+        REQUIRE( !tangents.empty() );
 
         auto& nameTan = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_TANGENT );
         auto attribHandlerTan =
@@ -91,7 +91,7 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
 
         // BiTangent test
         auto& biTangents = geometry->getBiTangents();
-        REQUIRE( !geometry->hasBiTangents() );
+        REQUIRE( biTangents.empty() );
         REQUIRE( geometry->getAttribManager()
                      .getAttribBase( MeshAttrib::VERTEX_BITANGENT )
                      ->isLocked() );
@@ -100,7 +100,7 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
         biTangents[0]  = Ra::Core::Vector3().setRandom();
         auto saveBiTan = biTangents[0];
         geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_BITANGENT )->unlock();
-        REQUIRE( geometry->hasBiTangents() );
+        REQUIRE( !biTangents.empty() );
 
         auto& nameBiTan = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_BITANGENT );
         auto attribHandlerBiTan =
@@ -119,7 +119,7 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
 
         // TexCoords test
         auto& texCoords = geometry->getTexCoords();
-        REQUIRE( !geometry->hasTextureCoordinates() );
+        REQUIRE( texCoords.empty() );
         REQUIRE(
             geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TEXCOORD )->isLocked() );
 
@@ -127,7 +127,7 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
         texCoords[0]       = Ra::Core::Vector3().setRandom();
         auto saveTexCoords = texCoords[0];
         geometry->getAttribManager().getAttribBase( MeshAttrib::VERTEX_TEXCOORD )->unlock();
-        REQUIRE( geometry->hasTextureCoordinates() );
+        REQUIRE( !texCoords.empty() );
 
         auto& nameTexCoords = Ra::Core::Geometry::getAttribName( MeshAttrib::VERTEX_TEXCOORD );
         auto attribHandlerTexCoords =
@@ -166,13 +166,13 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
     SECTION( "Edges test " ) {
         auto geometry = GeometryData();
         auto& edges   = geometry.getEdges();
-        REQUIRE( !geometry.hasEdges() );
+        REQUIRE( edges.empty() );
 
         edges.resize( 1 );
         edges[0]  = Ra::Core::Vector2ui().setRandom();
         auto save = edges[0];
         geometry.indexedDataUnlock( GeometryData::GeometryType::LINE_MESH, "in_edge" );
-        REQUIRE( geometry.hasEdges() );
+        REQUIRE( !edges.empty() );
 
         const auto& data = geometry.getIndexedData<Ra::Core::Vector2ui>( "in_edge" );
         REQUIRE( save == data[0] );
@@ -187,13 +187,13 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
     SECTION( "Faces test " ) {
         auto geometry = GeometryData();
         auto& faces   = geometry.getFaces();
-        REQUIRE( !geometry.hasFaces() );
+        REQUIRE( faces.empty() );
 
         faces.resize( 1 );
         faces[0]  = Ra::Core::VectorNui().setRandom();
         auto save = faces[0];
         geometry.indexedDataUnlock( GeometryData::GeometryType::POLY_MESH, "in_face" );
-        REQUIRE( geometry.hasFaces() );
+        REQUIRE( !faces.empty() );
 
         const auto& data = geometry.getIndexedData<Ra::Core::VectorNui>( "in_face" );
         REQUIRE( save == data[0] );
@@ -208,13 +208,13 @@ TEST_CASE( "Core/Asset/GeometryData", "[Core][Core/Asset][GeometryData]" ) {
     SECTION( "Polyhedron test " ) {
         auto geometry     = GeometryData();
         auto& polyhedrons = geometry.getPolyhedra();
-        REQUIRE( !geometry.hasPolyhedra() );
+        REQUIRE( polyhedrons.empty() );
 
         polyhedrons.resize( 1 );
         polyhedrons[0] = Ra::Core::VectorNui().setRandom();
         auto save      = polyhedrons[0];
         geometry.indexedDataUnlock( GeometryData::GeometryType::POLY_MESH, "in_polyhedron" );
-        REQUIRE( geometry.hasPolyhedra() );
+        REQUIRE( !polyhedrons.empty() );
 
         const auto& data = geometry.getIndexedData<Ra::Core::VectorNui>( "in_polyhedron" );
         REQUIRE( save == data[0] );

--- a/tests/unittest/Core/indexview.cpp
+++ b/tests/unittest/Core/indexview.cpp
@@ -42,7 +42,7 @@ TEST_CASE( "Core/Geometry/IndexedGeometry", "[Core][Core/Geometry][IndexedGeomet
         // optional: save semantics for later
         pilSemantics = pil->semantics();
         // insert with default name
-        bool layerAdded = geo.addLayer( std::move( pil ) );
+        bool layerAdded = geo.addLayer( std::move( pil ) ).first;
         //! [Creating and adding pointcloud layer]
         REQUIRE( layerAdded );
 
@@ -67,7 +67,7 @@ TEST_CASE( "Core/Geometry/IndexedGeometry", "[Core][Core/Geometry][IndexedGeomet
     REQUIRE( !geo.containsLayer( cilSemantics ) );
     REQUIRE( geo.countLayers( cilSemantics ) == 0 );
 
-    REQUIRE( geo.addLayer( std::move( cil ) ) );
+    REQUIRE( geo.addLayer( std::move( cil ) ).first );
     keys.insert( { cilSemantics, "" } );
 
     REQUIRE( geo.containsLayer( cilSemantics ) );


### PR DESCRIPTION
_Check if you branch history is PR compatible_
- Your branch need to be up to date with origin/master AND to have linear history (i.e. no merge commit).
- Update your git repository `git fetch origin` if origin is this remote
- Check with the script provided in `scripts/is-history-pr-compatible.sh`
- You must use clang-format style
_These checks are enforced by github workflow actions_
_Please refer to the corresponding log in case of failure_

_UPDATE the form below to describe your PR._

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Moving all depracated attributes (m_normal, m_tangent, m_bitangent, m_texCoord) and m_vertex to the attribManager of the multiIndexedLayer and m_edge, m_faces, m_polyhedron into layers.


* **What is the current behavior?** (You can also link to an open issue here)
File loaders use deprecated attributes to load data. 


* **What is the new behavior (if this is a feature change)?**
Now file loaders use an attribManager and layers to store this data instead of deprecated attributes, all tests passed. This will then allow to use this structure directly in the engine and avoid data duplication.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
There is no breaking change except unlock attrib an layer when user lock it to have write access on it.

 - Other information:
 Numerous functions were marked deprecated by this PR and their implementation were changed to correspond to the recommended alternative, sometime using some introduced helper functions (marked as such by a note in their documentation). 
 At the end of the deprecation process, all these functions (and the related helper function) will be removed from the source code.
