### PR TITLE
[headless] allow to access the optional window for event processing

### DIFF
--- a/src/Headless/CLIViewer.hpp
+++ b/src/Headless/CLIViewer.hpp
@@ -144,6 +144,15 @@ class HEADLESS_API CLIViewer : public CLIBaseApplication
                      OpenGLContext::EventMode mode = OpenGLContext::EventMode::POLL,
                      float delay                   = 1.f / 60.f );
 
+    /** \brief Gives access to the window to add event processing callbacks
+     *
+     * example :
+     * \code{.cpp}
+         idListener = getWindow().mouseListener.attach( mouseEventProcessingFunction );
+       \endcode
+      */
+    inline OpenGLContext& getWindow();
+
     /** If a window is shown, launch the interactive render loop */
     void renderLoop( std::function<void( float )> render );
 

--- a/src/Headless/CLIViewer.inl
+++ b/src/Headless/CLIViewer.inl
@@ -16,5 +16,9 @@ inline std::string CLIViewer::getDataFileName() const {
 inline void CLIViewer::setDataFileName( std::string filename ) {
     m_parameters.m_dataFile = std::move( filename );
 }
+
+inline OpenGLContext& CLIViewer::getWindow() {
+    return m_glContext;
+}
 } // namespace Headless
 } // namespace Ra

--- a/src/Headless/OpenGLContext/OpenGLContext.cpp
+++ b/src/Headless/OpenGLContext/OpenGLContext.cpp
@@ -73,10 +73,10 @@ OpenGLContext::OpenGLContext( const std::array<int, 2>& size ) {
             // see https://www.glfw.org/docs/latest/window_guide.html#window_scale
             float xscale, yscale;
             glfwGetWindowContentScale( window, &xscale, &yscale );
+            // seems that the scale is not to be taken into account
             double xpos, ypos;
             glfwGetCursorPos( window, &xpos, &ypos );
-            context->mouseEventCalback(
-                button, action, mods, int( xpos / xscale ), int( ypos / yscale ) );
+            context->mouseEventCalback( button, action, mods, int( xpos ), int( ypos ) );
         };
         glfwSetMouseButtonCallback( m_glfwContext, mouseCB );
 
@@ -84,7 +84,7 @@ OpenGLContext::OpenGLContext( const std::array<int, 2>& size ) {
             auto context = static_cast<OpenGLContext*>( glfwGetWindowUserPointer( window ) );
             float xscale, yscale;
             glfwGetWindowContentScale( window, &xscale, &yscale );
-            context->scrollEventCalback( int( xoffset / xscale ), int( yoffset / yscale ) );
+            context->scrollEventCalback( int( xoffset ), int( yoffset ) );
         };
         glfwSetScrollCallback( m_glfwContext, scrollCB );
     }

--- a/tests/ExampleApps/HeadlessDemo/main.cpp
+++ b/tests/ExampleApps/HeadlessDemo/main.cpp
@@ -61,6 +61,14 @@ int main( int argc, const char* argv[] ) {
 
     auto render = [&viewer]( float time_step ) { viewer.oneFrame( time_step ); };
 
+    //! [Attach a mouse event listener]
+    auto mouseListenerId = viewer.getWindow().mouseListener().attach(
+        []( int button, int action, int modifiers, int x, int y ) {
+            std::cout << "mouseEvent : button " << button << " // action " << action
+                      << " // modifiers " << modifiers << " // position " << x << ", " << y
+                      << std::endl;
+        } );
+    //! [Attach a mouse event listener]
     if ( showWindow ) {
         if ( viewerParameters.m_animationEnable ) {
             viewer.showWindow( true, OpenGLContext::EventMode::TIMEOUT );
@@ -90,6 +98,10 @@ int main( int argc, const char* argv[] ) {
         }
     }
     //! [Running the application]
+
+    //! [Detach mouse event listener]
+    viewer.getWindow().mouseListener().detach( mouseListenerId );
+    //! [Detach mouse event listener]
 
     //! [Unbind the OpenGLContext when no more needed]
     viewer.bindOpenGLContext( false );


### PR DESCRIPTION
Closes #938 
When using CLIViewer as a window on a non-Qt platform, there is no way to add event processing callback to develop interactive application.
This PR proposes a quick fix and will serve to fully test the event management capabilities on CLIViewer before being merged.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR allows applications using headless CLIViewer to add event processing callbacks on the optionally given window


* **What is the current behavior?** (You can also link to an open issue here)

Callback attachment to the window are available but the window is private and non accessible outside the viewer.

* **What is the new behavior (if this is a feature change)?**

The window could be accessed by reference

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
