### PR TITLE
[engine] let ShaderProgram manager control default glsl version.

### DIFF
--- a/src/Engine/Data/ShaderProgram.cpp
+++ b/src/Engine/Data/ShaderProgram.cpp
@@ -147,14 +147,22 @@ void ShaderProgram::loadShader( ShaderType type,
         } );
 
     std::unique_ptr<globjects::StaticStringSource> fullsource { nullptr };
+    std::string source;
     if ( fromFile ) {
         auto loadedSource = globjects::Shader::sourceFromFile( name );
-        fullsource = globjects::Shader::sourceFromString( shaderHeader + loadedSource->string() );
+        source            = loadedSource->string();
     }
     else {
-        fullsource = globjects::Shader::sourceFromString( shaderHeader + name );
+        source = name;
     }
-
+    std::string versionPrefix { "#version" };
+    // skip header if #version is set in shader source
+    if ( source.substr( 0, versionPrefix.size() ) == versionPrefix ) {
+        fullsource = globjects::Shader::sourceFromString( source );
+    }
+    else {
+        fullsource = globjects::Shader::sourceFromString( shaderHeader + source );
+    }
     // Radium V2 : allow to define global replacement per renderer, shader, rendertechnique ...
     auto shaderSource = globjects::Shader::applyGlobalReplacements( fullsource.get() );
 

--- a/src/Engine/Data/ShaderProgramManager.cpp
+++ b/src/Engine/Data/ShaderProgramManager.cpp
@@ -55,10 +55,13 @@ void ShaderProgramManager::reloadNamedString() {
 }
 
 Core::Utils::optional<const Data::ShaderProgram*>
-ShaderProgramManager::addShaderProgram( const Data::ShaderConfiguration& config ) {
+ShaderProgramManager::addShaderProgram( Data::ShaderConfiguration config ) {
     auto found = m_shaderPrograms.find( config );
 
     if ( found != m_shaderPrograms.end() ) { return found->second.get(); }
+
+    // set glsl version if not set in config
+    if ( config.getVersion().empty() ) config.setVersion( getDefaultVersion() );
 
     // add named strings
     for ( const auto& p : config.getNamedStrings() ) {

--- a/src/Engine/Data/ShaderProgramManager.hpp
+++ b/src/Engine/Data/ShaderProgramManager.hpp
@@ -49,13 +49,14 @@ class RA_ENGINE_API ShaderProgramManager final
      * The shader sources corresponding to the configuration will be compiled, linked and verified.
      *
      *
-     * @param config the configuration of the programm to add to the collection
+     * @param config the configuration of the programm to add to the collection. If no version is
+     * set in config, getDefaultVersion() is used as version.
      * @return the created shader program. In case of compile/link/verify error, return false
      * @note ownership on the returned pointer is keep by the manager.
      * @warning this method is *not* reentrant
      */
     Core::Utils::optional<const Data::ShaderProgram*>
-    addShaderProgram( const Data::ShaderConfiguration& config );
+    addShaderProgram( Data::ShaderConfiguration config );
 
     /**
      * Get the shader programm corresponding to the given id
@@ -100,6 +101,11 @@ class RA_ENGINE_API ShaderProgramManager final
      */
     void reloadNamedString();
 
+    const std::string& getDefaultVersion() const { return m_defaultVersion; }
+    void setDefaultVersion( const std::string& defaultVersion ) {
+        m_defaultVersion = defaultVersion;
+    }
+
   private:
     void insertShader( const Data::ShaderConfiguration& config,
                        const std::shared_ptr<Data::ShaderProgram>& shader );
@@ -112,6 +118,8 @@ class RA_ENGINE_API ShaderProgramManager final
     std::map<std::string,
              std::pair<std::unique_ptr<globjects::File>, std::unique_ptr<globjects::NamedString>>>
         m_namedStrings;
+
+    std::string m_defaultVersion { "#version 440" };
 };
 
 } // namespace Data

--- a/src/Engine/RadiumEngine.cpp
+++ b/src/Engine/RadiumEngine.cpp
@@ -54,6 +54,7 @@ void RadiumEngine::initialize() {
     m_renderObjectManager  = std::make_unique<Rendering::RenderObjectManager>();
     m_textureManager       = std::make_unique<Data::TextureManager>();
     m_shaderProgramManager = std::make_unique<Data::ShaderProgramManager>();
+    m_shaderProgramManager->setDefaultVersion( "#version 440" );
 
     m_loadedFile.reset();
     Scene::ComponentMessenger::createInstance();


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature: let control the default glsl "#version" string.


* **What is the current behavior?** (You can also link to an open issue here)
"#version 410" along with some struct def is injected automatically in all shader. Version verison can be controlled by shader configuration.


* **What is the new behavior (if this is a feature change)?**
Let the user specify the default version. Do not inject version nor default struct if the shader code already starts with "#version"
Also switch to a default version coherent with opengl context version.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Maybe depending on user shader code.

* **Other information**:

- [ ] maybe specify version as major, minor, and generate the string according to OpenGL doc https://www.khronos.org/opengl/wiki/Core_Language_(GLSL)
- [ ] Check version compatibility with OpenGL context (maybe in another PR)
- [ ] Discuss if we need to insert version/default struct in shaders
- [ ]  use glslangValidator during CI ? but include directive are badly supported
