### PR TITLE
Fix external compile

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -209,6 +209,11 @@ jobs:
         run: |
           cd build/Radium-Engine
           cmake --build . --parallel --config ${{ matrix.build-type }} --target check
+      - name: Run CoreExampleApp as a build and install test
+        if: runner.os != 'Windows'
+        run: |
+          ./build/Radium-Engine/tests/ExampleApps/CoreExampleApp/CoreExampleApp
+          ./install/bin/CoreExampleApp
       - name: Extract ref for badges prefix
         if: always()
         shell: bash

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -192,7 +192,7 @@ jobs:
           mkdir -p external/install/
           mkdir -p external/build/
           cd external/build/
-          cmake ../../src/Radium-Engine/external  -GNinja -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} -DCMAKE_C_COMPILER=${{ matrix.config.cc }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=STDOUT -DRADIUM_UPDATE_VERSION=OFF -DRADIUM_EXTERNAL_CMAKE_INSTALL_MESSAGE=LAZY -DCMAKE_INSTALL_PREFIX=../install/
+          cmake ../../src/Radium-Engine/external  -GNinja -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} -DCMAKE_C_COMPILER=${{ matrix.config.cc }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=STDOUT -DRADIUM_UPDATE_VERSION=OFF -DCMAKE_INSTALL_MESSAGE=LAZY -DCMAKE_INSTALL_PREFIX=../install/
           cmake --build . --parallel --config ${{ matrix.build-type }}
       - name: Configure Radium
         run: |

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -7,12 +7,12 @@ TL;DR; (linux command line version)
 
 ```bash
 git clone --recurse-submodules https://github.com/STORM-IRIT/Radium-Engine.git
-cd Radium-Engine/external
-cmake -DCMAKE_BUILD_TYPE=Release -B build-r/ . -DCMAKE_INSTALL_PREFIX=`pwd`/install-r
-cmake --build build-r --parallel
+mkdir radium-external # outside Radium Source dir
+cmake Radium-Engine/external -DCMAKE_BUILD_TYPE=Release -B radium-external/build-r/ -DCMAKE_INSTALL_PREFIX=`pwd`/radium-external/install-r
+cmake --build radium-external/build-r --parallel
 
-cd .. # go back in Radium-Engine root dir
-cmake -DCMAKE_BUILD_TYPE=Release -B build-r/ -C external/install-r/radium-options.cmake
+cd Radium-Engine # go in Radium-Engine root dir
+cmake -DCMAKE_BUILD_TYPE=Release -B build-r/ -C ../radium-external/install-r/radium-options.cmake  # or wherever you install radium externals
 cmake --build build-r --parallel --target install
 
 ```

--- a/doc/basics/compilation.md
+++ b/doc/basics/compilation.md
@@ -44,10 +44,10 @@ By default, `${CMAKE_INSTALL_PREFIX}` is set as follow:
     set(RADIUM_BUNDLE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Bundle-${CMAKE_CXX_COMPILER_ID}-${CMAKE_BUILD_TYPE})
 ~~~
 
-It has the following structure, if externals are compiled along Radium
+It has the following structure
 ~~~
 Bundle-*
- - bin/  include/  lib/  LICENSE  README.md  Resources/  share/
+ - bin/  include/  lib/  LICENSE  README.md  Resources/
 ~~~
 
 ### Configure build options
@@ -188,7 +188,7 @@ To fix it, edit `CMakeSettings.json`, such that
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "C:/Users/XXX/Dev/builds/Radium/${name}",
       "installRoot": "C:/Users/XXX/Dev/Radium-install",
-      "cmakeCommandArgs": "-C external/install-r/radium-options.cmake -DCMAKE_PREFIX_PATH=C:/Qt-5.15/5.15.0/msvc2017_64",
+      "cmakeCommandArgs": "-C external-install-dir/install-r/radium-options.cmake -DCMAKE_PREFIX_PATH=C:/Qt-5.15/5.15.0/msvc2017_64",
       "buildCommandArgs": "",
       "ctestCommandArgs": ""
     },
@@ -199,7 +199,7 @@ To fix it, edit `CMakeSettings.json`, such that
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "C:/Users/XXX/Dev/builds/Radium/${name}",
       "installRoot": "C:/Users/XXX/Dev/Radium-installdbg",
-      "cmakeCommandArgs": "-C external/install-r/radium-options.cmake -DCMAKE_PREFIX_PATH=C:/Qt-5.15/5.15.0/msvc2017_64",
+      "cmakeCommandArgs": "-C external-install-dir/install-r/radium-options.cmake -DCMAKE_PREFIX_PATH=C:/Qt-5.15/5.15.0/msvc2017_64",
       "buildCommandArgs": "",
       "ctestCommandArgs": ""
     }

--- a/doc/basics/dependencies.md
+++ b/doc/basics/dependencies.md
@@ -15,7 +15,7 @@ https://doc.qt.io/qt-5.15/cmake-manual.html#getting-started).
 
 # Dependencies management systems
 
-We offer three different systems to handle external dependencies (see details and how-to in the following sections):
+We offer two different systems to handle external dependencies (see details and how-to in the following sections):
  1. **[recommended]** external build: the user compiles and installs once for all the dependencies using a dedicated
     cmake project. Then, Radium cmake project is configured to link with installed dependencies.
  2. manual management: users can also provide their own version of the dependencies through cmake packages.
@@ -27,13 +27,14 @@ We offer three different systems to handle external dependencies (see details an
 We provide a standalone cmake project (`external/CMakeLists.txt`) to compile and install the Radium dependencies at any location.
 
 ## Configuration and compilation of the dependencies
-You can use the compile script `external/build.sh` which configure and builds external for Debug and Release, in directories `install-d` and `install-r`.
-This script actually do the following to configure and build the cmake project:
+External dependencies have to be installed outside Radium-Engine source tree (for mysterious reason).
+
 ~~~{.bash}
-cmake -DCMAKE_BUILD_TYPE=Release -B build-r/ . -DCMAKE_INSTALL_PREFIX=`pwd`/install-r
+# from wherever you want outside radium source tree
+cmake Radium-Source-Tree/external -DCMAKE_BUILD_TYPE=Release -B build-r/ -DCMAKE_INSTALL_PREFIX=`pwd`/install-r
 cmake --build build-r --parallel
 
-cmake -DCMAKE_BUILD_TYPE=Debug -B build-d/ . -DCMAKE_INSTALL_PREFIX=`pwd`/install-d
+cmake cmake Radium-Source-Tree/external -DCMAKE_BUILD_TYPE=Debug -B build-d/ -DCMAKE_INSTALL_PREFIX=`pwd`/install-d
 cmake --build build-d --parallel
 ~~~
 

--- a/doc/basics/dependencies.md
+++ b/doc/basics/dependencies.md
@@ -27,7 +27,7 @@ We offer two different systems to handle external dependencies (see details and 
 We provide a standalone cmake project (`external/CMakeLists.txt`) to compile and install the Radium dependencies at any location.
 
 ## Configuration and compilation of the dependencies
-External dependencies have to be installed outside Radium-Engine source tree (for mysterious reason).
+External dependencies have to be installed outside Radium-Engine source tree.
 
 ~~~{.bash}
 # from wherever you want outside radium source tree

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -12,6 +12,9 @@ if(NOT CMAKE_PROJECT_NAME STREQUAL ${RADIUM_DEPENDENCIES_PROJECT_NAME})
   ${CMAKE_PROJECT_NAME} !)"
     )
 else()
+    set(CMAKE_DISABLE_SOURCE_CHANGES ON)
+    set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
+
     # We can use include() and find_package() for our scripts in there
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)
 
@@ -62,6 +65,22 @@ else()
     if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
         set(CMAKE_INSTALL_PREFIX "${RADIUM_EXTERNAL_INSTALL}"
             CACHE PATH "Install path prefix, prepended onto install directories." FORCE
+        )
+    endif()
+
+    # Ensure that external dependencies built as standalone are not installed in a subdir of Radium
+    # source tree
+
+    get_filename_component(CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} ABSOLUTE)
+    string(LENGTH ${CMAKE_SOURCE_DIR} SourceDirLength)
+    string(LENGTH "external/" ExternalDirLength)
+    math(EXPR RadiumPrefixLength " ${SourceDirLength} - ${ExternalDirLength}")
+    string(SUBSTRING ${CMAKE_SOURCE_DIR} 0 ${RadiumPrefixLength} RadiumPREFIX)
+    string(FIND ${CMAKE_INSTALL_PREFIX} ${RadiumPREFIX} IsPrefix)
+    if(${IsPrefix} GREATER -1)
+        message(
+            FATAL_ERROR
+                "Externals can't be installed into a subdirectory of Radium source tree: ${CMAKE_INSTALL_PREFIX}  -- ${RadiumPREFIX}"
         )
     endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,15 +70,17 @@ configure_radium_package(
 )
 
 # install general scripts
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/RadiumSetupFunctions.cmake"
-              "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/QtFunctions.cmake"
-        DESTINATION ${ConfigPackageLocation}
+install(
+    FILES "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/RadiumSetupFunctions.cmake"
+          "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/QtFunctions.cmake"
+          "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/RPath.cmake" DESTINATION ${ConfigPackageLocation}
 )
 
 # copy scripts in the buildtree to be available when searching package in the buildtree
-file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/RadiumSetupFunctions.cmake"
-          "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/QtFunctions.cmake"
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+file(
+    COPY "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/RadiumSetupFunctions.cmake"
+         "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/QtFunctions.cmake"
+         "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/RPath.cmake" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 if(MSVC OR MSVC_IDE OR MINGW)

--- a/src/Config.cmake.in
+++ b/src/Config.cmake.in
@@ -8,22 +8,8 @@ add_custom_target(
 )
 
 # --------------------------------------------------------------------------------------------------
-# use, i.e. don't skip the full RPATH for the build tree
-set(CMAKE_SKIP_BUILD_RPATH FALSE)
-# when building, don't use the install RPATH already (but later on when installing)
-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-# add the automatically determined parts of the RPATH which point to directories outside the build
-# tree to the install RPATH
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-# the RPATH to be used when installing, but only if it's not a system directory
-list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-if("${isSystemDir}" STREQUAL "-1")
-    if(APPLE)
-        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;@executable_path/../lib")
-    else()
-        set(CMAKE_INSTALL_RPATH "\$ORIGIN:\$ORIGIN/../lib")
-    endif()
-endif("${isSystemDir}" STREQUAL "-1")
+# Load Radium rpath configuration
+include(${CMAKE_CURRENT_LIST_DIR}/RPath.cmake)
 
 # --------------------------------------------------------------------------------------------------
 # Configure components

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,10 @@ add_subdirectory(unittest)
 # etc.
 add_subdirectory(integration)
 
+add_test(NAME integration_CoreExampleApp WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+         COMMAND "$<TARGET_FILE:CoreExampleApp>"
+)
+
 # example apps are simple complete application, no test for now. TODO : we can imagine to capture
 # screen output and compare to refs
 add_subdirectory(ExampleApps)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -98,7 +98,6 @@ if(LIBXML2_XMLLINT_EXECUTABLE AND SED_EXECUTABLE)
         NAME integration_${INTEGRATION_TEST}_compare_to_ref
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${INTEGRATION_TEST}/
         COMMAND
-        COMMAND
             ${CMAKE_COMMAND} -E compare_files
             ${CMAKE_CURRENT_BINARY_DIR}/keymapping-valid-out-lint.xml
             ${CMAKE_CURRENT_BINARY_DIR}/keymapping-valid-in-lint.xml


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x]  Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Doc fix. PR #935 states that external can be built in a subdir of radium source tree, but it fails when installing (something related to rpath ?)
This PR revert the doc to state that the external dep have to be built outside source tree.

It also add an integration test (which actually pass even if external are installed in radium source tree, because it runs in radium build tree)
Add a CI test to try to run CoreExampleApps from build and install dirs.

