### PR TITLE
[github] trigger coverage without waiting other builds

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -23,7 +23,6 @@ jobs:
     with:
       build-debug: "false"
   call-coverage:
-    needs: [call-build]
     uses: ./.github/workflows/build-matrix.yml
     with:
       windows: "false"

--- a/.github/workflows/push-master-ci.yml
+++ b/.github/workflows/push-master-ci.yml
@@ -30,7 +30,7 @@ jobs:
     secrets:
       REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
   call-coverage:
-    needs: [call-build]
+    needs: [increase-version-number]
     uses: ./.github/workflows/build-matrix.yml
     with:
       windows: "false"

--- a/.github/workflows/push-rc-ci.yml
+++ b/.github/workflows/push-rc-ci.yml
@@ -30,7 +30,7 @@ jobs:
     secrets:
       REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
   call-coverage:
-    needs: [call-build]
+    needs: [increase-version-number]
     uses: ./.github/workflows/build-matrix.yml
     with:
       windows: "false"


### PR DESCRIPTION
Even if CI coverage is meaningfull only if CI builds succeded, process them in parallel can save some time.

This PR remove coverage needs of call_build 
