### PR TITLE
Set default GLSL version for shaders according to detected OpenGL context

### DIFF
--- a/src/Engine/Data/ShaderConfiguration.cpp
+++ b/src/Engine/Data/ShaderConfiguration.cpp
@@ -7,11 +7,11 @@
  */
 static const std::string defaultVertexShader {
     Ra::Core::Resources::getRadiumResourcesPath().value_or(
-        "[[Default resrouces path not found]]" ) +
+        "[[Default resources path not found]]" ) +
     "Shaders/Materials/Plain/Plain.vert.glsl" };
 static const std::string defaultFragmentShader {
     Ra::Core::Resources::getRadiumResourcesPath().value_or(
-        "[[Default resrouces path not found]]" ) +
+        "[[Default resources path not found]]" ) +
     "Shaders/Materials/Plain/Plain.frag.glsl" };
 
 namespace Ra {
@@ -44,12 +44,12 @@ ShaderConfiguration ShaderConfiguration::m_defaultShaderConfig( "Default Program
                                                                 defaultFragmentShader );
 
 ShaderConfiguration::ShaderConfiguration( const std::string& name ) :
-    m_name { name }, m_version { "#version 410" } {}
+    m_name { name }, m_version { "#version " + s_glslVersion } {}
 
 ShaderConfiguration::ShaderConfiguration( const std::string& name,
                                           const std::string& vertexShader,
                                           const std::string& fragmentShader ) :
-    m_name { name }, m_version { "#version 410" } {
+    m_name { name }, m_version { "#version " + s_glslVersion } {
     m_shaders[ShaderType_VERTEX]   = { vertexShader, true };
     m_shaders[ShaderType_FRAGMENT] = { fragmentShader, true };
 }
@@ -158,6 +158,32 @@ const std::vector<std::pair<std::string, ShaderType>>& ShaderConfiguration::getI
 const std::vector<std::pair<std::string, std::string>>&
 ShaderConfiguration::getNamedStrings() const {
     return m_named_strings;
+}
+
+std::string ShaderConfiguration::s_glslVersion { "410" };
+
+void ShaderConfiguration::setOpenGLVersion( const std::string& version ) {
+    std::map<std::string, std::string> openGLToGLSL { { "2.0", "110" },
+                                                      { "2.1", "120" },
+                                                      { "3.0", "130" },
+                                                      { "3.1", "140" },
+                                                      { "3.2", "150" },
+                                                      { "3.3", "330" },
+                                                      { "4.0", "400" },
+                                                      { "4.1", "410" },
+                                                      { "4.2", "420" },
+                                                      { "4.3", "430" },
+                                                      { "4.4", "440" },
+                                                      { "4.5", "450" },
+                                                      { "4.6", "460" } };
+    auto it = openGLToGLSL.find( version );
+    if ( it != openGLToGLSL.end() ) { s_glslVersion = it->second; }
+    else {
+        s_glslVersion = "410";
+    }
+}
+std::string ShaderConfiguration::getGLSLVersion() {
+    return s_glslVersion;
 }
 
 } // namespace Data

--- a/src/Engine/Data/ShaderConfiguration.hpp
+++ b/src/Engine/Data/ShaderConfiguration.hpp
@@ -150,6 +150,12 @@ class RA_ENGINE_API ShaderConfiguration final
     std::vector<std::pair<std::string, std::string>> m_named_strings;
 
     static ShaderConfiguration m_defaultShaderConfig;
+
+    static std::string s_glslVersion;
+
+  public:
+    static void setOpenGLVersion( const std::string& version );
+    static std::string getGLSLVersion();
 };
 
 } // namespace Data

--- a/src/Engine/Data/ShaderProgram.hpp
+++ b/src/Engine/Data/ShaderProgram.hpp
@@ -80,7 +80,8 @@ class RA_ENGINE_API ShaderProgram final
                      const std::set<std::string>& props,
                      const std::vector<std::pair<std::string, Data::ShaderType>>& includes,
                      bool fromFile              = true,
-                     const std::string& version = "#version 410" );
+                     const std::string& version = "#version " +
+                                                  ShaderConfiguration::getGLSLVersion() );
 
     std::string preprocessIncludes( const std::string& name,
                                     const std::string& shader,

--- a/src/Engine/RadiumEngine.cpp
+++ b/src/Engine/RadiumEngine.cpp
@@ -30,6 +30,14 @@
 #include <string>
 #include <thread>
 
+#include <glbinding-aux/ContextInfo.h>
+#include <glbinding-aux/debug.h>
+#include <glbinding-aux/types_to_string.h>
+#include <glbinding/Binding.h>
+#include <glbinding/Version.h>
+#include <glbinding/gl/gl.h>
+#include <glbinding/glbinding.h>
+
 namespace Ra {
 namespace Engine {
 
@@ -68,6 +76,10 @@ void RadiumEngine::initialize() {
 }
 
 void RadiumEngine::initializeGL() {
+    // get the OpenGL/GLSL version of the bounded context as default shader version
+    Data::ShaderConfiguration::setOpenGLVersion(
+        glbinding::aux::ContextInfo::version().toString() );
+
     m_openglState = std::make_unique<globjects::State>( globjects::State::DeferredMode );
     registerDefaultPrograms();
     // needed to upload non multiple of 4 width texture loaded with stbi.

--- a/src/Engine/RadiumEngine.cpp
+++ b/src/Engine/RadiumEngine.cpp
@@ -24,19 +24,11 @@
 #include <Engine/Scene/System.hpp>
 #include <Engine/Scene/SystemDisplay.hpp>
 
-#include <cstdio>
 #include <iostream>
-#include <streambuf>
 #include <string>
-#include <thread>
 
 #include <glbinding-aux/ContextInfo.h>
-#include <glbinding-aux/debug.h>
-#include <glbinding-aux/types_to_string.h>
-#include <glbinding/Binding.h>
 #include <glbinding/Version.h>
-#include <glbinding/gl/gl.h>
-#include <glbinding/glbinding.h>
 
 namespace Ra {
 namespace Engine {


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
instead of default `#version 410` added to all managed shaders, use the GLSL version corresponding to the OpenGL version of the context bound when initializing engine.


* **What is the current behavior?** (You can also link to an open issue here)
shader header default to `#version 410`


* **What is the new behavior (if this is a feature change)?**

shader header default to `#version context-dependant-version`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

NO


* **Other information**:

Need to be tested as some shader might not compile if GLSL version is less than 410
