### PR TITLE
Allow applications to set the opengl version according to their requirements

### DIFF
--- a/examples/HeadlessExample/main.cpp
+++ b/examples/HeadlessExample/main.cpp
@@ -17,7 +17,7 @@ using namespace Ra::Headless;
 int main( int argc, const char* argv[] ) {
     //! [Creating the viewer with custom parameters]
     bool showWindow { false };
-    std::string glVersion { "4.4" };
+    glbinding::Version glVersion { 4, 4 };
     CLIViewer viewer { glVersion };
     viewer.addFlag( "-w,--window", showWindow, "Map the viewer window." );
     //! [Creating the viewer with custom parameters]
@@ -29,8 +29,9 @@ int main( int argc, const char* argv[] ) {
 
     //! [Verifying the OpenGL version available to the engine]
     if ( glVersion != viewer.m_engine->getOpenGLVersion() ) {
-        std::cout << "OpenGL version mismatch : requested " << glVersion << " -- available "
-                  << viewer.m_engine->getOpenGLVersion() << std::endl;
+        std::cout << "OpenGL version mismatch : requested " << glVersion.toString()
+                  << " -- available " << viewer.m_engine->getOpenGLVersion().toString()
+                  << std::endl;
     }
     //! [Verifying the OpenGL version available to the engine]
 

--- a/examples/HeadlessExample/main.cpp
+++ b/examples/HeadlessExample/main.cpp
@@ -1,6 +1,7 @@
 #include <Headless/CLIViewer.hpp>
 #include <iostream>
 
+#include <Engine/RadiumEngine.hpp>
 #include <Engine/Rendering/ForwardRenderer.hpp>
 
 #include <Core/Resources/Resources.hpp>
@@ -16,7 +17,8 @@ using namespace Ra::Headless;
 int main( int argc, const char* argv[] ) {
     //! [Creating the viewer with custom parameters]
     bool showWindow { false };
-    CLIViewer viewer;
+    std::string glVersion { "4.4" };
+    CLIViewer viewer { glVersion };
     viewer.addFlag( "-w,--window", showWindow, "Map the viewer window." );
     //! [Creating the viewer with custom parameters]
 
@@ -24,6 +26,13 @@ int main( int argc, const char* argv[] ) {
     if ( int code = viewer.init( argc, argv ) ) { return code; }
     auto viewerParameters = viewer.getCommandLineParameters();
     //! [Configuring the viewer : initialize OpenGL and the Engine]
+
+    //! [Verifying the OpenGL version available to the engine]
+    if ( glVersion != viewer.m_engine->getOpenGLVersion() ) {
+        std::cout << "OpenGL version mismatch : requested " << glVersion << " -- available "
+                  << viewer.m_engine->getOpenGLVersion() << std::endl;
+    }
+    //! [Verifying the OpenGL version available to the engine]
 
     //! [Populating the viewer with needed services]
     viewer.setRenderer( new Ra::Engine::Rendering::ForwardRenderer() );

--- a/examples/HelloRadium/main.cpp
+++ b/examples/HelloRadium/main.cpp
@@ -13,9 +13,18 @@
 int main( int argc, char* argv[] ) {
     //! [Creating the application]
     Ra::Gui::BaseApplication app( argc, argv );
-    app.initialize( Ra::Gui::SimpleWindowFactory {} );
+    std::string glVersion { "4.4" };
+    app.initialize( Ra::Gui::SimpleWindowFactory {}, glVersion );
     app.addRadiumMenu();
     //! [Creating the application]
+
+    //! [Verifying the OpenGL version available to the engine]
+    if ( glVersion != app.m_engine->getOpenGLVersion() ) {
+        LOG( Ra::Core::Utils::logWARNING )
+            << "OpenGL version mismatch : requested " << glVersion << " -- available "
+            << app.m_engine->getOpenGLVersion() << std::endl;
+    }
+    //! [Verifying the OpenGL version available to the engine]
 
     //! [Creating the cube]
     auto cube = Ra::Core::Geometry::makeSharpBox( { 0.1f, 0.1f, 0.1f } );

--- a/examples/HelloRadium/main.cpp
+++ b/examples/HelloRadium/main.cpp
@@ -13,7 +13,7 @@
 int main( int argc, char* argv[] ) {
     //! [Creating the application]
     Ra::Gui::BaseApplication app( argc, argv );
-    std::string glVersion { "4.4" };
+    glbinding::Version glVersion { 4, 4 };
     app.initialize( Ra::Gui::SimpleWindowFactory {}, glVersion );
     app.addRadiumMenu();
     //! [Creating the application]
@@ -21,8 +21,8 @@ int main( int argc, char* argv[] ) {
     //! [Verifying the OpenGL version available to the engine]
     if ( glVersion != app.m_engine->getOpenGLVersion() ) {
         LOG( Ra::Core::Utils::logWARNING )
-            << "OpenGL version mismatch : requested " << glVersion << " -- available "
-            << app.m_engine->getOpenGLVersion() << std::endl;
+            << "OpenGL version mismatch : requested " << glVersion.toString() << " -- available "
+            << app.m_engine->getOpenGLVersion().toString() << std::endl;
     }
     //! [Verifying the OpenGL version available to the engine]
 

--- a/src/Engine/Data/ShaderConfiguration.cpp
+++ b/src/Engine/Data/ShaderConfiguration.cpp
@@ -1,6 +1,7 @@
 #include <Core/Resources/Resources.hpp>
 #include <Engine/Data/ShaderConfiguration.hpp>
 #include <Engine/Data/ShaderProgramManager.hpp>
+#include <glbinding/Version.h>
 
 /**
  * Plain will be the default shader program
@@ -162,7 +163,7 @@ ShaderConfiguration::getNamedStrings() const {
 
 std::string ShaderConfiguration::s_glslVersion { "410" };
 
-void ShaderConfiguration::setOpenGLVersion( const std::string& version ) {
+void ShaderConfiguration::setOpenGLVersion( const glbinding::Version& version ) {
     std::map<std::string, std::string> openGLToGLSL { { "2.0", "110" },
                                                       { "2.1", "120" },
                                                       { "3.0", "130" },
@@ -176,7 +177,7 @@ void ShaderConfiguration::setOpenGLVersion( const std::string& version ) {
                                                       { "4.4", "440" },
                                                       { "4.5", "450" },
                                                       { "4.6", "460" } };
-    auto it = openGLToGLSL.find( version );
+    auto it = openGLToGLSL.find( version.toString() );
     if ( it != openGLToGLSL.end() ) { s_glslVersion = it->second; }
     else {
         s_glslVersion = "410";

--- a/src/Engine/Data/ShaderConfiguration.hpp
+++ b/src/Engine/Data/ShaderConfiguration.hpp
@@ -156,9 +156,9 @@ class RA_ENGINE_API ShaderConfiguration final
   public:
     /**
      * \brief set the OpenGL version to use in the generated header for shaders.
-     * \param version
+     * \param glbinding::Version (e.g. {4,1})
      */
-    static void setOpenGLVersion( const std::string& version );
+    static void setOpenGLVersion( const glbinding::Version& version );
 
     /**
      * \brief get the OpenGL version used in the generated header for shaders.

--- a/src/Engine/Data/ShaderConfiguration.hpp
+++ b/src/Engine/Data/ShaderConfiguration.hpp
@@ -154,7 +154,16 @@ class RA_ENGINE_API ShaderConfiguration final
     static std::string s_glslVersion;
 
   public:
+    /**
+     * \brief set the OpenGL version to use in the generated header for shaders.
+     * \param version
+     */
     static void setOpenGLVersion( const std::string& version );
+
+    /**
+     * \brief get the OpenGL version used in the generated header for shaders.
+     * \return
+     */
     static std::string getGLSLVersion();
 };
 

--- a/src/Engine/RadiumEngine.cpp
+++ b/src/Engine/RadiumEngine.cpp
@@ -69,14 +69,18 @@ void RadiumEngine::initialize() {
 
 void RadiumEngine::initializeGL() {
     // get the OpenGL/GLSL version of the bounded context as default shader version
-    Data::ShaderConfiguration::setOpenGLVersion(
-        glbinding::aux::ContextInfo::version().toString() );
+    m_glVersion = glbinding::aux::ContextInfo::version().toString();
+    Data::ShaderConfiguration::setOpenGLVersion( m_glVersion );
 
     m_openglState = std::make_unique<globjects::State>( globjects::State::DeferredMode );
     registerDefaultPrograms();
     // needed to upload non multiple of 4 width texture loaded with stbi.
     m_openglState->pixelStore( GL_UNPACK_ALIGNMENT, 1 );
     m_openglState->apply();
+}
+
+std::string RadiumEngine::getOpenGLVersion() const {
+    return m_glVersion;
 }
 
 void RadiumEngine::registerDefaultPrograms() {

--- a/src/Engine/RadiumEngine.cpp
+++ b/src/Engine/RadiumEngine.cpp
@@ -69,7 +69,7 @@ void RadiumEngine::initialize() {
 
 void RadiumEngine::initializeGL() {
     // get the OpenGL/GLSL version of the bounded context as default shader version
-    m_glVersion = glbinding::aux::ContextInfo::version().toString();
+    m_glVersion = glbinding::aux::ContextInfo::version();
     Data::ShaderConfiguration::setOpenGLVersion( m_glVersion );
 
     m_openglState = std::make_unique<globjects::State>( globjects::State::DeferredMode );
@@ -79,7 +79,7 @@ void RadiumEngine::initializeGL() {
     m_openglState->apply();
 }
 
-std::string RadiumEngine::getOpenGLVersion() const {
+glbinding::Version RadiumEngine::getOpenGLVersion() const {
     return m_glVersion;
 }
 

--- a/src/Engine/RadiumEngine.hpp
+++ b/src/Engine/RadiumEngine.hpp
@@ -69,6 +69,13 @@ class RA_ENGINE_API RadiumEngine
     void initializeGL();
 
     /**
+     * \brief Get the currently used OpenGL version.
+     * \return the "Major.Minor" OpenGL version as a string.
+     * If openGL is not initialize, returns "Not initialized.",
+     */
+    std::string getOpenGLVersion() const;
+
+    /**
      * Free all resources acquired during initialize
      */
     void cleanup();
@@ -320,6 +327,8 @@ class RA_ENGINE_API RadiumEngine
     std::string getResourcesDir() { return m_resourcesRootDir; }
 
   private:
+    /// The OpenGL version used by the engine
+    std::string m_glVersion { "Not initialized." };
     /**
      * Register default shaders, materials and named strings
      */

--- a/src/Engine/RadiumEngine.hpp
+++ b/src/Engine/RadiumEngine.hpp
@@ -4,6 +4,7 @@
 #include <Core/Types.hpp>
 #include <Core/Utils/Singleton.hpp>
 
+#include <glbinding/Version.h>
 #include <map>
 #include <memory>
 #include <stack>
@@ -70,10 +71,10 @@ class RA_ENGINE_API RadiumEngine
 
     /**
      * \brief Get the currently used OpenGL version.
-     * \return the "Major.Minor" OpenGL version as a string.
-     * If openGL is not initialize, returns "Not initialized.",
+     * \return the initialized glbinding::Version
+     * If openGL is not initialize, version is not valid (e.g. Version.isValid() == false)
      */
-    std::string getOpenGLVersion() const;
+    glbinding::Version getOpenGLVersion() const;
 
     /**
      * Free all resources acquired during initialize
@@ -327,8 +328,8 @@ class RA_ENGINE_API RadiumEngine
     std::string getResourcesDir() { return m_resourcesRootDir; }
 
   private:
-    /// The OpenGL version used by the engine
-    std::string m_glVersion { "Not initialized." };
+    /// The OpenGL version used by the engine, can be read without Context active.
+    glbinding::Version m_glVersion {};
     /**
      * Register default shaders, materials and named strings
      */

--- a/src/Gui/BaseApplication.cpp
+++ b/src/Gui/BaseApplication.cpp
@@ -245,14 +245,11 @@ BaseApplication::BaseApplication( int& argc,
     Gui::KeyMappingManager::createInstance();
 }
 
-void BaseApplication::initialize( const WindowFactory& factory, const std::string& glVersion ) {
+void BaseApplication::initialize( const WindowFactory& factory,
+                                  const glbinding::Version& version ) {
     // Create default format for Qt.
-    std::istringstream in { glVersion };
-    int glMajor, glMinor;
-    char dot;
-    in >> glMajor >> dot >> glMinor;
     QSurfaceFormat format;
-    format.setVersion( glMajor, glMinor );
+    format.setVersion( version.majorVersion(), version.minorVersion() );
     format.setProfile( QSurfaceFormat::CoreProfile );
     format.setDepthBufferSize( 24 );
     format.setStencilBufferSize( 8 );

--- a/src/Gui/BaseApplication.cpp
+++ b/src/Gui/BaseApplication.cpp
@@ -245,10 +245,14 @@ BaseApplication::BaseApplication( int& argc,
     Gui::KeyMappingManager::createInstance();
 }
 
-void BaseApplication::initialize( const WindowFactory& factory ) {
+void BaseApplication::initialize( const WindowFactory& factory, const std::string& glVersion ) {
     // Create default format for Qt.
+    std::istringstream in { glVersion };
+    int glMajor, glMinor;
+    char dot;
+    in >> glMajor >> dot >> glMinor;
     QSurfaceFormat format;
-    format.setVersion( 4, 4 );
+    format.setVersion( glMajor, glMinor );
     format.setProfile( QSurfaceFormat::CoreProfile );
     format.setDepthBufferSize( 24 );
     format.setStencilBufferSize( 8 );

--- a/src/Gui/BaseApplication.hpp
+++ b/src/Gui/BaseApplication.hpp
@@ -80,6 +80,8 @@ class RA_GUI_API BaseApplication : public QApplication
      *     - loads the given scene, ...
      *
      * \param factory : a functor that instanciate the mainWindow
+     * \param glVersion : a string with "Major.Minor" definition of the requested OpenGL Version.
+     * If no version is given, the default recommended version for Radium (4.1) will be requested.
      * @note The initialize method call virtual methods on the object being initialized to
      * configure the engine and application services.
      * When redefining those methods, it is recommended to call the inherited one to have
@@ -89,7 +91,7 @@ class RA_GUI_API BaseApplication : public QApplication
      * \todo allow the user to ask for some "standard" systems to be added to the initialized
      * Engine.
      */
-    void initialize( const WindowFactory& factory );
+    void initialize( const WindowFactory& factory, const std::string& glVersion = "4.1" );
 
     /**
      * This method configure the base, non opengl dependant, scene services.

--- a/src/Gui/BaseApplication.hpp
+++ b/src/Gui/BaseApplication.hpp
@@ -10,6 +10,8 @@
 #include <Gui/TimerData/FrameTimerData.hpp>
 #include <PluginBase/RadiumPluginInterface.hpp>
 
+#include <glbinding/Version.h>
+
 class QTimer;
 class QCommandLineParser;
 namespace Ra {
@@ -80,7 +82,7 @@ class RA_GUI_API BaseApplication : public QApplication
      *     - loads the given scene, ...
      *
      * \param factory : a functor that instanciate the mainWindow
-     * \param glVersion : a string with "Major.Minor" definition of the requested OpenGL Version.
+     * \param glVersion : glbinding::Version of the requested OpenGL Version.
      * If no version is given, the default recommended version for Radium (4.1) will be requested.
      * @note The initialize method call virtual methods on the object being initialized to
      * configure the engine and application services.
@@ -91,7 +93,7 @@ class RA_GUI_API BaseApplication : public QApplication
      * \todo allow the user to ask for some "standard" systems to be added to the initialized
      * Engine.
      */
-    void initialize( const WindowFactory& factory, const std::string& glVersion = "4.1" );
+    void initialize( const WindowFactory& factory, const glbinding::Version& glVersion = { 4, 1 } );
 
     /**
      * This method configure the base, non opengl dependant, scene services.

--- a/src/Headless/CLIViewer.cpp
+++ b/src/Headless/CLIViewer.cpp
@@ -20,7 +20,8 @@ using namespace Ra::Core::Utils;
 
 constexpr int defaultSystemPriority = 1000;
 
-CLIViewer::CLIViewer() : CLIBaseApplication(), m_glContext {} {
+CLIViewer::CLIViewer( const std::string& glVersion ) :
+    CLIBaseApplication(), m_glContext { glVersion } {
     // add ->required() to force user to give a filename;
     addOption( "-f,--file", m_parameters.m_dataFile, "Data file to process." )
         ->check( CLI::ExistingFile );

--- a/src/Headless/CLIViewer.cpp
+++ b/src/Headless/CLIViewer.cpp
@@ -20,7 +20,7 @@ using namespace Ra::Core::Utils;
 
 constexpr int defaultSystemPriority = 1000;
 
-CLIViewer::CLIViewer( const std::string& glVersion ) :
+CLIViewer::CLIViewer( const glbinding::Version& glVersion ) :
     CLIBaseApplication(), m_glContext { glVersion } {
     // add ->required() to force user to give a filename;
     addOption( "-f,--file", m_parameters.m_dataFile, "Data file to process." )

--- a/src/Headless/CLIViewer.hpp
+++ b/src/Headless/CLIViewer.hpp
@@ -6,6 +6,8 @@
 
 #include <functional>
 
+#include <glbinding/Version.h>
+
 namespace Ra {
 namespace Core {
 namespace Asset {
@@ -74,7 +76,7 @@ class HEADLESS_API CLIViewer : public CLIBaseApplication
      * \brief Construct the viewer using an OpenGL context of the given version
      * \param glVersion
      */
-    explicit CLIViewer( const std::string& glVersion = "4.1" );
+    explicit CLIViewer( const glbinding::Version& glVersion = { 4, 1 } );
     /// Base destructor
     virtual ~CLIViewer();
 

--- a/src/Headless/CLIViewer.hpp
+++ b/src/Headless/CLIViewer.hpp
@@ -43,11 +43,17 @@ class HEADLESS_API CLIViewer : public CLIBaseApplication
         std::string m_dataFile = { "" };
     };
 
+  public:
+    /// Instance of the radium engine.
+    std::unique_ptr<Ra::Engine::RadiumEngine> m_engine;
+
+    /// To have the same API to access Engine than in Qt based application.
+    const Engine::RadiumEngine* getEngine() const { return m_engine.get(); }
+
   private:
     /// Headless OpenGLContext
     OpenGLContext m_glContext;
-    /// Instance of the radium engine.
-    std::unique_ptr<Ra::Engine::RadiumEngine> m_engine;
+
     /// Shared instance of the renderer
     std::shared_ptr<Ra::Engine::Rendering::Renderer> m_renderer;
 
@@ -64,8 +70,11 @@ class HEADLESS_API CLIViewer : public CLIBaseApplication
     bool m_exposedWindow { false };
 
   public:
-    /// Base constructor.
-    CLIViewer();
+    /**
+     * \brief Construct the viewer using an OpenGL context of the given version
+     * \param glVersion
+     */
+    explicit CLIViewer( const std::string& glVersion = "4.1" );
     /// Base destructor
     virtual ~CLIViewer();
 

--- a/src/Headless/OpenGLContext/OpenGLContext.cpp
+++ b/src/Headless/OpenGLContext/OpenGLContext.cpp
@@ -26,27 +26,41 @@ using namespace gl;
 using namespace glbinding;
 
 static void error( int errnum, const char* errmsg ) {
-    globjects::critical() << errnum << ": " << errmsg << std::endl;
+    std::cerr << "OpenGLContext::GLFW error -- "
+              << "0x" << std::hex << errnum << std::dec << ": " << errmsg << std::endl;
 }
 
-OpenGLContext::OpenGLContext( const std::array<int, 2>& size ) {
+OpenGLContext::OpenGLContext( const std::string& glVersion, const std::array<int, 2>& size ) {
     // initialize openGL
+    std::istringstream in { glVersion };
+    int glMajor, glMinor;
+    char dot;
+    in >> glMajor >> dot >> glMinor;
     if ( glfwInit() ) {
         glfwSetErrorCallback( error );
         glfwDefaultWindowHints();
         glfwWindowHint( GLFW_VISIBLE, false );
-        glfwWindowHint( GLFW_CONTEXT_VERSION_MAJOR, 4 );
-        glfwWindowHint( GLFW_CONTEXT_VERSION_MINOR, 1 );
+        glfwWindowHint( GLFW_CONTEXT_VERSION_MAJOR, glMajor );
+        glfwWindowHint( GLFW_CONTEXT_VERSION_MINOR, glMinor );
         glfwWindowHint( GLFW_OPENGL_FORWARD_COMPAT, true );
         glfwWindowHint( GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE );
         m_glfwContext =
             glfwCreateWindow( size[0], size[1], "Radium CommandLine Context", nullptr, nullptr );
     }
-    if ( m_glfwContext == nullptr ) {
+    const char* description;
+    int code = glfwGetError( &description );
+    if ( code == GLFW_VERSION_UNAVAILABLE ) {
+        // if the requested opengl version is not available, try to get the recommended version
+        // (4.1)
+        glfwWindowHint( GLFW_CONTEXT_VERSION_MAJOR, 4 );
+        glfwWindowHint( GLFW_CONTEXT_VERSION_MINOR, 1 );
+        m_glfwContext =
+            glfwCreateWindow( size[0], size[1], "Radium CommandLine Context", nullptr, nullptr );
+        code = glfwGetError( &description );
+    }
+    if ( code != GLFW_NO_ERROR ) {
         std::cerr << "OpenGL context creation failed. Terminate execution." << std::endl;
-        const char* description;
-        int code = glfwGetError( &description );
-        std::cerr << "\tError code :" << code << std::endl
+        std::cerr << "\tError code : 0x" << std::hex << code << std::dec << std::endl
                   << "\t error string : " << description << std::endl;
         glfwTerminate();
         std::exit( -1 );

--- a/src/Headless/OpenGLContext/OpenGLContext.cpp
+++ b/src/Headless/OpenGLContext/OpenGLContext.cpp
@@ -30,18 +30,15 @@ static void error( int errnum, const char* errmsg ) {
               << "0x" << std::hex << errnum << std::dec << ": " << errmsg << std::endl;
 }
 
-OpenGLContext::OpenGLContext( const std::string& glVersion, const std::array<int, 2>& size ) {
+OpenGLContext::OpenGLContext( const glbinding::Version& glVersion,
+                              const std::array<int, 2>& size ) {
     // initialize openGL
-    std::istringstream in { glVersion };
-    int glMajor, glMinor;
-    char dot;
-    in >> glMajor >> dot >> glMinor;
     if ( glfwInit() ) {
         glfwSetErrorCallback( error );
         glfwDefaultWindowHints();
         glfwWindowHint( GLFW_VISIBLE, false );
-        glfwWindowHint( GLFW_CONTEXT_VERSION_MAJOR, glMajor );
-        glfwWindowHint( GLFW_CONTEXT_VERSION_MINOR, glMinor );
+        glfwWindowHint( GLFW_CONTEXT_VERSION_MAJOR, glVersion.majorVersion() );
+        glfwWindowHint( GLFW_CONTEXT_VERSION_MINOR, glVersion.minorVersion() );
         glfwWindowHint( GLFW_OPENGL_FORWARD_COMPAT, true );
         glfwWindowHint( GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE );
         m_glfwContext =
@@ -60,8 +57,7 @@ OpenGLContext::OpenGLContext( const std::string& glVersion, const std::array<int
     }
     if ( code != GLFW_NO_ERROR ) {
         std::cerr << "OpenGL context creation failed. Terminate execution." << std::endl;
-        std::cerr << "\tError code : 0x" << std::hex << code << std::dec << std::endl
-                  << "\t error string : " << description << std::endl;
+        error( code, description );
         glfwTerminate();
         std::exit( -1 );
     }

--- a/src/Headless/OpenGLContext/OpenGLContext.hpp
+++ b/src/Headless/OpenGLContext/OpenGLContext.hpp
@@ -28,12 +28,15 @@ class HEADLESS_API OpenGLContext
     /**
      * Create an offscreen openGl context.
      * The created context has the following properties
-     *  - OpenGL version requested : >= 4.1
+     *  - OpenGL version requested : (default >= 4.1)
      *  - OpenGL context profile : Core Profile
      *  The created context is associated with a hidden window that can be shown later.
-     * @param size
+     *  \param glVersion (optional, default is 4.1) indicates the OpenGL version the context MUST
+     *  be compatible with. If there is no compatible context, the application will stop
+     * \param size
      */
-    explicit OpenGLContext( const std::array<int, 2>& size = { 1, 1 } );
+    explicit OpenGLContext( const std::string& glVersion   = "4.1",
+                            const std::array<int, 2>& size = { 1, 1 } );
     /// destructor
     ~OpenGLContext();
     /// make the context active

--- a/src/Headless/OpenGLContext/OpenGLContext.hpp
+++ b/src/Headless/OpenGLContext/OpenGLContext.hpp
@@ -5,6 +5,9 @@
 #include <array>
 #include <functional>
 #include <string>
+
+#include <glbinding/Version.h>
+
 struct GLFWwindow;
 
 namespace Ra {
@@ -35,8 +38,8 @@ class HEADLESS_API OpenGLContext
      *  be compatible with. If there is no compatible context, the application will stop
      * \param size
      */
-    explicit OpenGLContext( const std::string& glVersion   = "4.1",
-                            const std::array<int, 2>& size = { 1, 1 } );
+    explicit OpenGLContext( const glbinding::Version& glVersion = { 4, 1 },
+                            const std::array<int, 2>& size      = { 1, 1 } );
     /// destructor
     ~OpenGLContext();
     /// make the context active


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Follow up of #965.
OpenGL version could be requested and checked when creating an application (Qt based or headless/glfw based)


* **What is the current behavior?** (You can also link to an open issue here)
OpenGL version is fixed to some varying recommended version (4.4 for Qt apps, 4.1 for headless/glfw)


* **What is the new behavior (if this is a feature change)?**
OpenGL version might be reuested by users when creating an application (Qt or headless/glfw). If no specific version is given, the default is the minimum openGL required version for radium (4.1)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

NO

* **Other information**:
