### PR TITLE
[ci] Update install-qt-action version to v3.

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -127,18 +127,12 @@ jobs:
       - name: Add msbuild to PATH
         uses: seanmiddleditch/gha-setup-vsdevenv@master
         if: runner.os == 'Windows'
-      - name: Cache Qt
-        id: cache-qt
-        uses: actions/cache@v1
-        with:
-          path: ../Qt
-          key: ${{ matrix.config.name }}-QtCache-${{ matrix.qtversion.value }}
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3
         with:
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          cache: true
+          cache-key-prefix: install-qt-action-${{ matrix.config.name }}-${{ matrix.qtversion.value }}
           version: ${{ matrix.qtversion.value }}
-          setup-python: 'false'
       - name: Install dep Linux
         if: runner.os == 'Linux'
         run: sudo apt-get install -y libglfw3-dev


### PR DESCRIPTION
Update github action install-qt-action v2 to v3,
v2 has some issue with python setup on mac os runner, see [here](https://github.com/STORM-IRIT/Radium-Engine/runs/7932973246?check_suite_focus=true) (excerpt below).

v3 fix this issue.

```
 WARNING: Requested bcj-cffi<0.6.0,>=0.5.1 from https://files.pythonhosted.org/packages/97/9c/681442a5b3a5bb3a1210a8ddc6cc6f6a47ea90834b80daa15af767b1c29a/bcj-cffi-0.5.1.tar.gz (from py7zr==0.16.1), but installing version 0.0.0
Discarding https://files.pythonhosted.org/packages/97/9c/681442a5b3a5bb3a1210a8ddc6cc6f6a47ea90834b80daa15af767b1c29a/bcj-cffi-0.5.1.tar.gz (from https://pypi.org/simple/bcj-cffi/): Requested bcj-cffi<0.6.0,>=0.5.1 from https://files.pythonhosted.org/packages/97/9c/681442a5b3a5bb3a1210a8ddc6cc6f6a47ea90834b80daa15af767b1c29a/bcj-cffi-0.5.1.tar.gz (from py7zr==0.16.1) has inconsistent version: filename has '0.5.1', but metadata has '0.0.0'
ERROR: Could not find a version that satisfies the requirement bcj-cffi<0.6.0,>=0.5.1 (from py7zr) (from versions: 0.3.1, 0.4.0, 0.5.0, 0.5.1)
ERROR: No matching distribution found for bcj-cffi<0.6.0,>=0.5.1
Error: The process 'python3' failed with exit code 1
```