### PR TITLE
Fix missing engine deletion in CLIVIewer that prevent OpenGL related unittest to work

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -94,8 +94,9 @@ jobs:
           [[ "true" == "${{ inputs.qt5 }}" && "true" == "${{ inputs.qt6 }}" ]] && echo ','
           [[ "true" == "${{ inputs.qt6 }}" ]] && echo '{ "name" : "qt6", "value" : "6.2.0"}'
           echo '],'
-          echo '"coverage" :'
-          [[ "true" == "${{ inputs.coverage }}" ]] && echo '["ON"]' || echo '["OFF"]'
+          echo '"coverage" : ['
+          [[ "true" == "${{ inputs.coverage }}" ]] && echo '{ "value" : "ON", "extra-flags" : "-DRADIUM_ENABLE_GL_TESTING=ON" }' || echo '{ "value" : "OFF", "extra-flags" : "" }'
+          echo "]"
           echo "}"
           ) | jq -c .)
           echo $matrix
@@ -205,9 +206,10 @@ jobs:
           cmake ../../src/Radium-Engine -GNinja -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} \
           -DCMAKE_C_COMPILER=${{ matrix.config.cc }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
           ${{ matrix.config.extra-flags }} \
+          ${{ matrix.coverage.extra-flags }} \
           -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=STDOUT \
           -DRADIUM_USE_DOUBLE=${{ matrix.precision.value }} -DRADIUM_UPDATE_VERSION=OFF -DRADIUM_ENABLE_PCH=ON \
-          -DRADIUM_INSTALL_DOC=OFF -DRADIUM_ENABLE_TESTING=ON -DRADIUM_ENABLE_EXAMPLES=ON -DRADIUM_ENABLE_COVERAGE=${{ matrix.coverage }} \
+          -DRADIUM_INSTALL_DOC=OFF -DRADIUM_ENABLE_TESTING=ON -DRADIUM_ENABLE_EXAMPLES=ON -DRADIUM_ENABLE_COVERAGE=${{ matrix.coverage.value }} \
           -C ${{ env.ext-dir }}/radium-options.cmake \
           -DCMAKE_INSTALL_PREFIX=../../install/ \
           ${{ env.glfw-path }}
@@ -215,6 +217,7 @@ jobs:
         run: |
           cmake --build build/Radium-Engine --parallel --config ${{ matrix.build-type }} --target install
       - name: Run unit tests
+        if: ${{ inputs.coverage == 'false' }}
         run: |
           cmake --build build/Radium-Engine --parallel --config ${{ matrix.build-type }} --target check
           cmake --build build/Radium-Engine --parallel --config ${{ matrix.build-type }} --target Install_CoreExample
@@ -256,7 +259,7 @@ jobs:
           cd build/Radium-Engine
           cmake --build . --config Debug --target lcov_init
           cmake --build . --config Debug --target lcov_zerocounter
-          cmake --build . --config Debug --target check
+          xvfb-run -a cmake --build . --config Debug --target check
           cmake --build . --config Debug --target lcov_capture
           # show report for debug
           cmake --build . --config Debug --target lcov_list

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,14 @@ option(
     "Enable testing. Tests are automatically built with target all, run with target check or test."
     ON
 )
+include(CMakeDependentOption)
+cmake_dependent_option(
+    RADIUM_ENABLE_GL_TESTING
+    "Enable testing of OpenGL functionalities. Option only available if RADIUM_ENABLE_TESTING is ON."
+    OFF
+    "RADIUM_ENABLE_TESTING"
+    OFF
+)
 option(
     RADIUM_ENABLE_EXAMPLES
     "Enable examples app build. To install examples, build explicitly the target Install_RadiumExamples."
@@ -275,6 +283,7 @@ message_info("  set with ` cmake -DCMAKE_BUILD_TYPE=Debug .. `")
 message_info(" ")
 message_setting("RADIUM_ENABLE_EXAMPLES")
 message_setting("RADIUM_ENABLE_TESTING")
+message_setting("RADIUM_ENABLE_GL_TESTING")
 message_setting("RADIUM_ENABLE_COVERAGE")
 message_setting("RADIUM_ENABLE_PCH")
 message_setting("RADIUM_USE_DOUBLE")

--- a/doc/basics/compilation.md
+++ b/doc/basics/compilation.md
@@ -75,6 +75,9 @@ RADIUM_ENABLE_PCH:BOOL=OFF
 // Enable testing. Tests are automatically built with target all, run with target check or test.
 RADIUM_ENABLE_TESTING:BOOL=ON
 
+// Enable testing of OpenGL functionalities. Option only available if RADIUM_ENABLE_TESTING is ON.
+RADIUM_ENABLE_GL_TESTING:BOOL=OFF
+
 // Include Radium::Core in CMake project.
 RADIUM_GENERATE_LIB_CORE:BOOL=ON
 

--- a/src/Headless/CLIViewer.cpp
+++ b/src/Headless/CLIViewer.cpp
@@ -34,6 +34,8 @@ CLIViewer::~CLIViewer() {
         m_glContext.makeCurrent();
         m_renderer.reset();
         m_engine->cleanup();
+        Ra::Engine::RadiumEngine::destroyInstance();
+        m_engine.release();
         m_glContext.doneCurrent();
     }
 }

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -5,30 +5,29 @@
 
 # -----------------------------------------------------------------------------
 set(test_src
-    unittest.cpp
-    unittestUtils.hpp
     Core/algebra.cpp
     Core/animation.cpp
     Core/camera.cpp
     Core/color.cpp
     Core/containers.cpp
     Core/distance.cpp
+    Core/geometryData.cpp
     Core/indexmap.cpp
     Core/indexview.cpp
     Core/mapiterators.cpp
-    Core/observer.cpp
     Core/obb.cpp
+    Core/observer.cpp
     Core/polyline.cpp
     Core/raycast.cpp
     Core/resources.cpp
     Core/string.cpp
     Core/topomesh.cpp
     Engine/environmentmap.cpp
-    Engine/materials.cpp
-    Engine/signalmanager.cpp
     Engine/renderparameters.cpp
+    Engine/signalmanager.cpp
     Gui/keymapping.cpp
-    Core/geometryData.cpp
+    unittest.cpp
+    unittestUtils.hpp
 )
 
 get_target_property(HAS_VOLUMES IO RADIUM_IO_HAS_VOLUMES)
@@ -37,37 +36,40 @@ if(${HAS_VOLUMES})
     list(APPEND test_src IO/volumeloader.cpp)
 endif()
 
-add_executable(unittests ${test_src})
-target_compile_options(unittests PUBLIC ${RA_DEFAULT_COMPILE_OPTIONS})
-
-target_compile_definitions(unittests PRIVATE UNIT_TESTS) # add -DUNIT_TESTS define
-target_link_libraries(unittests PRIVATE Catch2::Catch2 Core Gui Engine)
-add_dependencies(unittests Catch2 Core Gui)
-
 if(RADIUM_ENABLE_GL_TESTING)
-    target_compile_definitions(unittests PRIVATE ENABLE_GL_TESTING)
-    target_link_libraries(unittests PRIVATE Headless)
-    add_dependencies(unittests Headless)
+    message(STATUS "Add gl related unit tests")
+    list(APPEND test_src Engine/materials.cpp)
 endif()
 
+add_executable(unittests ${test_src})
 target_include_directories(unittests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_options(unittests PUBLIC ${RA_DEFAULT_COMPILE_OPTIONS})
+target_compile_definitions(unittests PRIVATE UNIT_TESTS) # add -DUNIT_TESTS define
 
-include(../external/Catch2/src/Catch2_download/contrib/Catch.cmake)
-
-catch_discover_tests(unittests WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(unittests PRIVATE Catch2::Catch2 Core Engine Gui)
+add_dependencies(unittests Catch2 Core Engine Gui)
 
 find_package(Filesystem COMPONENTS Final Experimental REQUIRED)
-find_qt_package(COMPONENTS Core Widgets OpenGL Xml REQUIRED)
-
-# Qt
-set(Qt_LIBRARIES Qt::Core Qt::Widgets Qt::OpenGL Qt::Xml)
-target_link_libraries(unittests PRIVATE ${Qt_LIBRARIES} PRIVATE std::filesystem)
 target_compile_definitions(
     unittests
     PRIVATE -DCXX_FILESYSTEM_HAVE_FS
             -DCXX_FILESYSTEM_IS_EXPERIMENTAL=$<BOOL:${CXX_FILESYSTEM_IS_EXPERIMENTAL}>
             -DCXX_FILESYSTEM_NAMESPACE=${CXX_FILESYSTEM_NAMESPACE}
 )
+target_link_libraries(unittests PRIVATE std::filesystem)
+
+find_qt_package(COMPONENTS Core Widgets OpenGL Xml REQUIRED)
+set(Qt_LIBRARIES Qt::Core Qt::Widgets Qt::OpenGL Qt::Xml)
+target_link_libraries(unittests PRIVATE ${Qt_LIBRARIES})
+
+if(RADIUM_ENABLE_GL_TESTING)
+    target_link_libraries(unittests PRIVATE Headless)
+    add_dependencies(unittests Headless)
+endif()
+
+include(../external/Catch2/src/Catch2_download/contrib/Catch.cmake)
+
+catch_discover_tests(unittests WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 # convenience target for running only the unit tests
 add_custom_target(

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -41,7 +41,7 @@ add_executable(unittests ${test_src})
 target_compile_options(unittests PUBLIC ${RA_DEFAULT_COMPILE_OPTIONS})
 
 target_compile_definitions(unittests PRIVATE UNIT_TESTS) # add -DUNIT_TESTS define
-target_link_libraries(unittests PRIVATE Catch2::Catch2 Core Gui)
+target_link_libraries(unittests PRIVATE Catch2::Catch2 Core Gui Engine)
 add_dependencies(unittests Catch2 Core Gui)
 
 if(RADIUM_ENABLE_GL_TESTING)

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -24,6 +24,7 @@ set(test_src
     Core/string.cpp
     Core/topomesh.cpp
     Engine/environmentmap.cpp
+    Engine/materials.cpp
     Engine/signalmanager.cpp
     Engine/renderparameters.cpp
     Gui/keymapping.cpp
@@ -41,8 +42,14 @@ target_compile_options(unittests PUBLIC ${RA_DEFAULT_COMPILE_OPTIONS})
 
 target_compile_definitions(unittests PRIVATE UNIT_TESTS) # add -DUNIT_TESTS define
 target_link_libraries(unittests PRIVATE Catch2::Catch2 Core Gui)
-
 add_dependencies(unittests Catch2 Core Gui)
+
+if(RADIUM_ENABLE_GL_TESTING)
+    target_compile_definitions(unittests PRIVATE ENABLE_GL_TESTING)
+    target_link_libraries(unittests PRIVATE Headless)
+    add_dependencies(unittests Headless)
+endif()
+
 target_include_directories(unittests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 include(../external/Catch2/src/Catch2_download/contrib/Catch.cmake)

--- a/tests/unittest/Engine/materials.cpp
+++ b/tests/unittest/Engine/materials.cpp
@@ -1,19 +1,11 @@
-/*
- * Right now, we are unable to run unitests requiring openGL on the CI platform.
- * Some more work is needed to allow them only on Linux.
- * This will be done ASAP.
- * This unit test is activated by giving the option -DRADIUM_ENABLE_GL_TESTING=ON (available only if
- * RADIUM_ENABLE_TESTING is ON) at configure time.
- */
-#ifdef ENABLE_GL_TESTING
-#    include <catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
-#    include <Engine/Data/BlinnPhongMaterial.hpp>
-#    include <Engine/Data/LambertianMaterial.hpp>
-#    include <Engine/Data/PlainMaterial.hpp>
-#    include <Engine/RadiumEngine.hpp>
+#include <Engine/Data/BlinnPhongMaterial.hpp>
+#include <Engine/Data/LambertianMaterial.hpp>
+#include <Engine/Data/PlainMaterial.hpp>
+#include <Engine/RadiumEngine.hpp>
 
-#    include <Headless/CLIViewer.hpp>
+#include <Headless/CLIViewer.hpp>
 
 using namespace Ra::Headless;
 using namespace Ra::Engine::Data;
@@ -89,4 +81,3 @@ TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
         */
     }
 }
-#endif

--- a/tests/unittest/Engine/materials.cpp
+++ b/tests/unittest/Engine/materials.cpp
@@ -1,0 +1,92 @@
+/*
+ * Right now, we are unable to run unitests requiring openGL on the CI platform.
+ * Some more work is needed to allow them only on Linux.
+ * This will be done ASAP.
+ * This unit test is activated by giving the option -DRADIUM_ENABLE_GL_TESTING=ON (available only if
+ * RADIUM_ENABLE_TESTING is ON) at configure time.
+ */
+#ifdef ENABLE_GL_TESTING
+#    include <catch2/catch.hpp>
+
+#    include <Engine/Data/BlinnPhongMaterial.hpp>
+#    include <Engine/Data/LambertianMaterial.hpp>
+#    include <Engine/Data/PlainMaterial.hpp>
+#    include <Engine/RadiumEngine.hpp>
+
+#    include <Headless/CLIViewer.hpp>
+
+using namespace Ra::Headless;
+using namespace Ra::Engine::Data;
+
+TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
+
+    // Get the Engine and materials initialized
+    glbinding::Version glVersion { 4, 4 };
+    CLIViewer viewer { glVersion };
+    const char* testName = "Materials testing";
+    auto code            = viewer.init( 1, &testName );
+
+    SECTION( "Blinn-Phong material" ) {
+        REQUIRE( code == 0 );
+        BlinnPhongMaterial bp( "testBlinnPhong" );
+
+        REQUIRE( bp.m_alpha == 1.0 );
+        REQUIRE( !bp.m_renderAsSplat );
+
+        bp.updateGL();
+        auto bpParameters = bp.getParameters();
+        /* The method containsParameter and getParameter will be added in PR #950 */
+        /*
+        REQUIRE( bpParameters.containsParameter<RenderParameters::BoolParameter>(
+            "material.renderAsSplat" ) );
+        REQUIRE(
+            bpParameters.containsParameter<RenderParameters::ScalarParameter>( "material.alpha" ) );
+
+        auto ras =
+            bpParameters.getParameter<RenderParameters::BoolParameter>( "material.renderAsSplat" );
+        REQUIRE( ras.m_value == bp.m_renderAsSplat );
+
+        auto alp = bpParameters.getParameter<RenderParameters::ScalarParameter>( "material.alpha" );
+        REQUIRE( alp.m_value == bp.m_alpha );
+        */
+    }
+
+    SECTION( "Lambertian material" ) {
+        REQUIRE( code == 0 );
+        LambertianMaterial mat( "test LambertianMaterial" );
+
+        REQUIRE( !mat.m_perVertexColor );
+
+        mat.updateGL();
+        auto matParameters = mat.getParameters();
+        /* The method containsParameter and getParameter will be added in PR #950 */
+        /*
+        REQUIRE( matParameters.containsParameter<RenderParameters::BoolParameter>(
+            "material.perVertexColor" ) );
+
+        auto pvc = matParameters.getParameter<RenderParameters::BoolParameter>(
+            "material.perVertexColor" );
+        REQUIRE( pvc.m_value == mat.m_perVertexColor );
+        */
+    }
+
+    SECTION( "Plain material" ) {
+        REQUIRE( code == 0 );
+        PlainMaterial mat( "test PlainMaterial" );
+
+        REQUIRE( !mat.m_perVertexColor );
+
+        mat.updateGL();
+        auto matParameters = mat.getParameters();
+        /* The method containsParameter and getParameter will be added in PR #950 */
+        /*
+        REQUIRE( matParameters.containsParameter<RenderParameters::BoolParameter>(
+            "material.perVertexColor" ) );
+
+        auto pvc = matParameters.getParameter<RenderParameters::BoolParameter>(
+            "material.perVertexColor" );
+        REQUIRE( pvc.m_value == mat.m_perVertexColor );
+        */
+    }
+}
+#endif


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

The fix on Headless component allows to run unittests that require OpenGL context and fix a potential memory leak for some applications.
The RADIUM_ENABLE_GL_TESTING cmake option is added to enable OpenGL related unittests.


* **What is the current behavior?** (You can also link to an open issue here)

When running tests that use CLIViewer, as the engine singleton constructed when the CLIViewer is constructed is not destroyed when the CLI Viewer is destroy, the actual version segfault on the next engine singleton creation/deletion.


* **What is the new behavior (if this is a feature change)?**

Engine singleton created when initializing CLIViewer is destroyed when deleting the CLIVIewer


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No, only the dependent option RADIUM_ENABLE_GL_TESTING is added, OFF by default. 
OpenGL testing can be activated on any platform that allows to obtain an OpenGL context. This should be the case on your development machine. 
It is OFF by default as running applications or unittests that require OpenGL is not available on all CI platform.

* **Other information**:

Some code is commented out as it will be available only when PR #950 will be merged