### PR TITLE
[external] update Eigen to last stable release 3.4.0

### DIFF
--- a/external/Core/CMakeLists.txt
+++ b/external/Core/CMakeLists.txt
@@ -25,6 +25,8 @@ if(NOT DEFINED Eigen3_DIR)
         GIT_TAG tags/3.4.0
         GIT_SHALLOW FALSE
         GIT_PROGRESS TRUE
+        PATCH_COMMAND git reset --hard && git apply -v --ignore-whitespace
+                      "${CMAKE_CURRENT_LIST_DIR}/patches/eigen.patch"
         INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
         CMAKE_ARGS ${RADIUM_EXTERNAL_CMAKE_OPTIONS} -DEIGEN_TEST_CXX11=OFF -DBUILD_TESTING=OFF
                    -DEIGEN_BUILD_DOC=OFF "-DCMAKE_MESSAGE_INDENT=${indent_string}\;"

--- a/external/Core/CMakeLists.txt
+++ b/external/Core/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT DEFINED Eigen3_DIR)
     ExternalProject_Add(
         Eigen3
         GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-        GIT_TAG e80ec243
+        GIT_TAG tags/3.4.0
         GIT_SHALLOW FALSE
         GIT_PROGRESS TRUE
         INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"

--- a/external/Core/patches/eigen.patch
+++ b/external/Core/patches/eigen.patch
@@ -1,0 +1,30 @@
+From c9800d36fa958d1983efc94d72a44cf433eee655 Mon Sep 17 00:00:00 2001
+From: dlyr <github@dlyr.fr>
+Date: Fri, 9 Sep 2022 18:39:37 +0200
+Subject: [PATCH] patch
+
+---
+ CMakeLists.txt | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f3e69b845..8a76a13ad 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -495,14 +495,6 @@ if(BUILD_TESTING)
+   add_subdirectory(failtest)
+ endif()
+
+-if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
+-  add_subdirectory(blas)
+-  add_subdirectory(lapack)
+-else()
+-  add_subdirectory(blas EXCLUDE_FROM_ALL)
+-  add_subdirectory(lapack EXCLUDE_FROM_ALL)
+-endif()
+-
+ # add SYCL
+ option(EIGEN_TEST_SYCL "Add Sycl support." OFF)
+ option(EIGEN_SYCL_TRISYCL "Use the triSYCL Sycl implementation (ComputeCPP by default)." OFF)
+--
+2.30.2


### PR DESCRIPTION
Use tagged version 3.4.0 instead of commit sha for eigen external project.