### PR TITLE
[ci] Run PR checks on master also.

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - release-candidate
+      - master
 
 env:
   ext-dir: $GITHUB_WORKSPACE/external/install/


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Run PR checks agains master PR (not only release candidate)


* **What is the current behavior?** (You can also link to an open issue here)
PR CI checks are only run against RC PR. 


* **What is the new behavior (if this is a feature change)?**
Run PR CI chcckes for agains master PR as well.

* **Other information**:
When we factorize CI code, and change workflow using RC branch, we start push to master directly.
After some checks, RC to master PR seems to use fast forward, so we can use github PR mechanism here too, and have CI running to check before merging.