### PR TITLE
Use BijectiveAssociation for mesh translation table

### DIFF
--- a/src/Core/Utils/BijectiveAssociation.hpp
+++ b/src/Core/Utils/BijectiveAssociation.hpp
@@ -3,6 +3,8 @@
 #include <initializer_list>
 #include <map>
 
+#include <Core/Utils/StdOptional.hpp>
+
 namespace Ra {
 namespace Core {
 namespace Utils {
@@ -25,76 +27,86 @@ class BijectiveAssociation
      * \brief Constructor from { <T1, T2> } pairs
      */
     explicit BijectiveAssociation( std::initializer_list<std::pair<key_type, value_type>> pairs );
+    /**
+     * \brief Creates an empty association.
+     */
     explicit BijectiveAssociation() = default;
 
     /**
-     * \brief Add a pair to the association.
-     * \return false if the pair was not added due to collision with an already inserted pair
+     * \brief Insert a pair to the association.
+     * \return false if the pair was not added due to collision with an already inserted pair.
      */
     bool insert( std::pair<key_type, value_type> p );
     /**
-     * \brief Convenient alias for element insertion (hides pair creation).
-
-Code is equivalent to `insert({v1, v2})`.
+     * \brief Convenient alias for `insert({key, value})`.
      * \see Ra::Core::Utils::BijectiveAssociation::insert(std::pair<key_type, value_type>)
      */
-    bool insert( key_type v1, value_type v2 );
+    bool insert( key_type key, value_type value );
 
     /**
      * \brief Replace a pair in the association.
      *
-     * Remove the association {p.first, old_value} and {old_key, p.second} and insert {p.first,
-     * p.second} Equivalent to \code{.cpp} remove({p.first, old_value}); remove({old_key,
-     * p.second}); insert(p); \endcode But faster
+     * Remove the association `{p.first, old_value}` and `{old_key, p.second}` and insert `{p.first,
+     * p.second}`.
+     * Faster version of
+     * \code{.cpp}
+     * remove({p.first, old_value});
+     * remove({old_key, p.second});
+     * insert(p);
+     * \endcode
      */
     void replace( std::pair<key_type, value_type> p );
+    /**
+     * \brief Convenient alias of `replace({key, value})`.
+     * \see Ra::Core::Utils::BijectiveAssociation::replace(std::pair<key_type, value_type>)
+     */
+    void replace( key_type key, value_type value );
 
     /**
-     * \brief Convenient alias for replace({v1, v2}).
-     * \sa Ra::Core::Utils::BijectiveAssociation::replace(std::pair<key_type, value_type>)
+     * \brief Remove a pair from the association.
+     *
+     * Remove only `{key, value}`. If \b key (resp \b value) is present but associated with a value
+     * (resp. key)
+     * != \b value (resp \b key), the association stay unchanged.
+     * \return true if the pair was in the association, and removed. False otherwise.
      */
-    void replace( key_type v1, value_type v2 );
-
+    bool remove( std::pair<key_type, value_type> p );
     /**
-     * \brief Remove a pair in the association.
+     * \brief Convenient alias for `remove({key, value})`.
+     * \see Ra::Core::Utils::BijectiveAssociation::remove(std::pair<key_type, value_type>)
      */
-    void remove( std::pair<key_type, value_type> p );
-    /**
-     * \brief Convenient alias for remove({v1, v2});
-     * \sa Ra::Core::Utils::BijectiveAssociation::remove(std::pair<key_type, value_type>)
-     */
-    void remove( key_type v1, value_type v2 );
+    bool remove( key_type key, value_type value );
 
     /**
      * \brief Gets the value associated to the key
      */
-    value_type operator()( const key_type& k ) const;
+    value_type operator()( const key_type& key ) const;
 
     /**
-     * \brief Gets the value associated to the key.
-     * \throw std::out_of_range if k is not present in the association as a key.
+     * \brief Gets the value associated to \b key.
+     * \throw std::out_of_range if \b key is not present in the association as a key.
      */
-    value_type value( const key_type& k ) const;
+    value_type value( const key_type& key ) const;
 
     /**
-     * \brief Gets the value associated to a key if it exists.
+     * \brief Gets the value associated to \b key if it exists.
      *
-     * Otherwise the optional doesn't contain a value, and evaluate to false.
+     * Otherwise the optional doesn't contain anything, and evaluate to false.
      */
-    std::optional<value_type> valueIfExists( const key_type& k ) const;
+    optional<value_type> valueIfExists( const key_type& key ) const;
 
     /**
      * \brief Gets the key associated to a value.
-     * \throw std::out_of_range if k is not present in the association as a value.
+     * \throw std::out_of_range if \b value is not present in the association as a value.
      */
-    key_type key( const value_type& k ) const;
+    key_type key( const value_type& value ) const;
 
     /**
-     * \brief Gets the key associated to a value if it exists.
+     * \brief Gets the key associated to \b value if it exists.
      *
-     * Otherwise the optional doesn't contain a value, and evaluate to false.
+     * Otherwise the optional doesn't contain anything, and evaluate to false.
      */
-    std::optional<key_type> keyIfExists( const value_type& k ) const;
+    optional<key_type> keyIfExists( const value_type& value ) const;
 
     /**
      * \brief Gets an const iterator at beginning of the key to value map.
@@ -107,7 +119,7 @@ Code is equivalent to `insert({v1, v2})`.
      * \brief Gets a const iterator at the end of the key to value map.
      */
     typename std::map<key_type, value_type>::const_iterator end() const noexcept;
-    ///\copydoc end()
+    /// \copydoc end()
     typename std::map<key_type, value_type>::const_iterator cend() const noexcept;
 
     /**

--- a/src/Core/Utils/BijectiveAssociation.hpp
+++ b/src/Core/Utils/BijectiveAssociation.hpp
@@ -16,25 +16,54 @@ template <typename T1, typename T2>
 class BijectiveAssociation
 {
   public:
-    using key_type   = T1;
-    using value_type = T2;
+    using key_type         = T1;
+    using value_type       = T2;
+    using key_to_value_map = std::map<key_type, value_type>;
+    using value_to_key_map = std::map<value_type, key_type>;
 
     /**
      * \brief Constructor from { <T1, T2> } pairs
      */
     explicit BijectiveAssociation( std::initializer_list<std::pair<key_type, value_type>> pairs );
+    explicit BijectiveAssociation() = default;
 
     /**
-     * \brief Add a pair to the relation.
+     * \brief Add a pair to the association.
      * \return false if the pair was not added due to collision with an already inserted pair
      */
     bool insert( std::pair<key_type, value_type> p );
-
     /**
-     * \brief Add a pair to the relation.
-     * \return false if the pair was not added due to collision with an already inserted pair
+     * \brief Convenient alias for element insertion (hides pair creation).
+
+Code is equivalent to `insert({v1, v2})`.
+     * \see Ra::Core::Utils::BijectiveAssociation::insert(std::pair<key_type, value_type>)
      */
     bool insert( key_type v1, value_type v2 );
+
+    /**
+     * \brief Replace a pair in the association.
+     *
+     * Remove the association {p.first, old_value} and {old_key, p.second} and insert {p.first,
+     * p.second} Equivalent to \code{.cpp} remove({p.first, old_value}); remove({old_key,
+     * p.second}); insert(p); \endcode But faster
+     */
+    void replace( std::pair<key_type, value_type> p );
+
+    /**
+     * \brief Convenient alias for replace({v1, v2}).
+     * \sa Ra::Core::Utils::BijectiveAssociation::replace(std::pair<key_type, value_type>)
+     */
+    void replace( key_type v1, value_type v2 );
+
+    /**
+     * \brief Remove a pair in the association.
+     */
+    void remove( std::pair<key_type, value_type> p );
+    /**
+     * \brief Convenient alias for remove({v1, v2});
+     * \sa Ra::Core::Utils::BijectiveAssociation::remove(std::pair<key_type, value_type>)
+     */
+    void remove( key_type v1, value_type v2 );
 
     /**
      * \brief Gets the value associated to the key
@@ -42,43 +71,53 @@ class BijectiveAssociation
     value_type operator()( const key_type& k ) const;
 
     /**
-     * \brief Gets the value associated to the key
+     * \brief Gets the value associated to the key.
+     * \throw std::out_of_range if k is not present in the association as a key.
      */
     value_type value( const key_type& k ) const;
 
     /**
-     * \brief Gets the key  associated to the value
+     * \brief Gets the value associated to a key if it exists.
+     *
+     * Otherwise the optional doesn't contain a value, and evaluate to false.
+     */
+    std::optional<value_type> valueIfExists( const key_type& k ) const;
+
+    /**
+     * \brief Gets the key associated to a value.
+     * \throw std::out_of_range if k is not present in the association as a value.
      */
     key_type key( const value_type& k ) const;
 
     /**
-     * \brief Gets an const iterator at beginning of the key to value map
+     * \brief Gets the key associated to a value if it exists.
+     *
+     * Otherwise the optional doesn't contain a value, and evaluate to false.
      */
-    typename std::map<key_type, value_type>::const_iterator begin() const noexcept;
+    std::optional<key_type> keyIfExists( const value_type& k ) const;
 
     /**
-     * \brief Gets a const iterator at beginning of the key to value map
+     * \brief Gets an const iterator at beginning of the key to value map.
      */
+    typename std::map<key_type, value_type>::const_iterator begin() const noexcept;
+    /// \copydoc begin()
     typename std::map<key_type, value_type>::const_iterator cbegin() const noexcept;
 
     /**
-     * \brief Gets a const iterator at the end of the key to value map
+     * \brief Gets a const iterator at the end of the key to value map.
      */
     typename std::map<key_type, value_type>::const_iterator end() const noexcept;
-
-    /**
-     * \brief Gets a const iterator at the end of the key to value map
-     */
+    ///\copydoc end()
     typename std::map<key_type, value_type>::const_iterator cend() const noexcept;
 
     /**
-     * \brief Gets the size of the association, i.e. the numer of <Key, Value> pairs
+     * \brief Gets the size of the association, i.e. the numer of <Key, Value> pairs.
      */
     size_t size() const;
 
   private:
-    std::map<key_type, value_type> m_KeyToValue;
-    std::map<value_type, key_type> m_ValueToKey;
+    key_to_value_map m_keyToValue;
+    value_to_key_map m_valueToKey;
 };
 
 } // namespace Utils

--- a/src/Core/Utils/BijectiveAssociation.hpp
+++ b/src/Core/Utils/BijectiveAssociation.hpp
@@ -10,9 +10,9 @@ namespace Core {
 namespace Utils {
 
 /**
- * \brief Bijective association on a finite set of <key, value> pairs.
- * \tparam T1 Type of the key
- * \tparam T2 Type of the value
+ * \brief Bijective association between two sets {keys} and {values} having the same cardinality.
+ * The bijection \f$f\f$ is constructed by giving all the pairs <key, value> such that \f$f(key) =
+ * value\f$. \tparam T1 Type of the keys \tparam T2 Type of the values
  */
 template <typename T1, typename T2>
 class BijectiveAssociation
@@ -27,16 +27,18 @@ class BijectiveAssociation
      * \brief Constructor from { <T1, T2> } pairs
      */
     explicit BijectiveAssociation( std::initializer_list<std::pair<key_type, value_type>> pairs );
+
     /**
      * \brief Creates an empty association.
      */
     explicit BijectiveAssociation() = default;
 
     /**
-     * \brief Insert a pair to the association.
+     * \brief Insert a pair into the association.
      * \return false if the pair was not added due to collision with an already inserted pair.
      */
     bool insert( std::pair<key_type, value_type> p );
+
     /**
      * \brief Convenient alias for `insert({key, value})`.
      * \see Ra::Core::Utils::BijectiveAssociation::insert(std::pair<key_type, value_type>)
@@ -46,7 +48,8 @@ class BijectiveAssociation
     /**
      * \brief Replace a pair in the association.
      *
-     * Remove the association `{p.first, old_value}` and `{old_key, p.second}` and insert `{p.first,
+     * Remove the associations `{p.first, old_value}` and `{old_key, p.second}` and insert
+`{p.first,
      * p.second}`.
      * Faster version of
      * \code{.cpp}
@@ -56,6 +59,7 @@ class BijectiveAssociation
      * \endcode
      */
     void replace( std::pair<key_type, value_type> p );
+
     /**
      * \brief Convenient alias of `replace({key, value})`.
      * \see Ra::Core::Utils::BijectiveAssociation::replace(std::pair<key_type, value_type>)
@@ -65,12 +69,13 @@ class BijectiveAssociation
     /**
      * \brief Remove a pair from the association.
      *
-     * Remove only `{key, value}`. If \b key (resp \b value) is present but associated with a value
-     * (resp. key)
-     * != \b value (resp \b key), the association stay unchanged.
+     * Remove the `{key, value}` pair. If \b key (resp. \b value) is present but associated with a
+     * value (resp. key)
+     * != \b value (resp. \b key), the association stay unchanged.
      * \return true if the pair was in the association, and removed. False otherwise.
      */
     bool remove( std::pair<key_type, value_type> p );
+
     /**
      * \brief Convenient alias for `remove({key, value})`.
      * \see Ra::Core::Utils::BijectiveAssociation::remove(std::pair<key_type, value_type>)
@@ -79,6 +84,7 @@ class BijectiveAssociation
 
     /**
      * \brief Gets the value associated to the key
+     * \throw std::out_of_range if \b key is not present in the association as a key.
      */
     value_type operator()( const key_type& key ) const;
 
@@ -109,9 +115,10 @@ class BijectiveAssociation
     optional<key_type> keyIfExists( const value_type& value ) const;
 
     /**
-     * \brief Gets an const iterator at beginning of the key to value map.
+     * \brief Gets a const iterator at beginning of the key to value map.
      */
     typename std::map<key_type, value_type>::const_iterator begin() const noexcept;
+
     /// \copydoc begin()
     typename std::map<key_type, value_type>::const_iterator cbegin() const noexcept;
 
@@ -119,6 +126,7 @@ class BijectiveAssociation
      * \brief Gets a const iterator at the end of the key to value map.
      */
     typename std::map<key_type, value_type>::const_iterator end() const noexcept;
+
     /// \copydoc end()
     typename std::map<key_type, value_type>::const_iterator cend() const noexcept;
 

--- a/src/Core/Utils/BijectiveAssociation.inl
+++ b/src/Core/Utils/BijectiveAssociation.inl
@@ -26,30 +26,30 @@ bool BijectiveAssociation<T1, T2>::insert( std::pair<key_type, value_type> p ) {
 }
 
 template <typename T1, typename T2>
-bool BijectiveAssociation<T1, T2>::insert( key_type v1, value_type v2 ) {
-    return insert( { v1, v2 } );
+bool BijectiveAssociation<T1, T2>::insert( key_type key, value_type value ) {
+    return insert( { key, value } );
 }
 
 template <typename T1, typename T2>
-void BijectiveAssociation<T1, T2>::replace( key_type v1, value_type v2 ) {
+void BijectiveAssociation<T1, T2>::replace( key_type key, value_type value ) {
     // clean previously set association
     auto it1 = std::find_if(
         m_keyToValue.begin(),
         m_keyToValue.end(),
-        [&v2]( const typename key_to_value_map::value_type& v ) { return v2 == v.second; } );
+        [&value]( const typename key_to_value_map::value_type& v ) { return value == v.second; } );
 
     if ( it1 != m_keyToValue.end() ) m_keyToValue.erase( it1 );
 
     auto it2 = std::find_if(
         m_valueToKey.begin(),
         m_valueToKey.end(),
-        [&v1]( const typename value_to_key_map::value_type& v ) { return v1 == v.second; } );
+        [&key]( const typename value_to_key_map::value_type& v ) { return key == v.second; } );
 
     if ( it2 != m_valueToKey.end() ) m_valueToKey.erase( it2 );
 
     // set new association
-    m_keyToValue[v1] = v2;
-    m_valueToKey[v2] = v1;
+    m_keyToValue[key]   = value;
+    m_valueToKey[value] = key;
 }
 template <typename T1, typename T2>
 void BijectiveAssociation<T1, T2>::replace( std::pair<key_type, value_type> p ) {
@@ -57,27 +57,22 @@ void BijectiveAssociation<T1, T2>::replace( std::pair<key_type, value_type> p ) 
 }
 
 template <typename T1, typename T2>
-void BijectiveAssociation<T1, T2>::remove( key_type v1, value_type v2 ) {
+bool BijectiveAssociation<T1, T2>::remove( key_type key, value_type value ) {
     // clean previously set association
-    auto it1 = std::find_if(
-        m_keyToValue.begin(),
-        m_keyToValue.end(),
-        [&v2]( const typename key_to_value_map::value_type& v ) { return v2 == v.second; } );
+    auto it1 = m_keyToValue.find( key );
+    auto it2 = m_valueToKey.find( value );
+    if ( it1 == m_valueToKey.end() || it2 == m_keyToValue.end() ) return false;
 
-    if ( it1 != m_keyToValue.end() ) m_keyToValue.erase( it1 );
-    m_keyToValue.erase( v1 );
+    if ( it1->second != value || it2->second != key ) return false;
 
-    auto it2 = std::find_if(
-        m_valueToKey.begin(),
-        m_valueToKey.end(),
-        [&v1]( const typename value_to_key_map::value_type& v ) { return v1 == v.second; } );
-
-    if ( it2 != m_valueToKey.end() ) m_valueToKey.erase( it2 );
-    m_valueToKey.erase( v2 );
+    m_keyToValue.erase( it1 );
+    m_valueToKey.erase( it2 );
+    return true;
 }
+
 template <typename T1, typename T2>
-void BijectiveAssociation<T1, T2>::remove( std::pair<key_type, value_type> p ) {
-    remove( p.frist, p.second );
+bool BijectiveAssociation<T1, T2>::remove( std::pair<key_type, value_type> p ) {
+    return remove( p.frist, p.second );
 }
 
 template <typename T1, typename T2>

--- a/src/Core/Utils/BijectiveAssociation.inl
+++ b/src/Core/Utils/BijectiveAssociation.inl
@@ -61,7 +61,7 @@ bool BijectiveAssociation<T1, T2>::remove( key_type key, value_type value ) {
     // clean previously set association
     auto it1 = m_keyToValue.find( key );
     auto it2 = m_valueToKey.find( value );
-    if ( it1 == m_valueToKey.end() || it2 == m_keyToValue.end() ) return false;
+    if ( it1 == m_keyToValue.end() || it2 == m_valueToKey.end() ) return false;
 
     if ( it1->second != value || it2->second != key ) return false;
 

--- a/src/Core/Utils/BijectiveAssociation.inl
+++ b/src/Core/Utils/BijectiveAssociation.inl
@@ -1,5 +1,7 @@
 #pragma once
 #include <Core/Utils/BijectiveAssociation.hpp>
+#include <algorithm>
+#include <iostream>
 namespace Ra {
 namespace Core {
 namespace Utils {
@@ -8,16 +10,16 @@ template <typename T1, typename T2>
 BijectiveAssociation<T1, T2>::BijectiveAssociation(
     std::initializer_list<std::pair<key_type, value_type>> pairs ) {
     for ( auto& p : pairs ) {
-        m_ValueToKey.insert( { p.second, p.first } );
-        m_KeyToValue.insert( p );
+        m_valueToKey.insert( { p.second, p.first } );
+        m_keyToValue.insert( p );
     }
 }
 
 template <typename T1, typename T2>
 bool BijectiveAssociation<T1, T2>::insert( std::pair<key_type, value_type> p ) {
-    auto [i1, r1] = m_ValueToKey.insert( { p.second, p.first } );
+    auto [i1, r1] = m_valueToKey.insert( { p.second, p.first } );
     if ( r1 ) {
-        auto [i2, r2] = m_KeyToValue.insert( std::move( p ) );
+        auto [i2, r2] = m_keyToValue.insert( std::move( p ) );
         return r2;
     }
     return false;
@@ -29,46 +31,112 @@ bool BijectiveAssociation<T1, T2>::insert( key_type v1, value_type v2 ) {
 }
 
 template <typename T1, typename T2>
+void BijectiveAssociation<T1, T2>::replace( key_type v1, value_type v2 ) {
+    // clean previously set association
+    auto it1 = std::find_if(
+        m_keyToValue.begin(),
+        m_keyToValue.end(),
+        [&v2]( const typename key_to_value_map::value_type& v ) { return v2 == v.second; } );
+
+    if ( it1 != m_keyToValue.end() ) m_keyToValue.erase( it1 );
+
+    auto it2 = std::find_if(
+        m_valueToKey.begin(),
+        m_valueToKey.end(),
+        [&v1]( const typename value_to_key_map::value_type& v ) { return v1 == v.second; } );
+
+    if ( it2 != m_valueToKey.end() ) m_valueToKey.erase( it2 );
+
+    // set new association
+    m_keyToValue[v1] = v2;
+    m_valueToKey[v2] = v1;
+}
+template <typename T1, typename T2>
+void BijectiveAssociation<T1, T2>::replace( std::pair<key_type, value_type> p ) {
+    replace( p.first, p.second );
+}
+
+template <typename T1, typename T2>
+void BijectiveAssociation<T1, T2>::remove( key_type v1, value_type v2 ) {
+    // clean previously set association
+    auto it1 = std::find_if(
+        m_keyToValue.begin(),
+        m_keyToValue.end(),
+        [&v2]( const typename key_to_value_map::value_type& v ) { return v2 == v.second; } );
+
+    if ( it1 != m_keyToValue.end() ) m_keyToValue.erase( it1 );
+    m_keyToValue.erase( v1 );
+
+    auto it2 = std::find_if(
+        m_valueToKey.begin(),
+        m_valueToKey.end(),
+        [&v1]( const typename value_to_key_map::value_type& v ) { return v1 == v.second; } );
+
+    if ( it2 != m_valueToKey.end() ) m_valueToKey.erase( it2 );
+    m_valueToKey.erase( v2 );
+}
+template <typename T1, typename T2>
+void BijectiveAssociation<T1, T2>::remove( std::pair<key_type, value_type> p ) {
+    remove( p.frist, p.second );
+}
+
+template <typename T1, typename T2>
 typename BijectiveAssociation<T1, T2>::value_type
 BijectiveAssociation<T1, T2>::operator()( const key_type& k ) const {
-    return m_KeyToValue.at( k );
+    return m_keyToValue.at( k );
 }
 
 template <typename T1, typename T2>
 typename BijectiveAssociation<T1, T2>::key_type
 BijectiveAssociation<T1, T2>::key( const value_type& k ) const {
-    return m_ValueToKey.at( k );
+    return m_valueToKey.at( k );
+}
+
+template <typename T1, typename T2>
+std::optional<typename BijectiveAssociation<T1, T2>::key_type>
+BijectiveAssociation<T1, T2>::keyIfExists( const value_type& k ) const {
+    auto itr = m_valueToKey.find( k );
+    if ( itr == m_valueToKey.end() ) return {};
+    return itr->second;
 }
 
 template <typename T1, typename T2>
 typename BijectiveAssociation<T1, T2>::value_type
 BijectiveAssociation<T1, T2>::value( const key_type& k ) const {
-    return m_KeyToValue.at( k );
+    return m_keyToValue.at( k );
+}
+
+template <typename T1, typename T2>
+std::optional<typename BijectiveAssociation<T1, T2>::value_type>
+BijectiveAssociation<T1, T2>::valueIfExists( const key_type& k ) const {
+    auto itr = m_keyToValue.find( k );
+    if ( itr == m_keyToValue.end() ) return {};
+    return itr->second;
 }
 
 template <typename T1, typename T2>
 typename std::map<T1, T2>::const_iterator BijectiveAssociation<T1, T2>::cbegin() const noexcept {
-    return m_KeyToValue.cbegin();
+    return m_keyToValue.cbegin();
 }
 
 template <typename T1, typename T2>
 typename std::map<T1, T2>::const_iterator BijectiveAssociation<T1, T2>::cend() const noexcept {
-    return m_KeyToValue.cend();
+    return m_keyToValue.cend();
 }
 
 template <typename T1, typename T2>
 typename std::map<T1, T2>::const_iterator BijectiveAssociation<T1, T2>::begin() const noexcept {
-    return m_KeyToValue.begin();
+    return m_keyToValue.begin();
 }
 
 template <typename T1, typename T2>
 typename std::map<T1, T2>::const_iterator BijectiveAssociation<T1, T2>::end() const noexcept {
-    return m_KeyToValue.end();
+    return m_keyToValue.end();
 }
 
 template <typename T1, typename T2>
 size_t BijectiveAssociation<T1, T2>::size() const {
-    return m_KeyToValue.size();
+    return m_keyToValue.size();
 }
 
 } // namespace Utils

--- a/src/Engine/Data/Mesh.hpp
+++ b/src/Engine/Data/Mesh.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/Utils/BijectiveAssociation.hpp>
 #include <Engine/RaEngine.hpp>
 
 #include <Engine/Data/DisplayableObject.hpp>
@@ -299,9 +300,8 @@ class CoreGeometryDisplayable : public AttribArrayDisplayable
     void addToTranslationTable( const std::string& name );
 
     /// Core::Mesh attrib name to Render::Mesh attrib name
-    using TranslationTable = std::map<std::string, std::string>;
-    TranslationTable m_translationTableMeshToShader;
-    TranslationTable m_translationTableShaderToMesh;
+    /// key: core mesh name, value: shader name
+    BijectiveAssociation<std::string, std::string> m_translationTable {};
 
     CoreGeometry m_mesh;
 };

--- a/src/Engine/Data/Mesh.inl
+++ b/src/Engine/Data/Mesh.inl
@@ -195,11 +195,7 @@ CoreGeometry& CoreGeometryDisplayable<CoreGeometry>::getCoreGeometry() {
 
 template <typename CoreGeometry>
 void CoreGeometryDisplayable<CoreGeometry>::addToTranslationTable( const std::string& name ) {
-    auto it = m_translationTableMeshToShader.find( name );
-    if ( it == m_translationTableMeshToShader.end() ) {
-        m_translationTableMeshToShader[name] = name;
-        m_translationTableShaderToMesh[name] = name;
-    }
+    m_translationTable.insert( name, name );
 }
 
 template <typename CoreGeometry>
@@ -241,24 +237,29 @@ void CoreGeometryDisplayable<CoreGeometry>::autoVertexAttribPointer( const Shade
         glprog->getActiveAttrib( idx, bufSize, &length, &size, &type, name );
         auto loc = glprog->getAttributeLocation( name );
 
-        auto attribName = m_translationTableShaderToMesh[name];
-        auto attrib     = m_mesh.getAttribBase( attribName );
-
-        if ( attrib && attrib->getSize() > 0 ) {
-            m_vao->enable( loc );
-            auto binding = m_vao->binding( idx );
-            binding->setAttribute( loc );
-            CORE_ASSERT( m_vbos[m_handleToBuffer[attribName]].get(), "vbo is nullptr" );
+        auto attribNameOpt = m_translationTable.keyIfExists( name );
+        if ( attribNameOpt ) {
+            auto attribName = *attribNameOpt;
+            auto attrib     = m_mesh.getAttribBase( attribName );
+            if ( attrib && attrib->getSize() > 0 ) {
+                m_vao->enable( loc );
+                auto binding = m_vao->binding( idx );
+                binding->setAttribute( loc );
+                CORE_ASSERT( m_vbos[m_handleToBuffer[attribName]].get(), "vbo is nullptr" );
 #ifdef CORE_USE_DOUBLE
-            binding->setBuffer( m_vbos[m_handleToBuffer[attribName]].get(),
-                                0,
-                                attrib->getNumberOfComponents() * sizeof( float ) );
+                binding->setBuffer( m_vbos[m_handleToBuffer[attribName]].get(),
+                                    0,
+                                    attrib->getNumberOfComponents() * sizeof( float ) );
 #else
 
-            binding->setBuffer(
-                m_vbos[m_handleToBuffer[attribName]].get(), 0, attrib->getStride() );
+                binding->setBuffer(
+                    m_vbos[m_handleToBuffer[attribName]].get(), 0, attrib->getStride() );
 #endif
-            binding->setFormat( attrib->getNumberOfComponents(), GL_SCALAR );
+                binding->setFormat( attrib->getNumberOfComponents(), GL_SCALAR );
+            }
+            else {
+                m_vao->disable( loc );
+            }
         }
         else {
             m_vao->disable( loc );
@@ -388,26 +389,7 @@ void CoreGeometryDisplayable<CoreGeometry>::setAttribNameCorrespondance(
     const std::string& meshAttribName,
     const std::string& shaderAttribName ) {
 
-    // clean previously set translation
-
-    auto it1 = std::find_if( m_translationTableShaderToMesh.begin(),
-                             m_translationTableShaderToMesh.end(),
-                             [&meshAttribName]( const TranslationTable::value_type& p ) {
-                                 return p.second == meshAttribName;
-                             } );
-
-    if ( it1 != m_translationTableShaderToMesh.end() ) m_translationTableShaderToMesh.erase( it1 );
-
-    auto it2 = std::find_if( m_translationTableMeshToShader.begin(),
-                             m_translationTableMeshToShader.end(),
-                             [&shaderAttribName]( const TranslationTable::value_type& p ) {
-                                 return p.second == shaderAttribName;
-                             } );
-
-    if ( it2 != m_translationTableMeshToShader.end() ) m_translationTableMeshToShader.erase( it2 );
-
-    m_translationTableShaderToMesh[shaderAttribName] = meshAttribName;
-    m_translationTableMeshToShader[meshAttribName]   = shaderAttribName;
+    m_translationTable.replace( meshAttribName, shaderAttribName );
 }
 
 ////////////////  IndexedGeometry  ///////////////////////////////

--- a/tests/unittest/Core/bijectiveassociation.cpp
+++ b/tests/unittest/Core/bijectiveassociation.cpp
@@ -1,5 +1,6 @@
 #include <Core/Utils/BijectiveAssociation.hpp>
 
+#include <stdexcept>
 #include <string>
 
 #include <catch2/catch.hpp>
@@ -31,7 +32,7 @@ TEST_CASE( "Core/Utils/BijectiveAssociation", "[Core][Core/Utils][BijectiveAssoc
         myTranslator.insert( "Three", "Trois" );
         REQUIRE( myTranslator.insert( { "Four", "Quatre" } ) ); // first insert pass
         REQUIRE( !myTranslator.insert(
-            { "Four", "Quatre" } ) ); // seconid insert failed since already present
+            { "Four", "Quatre" } ) ); // second insert failed since already present
 
         REQUIRE( myTranslator( "Four" ) == "Quatre" );
         REQUIRE( myTranslator.value( "Three" ) == "Trois" );
@@ -45,5 +46,34 @@ TEST_CASE( "Core/Utils/BijectiveAssociation", "[Core][Core/Utils][BijectiveAssoc
             REQUIRE( myTranslator.value( e.first ) == e.second );
             REQUIRE( myTranslator.key( e.second ) == e.first );
         }
+    }
+
+    SECTION( "Erase, replace, get undef." ) {
+        BijectiveAssociation<std::string, int> myTranslator {
+            { "Foo", 1 }, { "Bar", 2 }, { "Baz", 3 } };
+
+        REQUIRE_THROWS_AS( myTranslator.value( "Faz" ), std::out_of_range );
+        REQUIRE_THROWS_AS( myTranslator.key( 4 ), std::out_of_range );
+
+        REQUIRE( !myTranslator.valueIfExists( "Faz" ) );
+        REQUIRE( !myTranslator.keyIfExists( 4 ) );
+
+        REQUIRE( myTranslator.value( "Foo" ) == 1 );
+        REQUIRE( myTranslator.key( 1 ) == "Foo" );
+        myTranslator.replace( "Foo", 4 );
+        REQUIRE( myTranslator.value( "Foo" ) == 4 );
+        REQUIRE( myTranslator.key( 4 ) == "Foo" );
+
+        myTranslator.remove( "Bar", 2 );
+        myTranslator.remove( "Unknown", 6 );
+        myTranslator.insert( "Bar", 6 );
+        REQUIRE( myTranslator.value( "Bar" ) == 6 );
+        REQUIRE( myTranslator.key( 6 ) == "Bar" );
+
+        REQUIRE( myTranslator.value( "Foo" ) == 4 );
+        REQUIRE( myTranslator.key( 4 ) == "Foo" );
+        myTranslator.replace( "Faz", 4 );
+        REQUIRE( myTranslator.value( "Faz" ) == 4 );
+        REQUIRE( myTranslator.key( 4 ) == "Faz" );
     }
 }

--- a/tests/unittest/Core/bijectiveassociation.cpp
+++ b/tests/unittest/Core/bijectiveassociation.cpp
@@ -64,9 +64,9 @@ TEST_CASE( "Core/Utils/BijectiveAssociation", "[Core][Core/Utils][BijectiveAssoc
         REQUIRE( myTranslator.value( "Foo" ) == 4 );
         REQUIRE( myTranslator.key( 4 ) == "Foo" );
 
-        myTranslator.remove( "Bar", 2 );
-        myTranslator.remove( "Unknown", 6 );
-        myTranslator.insert( "Bar", 6 );
+        REQUIRE( myTranslator.remove( "Bar", 2 ) );
+        REQUIRE( !myTranslator.remove( "Unknown", 6 ) );
+        REQUIRE( myTranslator.insert( "Bar", 6 ) );
         REQUIRE( myTranslator.value( "Bar" ) == 6 );
         REQUIRE( myTranslator.key( 6 ) == "Bar" );
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Refactor Engine::Mesh translation table using BijectiveAssociation.
Also add new functionality to meet the needs of Engine::Mesh translation table 

* **What is the current behavior?** (You can also link to an open issue here)
Engine::Mesh translation table use ad hoc std::maps to perform core attrib name to shader attrib name correspondance.


* **What is the new behavior (if this is a feature change)?**
Use BijectiveAssociation code, which was introduce in #950 
