### PR TITLE
Core variables

### DIFF
--- a/src/Core/Containers/VariableSet.cpp
+++ b/src/Core/Containers/VariableSet.cpp
@@ -1,0 +1,86 @@
+#include <Core/Containers/VariableSet.hpp>
+// inspirations :
+// Radium dataflow dynamic type management
+// Radium attribArray
+// factory design pattern
+// visitor design pattern
+// https://en.cppreference.com/w/cpp/utility/any/type
+// https://gieseanw.wordpress.com/2017/05/03/a-true-heterogeneous-container-in-c/
+namespace Ra {
+namespace Core {
+
+VariableSet& VariableSet::operator=( const VariableSet& other ) {
+    clear();
+    m_clearFunctions        = other.m_clearFunctions;
+    m_copyFunctions         = other.m_copyFunctions;
+    m_moveFunctions         = other.m_moveFunctions;
+    m_mergeKeepFunctions    = other.m_mergeKeepFunctions;
+    m_mergeReplaceFunctions = other.m_mergeReplaceFunctions;
+    m_sizeFunctions         = other.m_sizeFunctions;
+    m_visitFunctions        = other.m_visitFunctions;
+    m_storedType            = other.m_storedType;
+    for ( auto&& copyFunction : m_copyFunctions ) {
+        copyFunction( other, *this );
+    }
+    return *this;
+}
+
+VariableSet& VariableSet::operator=( VariableSet&& other ) {
+    clear();
+    m_clearFunctions        = std::move( other.m_clearFunctions );
+    m_copyFunctions         = std::move( other.m_copyFunctions );
+    m_moveFunctions         = std::move( other.m_moveFunctions );
+    m_mergeKeepFunctions    = std::move( other.m_mergeKeepFunctions );
+    m_mergeReplaceFunctions = std::move( other.m_mergeReplaceFunctions );
+    m_sizeFunctions         = std::move( other.m_sizeFunctions );
+    m_visitFunctions        = std::move( other.m_visitFunctions );
+    m_storedType            = std::move( other.m_storedType );
+    for ( auto&& moveFunction : m_moveFunctions ) {
+        moveFunction( other, *this );
+    }
+    return *this;
+}
+
+void VariableSet::clear() {
+    for ( auto&& clearFunc : m_clearFunctions ) {
+        clearFunc( *this );
+    }
+    m_clearFunctions.clear();
+    m_copyFunctions.clear();
+    m_moveFunctions.clear();
+    m_mergeKeepFunctions.clear();
+    m_mergeReplaceFunctions.clear();
+    m_sizeFunctions.clear();
+    m_visitFunctions.clear();
+    m_storedType.clear();
+}
+
+void VariableSet::mergeKeepVariables( const VariableSet& from ) {
+    for ( auto&& mergeFunc : from.m_mergeKeepFunctions ) {
+        mergeFunc( from, *this );
+    }
+}
+
+void VariableSet::mergeReplaceVariables( const VariableSet& from ) {
+    for ( auto&& mergeFunc : from.m_mergeReplaceFunctions ) {
+        mergeFunc( from, *this );
+    }
+}
+
+size_t VariableSet::size() const {
+    size_t sum = 0;
+    for ( auto&& sizeFunc : m_sizeFunctions ) {
+        sum += sizeFunc( *this );
+    }
+    return sum;
+}
+
+void VariableSet::DynamicVisitor::operator()( std::any&& in ) const {
+    if ( auto it = m_visitorOperator.find( std::type_index( in.type() ) );
+         it != m_visitorOperator.cend() ) {
+        it->second( in );
+    }
+}
+
+} // namespace Core
+} // namespace Ra

--- a/src/Core/Containers/VariableSet.hpp
+++ b/src/Core/Containers/VariableSet.hpp
@@ -1,0 +1,626 @@
+#pragma once
+#include <Core/RaCore.hpp>
+
+#include <Core/Utils/StdExperimentalTypeTraits.hpp>
+
+#include <any>
+#include <assert.h>
+#include <functional>
+#include <map>
+#include <typeindex>
+#include <unordered_map>
+#include <vector>
+
+namespace Ra {
+namespace Core {
+
+/// \brief Heterogeneous container storing "Variables", that maps a name (std::string) to a value
+/// (of any type T).
+///
+/// The container is compatible with any type, from simple arithmetic type to wrapped references to
+/// any other type.
+///
+/// "Variables" can be added, accessed and removed from the container given their type, name and
+/// value.
+///
+/// Given a type, the container gives access to the mapping name->value for all variables with the
+/// given type.
+///
+/// Stored variables can be referenced using a VariableHandle returned when a variable is inserted
+/// in the container or fetch giving the type and the name of the variable. Validity of the variable
+/// handle follows the same rules than the std::iterator attached to the underlying mapping storage
+/// (std::map<std::string, T>::iterator for the actual implementation).
+///
+/// From a variable handle (possibly invalid), the mapping name->value for all variables with the
+/// same type can be fetched. This allows generic, type agnostic, usage of the container as soon as
+/// a variable handle (even invalid) is available.
+///
+/// The container could be visited to apply processing, transformation, ... on all or part of the
+/// variables. The accept functions of the visitor are defined by the availability of a callable
+/// object whose profile is compatible with the visited types.
+///
+/// Visiting the container can be made
+///  - using a statically typed visitor : accepted types are defined at compile time,
+/// as template parameters, and the visit is pre-processed by the compiler.
+///  - using a dynamically configurable visitor where functor accepting types can be added/removed
+/// at runtime. This kind of visit is a little more expensive while being more configurable.
+///
+/// \note relies on C++ standard libraries extensions, version 2 or recommended implementation on
+/// compilers that do not provide this extension
+/// https://en.cppreference.com/w/cpp/experimental/lib_extensions_2
+///
+/// \see VariableSet unit test source code for examples of usage of this container
+class RA_CORE_API VariableSet
+{
+  public:
+    /// \brief Container type for the mapping name->value of variables with type T.
+    template <typename T>
+    using BaseContainer = std::map<std::string, T>;
+
+    /// \brief Handle of a variable
+    /// A handle on a variable with type T is an iterator into the BaseContainer.
+    /// De-referencing the handle give access to a non const pair
+    /// <const std::string, T> (BaseContainer<T>::value_type).
+    /// VariableHandle validity follows the rules of BaseContainer<T>::iterator validity.
+    template <typename T>
+    using VariableHandle = typename BaseContainer<T>::iterator;
+
+    /// \brief Type of the variable referenced by a VariableHandle
+    template <typename H>
+    using HandledType = typename std::iterator_traits<H>::value_type::second_type;
+
+    /// \brief CRTP based Type list for statically typed visitors.
+    template <class...>
+    struct TypeList {};
+
+    /// \brief Base class for visitors with static supported types.
+    /// Visiting will be prepared at compile time by unfolding type list and generating all
+    /// the required function calls for the visit.
+    /// Any class that defines the same alias for a public member "types" can be used as a visitor.
+    template <class... TYPES>
+    struct StaticVisitor {
+        using types = TypeList<TYPES...>;
+    };
+
+    // Pre declare base class for all dynamic visitors.
+    class DynamicVisitor;
+
+    // ----------------------------------------------------------
+    /// Constructors, destructors
+    /// \{
+    VariableSet() = default;
+    ~VariableSet() { clear(); }
+    /// A VariableSet is copyable
+    VariableSet( const VariableSet& other ) { *this = other; }
+    /// A VariableSet is movable
+    VariableSet( VariableSet&& other ) { *this = std::move( other ); }
+    /// \}
+
+    // ------------------------------------------------------------------------------------------
+    // Global variable set operations
+    // ------------------------------------------------------------------------------------------
+    /// Operators acting on a the whole VariableSet
+    /// \{
+    /// \brief Copy assignment operator
+    VariableSet& operator=( const VariableSet& other );
+
+    /// \brief Move assignment operator
+    VariableSet& operator=( VariableSet&& other );
+
+    /// \brief remove all elements from the container
+    void clear();
+
+    /// \brief Merge the VariableSet \b from into this
+    /// \param from the VariableSet to merge with the current.
+    /// Existing variable into this, with same name as in from, are kept unchanged
+    /// \see mergeReplaceVariables
+    void mergeKeepVariables( const VariableSet& from );
+
+    /// \brief Merge the VariableSet \b from into this
+    /// \param from the VariableSet to merge with the current.
+    /// Existing variable into this, with same name as in from, are replaced by from's one.
+    /// \see mergeKeepVariables
+    void mergeReplaceVariables( const VariableSet& from );
+
+    /// \brief Gets the total number of variables (of any type)
+    size_t size() const;
+
+    /// \brief Gets the stored data type
+    /// \return constant vector of type_index
+    const std::vector<std::type_index>& getStoredTypes() const { return m_storedType; }
+
+    /// \}
+    // ------------------------------------------------------------------------------------------
+    // Per variable operations
+    // ------------------------------------------------------------------------------------------
+    /// Operators acting on a per variable basis
+    /// \{
+    /// \brief Add a variable, i.e. an association name->value, into the container
+    /// \return true if the variable is inserted, false if the name was already associated with
+    /// another value (of the same type). In this case, keep the old value.
+    ///
+    template <typename T>
+    std::pair<VariableHandle<T>, bool> insertVariable( const std::string& name, const T& value );
+
+    /// \brief get the value of the given variable
+    /// \return a const reference to the value.
+    /// \pre The element \b name must exists with type \b T.
+    template <typename T>
+    const T& getVariable( const std::string& name ) const;
+
+    /// \brief get the handle on the variable with the given name
+    /// \tparam T the type of the variable
+    /// \param name the name of a variable
+    /// \return an handle which can be de-referenced to obtain a std::pair<const std::string, T>
+    /// representing the name and the value of the variable.
+    template <typename T>
+    VariableHandle<T> getVariableHandle( const std::string& name ) const;
+
+    /// \brief Test the validity of a handle
+    /// \tparam H Type of the handle. Expected to be VariableHandle<T> for some variable type T
+    /// \param handle the variable handle
+    /// \return true if the handle is valid, false if not.
+    template <typename H>
+    bool isHandleValid( const H& handle ) const;
+
+    /// \brief reset (or set if the variable does not exist yet) the value of the variable.
+    /// \return true if the value was reset, false it was set.
+    template <typename T>
+    std::pair<VariableHandle<T>, bool> insertOrAssignVariable( const std::string& name,
+                                                               const T& value );
+
+    /// \brief Remove a variable, i.e. a name->value association
+    /// \return true if the variable was removed, false if
+    /// \pre The element \b name must exists with type \b T.
+    template <typename T>
+    bool deleteVariable( const std::string& name );
+
+    /// \brief delete a variable from its handle
+    /// \tparam H Type of the handle. Expected to be VariableHandle<T> for some variable type T
+    /// \param handle the variable handle
+    /// \return true variable was removed, false if not.
+    /// If the variable was removed, handle is invalidated
+    /// \pre the handle must be valid
+    template <typename H>
+    bool deleteVariable( H& handle );
+
+    /// \brief test the existence of the given variable
+    /// \return true if a variable with the given name and type exists in the storage, false if not.
+    template <typename T>
+    bool existsVariable( const std::string& name ) const;
+
+    /// \}
+
+    // ------------------------------------------------------------------------------------------
+    // Per type access
+    // ------------------------------------------------------------------------------------------
+    /// Operators acting on a per type basis
+    /// \{
+  public:
+    /// \brief Test if the storage supports a given variable type
+    /// \tparam T The type of variable to test
+    /// \return true if the type is managed by the storage
+    template <typename T>
+    bool existsVariableType() const;
+
+    /// \brief Removes all variables of the given type.
+    /// \tparam T The type of variable to remove
+    /// \return true if the type is deleted, false if it was not managed before the call.
+    /// Unregister all the functions associated with the type and remove the storage of
+    /// existing variables. If several variables are still stored, they will be destroyed.
+    template <typename T>
+    bool deleteAllVariables();
+
+    /// \brief Get the whole container for variables of a given type
+    /// \tparam T The variable type to get
+    /// \return a reference to the storage of the mapping name->value for the given type.
+    /// \pre existsVariableType<T>()
+    template <typename T>
+    BaseContainer<T>& getAllVariables();
+
+    /// \brief Get the whole container for variables of the same type than the given handled
+    /// variable. \tparam H Type of the variable handle, should be VariableHandle<T> for some type T
+    /// \param handle the handle to an existing variable
+    /// \return a reference to the storage of the mapping name->value for the given type.
+    /// \pre existsVariableType<HandledType<H>>()
+    /// variable.
+    template <typename H>
+    auto getAllVariablesFromHandle( const H& handle ) -> BaseContainer<HandledType<H>>&;
+
+    /// \brief Get the number of variables of the given type
+    /// \tparam T The type to test
+    /// \return the number of variables with type T stored in the container
+    template <typename T>
+    size_t numberOf() const;
+    /// \}
+
+    /// Visiting operators
+    /// \{
+
+    /// \brief Visit the container using a dynamically typed visitor
+    /// \tparam F The type of the visitor to use (see below)
+    /// \param visitor The visitor to use
+    ///
+    /// This visiting method is adapted when the types to visit are only known at running time.
+    /// At running time, this visiting approach relies on two loops.
+    ///   - The first loop, done by the visiting logic in the class VariableSet iterate over ALL
+    ///     the stored mapping name->value to build a type-safe container for single values.
+    ///   - The second loop, done by the visitor, loop over visiting operators to find how to
+    ///     process the given type-safe container (https://en.cppreference.com/w/cpp/utility/any)
+    /// This visitor then iterate over all the managed type, and, for each of them, over all stored
+    /// variables then search for a compatible visiting operator.
+    ///
+    /// The type of the visiting functor F should be
+    ///   - either derived from VariableSet::DynamicVisitor with the needed visiting operators
+    ///     registered (\see see VariableSet::DynamicVisitor)
+    ///   - either a full user define callable
+    ///     (\see https://en.cppreference.com/w/cpp/named_req/Callable) object with profile
+    ///     void op(std::any&& param). In this case, the given std::any rvalue reference wraps a
+    ///     reference to a std::pair<const std::string, T> such that the first element of the pair
+    ///     is the name of the variable, and the second its value of type T.
+    template <typename F>
+    void visitDynamic( F&& visitor ) const;
+
+    /// \brief Visit the container using a statically typed visitor
+    /// \tparam F The type of the visitor to use (see below)
+    /// \param visitor The visitor object to use
+    ///
+    /// This visiting method is well adapted when the visited types are known at compile time.
+    /// In this case, part of the visit logic is done at compile time by unfolding the call of the
+    /// type-related visitors instead of looping over all the stored type.
+    /// This visiting strategy loops on visited types at compile time (loop unrolled) then
+    /// on each stored values at running time. So, this visiting strategy is more efficient than
+    /// the dynamic one if visited types are always the same.
+    ///
+    /// The type of the visiting functor F should be
+    ///     - either derived from VariableSet::StaticVisitor<Type1, Type2, ...> with function
+    ///     operators with profile const operator(const std::string& name, T& value) available for
+    ///     all the requested types Type1, Type2, ...
+    ///     - either a user define class exposing a type list to unfold F::types
+    ///     (see VariableSet::TypeList and VariableSet::StaticVisitor)
+    template <typename F>
+    void visit( F&& visitor ) const;
+
+    /// \brief Base class for visitors with dynamic supported types.
+    /// Visiting will be prepared at running time by dynamically adding visitor operators for each
+    /// type one want to visit in the container. The visitor operators should be any callable that
+    /// accept to be called using f(const std::string&, T&)
+    class RA_CORE_API DynamicVisitor
+    {
+      public:
+        /// allows the class to be derived
+        virtual ~DynamicVisitor() = default;
+
+        /// \brief Execute a visiting operator on accepted types
+        /// \param in The variable to process
+        /// The variable in contains a wrapping of the association name->value whose visit is
+        /// accepted if there exists an operator for this type in the Visitor. Visiting the
+        /// association is done by calling this operator.
+        virtual void operator()( std::any&& in ) const;
+
+        /// \brief Add a visiting operator.
+        /// \tparam T The accepted type for the visit.
+        /// \tparam F The operator type, a callable with profile void(const std::string&, [const
+        /// ]T[&]).
+        /// \param f The operator object.
+        /// \return true if the operator was added, false if not (e.g. there is already an operator
+        /// associated with the type T)
+        template <typename T, typename F>
+        bool addOperator( F&& f );
+
+        /// \brief Test the existence of an operator associated with a type
+        /// \tparam T
+        /// \return
+        template <typename T>
+        bool hasOperator();
+
+        /// \brief Add or replace a visiting operator
+        /// \tparam T
+        /// \tparam F
+        /// \param f
+        /// This method is similar to DynamicVisitor::addOperator but replace any existing operator
+        /// previously associated with the type T
+        template <typename T, typename F>
+        void addOrReplaceOperator( F&& f );
+
+        /// \brief Remove a visiting operator
+        /// \tparam T
+        /// \return
+        /// \pre The type \b T must be accepted by an operator.
+        template <typename T>
+        bool removeOperator();
+
+      private:
+        template <typename T>
+        using VisitedType = typename VariableSet::BaseContainer<T>::value_type;
+
+        template <typename T>
+        auto getTypeIndex() -> std::type_index;
+
+        template <class T, class F>
+        inline std::pair<const std::type_index, std::function<void( std::any& )>>
+        makeVisitorOperator( F& f );
+
+        using OperatorsStorageType =
+            std::unordered_map<std::type_index, std::function<void( std::any& )>>;
+
+        OperatorsStorageType m_visitorOperator;
+    };
+
+  private:
+  private:
+    /// \brief Add support for a given type.
+    /// \tparam T The type to manage
+    /// \return true if the type was correctly inserted
+    /// This method create functions for destroying, copying, inspecting and visiting variables
+    /// of the given type.
+    template <typename T>
+    void addVariableType();
+
+    /// The core of a container logic : a template member variable
+    template <typename T>
+    static std::unordered_map<const VariableSet*, BaseContainer<T>> m_variables;
+
+    /// \brief test if the type F has a callable operator with the right profile
+    template <typename F, typename T>
+    using VisitFunction = decltype(
+        std::declval<F>().operator()( std::declval<const std::string&>(), std::declval<T&>() ) );
+
+    /// Implementation of static visitor
+    /// \{
+    template <typename F, typename T>
+    static constexpr bool has_visit_v = Ra::Core::Utils::is_detected<VisitFunction, F, T>::value;
+
+    template <typename F, template <typename...> typename TYPESLIST, typename... TYPES>
+    void visitImpl( F&& visitor, TYPESLIST<TYPES...> ) const;
+
+    template <typename F, typename T>
+    void visitImplHelper( F& visitor ) const;
+    /// \}
+
+    /// Storage for the data management functions
+    /// \{
+    std::vector<std::function<void( VariableSet& )>> m_clearFunctions;
+    std::vector<std::function<void( const VariableSet&, VariableSet& )>> m_copyFunctions;
+    std::vector<std::function<void( VariableSet&, VariableSet& )>> m_moveFunctions;
+    std::vector<std::function<void( const VariableSet&, VariableSet& )>> m_mergeKeepFunctions;
+    std::vector<std::function<void( const VariableSet&, VariableSet& )>> m_mergeReplaceFunctions;
+    std::vector<std::function<size_t( const VariableSet& )>> m_sizeFunctions;
+    std::vector<std::function<void( const VariableSet&, DynamicVisitor& )>> m_visitFunctions;
+    std::vector<std::type_index> m_storedType;
+    /// \}
+};
+
+// ------------------------------------------------------------------------------------------
+// Templated methods definition
+// ------------------------------------------------------------------------------------------
+template <typename T>
+std::pair<VariableSet::VariableHandle<T>, bool>
+VariableSet::insertVariable( const std::string& name, const T& value ) {
+    // If it is the first parameter of the given type, first register the type
+    if ( !existsVariableType<T>() ) { addVariableType<T>(); }
+    // insert the parameter.
+    auto inserted = m_variables<T>[this].insert( { name, value } );
+    return inserted;
+}
+
+template <typename T>
+const T& VariableSet::getVariable( const std::string& name ) const {
+    assert( existsVariable<T>( name ) );
+    auto it = getVariableHandle<T>( name );
+    return it->second;
+}
+
+template <typename T>
+VariableSet::VariableHandle<T> VariableSet::getVariableHandle( const std::string& name ) const {
+    auto iter = m_variables<T>.find( this );
+    auto it   = iter->second.find( name );
+    return it;
+}
+
+template <typename H>
+bool VariableSet::isHandleValid( const H& handle ) const {
+    auto iter = m_variables<HandledType<H>>.find( this );
+    if ( iter != m_variables<HandledType<H>>.end() ) { return handle != iter->second.end(); }
+    return false;
+}
+
+template <typename T>
+std::pair<VariableSet::VariableHandle<T>, bool>
+VariableSet::insertOrAssignVariable( const std::string& name, const T& value ) {
+    if ( !existsVariableType<T>() ) { addVariableType<T>(); }
+    auto result = m_variables<T>[this].insert_or_assign( name, value );
+    return result;
+}
+
+template <typename T>
+bool VariableSet::deleteVariable( const std::string& name ) {
+    assert( existsVariable<T>( name ) );
+    auto iter    = m_variables<T>.find( this );
+    auto removed = iter->second.erase( name ) > 0;
+
+    // do we want to remove the type related function when the container has no more data of
+    // this type ?
+    if ( numberOf<T>() == 0 ) { deleteAllVariables<T>(); }
+
+    return removed;
+}
+
+template <typename H>
+bool VariableSet::deleteVariable( H& handle ) {
+    assert( isHandleValid( handle ) );
+    auto varname = handle->first;
+    handle       = m_variables<HandledType<H>>[this].end();
+    deleteVariable<HandledType<H>>( varname );
+    return !isHandleValid( handle );
+}
+
+template <typename T>
+bool VariableSet::existsVariable( const std::string& name ) const {
+    auto iter = m_variables<T>.find( this );
+    if ( iter != m_variables<T>.cend() ) {
+        auto it = iter->second.find( name );
+        return it != iter->second.cend();
+    }
+    return false;
+}
+
+template <typename T>
+void VariableSet::addVariableType() {
+    assert( !existsVariableType<T>() );
+    // used to remove all stored data at deletion time
+    m_clearFunctions.emplace_back( []( VariableSet& c ) { m_variables<T>.erase( &c ); } );
+    // used to copy the stored data when copying the object
+    m_copyFunctions.emplace_back( []( const VariableSet& from, VariableSet& to ) {
+        m_variables<T>[&to] = m_variables<T>[&from];
+    } );
+    m_moveFunctions.emplace_back( []( VariableSet& from, VariableSet& to ) {
+        m_variables<T>[&to] = std::move( m_variables<T>[&from] );
+    } );
+    // used to merge (keep) the stored data from container "from" to container "to"
+    m_mergeKeepFunctions.emplace_back( []( const VariableSet& from, VariableSet& to ) {
+        if ( !to.existsVariableType<T>() ) { to.addVariableType<T>(); }
+        for ( const auto& t : m_variables<T>[&from] ) {
+            m_variables<T>[&to].insert( t );
+        }
+    } );
+    // used to merge (replace) the stored data from container "from" to container "to"
+    m_mergeReplaceFunctions.emplace_back( []( const VariableSet& from, VariableSet& to ) {
+        if ( !to.existsVariableType<T>() ) { to.addVariableType<T>(); }
+        for ( const auto& t : m_variables<T>[&from] ) {
+            m_variables<T>[&to].insert_or_assign( t.first, t.second );
+        }
+    } );
+    // use to compute gauge on the stored data
+    m_sizeFunctions.emplace_back(
+        []( const VariableSet& c ) { return m_variables<T>[&c].size(); } );
+    // used to call dynamically typed visitors
+    m_visitFunctions.emplace_back( []( const VariableSet& c, DynamicVisitor& v ) {
+        for ( auto&& t : m_variables<T>[&c] ) {
+            v( { std::ref( t ) } );
+        }
+    } );
+    // remember the stored type and its rank
+    m_storedType.emplace_back( std::type_index( typeid( T ) ) );
+}
+
+template <typename T>
+bool VariableSet::existsVariableType() const {
+    auto iter = m_variables<T>.find( this );
+    return iter != m_variables<T>.cend();
+}
+
+template <typename T>
+bool VariableSet::deleteAllVariables() {
+    auto iter = m_variables<T>.find( this );
+    if ( iter != m_variables<T>.end() ) {
+        auto tidx = std::type_index( typeid( T ) );
+        auto it   = std::find( m_storedType.begin(), m_storedType.end(), tidx );
+        auto idx  = it - m_storedType.begin();
+        m_clearFunctions.erase( m_clearFunctions.begin() + idx );
+        m_copyFunctions.erase( m_copyFunctions.begin() + idx );
+        m_moveFunctions.erase( m_moveFunctions.begin() + idx );
+        m_mergeKeepFunctions.erase( m_mergeKeepFunctions.begin() + idx );
+        m_mergeReplaceFunctions.erase( m_mergeReplaceFunctions.begin() + idx );
+        m_sizeFunctions.erase( m_sizeFunctions.begin() + idx );
+        m_visitFunctions.erase( m_visitFunctions.begin() + idx );
+        m_storedType.erase( it );
+        m_variables<T>.erase( iter );
+        return true;
+    }
+    return false;
+}
+
+template <typename T>
+VariableSet::BaseContainer<T>& VariableSet::getAllVariables() {
+    assert( existsVariableType<T>() );
+    auto iter = m_variables<T>.find( this );
+    return iter->second;
+}
+
+template <typename H>
+auto VariableSet::getAllVariablesFromHandle( const H& ) -> BaseContainer<HandledType<H>>& {
+    assert( existsVariableType<HandledType<H>>() );
+    return getAllVariables<HandledType<H>>();
+}
+
+template <typename T>
+size_t VariableSet::numberOf() const {
+    auto iter = m_variables<T>.find( this );
+    if ( iter != m_variables<T>.cend() ) { return iter->second.size(); }
+    return 0;
+}
+
+template <typename F>
+void VariableSet::visitDynamic( F&& visitor ) const {
+    for ( auto&& visitFunc : m_visitFunctions ) {
+        visitFunc( *this, visitor );
+    }
+}
+
+template <typename F>
+void VariableSet::visit( F&& visitor ) const {
+    visitImpl( visitor, typename std::decay_t<F>::types {} );
+}
+
+template <typename F, template <typename...> typename TYPESLIST, typename... TYPES>
+void VariableSet::visitImpl( F&& visitor, TYPESLIST<TYPES...> ) const {
+    ( ..., visitImplHelper<std::decay_t<F>, TYPES>( visitor ) );
+}
+
+template <typename F, typename T>
+void VariableSet::visitImplHelper( F& visitor ) const {
+    static_assert( has_visit_v<F, T>,
+                   "Static visitors must provide a function with profile "
+                   "void( const std::string& name, [const ]T[&] value) for each "
+                   "declared visitable type T" );
+    if ( !existsVariableType<T>() ) { return; }
+    for ( auto& element : m_variables<T>[this] ) {
+        visitor( element.first, element.second );
+    }
+}
+
+template <typename T>
+std::unordered_map<const VariableSet*, std::map<std::string, T>> VariableSet::m_variables;
+
+template <typename T, typename F>
+bool VariableSet::DynamicVisitor::addOperator( F&& f ) {
+    auto [it, inserted] = m_visitorOperator.insert( makeVisitorOperator<T, F>( f ) );
+    return inserted;
+}
+
+template <typename T>
+bool VariableSet::DynamicVisitor::hasOperator() {
+    return m_visitorOperator.find( getTypeIndex<T>() ) != m_visitorOperator.end();
+}
+
+template <typename T, typename F>
+void VariableSet::DynamicVisitor::addOrReplaceOperator( F&& f ) {
+    auto op = makeVisitorOperator<T, F>( f );
+    m_visitorOperator.insert_or_assign( op.first, op.second );
+}
+
+template <typename T>
+bool VariableSet::DynamicVisitor::removeOperator() {
+    assert( hasOperator<T>() );
+    auto res = m_visitorOperator.erase( getTypeIndex<T>() ) > 0;
+    return res;
+}
+
+template <typename T>
+auto VariableSet::DynamicVisitor::getTypeIndex() -> std::type_index {
+    return std::type_index( typeid( std::reference_wrapper<VisitedType<T>> ) );
+}
+
+template <class T, class F>
+inline std::pair<const std::type_index, std::function<void( std::any& )>>
+VariableSet::DynamicVisitor::makeVisitorOperator( F& f ) {
+    return { getTypeIndex<T>(), [&f]( std::any& a ) {
+                auto rp = std::any_cast<std::reference_wrapper<VisitedType<T>>&>( a );
+                auto& p = rp.get();
+                f( p.first, p.second );
+            } };
+}
+
+} // namespace Core
+} // namespace Ra

--- a/src/Core/Utils/StdExperimentalTypeTraits.hpp
+++ b/src/Core/Utils/StdExperimentalTypeTraits.hpp
@@ -10,6 +10,7 @@
  */
 
 #ifdef __has_include
+// cppcheck-suppress preprocessorErrorDirective
 #    if __has_include( <experimental/type_traits> )
 #        include <experimental/type_traits>
 #        define have_experimental_type_traits

--- a/src/Core/Utils/StdExperimentalTypeTraits.hpp
+++ b/src/Core/Utils/StdExperimentalTypeTraits.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+/*
+ * This file provides
+ *  - Ra::Core::Utils::is_detected, which is an alias for std::experimental::is_detected
+ *  (see https://en.cppreference.com/w/cpp/experimental/is_detected) or which
+ *  follows the sample implementation from
+ *  https://en.cppreference.com/w/cpp/experimental/is_detected#Possible_implementation,
+ *
+ */
+
+#ifdef __has_include
+#    if __has_include( <experimental/type_traits> )
+#        include <experimental/type_traits>
+#        define have_experimental_type_traits
+#    endif
+#endif
+
+namespace Ra {
+namespace Core {
+namespace Utils {
+#ifdef have_experimental_type_traits
+// use std::experimental definition
+template <template <class...> class Op, class... Args>
+using is_detected = typename std::experimental::is_detected<Op, Args...>;
+
+template <template <class...> class Op, class... Args>
+using detected_t = typename std::experimental::detected_t<Op, Args...>;
+
+template <class Default, template <class...> class Op, class... Args>
+using detected_or = typename std::experimental::detected_or<Default, Op, Args...>;
+
+#else
+// use possible implementation given in
+// https://en.cppreference.com/w/cpp/experimental/is_detected#Possible_implementation
+namespace detail {
+template <class Default, class AlwaysVoid, template <class...> class Op, class... Args>
+struct detector {
+    using value_t = std::false_type;
+    using type    = Default;
+};
+
+template <class Default, template <class...> class Op, class... Args>
+struct detector<Default, std::void_t<Op<Args...>>, Op, Args...> {
+    using value_t = std::true_type;
+    using type    = Op<Args...>;
+};
+} // namespace detail
+
+struct nonesuch {
+    ~nonesuch()                 = delete;
+    nonesuch( nonesuch const& ) = delete;
+    void operator=( nonesuch const& ) = delete;
+};
+
+template <template <class...> class Op, class... Args>
+using is_detected = typename detail::detector<nonesuch, void, Op, Args...>::value_t;
+
+template <template <class...> class Op, class... Args>
+using detected_t = typename detail::detector<nonesuch, void, Op, Args...>::type;
+
+template <class Default, template <class...> class Op, class... Args>
+using detected_or = detail::detector<Default, void, Op, Args...>;
+#endif
+} // namespace Utils
+} // namespace Core
+} // namespace Ra

--- a/src/Core/filelist.cmake
+++ b/src/Core/filelist.cmake
@@ -24,6 +24,7 @@ set(core_sources
     Asset/LightData.cpp
     Asset/MaterialData.cpp
     Containers/AdjacencyList.cpp
+    Containers/VariableSet.cpp
     Geometry/CatmullClarkSubdivider.cpp
     Geometry/IndexedGeometry.cpp
     Geometry/LoopSubdivider.cpp
@@ -80,6 +81,7 @@ set(core_headers
     Containers/Iterators.hpp
     Containers/MakeShared.hpp
     Containers/Tex.hpp
+    Containers/VariableSet.hpp
     Containers/VectorArray.hpp
     CoreMacros.hpp
     Geometry/AbstractGeometry.hpp
@@ -123,6 +125,7 @@ set(core_headers
     Utils/Observable.hpp
     Utils/Singleton.hpp
     Utils/StackTrace.hpp
+    Utils/StdExperimentalTypeTraits.hpp
     Utils/StdFilesystem.hpp
     Utils/StdMapIterators.hpp
     Utils/StdOptional.hpp

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -27,6 +27,7 @@ set(test_src
     Core/singleton.cpp
     Core/taskqueue.cpp
     Core/topomesh.cpp
+    Core/variableset.cpp
     Core/vectorarray.cpp
     Engine/environmentmap.cpp
     Engine/renderparameters.cpp

--- a/tests/unittest/Core/variableset.cpp
+++ b/tests/unittest/Core/variableset.cpp
@@ -1,0 +1,357 @@
+#include <Core/Containers/VariableSet.hpp>
+
+#include <Core/Utils/TypesUtils.hpp>
+
+#include <catch2/catch.hpp>
+#include <string>
+
+using namespace Ra::Core;
+
+struct printThemAll {
+    using types =
+        VariableSet::TypeList<int, size_t, float, double, std::reference_wrapper<int>, std::string>;
+
+    template <typename T>
+    void operator()( const std::string& name, T& value ) {
+        std::cout << " [ " << name << " --> " << value << " ] ";
+    }
+};
+
+class MyParameterVisitor : public VariableSet::DynamicVisitor
+{
+  public:
+    MyParameterVisitor() : VariableSet::DynamicVisitor() {
+        addOperator<std::reference_wrapper<int>>( *this );
+        addOperator<float>( *this );
+        addOperator<std::string>( *this );
+    }
+
+    template <typename T>
+    void operator()( const std::string& name, T& _in ) {
+        std::cout << "\t(MyParameterVisitor : ( " << Utils::demangleType<T>() << " ) " << name
+                  << " --> " << _in << " // ";
+        _in /= 2;
+        std::cout << _in << "\n";
+        ++m_counter;
+    }
+
+    void operator()( const std::string& name, std::string& _in ) {
+        std::cout << "\t(MyParameterVisitor : ( std::string ) " << name << " --> " << _in << "\n";
+        ++m_counter;
+    }
+
+    size_t getCount() { return m_counter; }
+    void resetCount() { m_counter = 0; }
+
+  private:
+    size_t m_counter { 0 };
+};
+
+TEST_CASE( "Core/Container/VariableSet", "[Core][Container][VariableSet]" ) {
+    auto print_container = []( const std::string& name, VariableSet& ps ) {
+        std::cout << name << " content : ";
+        ps.visit( printThemAll {} );
+        std::cout << std::endl;
+    };
+
+    SECTION( "Construction, access and removal to and from a variable set" ) {
+        VariableSet params;
+        int i { 0 };
+        float x { 1.f };
+
+        std::cout << "Adding parameters" << std::endl;
+        params.insertVariable( "i", i );             // i added by value
+        params.insertVariable( "j", std::ref( i ) ); // j is a reference on i
+        params.insertVariable( "x", 1 );
+        params.insertVariable( "x", x );
+        params.insertVariable( "foo", std::string { "bar" } );
+        std::cout << " ... done!" << std::endl;
+
+        REQUIRE( params.existsVariable<int>( "i" ) );
+        REQUIRE( params.existsVariable<std::reference_wrapper<int>>( "j" ) );
+        REQUIRE( params.existsVariable<int>( "x" ) );
+        REQUIRE( params.existsVariable<float>( "x" ) );
+        REQUIRE( params.existsVariable<std::string>( "foo" ) );
+
+        auto added = params.insertVariable( "x", x );
+        REQUIRE( added.second == false );
+        REQUIRE( added.first->second == x );
+
+        // Verify handle validity
+        auto fooHandle = params.getVariableHandle<std::string>( "foo" );
+        REQUIRE( params.isHandleValid( fooHandle ) == true );
+        REQUIRE( fooHandle->first == "foo" );
+        REQUIRE( fooHandle->second == "bar" );
+
+        auto dummyHandle = params.getVariableHandle<int>( "z" );
+        REQUIRE( params.isHandleValid( dummyHandle ) == false );
+
+        REQUIRE( params.size() == 5 );
+        REQUIRE( params.numberOf<int>() == 2 );
+        REQUIRE( params.numberOf<std::reference_wrapper<int>>() == 1 );
+        REQUIRE( params.numberOf<float>() == 1 );
+        REQUIRE( params.numberOf<std::string>() == 1 );
+
+        print_container( "Initial set", params );
+
+        REQUIRE( params.getVariable<float>( "x" ) == x );
+        // modify "x" through its handle
+        auto xHandle = params.getVariableHandle<float>( "x" );
+        REQUIRE( xHandle->second == x );
+        xHandle->second = 5;
+        REQUIRE( params.getVariable<float>( "x" ) != x );
+        REQUIRE( params.getVariable<float>( "x" ) == 5 );
+
+        // variable i store a value, copy of local variable i. Changing its value ...
+        auto inserted = params.insertOrAssignVariable( "i", 2 );
+        REQUIRE( inserted.second == false );
+        REQUIRE( params.getVariable<int>( "i" ) == 2 );
+        // does not change the local variable i
+        REQUIRE( i == 0 );
+
+        inserted = params.insertOrAssignVariable( "k", 3 );
+        REQUIRE( inserted.second == true );
+
+        // variable "j" is a reference to local variable i, and has the same value
+        REQUIRE( params.getVariable<std::reference_wrapper<int>>( "j" ) == i );
+        // Changing local variable i ....
+        i = 3;
+        // ... changes the content of its reference "j"
+        REQUIRE( params.getVariable<std::reference_wrapper<int>>( "j" ) == i );
+
+        params.deleteVariable<float>( "x" );
+        REQUIRE( params.existsVariable<float>( "x" ) == false );
+        // as x (float) variable was removed, xHandle is now invalid
+        REQUIRE( params.isHandleValid( xHandle ) == false );
+        REQUIRE( params.existsVariable<int>( "x" ) );
+        params.deleteVariable<int>( "x" );
+        REQUIRE( params.existsVariable<int>( "x" ) == false );
+        print_container( "Final set", params );
+    }
+
+    SECTION( "Visiting and modifying variable set using static visitor" ) {
+        VariableSet params;
+        int i { 0 };
+
+        float x { 1.f };
+
+        std::cout << "Adding parameters" << std::endl;
+        params.insertVariable( "i", i );             // i added by value
+        params.insertVariable( "j", std::ref( i ) ); // j is a reference on i
+        params.insertVariable( "x", 1 );
+        params.insertVariable( "x", x );
+        params.insertVariable( "foo", std::string { "bar" } );
+        std::cout << " ... done!" << std::endl;
+
+        print_container( "Initial set", params );
+        struct modifyInts : public VariableSet::StaticVisitor<int> {
+            void operator()( const std::string&, int& value ) { value = 2 * value + 1; }
+        };
+
+        REQUIRE( params.getVariable<int>( "i" ) == 0 );
+        REQUIRE( params.getVariable<int>( "x" ) == 1 );
+        REQUIRE( params.getVariable<float>( "x" ) == 1 );
+        params.visit( modifyInts {} );
+        REQUIRE( params.getVariable<int>( "i" ) == ( 2 * i + 1 ) );
+        REQUIRE( params.getVariable<int>( "x" ) == ( 2 * 1 + 1 ) );
+        REQUIRE( params.getVariable<float>( "x" ) == 1 );
+        print_container( "Final set", params );
+    }
+
+    SECTION( "Visiting and modifying variable set using dynamic visitor" ) {
+        VariableSet params;
+        int i { 1 };
+
+        float x { 1.f };
+
+        std::cout << "Adding parameters" << std::endl;
+        params.insertVariable( "i", i );             // i added by value
+        params.insertVariable( "j", std::ref( i ) ); // j is a reference on i
+        params.insertVariable( "x", 2 );
+        params.insertVariable( "x", x );
+        params.insertVariable( "foo", std::string { "bar" } );
+        std::cout << " ... done!" << std::endl;
+
+        print_container( "Initial set", params );
+
+        REQUIRE( params.getVariable<int>( "i" ) == 1 );
+        REQUIRE( params.getVariable<int>( "x" ) == 2 );
+        REQUIRE( params.getVariable<float>( "x" ) == 1 );
+
+        VariableSet::DynamicVisitor vf;
+        // Adding a visitor operator on ints
+        vf.addOperator<int>( []( const std::string& name, auto& value ) {
+            std::cout << "\tDoubling the int " << name << " (equal to " << value << ")\n";
+            value *= 2;
+        } );
+        params.visitDynamic( vf );
+        print_container( "Doubled set", params );
+        REQUIRE( params.getVariable<int>( "i" ) == ( 2 * i ) );
+        REQUIRE( params.getVariable<int>( "x" ) == ( 2 * 2 ) );
+        REQUIRE( params.getVariable<float>( "x" ) == 1 );
+
+        // Changing the visitor operator on ints
+        vf.addOrReplaceOperator<int>( []( const std::string& name, auto& value ) {
+            std::cout << "\tHalving the int " << name << " (equal to " << value << ")\n";
+            value /= 2;
+        } );
+        params.visitDynamic( vf );
+        print_container( "Final set", params );
+        REQUIRE( params.getVariable<int>( "i" ) == ( i ) );
+        REQUIRE( params.getVariable<int>( "x" ) == ( 2 ) );
+        REQUIRE( params.getVariable<float>( "x" ) == 1 );
+        // removing the visitor operator on ints
+        vf.removeOperator<int>();
+        params.visitDynamic( vf );
+        REQUIRE( params.getVariable<int>( "i" ) == ( i ) );
+        REQUIRE( params.getVariable<int>( "x" ) == ( 2 ) );
+        REQUIRE( params.getVariable<float>( "x" ) == 1 );
+    }
+
+    SECTION( "Visiting and modifying variable set using standard range for" ) {
+        VariableSet params;
+        int i { 1 };
+        float x { 1.f };
+
+        std::cout << "Adding parameters" << std::endl;
+        params.insertVariable( "i", i );             // i added by value
+        params.insertVariable( "j", std::ref( i ) ); // j is a reference on i
+        params.insertVariable( "x", 2 );
+        params.insertVariable( "x", x );
+        params.insertVariable( "y", std::sqrt( 3 * x ) );
+        params.insertVariable( "foo", std::string { "bar" } );
+        std::cout << " ... done!" << std::endl;
+
+        print_container( "Initial set", params );
+
+        REQUIRE( params.getVariable<float>( "x" ) == x );
+        REQUIRE( params.getVariable<float>( "y" ) == std::sqrt( 3 * x ) );
+        auto& floatParams = params.getAllVariables<float>();
+        // read-write loop on float params
+        for ( auto& p : floatParams ) {
+            std::cout << p.first << " = " << p.second;
+            p.second = p.second * 2;
+            std::cout << " ==> " << p.second << "\n";
+        }
+        REQUIRE( params.getVariable<float>( "x" ) == 2 * x );
+        REQUIRE( params.getVariable<float>( "y" ) == 2 * std::sqrt( 3 * x ) );
+
+        // read-only loop on int params
+        for ( const auto& p : params.getAllVariables<int>() ) {
+            std::cout << p.first << " = " << p.second;
+            // p.second = p.second * 2; // this does not compile ^^
+            std::cout << " ==> " << p.second << "\n";
+        }
+        print_container( "Final set", params );
+
+        auto handle = params.getVariableHandle<int>( "i" );
+        REQUIRE( params.isHandleValid( handle ) );
+        params.deleteVariable( handle );
+        REQUIRE( params.isHandleValid( handle ) == false );
+        auto& intVariables = params.getAllVariablesFromHandle( handle );
+        std::cout << "Looping on all variables with the same type of a given handle\n";
+        for ( const auto& p : intVariables ) {
+            std::cout << p.first << " = " << p.second << " ";
+        }
+        std::cout << "\n";
+    }
+
+    SECTION( "General visit using a custom visitor" ) {
+        VariableSet params;
+        int i { 1 };
+        float x { 1.f };
+
+        std::cout << "Adding parameters" << std::endl;
+        params.insertVariable( "i", i );             // i added by value
+        params.insertVariable( "j", std::ref( i ) ); // j is a reference on i
+        params.insertVariable( "x", 2 );
+        params.insertVariable( "x", x );
+        params.insertVariable( "y", std::sqrt( 3 * x ) );
+        params.insertVariable( "foo", std::string { "bar" } );
+        std::cout << " ... done!" << std::endl;
+
+        print_container( "Initial set", params );
+
+        MyParameterVisitor mp;
+        REQUIRE( mp.getCount() == 0 );
+        params.visitDynamic( mp );
+        REQUIRE( mp.getCount() == 4 );
+        REQUIRE( i == 0 );
+
+        auto xHandle = params.getVariableHandle<float>( "x" );
+        REQUIRE( params.isHandleValid( xHandle ) == true );
+        params.deleteAllVariables<float>();
+        // as all floats was removed, xHandle is now invalid
+        REQUIRE( params.isHandleValid( xHandle ) == false );
+
+        mp.resetCount();
+        params.visitDynamic( mp );
+        REQUIRE( mp.getCount() == 2 );
+        print_container( "Final set", params );
+    }
+
+    SECTION( "Merging, copying, moving" ) {
+        VariableSet params;
+        params.insertVariable( "a", 1 );
+        params.insertVariable( "b", 2 );
+        print_container( "initial params ", params );
+
+        VariableSet params2;
+        params2.insertVariable( "b", 4 );
+        params2.insertVariable( "c", 5 );
+        params2.insertVariable( "e", 2.7182818285 );
+        print_container( "initial params2 ", params2 );
+
+        VariableSet params3;
+        params3.insertVariable( "a", 0 );
+        params3.insertVariable( "c", 4 );
+        params3.insertVariable( "pi", 3.151592f );
+        print_container( "initial params3 ", params3 );
+
+        print_container( "initial params ", params );
+
+        REQUIRE( params.getVariable<int>( "b" ) == 2 );
+        REQUIRE( params2.getVariable<int>( "b" ) == 4 );
+        params.mergeReplaceVariables( params2 );
+        REQUIRE( params.getVariable<int>( "b" ) == 4 );
+        print_container( "params after merge of params2 (replace)", params );
+
+        REQUIRE( params.getVariable<int>( "c" ) == 5 );
+        REQUIRE( params3.getVariable<int>( "c" ) == 4 );
+        params.mergeKeepVariables( params3 );
+        REQUIRE( params.getVariable<int>( "c" ) == 5 );
+        print_container( "params after merge of params3 (keep)", params );
+
+        // copy constructor
+        auto newparams = new VariableSet( params );
+        REQUIRE( newparams->size() == params.size() );
+
+        auto numInt  = params.numberOf<int>();
+        auto numIntN = newparams->numberOf<int>();
+        REQUIRE( numInt == numIntN );
+
+        auto numFloat  = params.numberOf<float>();
+        auto numFloatN = newparams->numberOf<float>();
+        REQUIRE( numFloat == numFloatN );
+
+        auto numDouble  = params.numberOf<double>();
+        auto numDoubleN = newparams->numberOf<double>();
+        REQUIRE( numDouble == numDoubleN );
+
+        REQUIRE( ( numIntN + numFloatN + numDoubleN ) == newparams->size() );
+
+        auto numString = newparams->numberOf<std::string>();
+        REQUIRE( numString == 0 );
+        auto removed = newparams->deleteAllVariables<std::string>();
+        REQUIRE( removed == false );
+
+        print_container( "Copied params into newparams", *newparams );
+
+        auto paramsMoved { std::move( params ) };
+        REQUIRE( params.size() == 0 );
+        REQUIRE( paramsMoved.size() == newparams->size() );
+        print_container( "Moved params into paramsMoved", paramsMoved );
+        print_container( "params is empty", params );
+        delete newparams;
+    }
+}


### PR DESCRIPTION
# Pull Request Description

First proposal to integrate into Core the management of "variables" from all other components.
A "variable is a mapping between a name and a type to a value.

The intent of this PR is to replace the class ("had-hoc and heavily specialized) RenderParameter to have the opportunity to manage several other variable representation and to simplify the extension of such renderParameter.

TODO
- [x] Validate the pattern (generic container with visitor pattern) (need review)
- [ ] Use it instead of RenderParameter (in a next PR)
- [ ] Use it for automatic building of "variable edition" GUI (in the same next PR)
