### PR TITLE
[headless] Move target include before set_target_property

### DIFF
--- a/src/Headless/Config.cmake.in
+++ b/src/Headless/Config.cmake.in
@@ -35,6 +35,8 @@ if(Configure_Headless)
         TARGET PROPERTY HEADLESS_HAS_EGL BRIEF_DOCS "Radium::Headless has EGL support."
         FULL_DOCS "Identify if Radium::Headless was compiled with EGL support."
     )
+    include("${CMAKE_CURRENT_LIST_DIR}/HeadlessTargets.cmake")
+
     if(@HEADLESS_HAS_GLFW@)
         set_target_properties(Radium::Headless PROPERTIES HEADLESS_HAS_GLFW TRUE)
         if (NOT glfw3_FOUND)
@@ -47,5 +49,4 @@ if(Configure_Headless)
             find_dependency(OpenGL COMPONENTS EGL REQUIRED)
         endif()
     endif()
-    include("${CMAKE_CURRENT_LIST_DIR}/HeadlessTargets.cmake")
 endif()


### PR DESCRIPTION
hot fix,
when using Radium::Headless as a component outside radium build, configure fails since it tries to set_target_property before target is defined.
the fix move the include target file before the set.
