### PR TITLE
Fix camera

### DIFF
--- a/examples/CustomCameraManipulator/main.cpp
+++ b/examples/CustomCameraManipulator/main.cpp
@@ -16,34 +16,16 @@
 class CameraManipulator2D : public Ra::Gui::TrackballCameraManipulator
 {
   public:
-    /// Default constructor
-    inline CameraManipulator2D() : Ra::Gui::TrackballCameraManipulator() {}
-
+    /// Default constructor, remove rotate callback
+    inline CameraManipulator2D() : Ra::Gui::TrackballCameraManipulator() {
+        m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_ROTATE, []( QEvent* ) {} );
+    }
     /// Copy constructor used when switching camera manipulator
     /// Requires that m_target is on the line of sight of the camera.
+    /// remove rotate callback
     inline explicit CameraManipulator2D( const CameraManipulator& other ) :
-        Ra::Gui::TrackballCameraManipulator( other ) {}
-
-    inline bool handleMousePressEvent( QMouseEvent* event,
-                                       const Qt::MouseButtons& buttons,
-                                       const Qt::KeyboardModifiers& modifiers,
-                                       int key ) {
-        m_lastMouseX = event->pos().x();
-        m_lastMouseY = event->pos().y();
-
-        m_currentAction = Ra::Gui::KeyMappingManager::getInstance()->getAction(
-            Ra::Gui::TrackballCameraManipulator::KeyMapping::getContext(),
-            buttons,
-            modifiers,
-            key,
-            false );
-
-        // ignore rotate
-        if ( m_currentAction == TRACKBALLCAMERA_ROTATE ) {
-            m_currentAction = Ra::Core::Utils::Index::Invalid();
-        }
-
-        return m_currentAction.isValid();
+        Ra::Gui::TrackballCameraManipulator( other ) {
+        m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_ROTATE, []( QEvent* ) {} );
     }
 };
 //! [extend trackball]
@@ -85,13 +67,8 @@ int main( int argc, char* argv[] ) {
     //! [Install new manipulator]
     auto viewer = app.m_mainWindow->getViewer();
     viewer->setCameraManipulator( new CameraManipulator2D( *( viewer->getCameraManipulator() ) ) );
+    viewer->fitCamera();
     //! [Install new manipulator]
-
-    // terminate the app after 4 second (approximatively). Camera can be moved using mouse moves.
-    auto close_timer = new QTimer( &app );
-    close_timer->setInterval( 4000 );
-    QObject::connect( close_timer, &QTimer::timeout, [&app]() { app.appNeedsToQuit(); } );
-    close_timer->start();
 
     return app.exec();
 }

--- a/examples/DrawPrimitives/minimalapp.cpp
+++ b/examples/DrawPrimitives/minimalapp.cpp
@@ -102,17 +102,20 @@ void MinimalApp::changeCameraManipulator() {
         LOG( logINFO ) << "select RotateAroundCameraManipulator";
         m_viewer->setCameraManipulator( new RotateAroundCameraManipulator(
             *( m_viewer->getCameraManipulator() ), m_viewer.get() ) );
+        m_viewer->fitCamera();
         break;
     case 1:
         LOG( logINFO ) << "select TrackballCameraManipulator";
         m_viewer->setCameraManipulator(
             new TrackballCameraManipulator( *( m_viewer->getCameraManipulator() ) ) );
+        m_viewer->fitCamera();
         break;
     case 2:
     default:
         LOG( logINFO ) << "select FlightCameraManipulator";
         m_viewer->setCameraManipulator(
             new FlightCameraManipulator( *( m_viewer->getCameraManipulator() ) ) );
+        m_viewer->fitCamera();
         break;
     }
 }

--- a/examples/DrawPrimitives/minimalapp.cpp
+++ b/examples/DrawPrimitives/minimalapp.cpp
@@ -51,9 +51,6 @@ void MinimalApp::initialize() {
     CORE_ASSERT( m_viewer != nullptr, "GUI was not initialized" );
 
     m_viewer->setupKeyMappingCallbacks();
-    auto keyMappingManager = KeyMappingManager::getInstance();
-    keyMappingManager->addListener(
-        RotateAroundCameraManipulator::KeyMapping::configureKeyMapping );
 
     connect( m_viewer.get(),
              &Viewer::requestEngineOpenGLInitialization,

--- a/examples/DrawPrimitives/minimalapp.hpp
+++ b/examples/DrawPrimitives/minimalapp.hpp
@@ -46,4 +46,8 @@ class MinimalApp : public QApplication
     // Our framerate
     uint m_targetFps { 60 };
 
+    uint m_manipulatorIndex { 0 };
+
+    void changeCameraManipulator();
+
 }; // end class

--- a/src/Gui/Configs/default.xml
+++ b/src/Gui/Configs/default.xml
@@ -18,7 +18,6 @@
   <keymap context="FlightManipulatorContext" action="FLIGHTMODECAMERA_PAN" key="" modifiers="ShiftModifier" buttons="LeftButton"/>
   <keymap context="FlightManipulatorContext" action="FLIGHTMODECAMERA_ZOOM" key="" modifiers="ControlModifier" buttons="LeftButton"/>
   <keymap context="FlightManipulatorContext" action="FLIGHTMODECAMERA_ZOOM" key="" modifiers="" buttons="" wheel="true"/>
-  <keymap context="FlightManipulatorContext" action="FLIGHTMODECAMERA_ROTATE_AROUND" key="Key_A" modifiers="" buttons=""/>
   <keymap context="GizmoContext" action="GIZMOMANAGER_MANIPULATION" key="" modifiers="" buttons="LeftButton"/>
   <keymap context="GizmoContext" action="GIZMOMANAGER_STEP" key="" modifiers="ControlModifier" buttons="LeftButton"/>
   <keymap context="GizmoContext" action="GIZMOMANAGER_WHOLE" key="" modifiers="ShiftModifier" buttons="LeftButton"/>
@@ -34,5 +33,5 @@
   <keymap context="ViewerContext" action="VIEWER_RAYCAST" key="Key_R" modifiers="AltModifier" buttons="LeftButton"/>
   <keymap context="ViewerContext" action="VIEWER_RELOAD_SHADERS" key="Key_R" modifiers="CtrlModifier" buttons=""/>
   <keymap context="ViewerContext" action="VIEWER_SCALE_BRUSH" key="" modifiers="ShiftModifier" buttons="" wheel="true"/>
-    <keymap context="ViewerContext" action="VIEWER_HELP" buttons="" modifiers="" key="Key_F1" />
+  <keymap context="ViewerContext" action="VIEWER_HELP" buttons="" modifiers="" key="Key_F1" />
 </keymaps>

--- a/src/Gui/Viewer/CameraManipulator.hpp
+++ b/src/Gui/Viewer/CameraManipulator.hpp
@@ -123,7 +123,7 @@ class RA_GUI_API CameraManipulator : public QObject
   signals:
 
   protected:
-    std::tuple<Scalar, Scalar> computeDeltaMouseMove( const QMouseEvent* mouseEvent ) {
+    std::pair<Scalar, Scalar> computeDeltaMouseMove( const QMouseEvent* mouseEvent ) {
         return { ( mouseEvent->pos().x() - m_lastMouseX ) / m_camera->getWidth(),
                  ( mouseEvent->pos().y() - m_lastMouseY ) / m_camera->getHeight() };
     }

--- a/src/Gui/Viewer/CameraManipulator.hpp
+++ b/src/Gui/Viewer/CameraManipulator.hpp
@@ -123,6 +123,17 @@ class RA_GUI_API CameraManipulator : public QObject
   signals:
 
   protected:
+    std::tuple<Scalar, Scalar> computeDeltaMouseMove( const QMouseEvent* mouseEvent ) {
+        return { ( mouseEvent->pos().x() - m_lastMouseX ) / m_camera->getWidth(),
+                 ( mouseEvent->pos().y() - m_lastMouseY ) / m_camera->getHeight() };
+    }
+
+    /// x-position of the mouse on the screen at the manipulation start.
+    Scalar m_lastMouseX { 0_ra };
+
+    /// y-position of the mouse on the screen at the manipulation start.
+    Scalar m_lastMouseY { 0_ra };
+
     /// the Camera sensitivity to manipulation.
     Scalar m_cameraSensitivity { 1_ra };
     /// Additional factor for camera sensitivity.

--- a/src/Gui/Viewer/CameraManipulator.hpp
+++ b/src/Gui/Viewer/CameraManipulator.hpp
@@ -150,9 +150,6 @@ class RA_GUI_API CameraManipulator : public QObject
     /// could be used as a "focus" point by a manipulator.
     Core::Vector3 m_target { 0_ra, 0_ra, 0_ra };
 
-    /// Whether the corresponding camera movement is active or not.
-    KeyMappingManager::KeyMappingAction m_currentAction {};
-
     Core::Asset::Camera* m_camera { nullptr }; ///< The Camera.
     Engine::Scene::Light* m_light { nullptr }; ///< The light attached to the Camera.
 };

--- a/src/Gui/Viewer/FlightCameraManipulator.cpp
+++ b/src/Gui/Viewer/FlightCameraManipulator.cpp
@@ -134,6 +134,7 @@ FlightCameraManipulator::FlightCameraManipulator() :
     CameraManipulator(), m_keyMappingCallbackManager { KeyMapping::getContext() } {
     resetCamera();
     setupKeyMappingCallbacks();
+    m_cameraSensitivity = 2_ra;
 }
 
 //! [Constructor]
@@ -142,6 +143,7 @@ FlightCameraManipulator::FlightCameraManipulator( const CameraManipulator& other
     m_flightSpeed = ( m_target - m_camera->getPosition() ).norm() / 10_ra;
     initializeFixedUpVector();
     setupKeyMappingCallbacks();
+    m_cameraSensitivity = 2_ra;
 }
 //! [Constructor]
 
@@ -190,10 +192,6 @@ bool FlightCameraManipulator::handleMouseMoveEvent( QMouseEvent* event,
                                                     int key ) {
 
     bool handled = m_keyMappingCallbackManager.triggerEventCallback( event, key );
-    if ( event->modifiers().testFlag( Qt::AltModifier ) ) { m_quickCameraModifier = 10.0_ra; }
-    else {
-        m_quickCameraModifier = 2.0_ra;
-    }
 
     m_lastMouseX = event->pos().x();
     m_lastMouseY = event->pos().y();

--- a/src/Gui/Viewer/FlightCameraManipulator.cpp
+++ b/src/Gui/Viewer/FlightCameraManipulator.cpp
@@ -319,7 +319,7 @@ void FlightCameraManipulator::handleCameraPan( Scalar dx, Scalar dy ) {
 }
 
 void FlightCameraManipulator::handleCameraZoom( Scalar dx, Scalar dy ) {
-    handleCameraZoom( Ra::Core::Math::sign( dx ) * ( std::abs( dx ) + std::abs( dy ) ) );
+    handleCameraZoom( Ra::Core::Math::sign( dy ) * ( std::abs( dx ) + std::abs( dy ) ) );
 }
 
 void FlightCameraManipulator::handleCameraZoom( Scalar z ) {

--- a/src/Gui/Viewer/FlightCameraManipulator.cpp
+++ b/src/Gui/Viewer/FlightCameraManipulator.cpp
@@ -16,6 +16,7 @@
 
 namespace Ra {
 namespace Gui {
+
 using Core::Math::Pi;
 
 //! [Implement KeyMappingManageable]
@@ -25,7 +26,7 @@ using FlightCameraKeyMapping = Ra::Gui::KeyMappingManageable<FlightCameraManipul
 KeyMappingFlightManipulator
 #undef KMA_VALUE
 
-void Gui::FlightCameraManipulator::configureKeyMapping_impl() {
+void FlightCameraManipulator::configureKeyMapping_impl() {
 
     FlightCameraKeyMapping::setContext(
         Gui::KeyMappingManager::getInstance()->getContext( "FlightManipulatorContext" ) );
@@ -38,17 +39,14 @@ void Gui::FlightCameraManipulator::configureKeyMapping_impl() {
         auto context = mgr->addContext( "FlightManipulatorContext" );
         FlightCameraKeyMapping::setContext( context );
         mgr->addAction( context,
-                        mgr->createEventBindingFromStrings( "LeftButton" ),
-                        "FLIGHTMODECAMERA_ROTATE" );
-        mgr->addAction( context,
                         mgr->createEventBindingFromStrings( "LeftButton", "ShiftModifier" ),
                         "FLIGHTMODECAMERA_PAN" );
         mgr->addAction( context,
+                        mgr->createEventBindingFromStrings( "LeftButton" ),
+                        "FLIGHTMODECAMERA_ROTATE" );
+        mgr->addAction( context,
                         mgr->createEventBindingFromStrings( "LeftButton", "ControlModifier" ),
                         "FLIGHTMODECAMERA_ZOOM" );
-        mgr->addAction( context,
-                        mgr->createEventBindingFromStrings( "", "", "Key_A" ),
-                        "FLIGHTMODECAMERA_ROTATE_AROUND" );
     }
 
 #define KMA_VALUE( XX )                                                                          \
@@ -59,43 +57,69 @@ void Gui::FlightCameraManipulator::configureKeyMapping_impl() {
 }
 //! [Implement KeyMappingManageable]
 
+void FlightCameraManipulator::setupKeyMappingCallbacks() {
+
+    m_keyMappingCallbackManager.addEventCallback( FLIGHTMODECAMERA_PAN,
+                                                  [=]( QEvent* event ) { panCallback( event ); } );
+    m_keyMappingCallbackManager.addEventCallback(
+        FLIGHTMODECAMERA_ROTATE, [=]( QEvent* event ) { rotateCallback( event ); } );
+
+    m_keyMappingCallbackManager.addEventCallback( FLIGHTMODECAMERA_ZOOM,
+                                                  [=]( QEvent* event ) { zoomCallback( event ); } );
+}
+
+void FlightCameraManipulator::panCallback( QEvent* event ) {
+    if ( event->type() == QEvent::MouseMove ) {
+        auto mouseEvent = reinterpret_cast<QMouseEvent*>( event );
+        auto [dx, dy]   = computeDeltaMouseMove( mouseEvent );
+        handleCameraPan( dx, dy );
+    }
+}
+
+void FlightCameraManipulator::rotateCallback( QEvent* event ) {
+    if ( event->type() == QEvent::MouseMove ) {
+        auto mouseEvent = reinterpret_cast<QMouseEvent*>( event );
+        auto [dx, dy]   = computeDeltaMouseMove( mouseEvent );
+        handleCameraRotate( dx, dy );
+    }
+}
+
+void FlightCameraManipulator::zoomCallback( QEvent* event ) {
+    if ( event->type() == QEvent::MouseMove ) {
+        auto mouseEvent = reinterpret_cast<QMouseEvent*>( event );
+        auto [dx, dy]   = computeDeltaMouseMove( mouseEvent );
+        handleCameraZoom( dx, dy );
+    }
+    if ( event->type() == QEvent::Wheel ) {
+        auto wheelEvent = reinterpret_cast<QWheelEvent*>( event );
+        handleCameraZoom(
+            ( wheelEvent->angleDelta().y() * 0.01_ra + wheelEvent->angleDelta().x() * 0.01_ra ) *
+            m_wheelSpeedModifier );
+    }
+}
+
 KeyMappingManager::Context Gui::FlightCameraManipulator::mappingContext() {
     return FlightCameraKeyMapping::getContext();
 }
 
-Gui::FlightCameraManipulator::FlightCameraManipulator() :
-    CameraManipulator(),
-    m_rotateAround( true ),
-    m_cameraRotateMode( false ),
-    m_cameraPanMode( false ),
-    m_cameraZoomMode( false ) {
+FlightCameraManipulator::FlightCameraManipulator() :
+    CameraManipulator(), m_keyMappingCallbackManager { KeyMapping::getContext() } {
     resetCamera();
+    setupKeyMappingCallbacks();
 }
 
-Gui::FlightCameraManipulator::FlightCameraManipulator( const FlightCameraManipulator& other ) :
-    CameraManipulator( other ),
-    m_rotateAround( other.m_rotateAround ),
-    m_cameraRotateMode( other.m_cameraRotateMode ),
-    m_cameraPanMode( other.m_cameraPanMode ),
-    m_cameraZoomMode( other.m_cameraZoomMode ),
-    m_fixUpVector( other.m_fixUpVector ),
-    m_flightSpeed( other.m_flightSpeed ) {}
-
 //! [Constructor]
-Gui::FlightCameraManipulator::FlightCameraManipulator( const CameraManipulator& other ) :
-    CameraManipulator( other ),
-    m_rotateAround( true ),
-    m_cameraRotateMode( false ),
-    m_cameraPanMode( false ),
-    m_cameraZoomMode( false ) {
+FlightCameraManipulator::FlightCameraManipulator( const CameraManipulator& other ) :
+    CameraManipulator( other ), m_keyMappingCallbackManager { KeyMapping::getContext() } {
     m_flightSpeed = ( m_target - m_camera->getPosition() ).norm() / 10_ra;
     initializeFixedUpVector();
+    setupKeyMappingCallbacks();
 }
 //! [Constructor]
 
-Gui::FlightCameraManipulator::~FlightCameraManipulator() = default;
+FlightCameraManipulator::~FlightCameraManipulator() = default;
 
-void Gui::FlightCameraManipulator::updateCamera() {
+void FlightCameraManipulator::updateCamera() {
 
     initializeFixedUpVector();
 
@@ -108,7 +132,7 @@ void Gui::FlightCameraManipulator::updateCamera() {
     }
 }
 
-void Gui::FlightCameraManipulator::resetCamera() {
+void FlightCameraManipulator::resetCamera() {
     m_camera->setFrame( Core::Transform::Identity() );
     m_camera->setPosition( Core::Vector3( 0, 0, 1 ) );
     initializeFixedUpVector();
@@ -122,43 +146,27 @@ void Gui::FlightCameraManipulator::resetCamera() {
     }
 }
 
-bool Gui::FlightCameraManipulator::handleMousePressEvent( QMouseEvent* event,
-                                                          const Qt::MouseButtons& buttons,
-                                                          const Qt::KeyboardModifiers& modifiers,
-                                                          int key ) {
+bool FlightCameraManipulator::handleMousePressEvent( QMouseEvent* event,
+                                                     const Qt::MouseButtons&,
+                                                     const Qt::KeyboardModifiers&,
+                                                     int key ) {
     m_lastMouseX = event->pos().x();
     m_lastMouseY = event->pos().y();
-
-    m_currentAction = KeyMappingManager::getInstance()->getAction(
-        FlightCameraKeyMapping::getContext(), buttons, modifiers, key, false );
-
-    return m_currentAction.isValid();
+    bool handled = m_keyMappingCallbackManager.triggerEventCallback( event, key );
+    return handled;
 }
 
-bool Gui::FlightCameraManipulator::handleMouseMoveEvent( QMouseEvent* event,
-                                                         const Qt::MouseButtons& /*buttons*/,
-                                                         const Qt::KeyboardModifiers& /*modifiers*/,
-                                                         int /*key*/ ) {
+bool FlightCameraManipulator::handleMouseMoveEvent( QMouseEvent* event,
+                                                    const Qt::MouseButtons& /*buttons*/,
+                                                    const Qt::KeyboardModifiers& /*modifiers*/,
+                                                    int key ) {
 
-    // auto action = KeyMappingManager::getInstance()->getAction( context, buttons, modifiers, key
-    // );
-
-    Scalar dx = ( event->pos().x() - m_lastMouseX ) / m_camera->getWidth();
-    Scalar dy = ( event->pos().y() - m_lastMouseY ) / m_camera->getHeight();
-
+    bool handled = m_keyMappingCallbackManager.triggerEventCallback( event, key );
     if ( event->modifiers().testFlag( Qt::AltModifier ) ) { m_quickCameraModifier = 10.0_ra; }
     else {
         m_quickCameraModifier = 2.0_ra;
     }
 
-    if ( m_currentAction == FLIGHTMODECAMERA_ROTATE ) { handleCameraRotate( dx, dy ); }
-    else if ( m_currentAction == FLIGHTMODECAMERA_PAN ) {
-        handleCameraPan( dx, dy );
-    }
-    else if ( m_currentAction == FLIGHTMODECAMERA_ZOOM ) {
-        handleCameraZoom( dx, dy );
-    }
-
     m_lastMouseX = event->pos().x();
     m_lastMouseY = event->pos().y();
 
@@ -167,56 +175,35 @@ bool Gui::FlightCameraManipulator::handleMouseMoveEvent( QMouseEvent* event,
         m_light->setDirection( m_camera->getDirection() );
     }
 
-    return m_currentAction.isValid();
+    return handled;
 }
 
-bool Gui::FlightCameraManipulator::handleMouseReleaseEvent( QMouseEvent* /*event*/ ) {
-    m_currentAction       = KeyMappingManager::KeyMappingAction::Invalid();
-    m_quickCameraModifier = 1.0_ra;
-
-    return true;
+bool FlightCameraManipulator::handleMouseReleaseEvent( QMouseEvent* /*event*/ ) {
+    return false;
 }
 
-bool Gui::FlightCameraManipulator::handleWheelEvent( QWheelEvent* event,
-                                                     const Qt::MouseButtons& buttons,
-                                                     const Qt::KeyboardModifiers& modifiers,
-                                                     int key ) {
+bool FlightCameraManipulator::handleWheelEvent( QWheelEvent* event,
+                                                const Qt::MouseButtons&,
+                                                const Qt::KeyboardModifiers&,
+                                                int key ) {
     ///\todo use action.
-
-    auto action = KeyMappingManager::getInstance()->getAction(
-        FlightCameraKeyMapping::getContext(), buttons, modifiers, key, true );
-
-    if ( action == FLIGHTMODECAMERA_ZOOM ) {
-        handleCameraZoom(
-            ( event->angleDelta().y() * 0.01_ra + event->angleDelta().x() * 0.01_ra ) *
-            m_wheelSpeedModifier );
-    }
+    bool handled = m_keyMappingCallbackManager.triggerEventCallback( event, key, true );
 
     if ( m_light != nullptr ) {
         m_light->setPosition( m_camera->getPosition() );
         m_light->setDirection( m_camera->getDirection() );
     }
 
-    return action.isValid();
+    return handled;
 }
 
-void Gui::FlightCameraManipulator::toggleRotateAround() {
-    m_rotateAround = !m_rotateAround;
-}
-
-bool Gui::FlightCameraManipulator::handleKeyPressEvent(
-    QKeyEvent* /*event*/,
+bool FlightCameraManipulator::handleKeyPressEvent(
+    QKeyEvent* event,
     const KeyMappingManager::KeyMappingAction& action ) {
-
-    if ( action == FLIGHTMODECAMERA_ROTATE_AROUND ) {
-        m_rotateAround = !m_rotateAround;
-        return true;
-    }
-
-    return false;
+    return m_keyMappingCallbackManager.triggerEventCallback( action, event );
 }
 
-void Gui::FlightCameraManipulator::setCameraPosition( const Core::Vector3& position ) {
+void FlightCameraManipulator::setCameraPosition( const Core::Vector3& position ) {
     if ( position == m_target ) {
         QMessageBox::warning( nullptr, "Error", "Position cannot be set to target point" );
         return;
@@ -230,7 +217,7 @@ void Gui::FlightCameraManipulator::setCameraPosition( const Core::Vector3& posit
     }
 }
 
-void Gui::FlightCameraManipulator::setCameraTarget( const Core::Vector3& target ) {
+void FlightCameraManipulator::setCameraTarget( const Core::Vector3& target ) {
     if ( m_camera->getPosition() == m_target ) {
         QMessageBox::warning( nullptr, "Error", "Target cannot be set to current camera position" );
         return;
@@ -242,7 +229,7 @@ void Gui::FlightCameraManipulator::setCameraTarget( const Core::Vector3& target 
     if ( m_light != nullptr ) { m_light->setDirection( m_camera->getDirection() ); }
 }
 
-void Gui::FlightCameraManipulator::fitScene( const Core::Aabb& aabb ) {
+void FlightCameraManipulator::fitScene( const Core::Aabb& aabb ) {
     resetCamera();
 
     Scalar f = m_camera->getFOV();
@@ -270,7 +257,7 @@ void Gui::FlightCameraManipulator::fitScene( const Core::Aabb& aabb ) {
     }
 }
 
-void Gui::FlightCameraManipulator::handleCameraRotate( Scalar dx, Scalar dy ) {
+void FlightCameraManipulator::handleCameraRotate( Scalar dx, Scalar dy ) {
     Scalar dphi   = dx * m_cameraSensitivity * m_quickCameraModifier;
     Scalar dtheta = -dy * m_cameraSensitivity * m_quickCameraModifier;
 
@@ -288,7 +275,7 @@ void Gui::FlightCameraManipulator::handleCameraRotate( Scalar dx, Scalar dy ) {
     m_target = m_camera->getPosition() + d * m_camera->getDirection();
 }
 
-void Gui::FlightCameraManipulator::handleCameraPan( Scalar dx, Scalar dy ) {
+void FlightCameraManipulator::handleCameraPan( Scalar dx, Scalar dy ) {
     Scalar x = dx * m_cameraSensitivity * m_quickCameraModifier;
     Scalar y = dy * m_cameraSensitivity * m_quickCameraModifier;
     // Move camera and trackball center, keep the distance to the center
@@ -303,11 +290,11 @@ void Gui::FlightCameraManipulator::handleCameraPan( Scalar dx, Scalar dy ) {
     m_target += t;
 }
 
-void Gui::FlightCameraManipulator::handleCameraZoom( Scalar dx, Scalar dy ) {
+void FlightCameraManipulator::handleCameraZoom( Scalar dx, Scalar dy ) {
     handleCameraZoom( Ra::Core::Math::sign( dx ) * ( std::abs( dx ) + std::abs( dy ) ) );
 }
 
-void Gui::FlightCameraManipulator::handleCameraZoom( Scalar z ) {
+void FlightCameraManipulator::handleCameraZoom( Scalar z ) {
     auto y = m_flightSpeed * z * m_cameraSensitivity * m_quickCameraModifier;
     Core::Transform T( Core::Transform::Identity() );
     Core::Vector3 t = y * m_camera->getDirection();
@@ -316,7 +303,7 @@ void Gui::FlightCameraManipulator::handleCameraZoom( Scalar z ) {
     m_target += t;
 }
 
-void Gui::FlightCameraManipulator::initializeFixedUpVector() {
+void FlightCameraManipulator::initializeFixedUpVector() {
 #if 0
     // This is supposed to adapt the up vector to the main up direction but is not really satisfactory.
     const auto& upVector = m_camera->getUpVector();

--- a/src/Gui/Viewer/FlightCameraManipulator.hpp
+++ b/src/Gui/Viewer/FlightCameraManipulator.hpp
@@ -18,8 +18,9 @@ class RA_GUI_API FlightCameraManipulator : public CameraManipulator,
     friend class KeyMappingManageable<FlightCameraManipulator>;
 
   public:
+    using KeyMapping = KeyMappingManageable<FlightCameraManipulator>;
+
     FlightCameraManipulator();
-    explicit FlightCameraManipulator( const FlightCameraManipulator& other );
     explicit FlightCameraManipulator( const CameraManipulator& other );
     virtual ~FlightCameraManipulator();
 
@@ -41,7 +42,6 @@ class RA_GUI_API FlightCameraManipulator : public CameraManipulator,
     bool handleKeyPressEvent( QKeyEvent* event,
                               const KeyMappingManager::KeyMappingAction& action ) override;
 
-    void toggleRotateAround();
     void updateCamera() override;
 
   public slots:
@@ -57,7 +57,11 @@ class RA_GUI_API FlightCameraManipulator : public CameraManipulator,
     virtual void handleCameraZoom( Scalar dx, Scalar dy );
     virtual void handleCameraZoom( Scalar z );
 
-  protected:
+  private:
+    void setupKeyMappingCallbacks();
+    void panCallback( QEvent* event );
+    void rotateCallback( QEvent* event );
+    void zoomCallback( QEvent* event );
     /// x-position of the mouse on the screen at the manipulation start.
     Scalar m_lastMouseX { 0_ra };
 
@@ -65,12 +69,12 @@ class RA_GUI_API FlightCameraManipulator : public CameraManipulator,
     Scalar m_lastMouseY { 0_ra };
 
     /// Whether the corresponding camera movement is active or not.
-    bool m_rotateAround;
-    bool m_cameraRotateMode;
-    bool m_cameraPanMode;
-    bool m_cameraZoomMode;
+    bool m_cameraRotateMode { false };
+    bool m_cameraPanMode { false };
+    bool m_cameraZoomMode { false };
 
-  private:
+    KeyMappingCallbackManager m_keyMappingCallbackManager;
+
     void initializeFixedUpVector();
     Ra::Core::Vector3 m_fixUpVector { 0_ra, 1_ra, 0_ra };
     Scalar m_flightSpeed { 1._ra };
@@ -78,10 +82,9 @@ class RA_GUI_API FlightCameraManipulator : public CameraManipulator,
 
   protected:
 #define KeyMappingFlightManipulator      \
-    KMA_VALUE( FLIGHTMODECAMERA_ROTATE ) \
     KMA_VALUE( FLIGHTMODECAMERA_PAN )    \
-    KMA_VALUE( FLIGHTMODECAMERA_ZOOM )   \
-    KMA_VALUE( FLIGHTMODECAMERA_ROTATE_AROUND )
+    KMA_VALUE( FLIGHTMODECAMERA_ROTATE ) \
+    KMA_VALUE( FLIGHTMODECAMERA_ZOOM )
 
 #define KMA_VALUE( XX ) static KeyMappingManager::KeyMappingAction XX;
     KeyMappingFlightManipulator

--- a/src/Gui/Viewer/FlightCameraManipulator.hpp
+++ b/src/Gui/Viewer/FlightCameraManipulator.hpp
@@ -62,16 +62,6 @@ class RA_GUI_API FlightCameraManipulator : public CameraManipulator,
     void panCallback( QEvent* event );
     void rotateCallback( QEvent* event );
     void zoomCallback( QEvent* event );
-    /// x-position of the mouse on the screen at the manipulation start.
-    Scalar m_lastMouseX { 0_ra };
-
-    /// y-position of the mouse on the screen at the manipulation start.
-    Scalar m_lastMouseY { 0_ra };
-
-    /// Whether the corresponding camera movement is active or not.
-    bool m_cameraRotateMode { false };
-    bool m_cameraPanMode { false };
-    bool m_cameraZoomMode { false };
 
     KeyMappingCallbackManager m_keyMappingCallbackManager;
 

--- a/src/Gui/Viewer/RotateAroundCameraManipulator.cpp
+++ b/src/Gui/Viewer/RotateAroundCameraManipulator.cpp
@@ -105,6 +105,7 @@ RotateAroundCameraManipulator::RotateAroundCameraManipulator( Ra::Gui::Viewer* v
     m_keyMappingCallbackManager { KeyMapping::getContext() },
     m_viewer( viewer ) {
     setupKeyMappingCallbacks();
+    m_cameraSensitivity = 0.5_ra;
 }
 
 RotateAroundCameraManipulator::RotateAroundCameraManipulator( const CameraManipulator& cm,
@@ -113,6 +114,7 @@ RotateAroundCameraManipulator::RotateAroundCameraManipulator( const CameraManipu
     m_keyMappingCallbackManager { KeyMapping::getContext() },
     m_viewer( viewer ) {
     setupKeyMappingCallbacks();
+    m_cameraSensitivity = 0.5_ra;
 }
 
 bool RotateAroundCameraManipulator::handleMouseMoveEvent(

--- a/src/Gui/Viewer/RotateAroundCameraManipulator.cpp
+++ b/src/Gui/Viewer/RotateAroundCameraManipulator.cpp
@@ -30,6 +30,58 @@ void RotateAroundCameraManipulator::configureKeyMapping_impl() {
 #undef KMA_VALUE
 }
 
+void RotateAroundCameraManipulator::setupKeyMappingCallbacks() {
+
+    m_keyMappingCallbackManager.addEventCallback(
+        TRACKBALLCAMERA_ROTATE, [=]( QEvent* event ) { rotateCallback( event ); } );
+    m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_PAN,
+                                                  [=]( QEvent* event ) { panCallback( event ); } );
+    m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_ZOOM,
+                                                  [=]( QEvent* event ) { zoomCallback( event ); } );
+    m_keyMappingCallbackManager.addEventCallback(
+        TRACKBALLCAMERA_MOVE_FORWARD, [=]( QEvent* event ) { moveForwardCallback( event ); } );
+    m_keyMappingCallbackManager.addEventCallback(
+        ROTATEAROUND_ALIGN_WITH_CLOSEST_AXIS,
+        [=]( QEvent* event ) { alignWithClosestAxisCallback( event ); } );
+    m_keyMappingCallbackManager.addEventCallback(
+        ROTATEAROUND_SET_PIVOT, [=]( QEvent* event ) { setPivotCallback( event ); } );
+}
+
+void RotateAroundCameraManipulator::alignWithClosestAxisCallback( QEvent* event ) {
+    if ( event->type() == QEvent::KeyPress ) { alignOnClosestAxis(); }
+}
+
+void RotateAroundCameraManipulator::moveForwardCallback( QEvent* event ) {
+    if ( event->type() == QEvent::MouseMove ) {
+        auto mouseEvent = reinterpret_cast<QMouseEvent*>( event );
+        auto [dx, dy]   = computeDeltaMouseMove( mouseEvent );
+        handleCameraMoveForward( dx, dy );
+    }
+}
+void RotateAroundCameraManipulator::panCallback( QEvent* event ) {
+    if ( event->type() == QEvent::MouseMove ) {
+        auto mouseEvent = reinterpret_cast<QMouseEvent*>( event );
+        auto [dx, dy]   = computeDeltaMouseMove( mouseEvent );
+        handleCameraPan( dx, dy );
+    }
+}
+void RotateAroundCameraManipulator::rotateCallback( QEvent* event ) {
+    if ( event->type() == QEvent::MouseMove ) {
+        auto mouseEvent = reinterpret_cast<QMouseEvent*>( event );
+        handleCameraRotate( mouseEvent->pos().x(), mouseEvent->pos().y() );
+    }
+}
+void RotateAroundCameraManipulator::setPivotCallback( QEvent* event ) {
+    if ( event->type() == QEvent::KeyPress ) { setPivotFromPixel( m_lastMouseX, m_lastMouseY ); }
+}
+void RotateAroundCameraManipulator::zoomCallback( QEvent* event ) {
+    if ( event->type() == QEvent::MouseMove ) {
+        auto mouseEvent = reinterpret_cast<QMouseEvent*>( event );
+        auto [dx, dy]   = computeDeltaMouseMove( mouseEvent );
+        handleCameraZoom( dx, dy );
+    }
+}
+
 void rotateAroundPoint( Ra::Core::Asset::Camera* cam,
                         Ra::Core::Vector3& target,
                         Ra::Core::Quaternion& rotation,
@@ -48,27 +100,28 @@ void rotateAroundPoint( Ra::Core::Asset::Camera* cam,
     target = cam->getPosition() + l * cam->getDirection();
 }
 
+RotateAroundCameraManipulator::RotateAroundCameraManipulator( Ra::Gui::Viewer* viewer ) :
+    TrackballCameraManipulator(),
+    m_keyMappingCallbackManager { KeyMapping::getContext() },
+    m_viewer( viewer ) {
+    setupKeyMappingCallbacks();
+}
+
 RotateAroundCameraManipulator::RotateAroundCameraManipulator( const CameraManipulator& cm,
                                                               Ra::Gui::Viewer* viewer ) :
-    TrackballCameraManipulator( cm ), m_viewer( viewer ) {}
+    TrackballCameraManipulator( cm ),
+    m_keyMappingCallbackManager { KeyMapping::getContext() },
+    m_viewer( viewer ) {
+    setupKeyMappingCallbacks();
+}
 
 bool RotateAroundCameraManipulator::handleMouseMoveEvent(
     QMouseEvent* event,
     const Qt::MouseButtons& /*buttons*/,
     const Qt::KeyboardModifiers& /* modifiers*/,
-    int /*key*/ ) {
+    int key ) {
 
-    Scalar dx = ( event->pos().x() - m_lastMouseX ) / m_camera->getWidth();
-    Scalar dy = ( event->pos().y() - m_lastMouseY ) / m_camera->getHeight();
-
-    if ( m_currentAction == TRACKBALLCAMERA_ROTATE )
-        handleCameraRotate( event->pos().x(), event->pos().y() );
-    else if ( m_currentAction == TRACKBALLCAMERA_PAN )
-        handleCameraPan( dx, dy );
-    else if ( m_currentAction == TRACKBALLCAMERA_ZOOM )
-        handleCameraZoom( dx, dy );
-    else if ( m_currentAction == TRACKBALLCAMERA_MOVE_FORWARD )
-        handleCameraMoveForward( dx, dy );
+    bool handled = m_keyMappingCallbackManager.triggerEventCallback( event, key );
 
     m_lastMouseX = event->pos().x();
     m_lastMouseY = event->pos().y();
@@ -78,23 +131,13 @@ bool RotateAroundCameraManipulator::handleMouseMoveEvent(
         m_light->setDirection( m_camera->getDirection() );
     }
 
-    return m_currentAction.isValid();
+    return handled;
 }
 
 bool RotateAroundCameraManipulator::handleKeyPressEvent(
     QKeyEvent* event,
     const Ra::Gui::KeyMappingManager::KeyMappingAction& action ) {
-
-    if ( action == ROTATEAROUND_ALIGN_WITH_CLOSEST_AXIS ) {
-        alignOnClosestAxis();
-        return true;
-    }
-    else if ( action == ROTATEAROUND_SET_PIVOT ) {
-        setPivotFromPixel( m_lastMouseX, m_lastMouseY );
-        return true;
-    }
-
-    return TrackballCameraManipulator::handleKeyPressEvent( event, action );
+    return m_keyMappingCallbackManager.triggerEventCallback( action, event );
 }
 
 void RotateAroundCameraManipulator::setPivot( Ra::Core::Vector3 pivot ) {

--- a/src/Gui/Viewer/RotateAroundCameraManipulator.hpp
+++ b/src/Gui/Viewer/RotateAroundCameraManipulator.hpp
@@ -14,6 +14,7 @@ class RA_GUI_API RotateAroundCameraManipulator
 
   public:
     using KeyMapping = KeyMappingManageable<RotateAroundCameraManipulator>;
+    RotateAroundCameraManipulator( Ra::Gui::Viewer* viewer );
     RotateAroundCameraManipulator( const CameraManipulator& cm, Ra::Gui::Viewer* viewer );
 
     /// @copydoc TrackballCameraManipulator::handleMouseMoveEvent()
@@ -49,9 +50,18 @@ class RA_GUI_API RotateAroundCameraManipulator
     Scalar projectOnBall( Scalar x, Scalar y );
 
   private:
-    Ra::Core::Vector3 m_pivot { 0.0_ra, 0.0_ra, 0.0_ra };
+    void setupKeyMappingCallbacks();
+    void alignWithClosestAxisCallback( QEvent* event );
+    void moveForwardCallback( QEvent* event );
+    void panCallback( QEvent* event );
+    void rotateCallback( QEvent* event );
+    void setPivotCallback( QEvent* event );
+    void zoomCallback( QEvent* event );
 
+    KeyMappingCallbackManager m_keyMappingCallbackManager;
     Ra::Gui::Viewer* m_viewer;
+
+    Ra::Core::Vector3 m_pivot { 0.0_ra, 0.0_ra, 0.0_ra };
 
     static void configureKeyMapping_impl();
 

--- a/src/Gui/Viewer/RotateAroundCameraManipulator.hpp
+++ b/src/Gui/Viewer/RotateAroundCameraManipulator.hpp
@@ -14,8 +14,8 @@ class RA_GUI_API RotateAroundCameraManipulator
 
   public:
     using KeyMapping = KeyMappingManageable<RotateAroundCameraManipulator>;
-    RotateAroundCameraManipulator( Ra::Gui::Viewer* viewer );
-    RotateAroundCameraManipulator( const CameraManipulator& cm, Ra::Gui::Viewer* viewer );
+    explicit RotateAroundCameraManipulator( Ra::Gui::Viewer* viewer );
+    explicit RotateAroundCameraManipulator( const CameraManipulator& cm, Ra::Gui::Viewer* viewer );
 
     /// @copydoc TrackballCameraManipulator::handleMouseMoveEvent()
     bool handleMouseMoveEvent( QMouseEvent* event,

--- a/src/Gui/Viewer/TrackballCameraManipulator.cpp
+++ b/src/Gui/Viewer/TrackballCameraManipulator.cpp
@@ -75,6 +75,7 @@ TrackballCameraManipulator::TrackballCameraManipulator() :
     CameraManipulator(), m_keyMappingCallbackManager { KeyMapping::getContext() } {
     resetCamera();
     setupKeyMappingCallbacks();
+    m_cameraSensitivity = 1.5_ra;
 }
 
 TrackballCameraManipulator::TrackballCameraManipulator( const CameraManipulator& other ) :
@@ -87,6 +88,7 @@ TrackballCameraManipulator::TrackballCameraManipulator( const CameraManipulator&
     updatePhiTheta();
 
     setupKeyMappingCallbacks();
+    m_cameraSensitivity = 1.5_ra;
 }
 
 TrackballCameraManipulator::~TrackballCameraManipulator() {};
@@ -284,7 +286,6 @@ void TrackballCameraManipulator::setCameraTarget( const Core::Vector3& target ) 
 }
 
 void TrackballCameraManipulator::fitScene( const Core::Aabb& aabb ) {
-
     Scalar f = m_camera->getFOV();
     Scalar a = m_camera->getAspect();
 

--- a/src/Gui/Viewer/TrackballCameraManipulator.cpp
+++ b/src/Gui/Viewer/TrackballCameraManipulator.cpp
@@ -157,12 +157,6 @@ void TrackballCameraManipulator::mousePressSaveData( const QMouseEvent* mouseEve
     m_phiDir     = -Core::Math::signNZ( m_theta );
 }
 
-std::tuple<Scalar, Scalar>
-TrackballCameraManipulator::computeDeltaMouseMove( const QMouseEvent* mouseEvent ) {
-    return { ( mouseEvent->pos().x() - m_lastMouseX ) / m_camera->getWidth(),
-             ( mouseEvent->pos().y() - m_lastMouseY ) / m_camera->getHeight() };
-}
-
 void TrackballCameraManipulator::rotateCallback( QEvent* event ) {
     if ( event->type() == QEvent::MouseMove ) {
         auto mouseEvent = reinterpret_cast<QMouseEvent*>( event );

--- a/src/Gui/Viewer/TrackballCameraManipulator.cpp
+++ b/src/Gui/Viewer/TrackballCameraManipulator.cpp
@@ -46,23 +46,14 @@ void TrackballCameraManipulator::configureKeyMapping_impl() {
 
 void TrackballCameraManipulator::setupKeyMappingCallbacks() {
 
-    m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_ROTATE, [=]( QEvent* event ) {
-        m_currentAction = TRACKBALLCAMERA_ROTATE;
-        rotateCallback( event );
-    } );
-    m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_PAN, [=]( QEvent* event ) {
-        m_currentAction = TRACKBALLCAMERA_PAN;
-        panCallback( event );
-    } );
-    m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_ZOOM, [=]( QEvent* event ) {
-        m_currentAction = TRACKBALLCAMERA_ZOOM;
-        zoomCallback( event );
-    } );
     m_keyMappingCallbackManager.addEventCallback(
-        TRACKBALLCAMERA_MOVE_FORWARD, [=]( QEvent* event ) {
-            m_currentAction = TRACKBALLCAMERA_MOVE_FORWARD;
-            moveForwardCallback( event );
-        } );
+        TRACKBALLCAMERA_ROTATE, [=]( QEvent* event ) { rotateCallback( event ); } );
+    m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_PAN,
+                                                  [=]( QEvent* event ) { panCallback( event ); } );
+    m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_ZOOM,
+                                                  [=]( QEvent* event ) { zoomCallback( event ); } );
+    m_keyMappingCallbackManager.addEventCallback(
+        TRACKBALLCAMERA_MOVE_FORWARD, [=]( QEvent* event ) { moveForwardCallback( event ); } );
 
     m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_PROJ_MODE, [=]( QEvent* ) {
         using ProjType = Ra::Core::Asset::Camera::ProjType;
@@ -204,8 +195,8 @@ void TrackballCameraManipulator::moveForwardCallback( QEvent* event ) {
 }
 
 bool TrackballCameraManipulator::handleMousePressEvent( QMouseEvent* event,
-                                                        const Qt::MouseButtons& buttons,
-                                                        const Qt::KeyboardModifiers& modifiers,
+                                                        const Qt::MouseButtons&,
+                                                        const Qt::KeyboardModifiers&,
                                                         int key ) {
 
     m_lastMouseX = event->pos().x();
@@ -218,8 +209,8 @@ bool TrackballCameraManipulator::handleMousePressEvent( QMouseEvent* event,
 }
 
 bool TrackballCameraManipulator::handleMouseMoveEvent( QMouseEvent* event,
-                                                       const Qt::MouseButtons& buttons,
-                                                       const Qt::KeyboardModifiers& modifiers,
+                                                       const Qt::MouseButtons&,
+                                                       const Qt::KeyboardModifiers&,
                                                        int key ) {
     bool handled = m_keyMappingCallbackManager.triggerEventCallback( event, key );
 
@@ -235,14 +226,13 @@ bool TrackballCameraManipulator::handleMouseMoveEvent( QMouseEvent* event,
 }
 
 bool TrackballCameraManipulator::handleMouseReleaseEvent( QMouseEvent* /*event*/ ) {
-    m_currentAction = KeyMappingManager::KeyMappingAction::Invalid();
 
-    return true;
+    return false;
 }
 
 bool TrackballCameraManipulator::handleWheelEvent( QWheelEvent* event,
-                                                   const Qt::MouseButtons& buttons,
-                                                   const Qt::KeyboardModifiers& modifiers,
+                                                   const Qt::MouseButtons&,
+                                                   const Qt::KeyboardModifiers&,
                                                    int key
 
 ) {

--- a/src/Gui/Viewer/TrackballCameraManipulator.cpp
+++ b/src/Gui/Viewer/TrackballCameraManipulator.cpp
@@ -46,14 +46,23 @@ void TrackballCameraManipulator::configureKeyMapping_impl() {
 
 void TrackballCameraManipulator::setupKeyMappingCallbacks() {
 
+    m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_ROTATE, [=]( QEvent* event ) {
+        m_currentAction = TRACKBALLCAMERA_ROTATE;
+        rotateCallback( event );
+    } );
+    m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_PAN, [=]( QEvent* event ) {
+        m_currentAction = TRACKBALLCAMERA_PAN;
+        panCallback( event );
+    } );
+    m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_ZOOM, [=]( QEvent* event ) {
+        m_currentAction = TRACKBALLCAMERA_ZOOM;
+        zoomCallback( event );
+    } );
     m_keyMappingCallbackManager.addEventCallback(
-        TRACKBALLCAMERA_ROTATE, [=]( QEvent* event ) { rotateCallback( event ); } );
-    m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_PAN,
-                                                  [=]( QEvent* event ) { panCallback( event ); } );
-    m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_ZOOM,
-                                                  [=]( QEvent* event ) { zoomCallback( event ); } );
-    m_keyMappingCallbackManager.addEventCallback(
-        TRACKBALLCAMERA_MOVE_FORWARD, [=]( QEvent* event ) { moveForwardCallback( event ); } );
+        TRACKBALLCAMERA_MOVE_FORWARD, [=]( QEvent* event ) {
+            m_currentAction = TRACKBALLCAMERA_MOVE_FORWARD;
+            moveForwardCallback( event );
+        } );
 
     m_keyMappingCallbackManager.addEventCallback( TRACKBALLCAMERA_PROJ_MODE, [=]( QEvent* ) {
         using ProjType = Ra::Core::Asset::Camera::ProjType;

--- a/src/Gui/Viewer/TrackballCameraManipulator.hpp
+++ b/src/Gui/Viewer/TrackballCameraManipulator.hpp
@@ -87,12 +87,6 @@ class RA_GUI_API TrackballCameraManipulator
   protected:
     // the center of the trackball is defined by the m_referenceFrame.translation()
 
-    /// x-position of the mouse on the screen at the manipulation start.
-    Scalar m_lastMouseX { 0_ra };
-
-    /// y-position of the mouse on the screen at the manipulation start.
-    Scalar m_lastMouseY { 0_ra };
-
     /// Spherical coordinates   (ISO 80000-2:2019 convention)
     /// https://en.wikipedia.org/wiki/Spherical_coordinate_system
     /// phi is azimutal
@@ -121,7 +115,6 @@ class RA_GUI_API TrackballCameraManipulator
     void moveForwardCallback( QEvent* event );
     void zoomCallback( QEvent* event );
     void mousePressSaveData( const QMouseEvent* mouseEvent );
-    std::tuple<Scalar, Scalar> computeDeltaMouseMove( const QMouseEvent* mouseEvent );
 
   protected:
     ///\todo move CAMERA_ to CameraManipulator, will be done soon ;)

--- a/src/Gui/Viewer/Viewer.cpp
+++ b/src/Gui/Viewer/Viewer.cpp
@@ -10,16 +10,14 @@
 
 #include <globjects/globjects.h>
 
-#include <Engine/RadiumEngine.hpp>
-
-#include <Core/Asset/FileData.hpp>
-#include <Core/Utils/StringUtils.hpp>
+// include radium engine here to prevent glbinding incompatibility with gl.h
 #include <Gui/Viewer/Viewer.hpp>
 
 #include <iostream>
 
 #include <QOpenGLContext>
 
+#include <QApplication>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QTimer>
@@ -27,12 +25,13 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb/stb_image_write.h>
 
+#include <Core/Asset/Camera.hpp>
+#include <Core/Asset/FileData.hpp>
 #include <Core/Containers/MakeShared.hpp>
 #include <Core/Math/Math.hpp>
 #include <Core/Utils/Color.hpp>
 #include <Core/Utils/Log.hpp>
 #include <Core/Utils/StringUtils.hpp>
-
 #include <Engine/Data/ShaderProgramManager.hpp>
 #include <Engine/Data/ViewingParameters.hpp>
 #include <Engine/Rendering/ForwardRenderer.hpp>
@@ -43,17 +42,13 @@
 #include <Engine/Scene/DirLight.hpp>
 #include <Engine/Scene/EntityManager.hpp>
 #include <Engine/Scene/SystemDisplay.hpp>
-
 #include <Gui/Utils/KeyMappingManager.hpp>
 #include <Gui/Utils/Keyboard.hpp>
 #include <Gui/Utils/PickingManager.hpp>
-
-#include <Core/Asset/Camera.hpp>
-#include <Engine/Scene/CameraComponent.hpp>
+#include <Gui/Viewer/FlightCameraManipulator.hpp>
 #include <Gui/Viewer/Gizmo/GizmoManager.hpp>
+#include <Gui/Viewer/RotateAroundCameraManipulator.hpp>
 #include <Gui/Viewer/TrackballCameraManipulator.hpp>
-
-#include <QApplication>
 
 namespace Ra {
 namespace Gui {
@@ -74,6 +69,9 @@ void Viewer::setupKeyMappingCallbacks() {
 
     // Add default manipulator listener
     keyMappingManager->addListener( TrackballCameraManipulator::configureKeyMapping );
+    keyMappingManager->addListener( FlightCameraManipulator::configureKeyMapping );
+    keyMappingManager->addListener(
+        RotateAroundCameraManipulator::KeyMapping::configureKeyMapping );
     // add viewer related listener
     keyMappingManager->addListener( GizmoManager::configureKeyMapping );
     keyMappingManager->addListener( configureKeyMapping );


### PR DESCRIPTION
# Pull Request Desription

Fix camera manipulators wrt KeyMapping callbacks.

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.

- **What kind of change does this PR introduce?**
  - [x] bug fix
  - [x] feature
  - [ ] docs update
  - [ ] other:

- **What is the current behavior?** (You can also link to an open issue here)

RotateAround was broken since it derives from Trackball, and m_currentAction was out of sync since the use of callback to manager action.

- **What is the new behavior (if this is a feature change)?**

Handle all camera manipulators with callback associated to action.
 
Also add camera manipulator switch in draw primitive demo, to check the three provided camera manipulator.

- **Other information**:

For futur PR, maybe remove FlightManipulatorContext, move KeyMappingContext to CameraManipulator, and then #545 