### PR TITLE
Format new proposal

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,11 +1,11 @@
 ---
 BasedOnStyle: LLVM
 Language: Cpp
-Standard: Cpp11
+Standard: c++11
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortBlocksOnASingleLine: true
 AllowShortIfStatementsOnASingleLine: true
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: Yes
 BreakBeforeBraces: Custom
 BraceWrapping:
   AfterClass: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,12 +26,12 @@ repos:
 #      - id: cppcheck
 #        args: [--enable=all]
 - repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.33.0
+  rev: v0.37.0
   hooks:
   - id: markdownlint
     args: [-f]
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v15.0.6
+  rev: v16.0.6
   hooks:
   - id: clang-format
     types_or: [c++, c, cuda]

--- a/src/Core/Containers/VariableSet.hpp
+++ b/src/Core/Containers/VariableSet.hpp
@@ -719,7 +719,7 @@ auto VariableSet::addVariableType() -> Utils::optional<VariableContainer<T>*> {
         // used to visit the variableSet with a dynamic visitor
         m_vtable->m_visitFunctions.emplace_back(
             []( const VariableSet& c, const DynamicVisitorBase& v )
-                -> std::pair<bool, std::function<void( DynamicVisitorBase&, std::any && )>> {
+                -> std::pair<bool, std::function<void( DynamicVisitorBase&, std::any&& )>> {
                 auto id = getVariableVisitTypeIndex<T>();
                 if ( v.accept( id ) ) {
                     auto& visitedStorage = c.getVariableStorage<T>();

--- a/src/Core/Utils/Singleton.hpp
+++ b/src/Core/Utils/Singleton.hpp
@@ -23,7 +23,9 @@
     TYPE( const TYPE& )           = delete;                                            \
     void operator=( const TYPE& ) = delete;                                            \
     struct Deleter {                                                                   \
-        void operator()( TYPE* p ) const { delete p; }                                 \
+        void operator()( TYPE* p ) const {                                             \
+            delete p;                                                                  \
+        }                                                                              \
     };                                                                                 \
     static std::unique_ptr<TYPE, Deleter> s_instance;                                  \
                                                                                        \
@@ -33,8 +35,12 @@
         s_instance = std::unique_ptr<TYPE, Deleter>( new TYPE( args... ), Deleter() ); \
         return getInstance();                                                          \
     }                                                                                  \
-    inline static TYPE* getInstance() { return s_instance.get(); }                     \
-    inline static void destroyInstance() { s_instance.reset( nullptr ); }
+    inline static TYPE* getInstance() {                                                \
+        return s_instance.get();                                                       \
+    }                                                                                  \
+    inline static void destroyInstance() {                                             \
+        s_instance.reset( nullptr );                                                   \
+    }
 
 /// Add this macro in the singleton cpp, followed by a semicolon.
 // Limitations : TYPE cannot be a nested type


### PR DESCRIPTION
AFTER #1066 

Try slight changes on clang format configuration to have more oneline, and inline template.
Inline template are specifically usefull for using declaration

```{.cpp}
template<typname T> 
using type1 = T*;
template<typname T> 
using t2 = T**;
```
vs.

```{.cpp}
template<typname T> using type1 = T*;
template<typname TA> using t2   = TA**;
```