### PR TITLE
Render parameters variable set

### DIFF
--- a/doc/developer/material.md
+++ b/doc/developer/material.md
@@ -604,8 +604,8 @@ public:
   void updateGL() override {
     // Method called before drawing each frame in Rendering::updateRenderObjectsInternal.
     // The name of the parameter corresponds to the shader's uniform name.
-    m_renderParameters.addParameter( "aColorUniform", m_colorParameter );
-    m_renderParameters.addParameter( "aScalarUniform", m_scalarParameter );
+    m_renderParameters.setVariable( "aColorUniform", m_colorParameter );
+    m_renderParameters.setVariable( "aScalarUniform", m_scalarParameter );
   }
 
   void setOrComputeTheParameterValues() {
@@ -652,7 +652,7 @@ renderTechnique.setConfiguration( myConfig, DefaultRenderingPasses::LIGHTING_OPA
 // 5. Create and associate the parameter provider with the RenderTechnique
 auto parameterProvider = std::make_shared<MyParameterProvider>();
 parameterProvider->setOrComputeTheParameterValues();
-renderTechnique.setParametersProvider(parameterProvider);
+renderTechnique.setVariablesProvider(parameterProvider);
 
 // 6. Associate the render technique with a geometry in a Ra::Engine::Rendering::RenderObject
 std::shared_ptr<Ra::Engine::Data::Mesh> mesh( new Ra::Engine::Data::Mesh( "my mesh" ) );

--- a/examples/ParameterEditing/main.cpp
+++ b/examples/ParameterEditing/main.cpp
@@ -1,5 +1,7 @@
 // Include Radium base application and its simple Gui
 
+#include <Core/Containers/VariableSet.hpp>
+#include <Core/Containers/VariableSetEnumManagement.hpp>
 #include <Core/Utils/TypesUtils.hpp>
 #include <Engine/Data/RenderParameters.hpp>
 #include <Gui/ParameterSetEditor/ParameterSetEditor.hpp>
@@ -192,7 +194,8 @@ int main( int argc, char* argv[] ) {
 
     //! [filling the parameter set to edit ]
     RenderParameters parameters;
-    parameters.addEnumConverter( "enum", valuesEnumConverter );
+    using namespace Ra::Core::VariableSetEnumManagement;
+    addEnumConverter( parameters, "enum", valuesEnumConverter );
     parameters.setVariable( "bool", false );
     parameters.setVariable( "enum", Values::VALUE_1 );
     parameters.setVariable( "int", int( 0 ) );

--- a/examples/ParameterEditing/main.cpp
+++ b/examples/ParameterEditing/main.cpp
@@ -179,7 +179,7 @@ int main( int argc, char* argv[] ) {
     QDialog dialog( nullptr );
     dialog.setWindowTitle( "ParameterSet editing example" );
     auto layout = new QVBoxLayout( dialog.window() );
-    ParameterSetEditor editor( "Demonstration parameter set", dialog.window() );
+    VariableSetEditor editor( "Demonstration parameter set", dialog.window() );
 
     editor.setShowUnspecified( true );
     layout->addWidget( &editor );
@@ -226,14 +226,14 @@ int main( int argc, char* argv[] ) {
     //! [Printing several parameters before editing ]
 
     //! [Filling the editor with the parameter set ]
-    editor.setupFromParameters( parameters, parameterSet_metadata );
+    editor.setupUi( parameters, parameterSet_metadata );
     auto printParameter = [&parameters]( const std::string& p ) {
         std::cout << "Parameter " << p << " was modified. New value is ";
         parameters.visit( ParameterPrinter {},
                           [p]( const std::string& name ) { return p == name; } );
         std::cout << "\n";
     };
-    QObject::connect( &editor, &ParameterSetEditor::parameterModified, printParameter );
+    QObject::connect( &editor, &VariableSetEditor::parameterModified, printParameter );
     dialog.show();
     //! [Filling the editor with the parameter set ]
 

--- a/examples/ParameterEditing/main.cpp
+++ b/examples/ParameterEditing/main.cpp
@@ -193,28 +193,28 @@ int main( int argc, char* argv[] ) {
     //! [filling the parameter set to edit ]
     RenderParameters parameters;
     parameters.addEnumConverter( "enum", valuesEnumConverter );
-    parameters.addParameter( "bool", false );
-    parameters.addParameter( "enum", Values::VALUE_1 );
-    parameters.addParameter( "int", int( 0 ) );
-    parameters.addParameter( "int_constrained", int( 0 ) );
-    parameters.addParameter( "uint", (unsigned int)( 10 ) );
-    parameters.addParameter( "uint_constrained", (unsigned int)( 5 ) );
-    parameters.addParameter( "Scalar", 0_ra );
-    parameters.addParameter( "Scalar_constrained", 0.5_ra );
-    parameters.addParameter( "Scalar_half_constrained", 0_ra );
-    parameters.addParameter( "Scalar_multiconstrained", 0.5_ra );
-    parameters.addParameter( "Color", Ra::Core::Utils::Color::Magenta() );
-    parameters.addParameter( "Vec2", Ra::Core::Vector2 { 1_ra, 0_ra } );
-    parameters.addParameter( "Vec3", Ra::Core::Vector3 { 1_ra, 1_ra, 1_ra } );
-    parameters.addParameter(
+    parameters.setVariable( "bool", false );
+    parameters.setVariable( "enum", Values::VALUE_1 );
+    parameters.setVariable( "int", int( 0 ) );
+    parameters.setVariable( "int_constrained", int( 0 ) );
+    parameters.setVariable( "uint", (unsigned int)( 10 ) );
+    parameters.setVariable( "uint_constrained", (unsigned int)( 5 ) );
+    parameters.setVariable( "Scalar", 0_ra );
+    parameters.setVariable( "Scalar_constrained", 0.5_ra );
+    parameters.setVariable( "Scalar_half_constrained", 0_ra );
+    parameters.setVariable( "Scalar_multiconstrained", 0.5_ra );
+    parameters.setVariable( "Color", Ra::Core::Utils::Color::Magenta() );
+    parameters.setVariable( "Vec2", Ra::Core::Vector2 { 1_ra, 0_ra } );
+    parameters.setVariable( "Vec3", Ra::Core::Vector3 { 1_ra, 1_ra, 1_ra } );
+    parameters.setVariable(
         "Matrix3",
         Ra::Core::Matrix3 { { 0_ra, 0_ra, 0_ra }, { 1_ra, 1_ra, 1_ra }, { 2_ra, 2_ra, 2_ra } } );
-    parameters.addParameter( "std::vector<int>", std::vector<int> { 0, 1, 2 } );
+    parameters.setVariable( "std::vector<int>", std::vector<int> { 0, 1, 2 } );
 
     RenderParameters embedded;
-    embedded.addParameter( "embedded.int value", 1 );
-    embedded.addParameter( "embedded.scalar value", 1_ra );
-    parameters.addParameter( "embedded", embedded );
+    embedded.setVariable( "embedded.int value", 1 );
+    embedded.setVariable( "embedded.scalar value", 1_ra );
+    parameters.setVariable( "embedded", embedded );
     //! [filling the parameter set to edit ]
 
     //! [Printing several parameters before editing ]

--- a/examples/ParameterEditing/main.cpp
+++ b/examples/ParameterEditing/main.cpp
@@ -181,7 +181,7 @@ int main( int argc, char* argv[] ) {
     auto layout = new QVBoxLayout( dialog.window() );
     ParameterSetEditor editor( "Demonstration parameter set", dialog.window() );
 
-    editor.showUnspecified( true );
+    editor.setShowUnspecified( true );
     layout->addWidget( &editor );
     //! [Creating the editing dialog]
 

--- a/examples/RawShaderMaterial/main.cpp
+++ b/examples/RawShaderMaterial/main.cpp
@@ -71,8 +71,8 @@ class MyParameterProvider : public Ra::Engine::Data::ShaderParameterProvider
         // Method called before drawing each frame in Renderer::updateRenderObjectsInternal.
         // The name of the parameter corresponds to the shader's uniform name.
         auto& renderParameters = getParameters();
-        renderParameters.addParameter( "aColorUniform", m_colorParameter );
-        renderParameters.addParameter( "aScalarUniform", m_scalarParameter );
+        renderParameters.setVariable( "aColorUniform", m_colorParameter );
+        renderParameters.setVariable( "aScalarUniform", m_scalarParameter );
     }
     void setOrComputeTheParameterValues() {
         // client side computation of the parameters, e.g.

--- a/examples/TexturedQuad/main.cpp
+++ b/examples/TexturedQuad/main.cpp
@@ -1,7 +1,7 @@
 // Include Radium base application and its simple Gui
-#include "Engine/Data/BlinnPhongMaterial.hpp"
-#include "Engine/Data/LambertianMaterial.hpp"
-#include "Engine/Data/SimpleMaterial.hpp"
+#include <Engine/Data/BlinnPhongMaterial.hpp>
+#include <Engine/Data/LambertianMaterial.hpp>
+#include <Engine/Data/SimpleMaterial.hpp>
 #include <Gui/BaseApplication.hpp>
 #include <Gui/RadiumWindow/SimpleWindowFactory.hpp>
 

--- a/src/Core/Containers/VariableSet.cpp
+++ b/src/Core/Containers/VariableSet.cpp
@@ -56,21 +56,6 @@ size_t VariableSet::size() const {
     return sum;
 }
 
-void VariableSet::setEnumVariable( const std::string& name, const std::string& value ) {
-    auto converterFunc = existsVariable<
-        std::function<void( Core::VariableSet&, const std::string&, const std::string& )>>( name );
-    if ( converterFunc ) { ( *converterFunc )->second( *this, name, value ); }
-    else {
-        LOG( Core::Utils::logWARNING ) << "VariableSet: try to set enum value from string without "
-                                          "converter, ignored. Variable name: ["
-                                       << name << "], value: [" << value << "]";
-    }
-}
-
-void VariableSet::setEnumVariable( const std::string& name, const char* value ) {
-    setEnumVariable( name, std::string( value ) );
-}
-
 bool VariableSet::DynamicVisitor::accept( const std::type_index& id ) const {
     return m_visitorOperator.find( id ) != m_visitorOperator.cend();
 }

--- a/src/Core/Containers/VariableSet.cpp
+++ b/src/Core/Containers/VariableSet.cpp
@@ -56,6 +56,25 @@ size_t VariableSet::size() const {
     return sum;
 }
 
+void VariableSet::setEnumVariable( const std::string& name, const std::string& value ) {
+    auto converterFunc = existsVariable<
+        std::function<void( Core::VariableSet&, const std::string&, const std::string& )>>( name );
+    if ( converterFunc ) {
+        ( *converterFunc )->second( dynamic_cast<Core::VariableSet&>( *this ), name, value );
+    }
+    else {
+        LOG( Core::Utils::logWARNING )
+            << "VariableSet, try to set enum value from string without converter. Adding "
+               "non-bindable TParameter<string> "
+            << name << " " << value;
+        setVariable( name, value );
+    }
+}
+
+void VariableSet::setEnumVariable( const std::string& name, const char* value ) {
+    setEnumVariable( name, std::string( value ) );
+}
+
 bool VariableSet::DynamicVisitor::accept( const std::type_index& id ) const {
     return m_visitorOperator.find( id ) != m_visitorOperator.cend();
 }

--- a/src/Core/Containers/VariableSet.cpp
+++ b/src/Core/Containers/VariableSet.cpp
@@ -59,15 +59,11 @@ size_t VariableSet::size() const {
 void VariableSet::setEnumVariable( const std::string& name, const std::string& value ) {
     auto converterFunc = existsVariable<
         std::function<void( Core::VariableSet&, const std::string&, const std::string& )>>( name );
-    if ( converterFunc ) {
-        ( *converterFunc )->second( dynamic_cast<Core::VariableSet&>( *this ), name, value );
-    }
+    if ( converterFunc ) { ( *converterFunc )->second( *this, name, value ); }
     else {
-        LOG( Core::Utils::logWARNING )
-            << "VariableSet, try to set enum value from string without converter. Adding "
-               "non-bindable TParameter<string> "
-            << name << " " << value;
-        setVariable( name, value );
+        LOG( Core::Utils::logWARNING ) << "VariableSet: try to set enum value from string without "
+                                          "converter, ignored. Variable name: ["
+                                       << name << "], value: [" << value << "]";
     }
 }
 

--- a/src/Core/Containers/VariableSet.hpp
+++ b/src/Core/Containers/VariableSet.hpp
@@ -675,12 +675,25 @@ auto VariableSet::insertVariable( const std::string& name, const T& value )
 template <typename T>
 auto VariableSet::getVariable( const std::string& name ) const -> T& {
     assert( existsVariable<T>( name ) );
+
+    if constexpr ( std::is_enum<T>::value ) {
+        // need to cast to take into account the way enums are managed
+        return reinterpret_cast<const T&>(
+            getVariable<typename std::underlying_type<T>::type>( name ) );
+    }
+
     return getVariableHandle<T>( name )->second;
 }
 
 template <typename T>
 auto VariableSet::getVariableHandle( const std::string& name ) const -> VariableHandle<T> {
     assert( existsVariableType<T>() );
+    if constexpr ( std::is_enum<T>::value ) {
+        // need to cast to take into account the way enums are managed
+        return reinterpret_cast<const T&>(
+            getVariableStorage<typename std::underlying_type<T>::type>().find( name ) );
+    }
+
     return getVariableStorage<T>().find( name );
 }
 

--- a/src/Core/Containers/VariableSet.hpp
+++ b/src/Core/Containers/VariableSet.hpp
@@ -166,7 +166,9 @@ class RA_CORE_API VariableSet
     /// \pre The element \b name must exists with type \b T. If not verified (assert in debug mode)
     /// std::bad_any_cast exception could be thrown by the underlying management of type erasure
     template <typename T>
-    auto getVariable( const std::string& name ) const -> T&;
+    auto getVariable( const std::string& name ) const -> const T&;
+    template <typename T>
+    auto getVariable( const std::string& name ) -> T&;
 
     /// \brief get the handle on the variable with the given name
     /// \tparam T the type of the variable
@@ -174,7 +176,7 @@ class RA_CORE_API VariableSet
     /// \return an handle which can be de-referenced to obtain a std::pair<const std::string, T>
     /// representing the name and the value of the variable.
     template <typename T>
-    auto getVariableHandle( const std::string& name ) const -> VariableHandle<T>;
+    auto getVariableHandle( const std::string& name ) const -> const VariableHandle<T>;
 
     /// \brief Test the validity of a handle
     /// \tparam H Type of the handle. Expected to be VariableHandle<T> for some variable type T
@@ -262,7 +264,7 @@ class RA_CORE_API VariableSet
     /// \}
 
     /**
-     * \brief Associate a converter for enumerated type to the given parameter name
+     * \brief Associate a converter for enumerated type to the given variable name
      * \tparam EnumBaseType The enum base type to manage (\see Ra::Core::Utils::EnumConverter)
      * \param name
      * \param converter
@@ -272,7 +274,7 @@ class RA_CORE_API VariableSet
                            std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>> converter );
 
     /**
-     * \brief Search for a converter associated with an enumeration parameter
+     * \brief Search for a converter associated with an enumeration variable
      * \tparam EnumBaseType The enum base type to manage (\see Ra::Core::Utils::EnumConverter)
      * \param name the name of the parameter
      * \return an optional containing the converter or false if no converter is found.
@@ -282,7 +284,7 @@ class RA_CORE_API VariableSet
     getEnumConverter( const std::string& name );
 
     /**
-     * \brief Return the string associated to the actual value of a parameter
+     * \brief Return the string associated to the actual value of an enumeration variable
      * \tparam Enum The enum type (\see Ra::Core::Utils::EnumConverter)
      * \param name The name of the enum variable
      * \param value The value to convert
@@ -292,12 +294,10 @@ class RA_CORE_API VariableSet
     std::string getEnumString( const std::string& name, Enum value );
 
     /**
-     * \brief (overload) Return the string associated to the actual value of a parameter, from a
-     * value with underlying_type<Enum>.
-     * \tparam EnumBaseType The underlying enum type (\see Ra::Core::Utils::EnumConverter)
-     * \param name The name of the enum variable
-     * \param value The value to convert
-     * \return
+     * \brief (overload) Return the string associated to the actual value of a n enumeration
+     * variable, from a value with underlying_type<Enum>. \tparam EnumBaseType The underlying enum
+     * type (\see Ra::Core::Utils::EnumConverter) \param name The name of the enum variable \param
+     * value The value to convert \return
      */
     template <typename EnumBaseType>
     std::string
@@ -306,11 +306,10 @@ class RA_CORE_API VariableSet
                    typename std::enable_if<!std::is_enum<EnumBaseType> {}, bool>::type = true );
 
     /**
-     * \brief set the value of the given parameter, according to a string representation of an enum.
-     * \note If there is no EnumConverter associated with the parameter name, the string is
-     * registered in the RenderParameter set.
-     * \param name Name of the parameter
-     * \param value value of the parameter
+     * \brief set the value of the given enumeration variable, according to a string representation
+     * of an enum. \note If there is no EnumConverter associated with the variable name, the string
+     * is registered in the RenderParameter set. \param name Name of the variable \param value value
+     * of the variable
      */
     void setEnumVariable( const std::string& name, const std::string& value );
     void setEnumVariable( const std::string& name, const char* value );
@@ -673,27 +672,26 @@ auto VariableSet::insertVariable( const std::string& name, const T& value )
 }
 
 template <typename T>
-auto VariableSet::getVariable( const std::string& name ) const -> T& {
-    assert( existsVariable<T>( name ) );
+auto VariableSet::getVariable( const std::string& name ) -> T& {
+    return const_cast<T&>( const_cast<const VariableSet*>( this )->getVariable<T>( name ) );
+}
+
+template <typename T>
+auto VariableSet::getVariable( const std::string& name ) const -> const T& {
 
     if constexpr ( std::is_enum<T>::value ) {
         // need to cast to take into account the way enums are managed
         return reinterpret_cast<const T&>(
             getVariable<typename std::underlying_type<T>::type>( name ) );
     }
+    //    assert( existsVariable<T>( name ) );
 
     return getVariableHandle<T>( name )->second;
 }
 
 template <typename T>
-auto VariableSet::getVariableHandle( const std::string& name ) const -> VariableHandle<T> {
+auto VariableSet::getVariableHandle( const std::string& name ) const -> const VariableHandle<T> {
     assert( existsVariableType<T>() );
-    if constexpr ( std::is_enum<T>::value ) {
-        // need to cast to take into account the way enums are managed
-        return reinterpret_cast<const T&>(
-            getVariableStorage<typename std::underlying_type<T>::type>().find( name ) );
-    }
-
     return getVariableStorage<T>().find( name );
 }
 

--- a/src/Core/Containers/VariableSet.hpp
+++ b/src/Core/Containers/VariableSet.hpp
@@ -722,6 +722,10 @@ bool VariableSet::deleteVariable( H& handle ) {
 template <typename T>
 auto VariableSet::existsVariable( const std::string& name ) const
     -> Utils::optional<VariableHandle<T>> {
+
+    if constexpr ( std::is_enum<T>::value ) {
+        return existsVariable<typename std::underlying_type<T>::type>( name );
+    }
     if ( auto typeAccess = existsVariableType<T>(); typeAccess ) {
         auto itr = ( *typeAccess )->find( name );
         if ( itr != ( *typeAccess )->cend() ) { return itr; }
@@ -799,6 +803,12 @@ auto VariableSet::addVariableType() -> Utils::optional<VariableContainer<T>*> {
 
 template <typename T>
 auto VariableSet::existsVariableType() const -> Utils::optional<VariableContainer<T>*> {
+    if constexpr ( std::is_enum<T>::value ) {
+        // Do not return
+        // existsVariableType< typename std::underlying_type< T >::type >();
+        // to prevent misuse of this function. The user should infer this with another logic.
+        return {};
+    }
     auto iter = m_variables.find( std::type_index { typeid( T ) } );
     if ( iter == m_variables.cend() ) { return {}; }
     else { return std::any_cast<VariableSet::VariableContainer<T>>( &( iter->second ) ); }

--- a/src/Core/Containers/VariableSet.hpp
+++ b/src/Core/Containers/VariableSet.hpp
@@ -186,7 +186,7 @@ class RA_CORE_API VariableSet
     /// \return a pair with the variable handle and a bool : true if the variable value was reset,
     /// false if the variable value was set.
     template <typename T>
-    auto insertOrAssignVariable( const std::string& name, const T& value )
+    auto setVariable( const std::string& name, const T& value )
         -> std::pair<VariableHandle<T>, bool>;
 
     /// \brief Remove a variable, i.e. a name->value association
@@ -631,7 +631,7 @@ bool VariableSet::isHandleValid( const H& handle ) const {
 }
 
 template <typename T>
-auto VariableSet::insertOrAssignVariable( const std::string& name, const T& value )
+auto VariableSet::setVariable( const std::string& name, const T& value )
     -> std::pair<VariableHandle<T>, bool> {
     auto typeAccess = existsVariableType<T>();
     // If it is the first parameter of the given type, first register the type

--- a/src/Core/Containers/VariableSetEnumManagement.cpp
+++ b/src/Core/Containers/VariableSetEnumManagement.cpp
@@ -20,6 +20,5 @@ void setEnumVariable( VariableSet& vs, const std::string& name, const char* valu
 }
 
 } // namespace VariableSetEnumManagement
-
 } // namespace Core
 } // namespace Ra

--- a/src/Core/Containers/VariableSetEnumManagement.cpp
+++ b/src/Core/Containers/VariableSetEnumManagement.cpp
@@ -1,0 +1,25 @@
+#include <Core/Containers/VariableSetEnumManagement.hpp>
+
+namespace Ra {
+namespace Core {
+namespace VariableSetEnumManagement {
+
+void setEnumVariable( VariableSet& vs, const std::string& name, const std::string& value ) {
+    auto converterFunc = vs.existsVariable<
+        std::function<void( Core::VariableSet&, const std::string&, const std::string& )>>( name );
+    if ( converterFunc ) { ( *converterFunc )->second( vs, name, value ); }
+    else {
+        LOG( Core::Utils::logWARNING ) << "VariableSet: try to set enum value from string without "
+                                          "converter, ignored. Variable name: ["
+                                       << name << "], value: [" << value << "]";
+    }
+}
+
+void setEnumVariable( VariableSet& vs, const std::string& name, const char* value ) {
+    setEnumVariable( vs, name, std::string( value ) );
+}
+
+} // namespace VariableSetEnumManagement
+
+} // namespace Core
+} // namespace Ra

--- a/src/Core/Containers/VariableSetEnumManagement.hpp
+++ b/src/Core/Containers/VariableSetEnumManagement.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <Core/Containers/VariableSet.hpp>
+#include <Core/Utils/EnumConverter.hpp>
+
+#include <string>
+
+/// hepler function to manage enum as underlying types in VariableSet
+namespace Ra {
+namespace Core {
+namespace VariableSetEnumManagement {
+
+/**
+ * \brief Associate a converter for enumerated type to the given variable name
+ * \tparam EnumBaseType The enum base type to manage (\see Ra::Core::Utils::EnumConverter)
+ * \param name
+ * \param converter
+ */
+template <typename EnumBaseType>
+void addEnumConverter( VariableSet& vs,
+                       const std::string& name,
+                       std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>> converter );
+
+/**
+ * \brief Search for a converter associated with an enumeration variable
+ * \tparam EnumBaseType The enum base type to manage (\see Ra::Core::Utils::EnumConverter)
+ * \param name the name of the parameter
+ * \return an optional containing the converter or false if no converter is found.
+ */
+template <typename EnumBaseType>
+Core::Utils::optional<std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>
+getEnumConverter( const VariableSet& vs, const std::string& name );
+
+/**
+ * \brief Return the string associated to the actual value of an enumeration variable
+ * \tparam Enum The enum type (\see Ra::Core::Utils::EnumConverter)
+ * \param name The name of the enum variable
+ * \param value The value to convert
+ * \return
+ */
+template <typename Enum, typename std::enable_if<std::is_enum<Enum> {}, bool>::type = true>
+std::string getEnumString( const VariableSet& vs, const std::string& name, Enum value );
+
+/**
+ * \brief (overload) Return the string associated to the actual value of a n enumeration
+ * variable, from a value with underlying_type<Enum>. \tparam EnumBaseType The underlying enum
+ * type (\see Ra::Core::Utils::EnumConverter) \param name The name of the enum variable \param
+ * value The value to convert \return
+ */
+template <typename EnumBaseType>
+std::string
+getEnumString( const VariableSet& vs,
+               const std::string& name,
+               EnumBaseType value,
+               typename std::enable_if<!std::is_enum<EnumBaseType> {}, bool>::type = true );
+
+/**
+ * \brief set the value of the given enumeration variable, according to a string representation
+ * of an enum. \note If there is no EnumConverter associated with the variable name, the string
+ * is registered in the RenderParameter set. \param name Name of the variable \param value value
+ * of the variable
+ */
+void RA_CORE_API setEnumVariable( VariableSet& vs,
+                                  const std::string& name,
+                                  const std::string& value );
+
+void RA_CORE_API setEnumVariable( VariableSet& vs, const std::string& name, const char* value );
+
+template <typename T>
+void setEnumVariable( VariableSet& vs, const std::string& name, T value ) {
+    auto v = static_cast<typename std::underlying_type<T>::type>( value );
+    vs.setVariable( name, v );
+}
+
+template <typename T>
+auto getEnumVariable( const VariableSet& vs, const std::string& name ) -> const T& {
+    static_assert( std::is_enum<T>::value );
+    return reinterpret_cast<const T&>(
+        vs.getVariable<typename std::underlying_type<T>::type>( name ) );
+}
+
+template <typename T>
+auto getEnumVariable( VariableSet& vs, const std::string& name ) -> T& {
+    return const_cast<T&>( getEnumVariable<T>( const_cast<const VariableSet&>( vs ), name ) );
+}
+
+template <typename EnumBaseType>
+void addEnumConverter( VariableSet& vs,
+                       const std::string& name,
+                       std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>> converter ) {
+
+    // typed converter
+    auto converterHandle = vs.setVariable( name, converter );
+
+    // string string converter/setter for setEnumVariable
+    std::function<void( Core::VariableSet&, const std::string&, const std::string& )>
+        convertingFunction = [converter = converterHandle.first]( Core::VariableSet& vs,
+                                                                  const std::string& nm,
+                                                                  const std::string& vl ) {
+            vs.setVariable( nm, converter->second->getEnumerator( vl ) );
+        };
+    vs.setVariable( name, convertingFunction );
+}
+
+template <typename EnumBaseType>
+Core::Utils::optional<std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>
+getEnumConverter( const VariableSet& vs, const std::string& name ) {
+    auto storedConverter =
+        vs.existsVariable<std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>( name );
+    if ( storedConverter ) { return ( *storedConverter )->second; }
+    return {};
+}
+
+template <typename EnumBaseType>
+std::string getEnumString( const VariableSet& vs,
+                           const std::string& name,
+                           EnumBaseType value,
+                           typename std::enable_if<!std::is_enum<EnumBaseType> {}, bool>::type ) {
+    auto storedConverter =
+        vs.existsVariable<std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>( name );
+    if ( storedConverter ) { return ( *storedConverter )->second->getEnumerator( value ); }
+    LOG( Ra::Core::Utils::logWARNING ) << name + " is not a registered Enum with underlying type " +
+                                              Ra::Core::Utils::demangleType<EnumBaseType>() + ".";
+    return "";
+}
+
+template <typename Enum, typename std::enable_if<std::is_enum<Enum> {}, bool>::type>
+std::string getEnumString( const VariableSet& vs, const std::string& name, Enum value ) {
+    using EnumBaseType = typename std::underlying_type_t<Enum>;
+    return getEnumString( vs, name, EnumBaseType( value ) );
+}
+
+} // namespace VariableSetEnumManagement
+} // namespace Core
+} // namespace Ra

--- a/src/Core/Containers/VariableSetEnumManagement.hpp
+++ b/src/Core/Containers/VariableSetEnumManagement.hpp
@@ -94,10 +94,10 @@ void addEnumConverter( VariableSet& vs,
 
     // string string converter/setter for setEnumVariable
     std::function<void( Core::VariableSet&, const std::string&, const std::string& )>
-        convertingFunction = [converter = converterHandle.first]( Core::VariableSet& vs,
-                                                                  const std::string& nm,
-                                                                  const std::string& vl ) {
-            vs.setVariable( nm, converter->second->getEnumerator( vl ) );
+        convertingFunction = [converter_ = converterHandle.first]( Core::VariableSet& vs_,
+                                                                   const std::string& name_,
+                                                                   const std::string& value_ ) {
+            vs_.setVariable( name_, converter_->second->getEnumerator( value_ ) );
         };
     vs.setVariable( name, convertingFunction );
 }

--- a/src/Core/Utils/EnumConverter.hpp
+++ b/src/Core/Utils/EnumConverter.hpp
@@ -19,9 +19,14 @@ namespace Utils {
  * of the enumeration to manage.
  *
  */
+
 template <typename EnumBaseType>
 class EnumConverter
 {
+    /// \todo think of manage both EnumType and EnumUnderlyingType
+    /// Eg using EnumUnderlyingType = std::underling_type_t<Enum>;
+    /// getEnumeratorUnderlying -> UnumUnderlyingType
+    /// getEunemrator -> Enum
   public:
     explicit EnumConverter( std::initializer_list<std::pair<EnumBaseType, std::string>> pairs );
 

--- a/src/Core/Utils/EnumConverter.hpp
+++ b/src/Core/Utils/EnumConverter.hpp
@@ -1,9 +1,11 @@
 #pragma once
+
 #include <Core/CoreMacros.hpp>
 
-#include <initializer_list>
-
 #include <Core/Utils/BijectiveAssociation.hpp>
+
+#include <initializer_list>
+#include <vector>
 
 namespace Ra {
 namespace Core {

--- a/src/Core/Utils/EnumConverter.hpp
+++ b/src/Core/Utils/EnumConverter.hpp
@@ -25,8 +25,8 @@ class EnumConverter
 {
     /// \todo think of manage both EnumType and EnumUnderlyingType
     /// Eg using EnumUnderlyingType = std::underling_type_t<Enum>;
-    /// getEnumeratorUnderlying -> UnumUnderlyingType
-    /// getEunemrator -> Enum
+    /// getEnumeratorUnderlying ->EnumUnderlyingType
+    /// getEnumerator -> Enum
   public:
     explicit EnumConverter( std::initializer_list<std::pair<EnumBaseType, std::string>> pairs );
 

--- a/src/Core/Utils/TypesUtils.cpp
+++ b/src/Core/Utils/TypesUtils.cpp
@@ -1,0 +1,48 @@
+#include <Core/Utils/TypesUtils.hpp>
+
+#include <Core/Utils/StringUtils.hpp>
+
+#include <map>
+
+namespace Ra {
+namespace Core {
+namespace Utils {
+namespace TypeInternal {
+
+RA_CORE_API auto makeTypeReadable( const std::string& fullType ) -> std::string {
+    static std::map<std::string, std::string> knownTypes {
+        { "std::", "" },
+        { "__cxx11::", "" },
+        { ", std::allocator<float>", "" },
+        { ", std::allocator<double>", "" },
+        { ", std::allocator<int>", "" },
+        { ", std::allocator<unsigned int>", "" },
+        { "Ra::Core::VectorArray", "RaVector" },
+        { "Ra::Core::Utils::ColorBase<float>", "Color" },
+        { "Ra::Core::Utils::ColorBase<double>", "Color" },
+        { "Eigen::Matrix<float, 2, 1, 0, 2, 1>", "Vector2" },
+        { "Eigen::Matrix<double, 2, 1, 0, 2, 1>", "Vector2d" },
+        { "Eigen::Matrix<int, 2, 1, 0, 2, 1>", "Vector2i" },
+        { "Eigen::Matrix<unsigned int, 2, 1, 0, 2, 1>", "Vector2ui" },
+        { "Eigen::Matrix<float, 3, 1, 0, 3, 1>", "Vector3" },
+        { "Eigen::Matrix<double, 3, 1, 0, 3, 1>", "Vector3d" },
+        { "Eigen::Matrix<int, 3, 1, 0, 3, 1>", "Vector3i" },
+        { "Eigen::Matrix<unsigned int, 3, 1, 0, 3, 1>", "Vector3ui" },
+        { "Eigen::Matrix<float, 4, 1, 0, 4, 1>", "Vector4" },
+        { "Eigen::Matrix<double, 4, 1, 0, 4, 1>", "Vector4d" },
+        { "Eigen::Matrix<int, 4, 1, 0, 4, 1>", "Vector4i" },
+        { "Eigen::Matrix<unsigned int, 4, 1, 0, 4, 1>", "Vector4ui" },
+        // Windows (visual studio 2022) specific name fix
+        { " __ptr64", "" } };
+
+    auto processedType = fullType;
+    for ( const auto& [key, value] : knownTypes ) {
+        Ra::Core::Utils::replaceAllInString( processedType, key, value );
+    }
+    return processedType;
+}
+
+} // namespace TypeInternal
+} // namespace Utils
+} // namespace Core
+} // namespace Ra

--- a/src/Core/Utils/TypesUtils.hpp
+++ b/src/Core/Utils/TypesUtils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Core/CoreMacros.hpp>
+#include <Core/Utils/StringUtils.hpp>
 
 #ifndef _WIN32
 #    include <cxxabi.h>
@@ -10,8 +11,7 @@
 #endif
 
 #include <string>
-
-#include <Core/Utils/StringUtils.hpp>
+#include <typeindex>
 
 namespace Ra {
 namespace Core {
@@ -19,11 +19,81 @@ namespace Utils {
 
 /// Return the human readable version of the type name T
 template <typename T>
-const char* demangleType() noexcept;
+std::string demangleType() noexcept;
 
 /// Return the human readable version of the given object's type
 template <typename T>
-const char* demangleType( const T& ) noexcept;
+std::string demangleType( const T& ) noexcept;
+
+/// Return the human readable version of the given type name
+std::string demangleType( const std::type_index& typeIndex ) noexcept;
+
+/// \brief Return the human readable version of the type name T with simplified radium type names
+template <typename T>
+auto simplifiedDemangledType() noexcept -> std::string;
+
+/// \brief Return the human readable version of the type name T with simplified radium type names
+template <typename T>
+auto simplifiedDemangledType( const T& ) noexcept -> std::string;
+
+/// \brief Return the human readable version of the type name whose index is known, with simplified
+/// radium type names
+/// \param typeName The typeIndex whose simplified named is requested
+/// \return The Radium-simplified type name
+// RA_CORE_API auto simplifiedDemangledType( const std::type_index& typeName ) noexcept ->
+// std::string;
+
+// -----------------------------------------------------------------
+// ---------------------- inline methods ---------------------------
+
+namespace TypeInternal {
+RA_CORE_API auto makeTypeReadable( const std::string& ) -> std::string;
+}
+
+template <typename T>
+auto simplifiedDemangledType() noexcept -> std::string {
+    static auto demangled_name = []() {
+        std::string demangledType =
+            TypeInternal::makeTypeReadable( Ra::Core::Utils::demangleType<T>() );
+        return demangledType;
+    }();
+    return demangled_name;
+}
+
+template <typename T>
+auto simplifiedDemangledType( const T& ) noexcept -> std::string {
+    return simplifiedDemangledType<T>();
+}
+
+inline auto simplifiedDemangledType( const std::type_index& typeName ) noexcept -> std::string {
+    return TypeInternal::makeTypeReadable( Ra::Core::Utils::demangleType( typeName ) );
+}
+
+// Check if a type is a container with access to its element type and number
+// adapted from https://stackoverflow.com/questions/13830158/check-if-a-variable-type-is-iterable
+namespace detail {
+
+using std::begin;
+using std::end;
+
+template <typename T>
+auto is_container_impl( int )
+    -> decltype( begin( std::declval<T&>() ) !=
+                     end( std::declval<T&>() ), // begin/end and operator !=
+                 void(),                        // Handle evil operator ,
+                 std::declval<T&>().empty(),
+                 std::declval<T&>().size(),
+                 ++std::declval<decltype( begin( std::declval<T&>() ) )&>(), // operator ++
+                 void( *begin( std::declval<T&>() ) ),                       // operator*
+                 std::true_type {} );
+
+template <typename T>
+std::false_type is_container_impl( ... );
+
+} // namespace detail
+
+template <typename T>
+using is_container = decltype( detail::is_container_impl<T>( 0 ) );
 
 // TypeList taken and adapted from
 // https://github.com/AcademySoftwareFoundation/openvdb/blob/master/openvdb/openvdb/TypeList.h
@@ -89,55 +159,49 @@ struct TypeList {
 };
 
 #ifdef _WIN32
-// On windows (since MSVC 2019), typeid( T ).name() returns the demangled name
-template <typename T>
-const char* demangleType() noexcept {
-    static auto demangled_name = []() {
-        std::string retval { typeid( T ).name() };
-        removeAllInString( retval, "class " );
-        removeAllInString( retval, "struct " );
-        replaceAllInString( retval, ",", ", " );
-        replaceAllInString( retval, "> >", ">>" );
-        return retval;
-    }();
-
-    return demangled_name.data();
+// On windows (since MSVC 2019), typeid( T ).name() (and then typeIndex.name() returns the demangled
+// name
+inline std::string demangleType( const std::type_index& typeIndex ) noexcept {
+    std::string retval = typeIndex.name();
+    removeAllInString( retval, "class " );
+    removeAllInString( retval, "struct " );
+    removeAllInString( retval, "__cdecl" );
+    replaceAllInString( retval, "& __ptr64", "&" );
+    replaceAllInString( retval, ",", ", " );
+    replaceAllInString( retval, " >", ">" );
+    replaceAllInString( retval, "__int64", "long" );
+    replaceAllInString( retval, "const &", "const&" );
+    return retval;
 }
 #else
-template <typename T>
-const char* demangleType() noexcept {
-    // once per one type
-    static auto demangled_name = []() {
-        int error = 0;
-        std::string retval;
-        char* name = abi::__cxa_demangle( typeid( T ).name(), 0, 0, &error );
-
-        switch ( error ) {
-        case 0:
-            retval = name;
-            break;
-        case -1:
-            retval = "memory allocation failed";
-            break;
-        case -2:
-            retval = "not a valid mangled name";
-            break;
-        default:
-            retval = "__cxa_demangle failed";
-            break;
-        }
-        std::free( name );
-        removeAllInString( retval, "__1::" ); // or "::__1" ?
-        replaceAllInString( retval, "> >", ">>" );
-        return retval;
-    }();
-
-    return demangled_name.data();
+// On Linux/macos, use the C++ ABI demangler
+inline std::string demangleType( const std::type_index& typeIndex ) noexcept {
+    int error = 0;
+    std::string retval;
+    char* name = abi::__cxa_demangle( typeIndex.name(), 0, 0, &error );
+    if ( error == 0 ) { retval = name; }
+    else {
+        // error : -1 --> memory allocation failed
+        // error : -2 --> not a valid mangled name
+        // error : other --> __cxa_demangle
+        retval = std::string( "Type demangler error : " ) + std::to_string( error );
+    }
+    std::free( name );
+    removeAllInString( retval, "__1::" ); // or "::__1" ?
+    replaceAllInString( retval, " >", ">" );
+    return retval;
 }
 #endif
+template <typename T>
+std::string demangleType() noexcept {
+    // once per one type
+    static auto demangled_name = demangleType( std::type_index( typeid( T ) ) );
+    return demangled_name;
+}
+
 // calling with instances
 template <typename T>
-const char* demangleType( const T& ) noexcept {
+std::string demangleType( const T& ) noexcept {
     return demangleType<T>();
 }
 

--- a/src/Core/filelist.cmake
+++ b/src/Core/filelist.cmake
@@ -25,6 +25,7 @@ set(core_sources
     Asset/MaterialData.cpp
     Containers/AdjacencyList.cpp
     Containers/VariableSet.cpp
+    Containers/VariableSetEnumManagement.cpp
     Geometry/CatmullClarkSubdivider.cpp
     Geometry/IndexedGeometry.cpp
     Geometry/LoopSubdivider.cpp
@@ -82,6 +83,7 @@ set(core_headers
     Containers/MakeShared.hpp
     Containers/Tex.hpp
     Containers/VariableSet.hpp
+    Containers/VariableSetEnumManagement.hpp
     Containers/VectorArray.hpp
     CoreMacros.hpp
     Geometry/AbstractGeometry.hpp

--- a/src/Core/filelist.cmake
+++ b/src/Core/filelist.cmake
@@ -43,6 +43,7 @@ set(core_sources
     Utils/Color.cpp
     Utils/StackTrace.cpp
     Utils/StringUtils.cpp
+    Utils/TypesUtils.cpp
 )
 
 set(core_headers

--- a/src/Engine/Data/BlinnPhongMaterial.cpp
+++ b/src/Engine/Data/BlinnPhongMaterial.cpp
@@ -54,12 +54,12 @@ void BlinnPhongMaterial::updateGL() {
 
 void BlinnPhongMaterial::updateFromParameters() {
     auto& renderParameters = getParameters();
-    m_kd                   = renderParameters.getParameter<Core::Utils::Color>( "material.kd" );
-    m_perVertexColor       = renderParameters.getParameter<bool>( "material.hasPerVertexKd" );
-    m_renderAsSplat        = renderParameters.getParameter<bool>( "material.renderAsSplat" );
-    m_ks                   = renderParameters.getParameter<Core::Utils::Color>( "material.ks" );
-    m_ns                   = renderParameters.getParameter<Scalar>( "material.ns" );
-    m_alpha                = renderParameters.getParameter<Scalar>( "material.alpha" );
+    m_kd                   = renderParameters.getVariable<Core::Utils::Color>( "material.kd" );
+    m_perVertexColor       = renderParameters.getVariable<bool>( "material.hasPerVertexKd" );
+    m_renderAsSplat        = renderParameters.getVariable<bool>( "material.renderAsSplat" );
+    m_ks                   = renderParameters.getVariable<Core::Utils::Color>( "material.ks" );
+    m_ns                   = renderParameters.getVariable<Scalar>( "material.ns" );
+    m_alpha                = renderParameters.getVariable<Scalar>( "material.alpha" );
 }
 
 bool BlinnPhongMaterial::isTransparent() const {

--- a/src/Engine/Data/BlinnPhongMaterial.cpp
+++ b/src/Engine/Data/BlinnPhongMaterial.cpp
@@ -22,27 +22,27 @@ BlinnPhongMaterial::BlinnPhongMaterial( const std::string& instanceName ) :
 void BlinnPhongMaterial::updateRenderingParameters() {
     // update the rendering parameters
     auto& renderParameters = getParameters();
-    renderParameters.addParameter( "material.kd", m_kd );
-    renderParameters.addParameter( "material.hasPerVertexKd", m_perVertexColor );
-    renderParameters.addParameter( "material.renderAsSplat", m_renderAsSplat );
-    renderParameters.addParameter( "material.ks", m_ks );
-    renderParameters.addParameter( "material.ns", m_ns );
-    renderParameters.addParameter( "material.alpha", std::min( m_alpha, m_kd[3] ) );
+    renderParameters.setVariable( "material.kd", m_kd );
+    renderParameters.setVariable( "material.hasPerVertexKd", m_perVertexColor );
+    renderParameters.setVariable( "material.renderAsSplat", m_renderAsSplat );
+    renderParameters.setVariable( "material.ks", m_ks );
+    renderParameters.setVariable( "material.ns", m_ns );
+    renderParameters.setVariable( "material.alpha", std::min( m_alpha, m_kd[3] ) );
     Texture* tex = getTexture( BlinnPhongMaterial::TextureSemantic::TEX_DIFFUSE );
-    if ( tex != nullptr ) { renderParameters.addParameter( "material.tex.kd", tex ); }
-    renderParameters.addParameter( "material.tex.hasKd", tex != nullptr );
+    if ( tex != nullptr ) { renderParameters.setTexture( "material.tex.kd", tex ); }
+    renderParameters.setVariable( "material.tex.hasKd", tex != nullptr );
     tex = getTexture( BlinnPhongMaterial::TextureSemantic::TEX_SPECULAR );
-    if ( tex != nullptr ) { renderParameters.addParameter( "material.tex.ks", tex ); }
-    renderParameters.addParameter( "material.tex.hasKs", tex != nullptr );
+    if ( tex != nullptr ) { renderParameters.setTexture( "material.tex.ks", tex ); }
+    renderParameters.setVariable( "material.tex.hasKs", tex != nullptr );
     tex = getTexture( BlinnPhongMaterial::TextureSemantic::TEX_NORMAL );
-    if ( tex != nullptr ) { renderParameters.addParameter( "material.tex.normal", tex ); }
-    renderParameters.addParameter( "material.tex.hasNormal", tex != nullptr );
+    if ( tex != nullptr ) { renderParameters.setTexture( "material.tex.normal", tex ); }
+    renderParameters.setVariable( "material.tex.hasNormal", tex != nullptr );
     tex = getTexture( BlinnPhongMaterial::TextureSemantic::TEX_SHININESS );
-    if ( tex != nullptr ) { renderParameters.addParameter( "material.tex.ns", tex ); }
-    renderParameters.addParameter( "material.tex.hasNs", tex != nullptr );
+    if ( tex != nullptr ) { renderParameters.setTexture( "material.tex.ns", tex ); }
+    renderParameters.setVariable( "material.tex.hasNs", tex != nullptr );
     tex = getTexture( BlinnPhongMaterial::TextureSemantic::TEX_ALPHA );
-    if ( tex != nullptr ) { renderParameters.addParameter( "material.tex.alpha", tex ); }
-    renderParameters.addParameter( "material.tex.hasAlpha", tex != nullptr );
+    if ( tex != nullptr ) { renderParameters.setTexture( "material.tex.alpha", tex ); }
+    renderParameters.setVariable( "material.tex.hasAlpha", tex != nullptr );
 }
 
 void BlinnPhongMaterial::updateGL() {

--- a/src/Engine/Data/LambertianMaterial.cpp
+++ b/src/Engine/Data/LambertianMaterial.cpp
@@ -61,8 +61,8 @@ void LambertianMaterial::unregisterMaterial() {
 
 void LambertianMaterial::updateFromParameters() {
     auto& renderParameters = getParameters();
-    setColor( renderParameters.getParameter<Core::Utils::Color>( "material.color" ) );
-    setColoredByVertexAttrib( renderParameters.getParameter<bool>( "material.perVertexColor" ) );
+    setColor( renderParameters.getVariable<Core::Utils::Color>( "material.color" ) );
+    setColoredByVertexAttrib( renderParameters.getVariable<bool>( "material.perVertexColor" ) );
 }
 
 nlohmann::json LambertianMaterial::getParametersMetadata() const {

--- a/src/Engine/Data/PlainMaterial.cpp
+++ b/src/Engine/Data/PlainMaterial.cpp
@@ -61,8 +61,8 @@ void PlainMaterial::unregisterMaterial() {
 
 void PlainMaterial::updateFromParameters() {
     auto& renderParameters = getParameters();
-    setColor( renderParameters.getParameter<Core::Utils::Color>( "material.color" ) );
-    setColoredByVertexAttrib( renderParameters.getParameter<bool>( "material.perVertexColor" ) );
+    setColor( renderParameters.getVariable<Core::Utils::Color>( "material.color" ) );
+    setColoredByVertexAttrib( renderParameters.getVariable<bool>( "material.perVertexColor" ) );
 }
 
 nlohmann::json PlainMaterial::getParametersMetadata() const {

--- a/src/Engine/Data/RenderParameters.cpp
+++ b/src/Engine/Data/RenderParameters.cpp
@@ -1,3 +1,4 @@
+#include "Core/Containers/VariableSet.hpp"
 #include <Core/Utils/Log.hpp>
 
 #include <Engine/Data/RenderParameters.hpp>
@@ -11,32 +12,26 @@ namespace Data {
 RenderParameters::StaticParameterBinder RenderParameters::s_binder;
 
 void RenderParameters::bind( const Data::ShaderProgram* shader ) const {
-    m_parameterSets.visit( s_binder, shader );
+    visit( s_binder, shader );
 }
 
-void RenderParameters::addParameter( const std::string& name, const std::string& value ) {
-    auto converterFunc = m_parameterSets.existsVariable<
+void RenderParameters::setEnumVariable( const std::string& name, const std::string& value ) {
+    auto converterFunc = existsVariable<
         std::function<void( Core::VariableSet&, const std::string&, const std::string& )>>( name );
-    if ( converterFunc ) { ( *converterFunc )->second( m_parameterSets, name, value ); }
+    if ( converterFunc ) {
+        ( *converterFunc )->second( dynamic_cast<Core::VariableSet&>( *this ), name, value );
+    }
     else {
         LOG( Core::Utils::logWARNING )
             << "RenderParameters, try to set enum value from string without converter. Adding "
                "non-bindable TParameter<string> "
             << name << " " << value;
-        m_parameterSets.insertOrAssignVariable( name, value );
+        setVariable( name, value );
     }
 }
 
-void RenderParameters::addParameter( const std::string& name, const char* value ) {
-    addParameter( name, std::string( value ) );
-}
-
-void RenderParameters::mergeKeepParameters( const RenderParameters& params ) {
-    m_parameterSets.mergeKeepVariables( params.getStorage() );
-}
-
-void RenderParameters::mergeReplaceParameters( const RenderParameters& params ) {
-    m_parameterSets.mergeReplaceVariables( params.getStorage() );
+void RenderParameters::setEnumVariable( const std::string& name, const char* value ) {
+    setEnumVariable( name, std::string( value ) );
 }
 
 void ParameterSetEditingInterface::loadMetaData( const std::string& basename,

--- a/src/Engine/Data/RenderParameters.cpp
+++ b/src/Engine/Data/RenderParameters.cpp
@@ -15,25 +15,6 @@ void RenderParameters::bind( const Data::ShaderProgram* shader ) const {
     visit( s_binder, shader );
 }
 
-void RenderParameters::setEnumVariable( const std::string& name, const std::string& value ) {
-    auto converterFunc = existsVariable<
-        std::function<void( Core::VariableSet&, const std::string&, const std::string& )>>( name );
-    if ( converterFunc ) {
-        ( *converterFunc )->second( dynamic_cast<Core::VariableSet&>( *this ), name, value );
-    }
-    else {
-        LOG( Core::Utils::logWARNING )
-            << "RenderParameters, try to set enum value from string without converter. Adding "
-               "non-bindable TParameter<string> "
-            << name << " " << value;
-        setVariable( name, value );
-    }
-}
-
-void RenderParameters::setEnumVariable( const std::string& name, const char* value ) {
-    setEnumVariable( name, std::string( value ) );
-}
-
 void ParameterSetEditingInterface::loadMetaData( const std::string& basename,
                                                  nlohmann::json& destination ) {
     auto resourcesRootDir { RadiumEngine::getInstance()->getResourcesDir() };

--- a/src/Engine/Data/RenderParameters.cpp
+++ b/src/Engine/Data/RenderParameters.cpp
@@ -9,12 +9,6 @@ namespace Ra {
 namespace Engine {
 namespace Data {
 
-RenderParameters::StaticParameterBinder RenderParameters::s_binder;
-
-void RenderParameters::bind( const Data::ShaderProgram* shader ) const {
-    visit( s_binder, shader );
-}
-
 void ParameterSetEditingInterface::loadMetaData( const std::string& basename,
                                                  nlohmann::json& destination ) {
     auto resourcesRootDir { RadiumEngine::getInstance()->getResourcesDir() };

--- a/src/Engine/Data/RenderParameters.hpp
+++ b/src/Engine/Data/RenderParameters.hpp
@@ -40,9 +40,6 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
      */
     using TextureInfo = std::pair<Data::Texture*, int>;
 
-    /// \brief Aliases for bindable parameter types
-    /// \{
-
     /// List of bindable types, to be used with static visitors
     using BindableTypes = Core::Utils::TypeList<bool,
                                                 Core::Utils::Color,
@@ -78,13 +75,13 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
         setVariable( name, TextureInfo { tex, texUnit } );
     }
 
-    /**\}*/
-
     /** Bind the parameter uniform on the shader program
      * \note, this will only bind the supported parameter types.
      * \param shader The shader to bind to.
      */
-    void bind( const Data::ShaderProgram* shader ) const;
+    void bind( const Data::ShaderProgram* shader ) const {
+        visit( StaticParameterBinder {}, shader );
+    }
 
   private:
     /**
@@ -95,7 +92,7 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
     class StaticParameterBinder
     {
       public:
-        /// Type supported by the binder
+        /// Type supported by the binder, as expected by VariableSet
         using types = BindableTypes;
 
         /**
@@ -137,11 +134,6 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
             shader->setUniform( name.c_str(), p );
         }
     };
-
-    /** \brief Functor to bind parameters
-     * There will be only one StaticParameterBinder used by all RenderParameters
-     */
-    static StaticParameterBinder s_binder;
 };
 
 /**

--- a/src/Engine/Data/RenderParameters.hpp
+++ b/src/Engine/Data/RenderParameters.hpp
@@ -62,31 +62,6 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
                                                 std::reference_wrapper<RenderParameters>,
                                                 std::reference_wrapper<const RenderParameters>>;
 
-    /** Set of typed parameters
-     * For a given shader Program, all the parameters are stored by type, using Core::VariableSet as
-     * container.
-     *
-     * \tparam T The type of parameters in the set.
-     */
-    template <typename T>
-    using UniformBindableSet = Core::VariableSet::VariableContainer<T>;
-
-    /** Handle to a bindable parameters.
-     *  A handle is an iterator on a pair <name, value> such that the value is of type T
-     *
-     * \tparam T The type of parameter in the set.
-     */
-    template <typename T>
-    using UniformVariable = Core::VariableSet::VariableHandle<T>;
-    /// \}
-
-    /**
-     * Overloaded operators to set shader parameters
-     * \{
-     */
-
-    using VariableSet::setVariable;
-
     /**
      * \brief Adding a texture parameter.
      * \tparam T The type of parameter to add. Must be derived from Texture for this overload.

--- a/src/Engine/Data/RenderParameters.hpp
+++ b/src/Engine/Data/RenderParameters.hpp
@@ -28,7 +28,7 @@ class Texture;
  * \note Automatic binding is only available for supported type described in BindableTypes.
  * \note Enums are stored according to their underlying_type. Enum management is automatic except
  * when requesting for the associated uniformBindableSet. To access bindable set containing a given
- * enum with type Enum, use `getParameterSet<typename std::underlying_type<typename
+ * enum with type Enum, use `getAllVariable<typename std::underlying_type<typename
  * Enum>::type>`
  *
  */
@@ -171,18 +171,6 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
     void bind( const Data::ShaderProgram* shader ) const;
 
     /**
-     * \brief Get a typed parameter set
-     * \tparam T the type of the parameter set to get
-     * \return The corresponding set parameter
-     */
-    /// \{
-    template <typename T>
-    const UniformBindableSet<T>& getParameterSet() const;
-    template <typename T>
-    UniformBindableSet<T>& getParameterSet();
-    /// \}
-
-    /**
      * \brief Test if parameters of type T are stored
      * \tparam T
      * \return an optional, empty if the ParameterSet does not exists or whose value is
@@ -190,7 +178,7 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
      * pointer remains valid as long as the RenderParameter exists and contains the given type.
      */
     template <typename T>
-    Core::Utils::optional<UniformBindableSet<T>*> hasParameterSet() const;
+    Core::Utils::optional<UniformBindableSet<T>*> existsVariableType() const;
 
     /**
      * Check if a typed parameter exists
@@ -199,7 +187,7 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
      * \return true if the parameter exists
      */
     template <typename T>
-    Core::Utils::optional<UniformVariable<T>> containsParameter( const std::string& name ) const;
+    Core::Utils::optional<UniformVariable<T>> existsVariable( const std::string& name ) const;
 
     /**
      * \brief Get a typed parameter
@@ -354,8 +342,8 @@ void RenderParameters::addEnumConverter(
 template <typename EnumBaseType>
 Core::Utils::optional<std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>
 RenderParameters::getEnumConverter( const std::string& name ) {
-    auto storedConverter =
-        existsVariable<std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>( name );
+    auto storedConverter = Core::VariableSet::existsVariable<
+        std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>( name );
     if ( storedConverter ) { return ( *storedConverter )->second; }
     return {};
 }
@@ -365,8 +353,8 @@ std::string RenderParameters::getEnumString(
     const std::string& name,
     EnumBaseType value,
     typename std::enable_if<!std::is_enum<EnumBaseType> {}, bool>::type ) {
-    auto storedConverter =
-        existsVariable<std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>( name );
+    auto storedConverter = Core::VariableSet::existsVariable<
+        std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>( name );
     if ( storedConverter ) { return ( *storedConverter )->second->getEnumerator( value ); }
     LOG( Ra::Core::Utils::logWARNING ) << name + " is not a registered Enum with underlying type " +
                                               Ra::Core::Utils::demangleType<EnumBaseType>() + ".";
@@ -382,34 +370,24 @@ std::string RenderParameters::getEnumString( const std::string& name, Enum value
 /* --------------- enum parameter management --------------- */
 
 template <typename T>
-inline const RenderParameters::UniformBindableSet<T>& RenderParameters::getParameterSet() const {
-    return getAllVariables<T>();
-}
-
-template <typename T>
-inline RenderParameters::UniformBindableSet<T>& RenderParameters::getParameterSet() {
-    return getAllVariables<T>();
-}
-
-template <typename T>
 inline Core::Utils::optional<RenderParameters::UniformBindableSet<T>*>
-RenderParameters::hasParameterSet() const {
+RenderParameters::existsVariableType() const {
     if constexpr ( std::is_enum<T>::value ) {
         // Do not return
         // existsVariableType< typename std::underlying_type< T >::type >();
         // to prevent misuse of this function. The user should infer this with another logic.
         return {};
     }
-    else { return existsVariableType<T>(); }
+    else { return Core::VariableSet::existsVariableType<T>(); }
 }
 
 template <typename T>
 inline Core::Utils::optional<RenderParameters::UniformVariable<T>>
-RenderParameters::containsParameter( const std::string& name ) const {
+RenderParameters::existsVariable( const std::string& name ) const {
     if constexpr ( std::is_enum<T>::value ) {
-        return existsVariable<typename std::underlying_type<T>::type>( name );
+        return Core::VariableSet::existsVariable<typename std::underlying_type<T>::type>( name );
     }
-    else { return existsVariable<T>( name ); }
+    else { return Core::VariableSet::existsVariable<T>( name ); }
 }
 
 template <typename T>

--- a/src/Engine/Data/RenderParameters.hpp
+++ b/src/Engine/Data/RenderParameters.hpp
@@ -86,20 +86,6 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
      */
     void bind( const Data::ShaderProgram* shader ) const;
 
-    /**
-     * \brief Get a typed parameter
-     * \tparam T the type of the parameter to get
-     * \param name The name of the parameter to get
-     * \return The corresponding parameter
-     * \throw std::out_of_range if the container does not have an parameter with the specified name
-     */
-    /// \{
-    template <typename T>
-    const T& getParameter( const std::string& name ) const;
-    template <typename T>
-    T& getParameter( const std::string& name );
-    /// \}
-
   private:
     /**
      * \brief Static visitor to bind the stored parameters.
@@ -219,21 +205,6 @@ class RA_ENGINE_API ShaderParameterProvider
     /// replace this by coreVariables
     RenderParameters m_renderParameters;
 };
-
-template <typename T>
-inline const T& RenderParameters::getParameter( const std::string& name ) const {
-    if constexpr ( std::is_enum<T>::value ) {
-        // need to cast to take into account the way enums are managed in the RenderParameters
-        return reinterpret_cast<const T&>(
-            getVariable<typename std::underlying_type<T>::type>( name ) );
-    }
-    else { return getVariable<T>( name ); }
-}
-
-template <typename T>
-inline T& RenderParameters::getParameter( const std::string& name ) {
-    return const_cast<T&>( const_cast<const RenderParameters*>( this )->getParameter<T>( name ) );
-}
 
 } // namespace Data
 } // namespace Engine

--- a/src/Engine/Data/RenderParameters.hpp
+++ b/src/Engine/Data/RenderParameters.hpp
@@ -74,6 +74,16 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
         setVariable( name, TextureInfo { tex, texUnit } );
     }
 
+    using VariableSet::setVariable;
+
+    /// overload create ref wrapper for RenderParameters variable
+    void setVariable( const std::string& name, RenderParameters& rp ) {
+        VariableSet::setVariable( name, std::ref( rp ) );
+    }
+    void setVariable( const std::string& name, const RenderParameters& rp ) {
+        VariableSet::setVariable( name, std::cref( rp ) );
+    }
+
     /** \brief Bind the parameter uniform on the shader program.
      *
      * \note, this will only bind the supported parameter types.

--- a/src/Engine/Data/RenderParameters.hpp
+++ b/src/Engine/Data/RenderParameters.hpp
@@ -32,7 +32,7 @@ class Texture;
  * Enum>::type>`
  *
  */
-class RA_ENGINE_API RenderParameters final
+class RA_ENGINE_API RenderParameters final : public Core::VariableSet
 {
   public:
     /**
@@ -129,24 +129,7 @@ class RA_ENGINE_API RenderParameters final
      * \{
      */
 
-    /**
-     * \brief Add a parameter by value
-     * \tparam T The type of parameter to add. Must be a non class type for this overload to be
-     * chosen. \param name Name of the parameter. \param value Value of the parameter.
-     */
-    template <typename T>
-    void addParameter( const std::string& name,
-                       T value,
-                       typename std::enable_if<!std::is_class<T> {}, bool>::type = true );
-
-    /**
-     * \brief Add a parameter by const ref
-     * \tparam T The type of parameter to add. Must be a class type for this overload to be chosen.
-     * \param name Name of the parameter.
-     * \param value Value of the parameter.
-     */
-    template <typename T, typename std::enable_if<std::is_class<T> {}, bool>::type = true>
-    void addParameter( const std::string& name, const T& value );
+    using VariableSet::setVariable;
 
     /**
      * \brief Adding a texture parameter.
@@ -160,7 +143,9 @@ class RA_ENGINE_API RenderParameters final
      */
     template <typename T,
               typename std::enable_if<std::is_base_of<Data::Texture, T>::value, bool>::type = true>
-    void addParameter( const std::string& name, T* tex, int texUnit = -1 );
+    void setTexture( const std::string& name, T* tex, int texUnit = -1 ) {
+        setVariable( name, TextureInfo { tex, texUnit } );
+    }
 
     /**
      * \brief set the value of the given parameter, according to a string representation of an enum.
@@ -169,44 +154,15 @@ class RA_ENGINE_API RenderParameters final
      * \param name Name of the parameter
      * \param value value of the parameter
      */
-    void addParameter( const std::string& name, const std::string& value );
-    void addParameter( const std::string& name, const char* value );
-
-    /**
-     * \brief add a render parameter variable
-     * \param name
-     * \param value
-     */
-    void addParameter( const std::string& name, RenderParameters& value );
-
-    void addParameter( const std::string& name, const RenderParameters& value );
+    void setEnumVariable( const std::string& name, const std::string& value );
+    void setEnumVariable( const std::string& name, const char* value );
+    template <typename T>
+    void setEnumVariable( const std::string& name, T value ) {
+        auto v = static_cast<typename std::underlying_type<T>::type>( value );
+        setVariable( name, v );
+    }
 
     /**\}*/
-
-    /**
-     * \brief Remove the given parameter from the parameterSet
-     * \tparam T Type of the parameter to remove
-     * \param name Name of the parameter to remove
-     * \return true if the parameter was found and removed. false else.
-     */
-    template <typename T>
-    bool removeParameter( const std::string& name );
-
-    /**
-     * Merges a RenderParameters \a params with this
-     * \param params the render parameter to merge with the current.
-     * Existing parameter value are kept from this
-     * \see mergeReplaceParameters
-     */
-    void mergeKeepParameters( const RenderParameters& params );
-
-    /**
-     * Merges a RenderParameters \a params with this
-     * \param params the render parameter to merge with the current.
-     * Existing parameter values are replaced by params's one.
-     * \see mergeKeepParameters
-     */
-    void mergeReplaceParameters( const RenderParameters& params );
 
     /** Bind the parameter uniform on the shader program
      * \note, this will only bind the supported parameter types.
@@ -259,23 +215,6 @@ class RA_ENGINE_API RenderParameters final
     T& getParameter( const std::string& name );
     /// \}
 
-    /** Visit the parameter using any kind of visitor
-     */
-    template <typename V>
-    void visit( V&& visitor ) const;
-
-    template <typename V, typename T>
-    void visit( V&& visitor, T& userParams ) const;
-
-    template <typename V, typename T>
-    void visit( V&& visitor, T&& userParams ) const;
-
-    /// \brief Get access to the parameter storage
-    /// \return the Core::VariableSet storing the parameters
-    /// \{
-    const Core::VariableSet& getStorage() const { return m_parameterSets; }
-    Core::VariableSet& getStorage() { return m_parameterSets; }
-    /// \}
   private:
     /**
      * \brief Static visitor to bind the stored parameters.
@@ -332,11 +271,6 @@ class RA_ENGINE_API RenderParameters final
      * There will be only one StaticParameterBinder used by all RenderParameters
      */
     static StaticParameterBinder s_binder;
-
-    /**
-     * Storage of the parameters
-     */
-    Core::VariableSet m_parameterSets;
 };
 
 /**
@@ -407,22 +341,21 @@ template <typename EnumBaseType>
 void RenderParameters::addEnumConverter(
     const std::string& name,
     std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>> converter ) {
-    auto converterHandle = m_parameterSets.insertOrAssignVariable( name, converter );
+    auto converterHandle = setVariable( name, converter );
     std::function<void( Core::VariableSet&, const std::string&, const std::string& )>
         convertingFunction = [converter = converterHandle.first]( Core::VariableSet& vs,
                                                                   const std::string& nm,
                                                                   const std::string& vl ) {
-            vs.insertOrAssignVariable( nm, converter->second->getEnumerator( vl ) );
+            vs.setVariable( nm, converter->second->getEnumerator( vl ) );
         };
-    m_parameterSets.insertOrAssignVariable( name, convertingFunction );
+    setVariable( name, convertingFunction );
 }
 
 template <typename EnumBaseType>
 Core::Utils::optional<std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>
 RenderParameters::getEnumConverter( const std::string& name ) {
     auto storedConverter =
-        m_parameterSets.existsVariable<std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>(
-            name );
+        existsVariable<std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>( name );
     if ( storedConverter ) { return ( *storedConverter )->second; }
     return {};
 }
@@ -433,8 +366,7 @@ std::string RenderParameters::getEnumString(
     EnumBaseType value,
     typename std::enable_if<!std::is_enum<EnumBaseType> {}, bool>::type ) {
     auto storedConverter =
-        m_parameterSets.existsVariable<std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>(
-            name );
+        existsVariable<std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>( name );
     if ( storedConverter ) { return ( *storedConverter )->second->getEnumerator( value ); }
     LOG( Ra::Core::Utils::logWARNING ) << name + " is not a registered Enum with underlying type " +
                                               Ra::Core::Utils::demangleType<EnumBaseType>() + ".";
@@ -450,49 +382,13 @@ std::string RenderParameters::getEnumString( const std::string& name, Enum value
 /* --------------- enum parameter management --------------- */
 
 template <typename T>
-inline void
-RenderParameters::addParameter( const std::string& name,
-                                T value,
-                                typename std::enable_if<!std::is_class<T> {}, bool>::type ) {
-    if constexpr ( std::is_enum<T>::value ) {
-        auto v = static_cast<typename std::underlying_type<T>::type>( value );
-        m_parameterSets.insertOrAssignVariable( name, v );
-    }
-    else { m_parameterSets.insertOrAssignVariable( name, value ); }
-}
-
-template <typename T, typename std::enable_if<std::is_class<T> {}, bool>::type>
-inline void RenderParameters::addParameter( const std::string& name, const T& value ) {
-    m_parameterSets.insertOrAssignVariable( name, value );
-}
-
-template <typename T, typename std::enable_if<std::is_base_of<Data::Texture, T>::value, bool>::type>
-inline void RenderParameters::addParameter( const std::string& name, T* tex, int texUnit ) {
-    addParameter( name, TextureInfo { tex, texUnit } );
-}
-
-inline void RenderParameters::addParameter( const std::string& name, RenderParameters& value ) {
-    m_parameterSets.insertOrAssignVariable( name, std::ref( value ) );
-}
-
-inline void RenderParameters::addParameter( const std::string& name,
-                                            const RenderParameters& value ) {
-    m_parameterSets.insertOrAssignVariable( name, std::cref( value ) );
-}
-
-template <typename T>
-bool RenderParameters::removeParameter( const std::string& name ) {
-    return m_parameterSets.deleteVariable<T>( name );
-}
-
-template <typename T>
 inline const RenderParameters::UniformBindableSet<T>& RenderParameters::getParameterSet() const {
-    return m_parameterSets.getAllVariables<T>();
+    return getAllVariables<T>();
 }
 
 template <typename T>
 inline RenderParameters::UniformBindableSet<T>& RenderParameters::getParameterSet() {
-    return m_parameterSets.getAllVariables<T>();
+    return getAllVariables<T>();
 }
 
 template <typename T>
@@ -500,20 +396,20 @@ inline Core::Utils::optional<RenderParameters::UniformBindableSet<T>*>
 RenderParameters::hasParameterSet() const {
     if constexpr ( std::is_enum<T>::value ) {
         // Do not return
-        // m_parameterSets.existsVariableType< typename std::underlying_type< T >::type >();
+        // existsVariableType< typename std::underlying_type< T >::type >();
         // to prevent misuse of this function. The user should infer this with another logic.
         return {};
     }
-    else { return m_parameterSets.existsVariableType<T>(); }
+    else { return existsVariableType<T>(); }
 }
 
 template <typename T>
 inline Core::Utils::optional<RenderParameters::UniformVariable<T>>
 RenderParameters::containsParameter( const std::string& name ) const {
     if constexpr ( std::is_enum<T>::value ) {
-        return m_parameterSets.existsVariable<typename std::underlying_type<T>::type>( name );
+        return existsVariable<typename std::underlying_type<T>::type>( name );
     }
-    else { return m_parameterSets.existsVariable<T>( name ); }
+    else { return existsVariable<T>( name ); }
 }
 
 template <typename T>
@@ -521,29 +417,14 @@ inline const T& RenderParameters::getParameter( const std::string& name ) const 
     if constexpr ( std::is_enum<T>::value ) {
         // need to cast to take into account the way enums are managed in the RenderParameters
         return reinterpret_cast<const T&>(
-            m_parameterSets.getVariable<typename std::underlying_type<T>::type>( name ) );
+            getVariable<typename std::underlying_type<T>::type>( name ) );
     }
-    else { return m_parameterSets.getVariable<T>( name ); }
+    else { return getVariable<T>( name ); }
 }
 
 template <typename T>
 inline T& RenderParameters::getParameter( const std::string& name ) {
     return const_cast<T&>( const_cast<const RenderParameters*>( this )->getParameter<T>( name ) );
-}
-
-template <typename V>
-inline void RenderParameters::visit( V&& visitor ) const {
-    m_parameterSets.visit( visitor );
-}
-
-template <typename V, typename T>
-inline void RenderParameters::visit( V&& visitor, T& userParams ) const {
-    m_parameterSets.visit( visitor, std::forward<T&>( userParams ) );
-}
-
-template <typename V, typename T>
-inline void RenderParameters::visit( V&& visitor, T&& userParams ) const {
-    m_parameterSets.visit( visitor, std::forward<T&&>( userParams ) );
 }
 
 } // namespace Data

--- a/src/Engine/Data/RenderParameters.hpp
+++ b/src/Engine/Data/RenderParameters.hpp
@@ -112,25 +112,6 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
     void bind( const Data::ShaderProgram* shader ) const;
 
     /**
-     * \brief Test if parameters of type T are stored
-     * \tparam T
-     * \return an optional, empty if the ParameterSet does not exists or whose value is
-     * a **non owning** pointer to the ParameterSet collection if it exists. This **non owning**
-     * pointer remains valid as long as the RenderParameter exists and contains the given type.
-     */
-    template <typename T>
-    Core::Utils::optional<UniformBindableSet<T>*> existsVariableType() const;
-
-    /**
-     * Check if a typed parameter exists
-     * \tparam T the type of the parameter to get
-     * \param name The name of the parameter to get
-     * \return true if the parameter exists
-     */
-    template <typename T>
-    Core::Utils::optional<UniformVariable<T>> existsVariable( const std::string& name ) const;
-
-    /**
      * \brief Get a typed parameter
      * \tparam T the type of the parameter to get
      * \param name The name of the parameter to get
@@ -263,27 +244,6 @@ class RA_ENGINE_API ShaderParameterProvider
     /// replace this by coreVariables
     RenderParameters m_renderParameters;
 };
-
-template <typename T>
-inline Core::Utils::optional<RenderParameters::UniformBindableSet<T>*>
-RenderParameters::existsVariableType() const {
-    if constexpr ( std::is_enum<T>::value ) {
-        // Do not return
-        // existsVariableType< typename std::underlying_type< T >::type >();
-        // to prevent misuse of this function. The user should infer this with another logic.
-        return {};
-    }
-    else { return Core::VariableSet::existsVariableType<T>(); }
-}
-
-template <typename T>
-inline Core::Utils::optional<RenderParameters::UniformVariable<T>>
-RenderParameters::existsVariable( const std::string& name ) const {
-    if constexpr ( std::is_enum<T>::value ) {
-        return Core::VariableSet::existsVariable<typename std::underlying_type<T>::type>( name );
-    }
-    else { return Core::VariableSet::existsVariable<T>( name ); }
-}
 
 template <typename T>
 inline const T& RenderParameters::getParameter( const std::string& name ) const {

--- a/src/Engine/Data/RenderParameters.hpp
+++ b/src/Engine/Data/RenderParameters.hpp
@@ -81,50 +81,6 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
     /// \}
 
     /**
-     * \brief Associate a converter for enumerated type to the given parameter name
-     * \tparam EnumBaseType The enum base type to manage (\see Ra::Core::Utils::EnumConverter)
-     * \param name
-     * \param converter
-     */
-    template <typename EnumBaseType>
-    void addEnumConverter( const std::string& name,
-                           std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>> converter );
-
-    /**
-     * \brief Search for a converter associated with an enumeration parameter
-     * \tparam EnumBaseType The enum base type to manage (\see Ra::Core::Utils::EnumConverter)
-     * \param name the name of the parameter
-     * \return an optional containing the converter or false if no converter is found.
-     */
-    template <typename EnumBaseType>
-    Core::Utils::optional<std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>
-    getEnumConverter( const std::string& name );
-
-    /**
-     * \brief Return the string associated to the actual value of a parameter
-     * \tparam Enum The enum type (\see Ra::Core::Utils::EnumConverter)
-     * \param name The name of the enum variable
-     * \param value The value to convert
-     * \return
-     */
-    template <typename Enum, typename std::enable_if<std::is_enum<Enum> {}, bool>::type = true>
-    std::string getEnumString( const std::string& name, Enum value );
-
-    /**
-     * \brief (overload) Return the string associated to the actual value of a parameter, from a
-     * value with underlying_type<Enum>.
-     * \tparam EnumBaseType The underlying enum type (\see Ra::Core::Utils::EnumConverter)
-     * \param name The name of the enum variable
-     * \param value The value to convert
-     * \return
-     */
-    template <typename EnumBaseType>
-    std::string
-    getEnumString( const std::string& name,
-                   EnumBaseType value,
-                   typename std::enable_if<!std::is_enum<EnumBaseType> {}, bool>::type = true );
-
-    /**
      * Overloaded operators to set shader parameters
      * \{
      */
@@ -145,21 +101,6 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
               typename std::enable_if<std::is_base_of<Data::Texture, T>::value, bool>::type = true>
     void setTexture( const std::string& name, T* tex, int texUnit = -1 ) {
         setVariable( name, TextureInfo { tex, texUnit } );
-    }
-
-    /**
-     * \brief set the value of the given parameter, according to a string representation of an enum.
-     * \note If there is no EnumConverter associated with the parameter name, the string is
-     * registered in the RenderParameter set.
-     * \param name Name of the parameter
-     * \param value value of the parameter
-     */
-    void setEnumVariable( const std::string& name, const std::string& value );
-    void setEnumVariable( const std::string& name, const char* value );
-    template <typename T>
-    void setEnumVariable( const std::string& name, T value ) {
-        auto v = static_cast<typename std::underlying_type<T>::type>( value );
-        setVariable( name, v );
     }
 
     /**\}*/
@@ -322,52 +263,6 @@ class RA_ENGINE_API ShaderParameterProvider
     /// replace this by coreVariables
     RenderParameters m_renderParameters;
 };
-
-/* --------------- enum parameter management --------------- */
-
-template <typename EnumBaseType>
-void RenderParameters::addEnumConverter(
-    const std::string& name,
-    std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>> converter ) {
-    auto converterHandle = setVariable( name, converter );
-    std::function<void( Core::VariableSet&, const std::string&, const std::string& )>
-        convertingFunction = [converter = converterHandle.first]( Core::VariableSet& vs,
-                                                                  const std::string& nm,
-                                                                  const std::string& vl ) {
-            vs.setVariable( nm, converter->second->getEnumerator( vl ) );
-        };
-    setVariable( name, convertingFunction );
-}
-
-template <typename EnumBaseType>
-Core::Utils::optional<std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>
-RenderParameters::getEnumConverter( const std::string& name ) {
-    auto storedConverter = Core::VariableSet::existsVariable<
-        std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>( name );
-    if ( storedConverter ) { return ( *storedConverter )->second; }
-    return {};
-}
-
-template <typename EnumBaseType>
-std::string RenderParameters::getEnumString(
-    const std::string& name,
-    EnumBaseType value,
-    typename std::enable_if<!std::is_enum<EnumBaseType> {}, bool>::type ) {
-    auto storedConverter = Core::VariableSet::existsVariable<
-        std::shared_ptr<Core::Utils::EnumConverter<EnumBaseType>>>( name );
-    if ( storedConverter ) { return ( *storedConverter )->second->getEnumerator( value ); }
-    LOG( Ra::Core::Utils::logWARNING ) << name + " is not a registered Enum with underlying type " +
-                                              Ra::Core::Utils::demangleType<EnumBaseType>() + ".";
-    return "";
-}
-
-template <typename Enum, typename std::enable_if<std::is_enum<Enum> {}, bool>::type>
-std::string RenderParameters::getEnumString( const std::string& name, Enum value ) {
-    using EnumBaseType = typename std::underlying_type_t<Enum>;
-    return getEnumString( name, EnumBaseType( value ) );
-}
-
-/* --------------- enum parameter management --------------- */
 
 template <typename T>
 inline Core::Utils::optional<RenderParameters::UniformBindableSet<T>*>

--- a/src/Engine/Data/RenderParameters.hpp
+++ b/src/Engine/Data/RenderParameters.hpp
@@ -23,14 +23,13 @@ namespace Data {
 class Texture;
 
 /**
- * Management of shader parameters with automatic binding of a named parameter to the corresponding
- * glsl uniform.
+ * \brief Management of shader parameters with automatic binding of a named parameter to the
+ * corresponding glsl uniform.
+ *
  * \note Automatic binding is only available for supported type described in BindableTypes.
  * \note Enums are stored according to their underlying_type. Enum management is automatic except
  * when requesting for the associated uniformBindableSet. To access bindable set containing a given
- * enum with type Enum, use `getAllVariable<typename std::underlying_type<typename
- * Enum>::type>`
- *
+ * enum with type Enum, use `getAllVariable<typename std::underlying_type<typename Enum>::type>`
  */
 class RA_ENGINE_API RenderParameters final : public Core::VariableSet
 {
@@ -59,8 +58,8 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
                                                 std::reference_wrapper<RenderParameters>,
                                                 std::reference_wrapper<const RenderParameters>>;
 
-    /**
-     * \brief Adding a texture parameter.
+    /** \brief Adding a texture parameter.
+     *
      * \tparam T The type of parameter to add. Must be derived from Texture for this overload.
      * \param name Name of the parameter
      * \param tex Texture to add in the parameterSet
@@ -75,7 +74,8 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
         setVariable( name, TextureInfo { tex, texUnit } );
     }
 
-    /** Bind the parameter uniform on the shader program
+    /** \brief Bind the parameter uniform on the shader program.
+     *
      * \note, this will only bind the supported parameter types.
      * \param shader The shader to bind to.
      */
@@ -84,8 +84,7 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
     }
 
   private:
-    /**
-     * \brief Static visitor to bind the stored parameters.
+    /** \brief Static visitor to bind the stored parameters.
      * \note Binds only statically supported types. To bind unsupported types, use a custom
      * dynamic visitor and the RenderParameter::visit method.
      */
@@ -95,8 +94,7 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
         /// Type supported by the binder, as expected by VariableSet
         using types = BindableTypes;
 
-        /**
-         * \brief Binds a color parameter as this requires special access to the parameter value.
+        /** \brief Binds a color parameter as this requires special access to the parameter value.
          */
         void operator()( const std::string& name,
                          const Ra::Core::Utils::Color& p,
@@ -104,8 +102,7 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
             shader->setUniform( name.c_str(), Ra::Core::Utils::Color::VectorType( p ) );
         }
 
-        /**
-         * \brief Binds a Texture parameter as this requires special access to the parameter value.
+        /** \brief Binds a Texture parameter as this requires special access to the parameter value.
          */
         void operator()( const std::string& name,
                          const RenderParameters::TextureInfo& p,
@@ -115,8 +112,8 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
             else { shader->setUniform( name.c_str(), tex, texUnit ); }
         }
 
-        /**
-         * \brief Binds a embedded const RenderParameter.
+        /** \brief Binds a embedded const RenderParameter.
+         *
          * This allows to build hierarchies of RenderParameters.
          */
         template <typename T>
@@ -126,8 +123,7 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
             p.get().bind( shader );
         }
 
-        /**
-         * \brief Bind any type of parameter that do not requires special access
+        /** \brief Bind any type of parameter that do not requires special access
          */
         template <typename T>
         void operator()( const std::string& name, const T& p, const Data::ShaderProgram* shader ) {
@@ -136,8 +132,8 @@ class RA_ENGINE_API RenderParameters final : public Core::VariableSet
     };
 };
 
-/**
- * Interface to define metadata (constraints, description, ...) for the editing of parameter set
+/** \brief Interface to define metadata (constraints, description, ...) for the editing of parameter
+ * set
  */
 class RA_ENGINE_API ParameterSetEditingInterface
 {
@@ -154,9 +150,9 @@ class RA_ENGINE_API ParameterSetEditingInterface
     static void loadMetaData( const std::string& basename, nlohmann::json& destination );
 };
 
-/**
- * Shader program parameter provider.
- * a ShaderParameterProvider is an object that is associated to a render technique to provide the
+/** \brief Shader program parameter provider.
+ *
+ * A ShaderParameterProvider is an object that is associated to a render technique to provide the
  * uniform parameter set for the program. When an RenderObject is drawn using a given
  * rendertechnique, the ShaderParameterProvider associated to the renderTechnique is responsible to
  * set all the uniforms needed by the rendertechnique.
@@ -167,22 +163,22 @@ class RA_ENGINE_API ShaderParameterProvider
     virtual ~ShaderParameterProvider() = default;
     virtual RenderParameters& getParameters() { return m_renderParameters; }
     virtual const RenderParameters& getParameters() const { return m_renderParameters; }
-    /**
-     * \brief Update the OpenGL states used by the ShaderParameterProvider.
+
+    /** \brief Update the OpenGL states used by the ShaderParameterProvider.
+     *
      * These state could be the ones from an associated material (textures, precomputed tables or
      * whatever data associated to the material)  or some parameters that are
      * specific to the provider semantic.
      */
     virtual void updateGL() = 0;
 
-    /**
-     * \brief Update the attributes of the ShaderParameterProvider to their actual values stored in
+    /** \brief Update the attributes of the ShaderParameterProvider to their actual values stored in
      * the renderParameters.
      */
     virtual void updateFromParameters() {};
 
-    /**
-     * \brief Get the list of properties the provider might use in a shader.
+    /** \brief Get the list of properties the provider might use in a shader.
+     *
      * Each property will be added to the shader used for rendering under the form
      * "#define theProperty" when the provider is associated with the render technique.
      *
@@ -194,7 +190,6 @@ class RA_ENGINE_API ShaderParameterProvider
 
   private:
     /// The parameters to set for a shader
-    /// replace this by coreVariables
     RenderParameters m_renderParameters;
 };
 

--- a/src/Engine/Data/SimpleMaterial.cpp
+++ b/src/Engine/Data/SimpleMaterial.cpp
@@ -15,14 +15,14 @@ SimpleMaterial::SimpleMaterial( const std::string& instanceName,
 void SimpleMaterial::updateRenderingParameters() {
     auto& renderParameters = getParameters();
     // update the rendering paramaters
-    renderParameters.addParameter( "material.color", m_color );
-    renderParameters.addParameter( "material.perVertexColor", m_perVertexColor );
+    renderParameters.setVariable( "material.color", m_color );
+    renderParameters.setVariable( "material.perVertexColor", m_perVertexColor );
     Texture* tex = getTexture( SimpleMaterial::TextureSemantic::TEX_COLOR );
-    if ( tex != nullptr ) { renderParameters.addParameter( "material.tex.color", tex ); }
-    renderParameters.addParameter( "material.tex.hasColor", tex != nullptr );
+    if ( tex != nullptr ) { renderParameters.setTexture( "material.tex.color", tex ); }
+    renderParameters.setVariable( "material.tex.hasColor", tex != nullptr );
     tex = getTexture( SimpleMaterial::TextureSemantic::TEX_MASK );
-    if ( tex != nullptr ) { renderParameters.addParameter( "material.tex.mask", tex ); }
-    renderParameters.addParameter( "material.tex.hasMask", tex != nullptr );
+    if ( tex != nullptr ) { renderParameters.setTexture( "material.tex.mask", tex ); }
+    renderParameters.setVariable( "material.tex.hasMask", tex != nullptr );
 }
 
 void SimpleMaterial::updateGL() {

--- a/src/Engine/Data/VolumeObject.cpp
+++ b/src/Engine/Data/VolumeObject.cpp
@@ -64,15 +64,15 @@ void VolumeObject::loadGeometry( Core::Geometry::AbstractVolume* volume, const C
             getName(),
             { GL_CLAMP_TO_BORDER, GL_CLAMP_TO_BORDER, GL_CLAMP_TO_BORDER, GL_LINEAR, GL_LINEAR },
             { GL_TEXTURE_3D,
-              size_t( dim( 0 ) ),
-              size_t( dim( 1 ) ),
-              size_t( dim( 2 ) ),
-              GL_RED,
-              GL_R32F,
-              GL_SCALAR,
+                                     size_t( dim( 0 ) ),
+                                     size_t( dim( 1 ) ),
+                                     size_t( dim( 2 ) ),
+                                     GL_RED,
+                                     GL_R32F,
+                                     GL_SCALAR,
               false,
               data } };
-        m_tex.setParameters( texparam );
+        m_tex.setVariables( texparam );
 
         m_isDirty = true;
     }

--- a/src/Engine/Data/VolumeObject.cpp
+++ b/src/Engine/Data/VolumeObject.cpp
@@ -64,15 +64,15 @@ void VolumeObject::loadGeometry( Core::Geometry::AbstractVolume* volume, const C
             getName(),
             { GL_CLAMP_TO_BORDER, GL_CLAMP_TO_BORDER, GL_CLAMP_TO_BORDER, GL_LINEAR, GL_LINEAR },
             { GL_TEXTURE_3D,
-                                     size_t( dim( 0 ) ),
-                                     size_t( dim( 1 ) ),
-                                     size_t( dim( 2 ) ),
-                                     GL_RED,
-                                     GL_R32F,
-                                     GL_SCALAR,
+              size_t( dim( 0 ) ),
+              size_t( dim( 1 ) ),
+              size_t( dim( 2 ) ),
+              GL_RED,
+              GL_R32F,
+              GL_SCALAR,
               false,
               data } };
-        m_tex.setVariables( texparam );
+        m_tex.setParameters( texparam );
 
         m_isDirty = true;
     }

--- a/src/Engine/Data/VolumetricMaterial.cpp
+++ b/src/Engine/Data/VolumetricMaterial.cpp
@@ -31,11 +31,11 @@ void VolumetricMaterial::updateGL() {
 
 void VolumetricMaterial::updateFromParameters() {
     auto& renderParameters = getParameters();
-    m_sigma_a  = renderParameters.getParameter<Core::Utils::Color>( "material.sigma_a" );
-    m_sigma_s  = renderParameters.getParameter<Core::Utils::Color>( "material.sigma_s" );
-    m_g        = renderParameters.getParameter<Scalar>( "material.g" );
-    m_scale    = renderParameters.getParameter<Scalar>( "material.scale" );
-    m_stepsize = renderParameters.getParameter<Scalar>( "material.stepsize" );
+    m_sigma_a              = renderParameters.getVariable<Core::Utils::Color>( "material.sigma_a" );
+    m_sigma_s              = renderParameters.getVariable<Core::Utils::Color>( "material.sigma_s" );
+    m_g                    = renderParameters.getVariable<Scalar>( "material.g" );
+    m_scale                = renderParameters.getVariable<Scalar>( "material.scale" );
+    m_stepsize             = renderParameters.getVariable<Scalar>( "material.stepsize" );
 }
 
 void VolumetricMaterial::updateRenderingParameters() {

--- a/src/Engine/Data/VolumetricMaterial.cpp
+++ b/src/Engine/Data/VolumetricMaterial.cpp
@@ -40,19 +40,19 @@ void VolumetricMaterial::updateFromParameters() {
 
 void VolumetricMaterial::updateRenderingParameters() {
     auto& renderParameters = getParameters();
-    renderParameters.addParameter( "material.sigma_a", m_sigma_a );
-    renderParameters.addParameter( "material.sigma_s", m_sigma_s );
-    renderParameters.addParameter( "material.g", m_g );
-    renderParameters.addParameter( "material.scale", m_scale );
+    renderParameters.setVariable( "material.sigma_a", m_sigma_a );
+    renderParameters.setVariable( "material.sigma_s", m_sigma_s );
+    renderParameters.setVariable( "material.g", m_g );
+    renderParameters.setVariable( "material.scale", m_scale );
     if ( m_stepsize < 0 ) {
         auto dim = std::sqrt( Scalar( m_texture->getWidth() * m_texture->getWidth() +
                                       m_texture->getHeight() * m_texture->getHeight() +
                                       m_texture->getDepth() * m_texture->getDepth() ) );
-        renderParameters.addParameter( "material.stepsize", 1._ra / dim );
+        renderParameters.setVariable( "material.stepsize", 1._ra / dim );
     }
-    else { renderParameters.addParameter( "material.stepsize", m_stepsize ); }
-    renderParameters.addParameter( "material.density", m_texture );
-    renderParameters.addParameter( "material.modelToDensity", m_modelToMedium.matrix() );
+    else { renderParameters.setVariable( "material.stepsize", m_stepsize ); }
+    renderParameters.setTexture( "material.density", m_texture );
+    renderParameters.setVariable( "material.modelToDensity", m_modelToMedium.matrix() );
 }
 
 bool VolumetricMaterial::isTransparent() const {

--- a/src/Engine/Rendering/ForwardRenderer.cpp
+++ b/src/Engine/Rendering/ForwardRenderer.cpp
@@ -3,6 +3,7 @@
 #include <Engine/Rendering/ForwardRenderer.hpp>
 
 #include <Core/Containers/MakeShared.hpp>
+#include <Core/Containers/VariableSetEnumManagement.hpp>
 #include <Core/Geometry/TopologicalMesh.hpp>
 #include <Core/Utils/Color.hpp>
 #include <Core/Utils/Log.hpp>
@@ -507,8 +508,9 @@ void ForwardRenderer::debugInternal( const Data::ViewingParameters& renderData )
         GL_ASSERT( glDepthMask( GL_TRUE ) );
         GL_ASSERT( glClear( GL_DEPTH_BUFFER_BIT ) );
         Data::RenderParameters xrayLightParams;
+        using namespace Core::VariableSetEnumManagement;
         xrayLightParams.setVariable( "light.color", Ra::Core::Utils::Color::Grey( 5.0 ) );
-        xrayLightParams.setEnumVariable( "light.type", Scene::Light::LightType::DIRECTIONAL );
+        setEnumVariable( xrayLightParams, "light.type", Scene::Light::LightType::DIRECTIONAL );
         xrayLightParams.setVariable( "light.directional.direction", Core::Vector3( 0, -1, 0 ) );
         for ( const auto& ro : m_xrayRenderObjects ) {
             if ( ro->isVisible() ) { ro->render( xrayLightParams, renderData ); }

--- a/src/Engine/Rendering/ForwardRenderer.cpp
+++ b/src/Engine/Rendering/ForwardRenderer.cpp
@@ -378,15 +378,15 @@ void ForwardRenderer::renderInternal( const Data::ViewingParameters& renderData 
             GL_ASSERT( glDisable( GL_BLEND ) );
 
             Data::RenderParameters composeParams;
-            composeParams.addParameter( "imageColor", m_textures[RendererTextures_HDR].get() );
-            composeParams.addParameter( "imageDepth", m_textures[RendererTextures_Depth].get() );
+            composeParams.setTexture( "imageColor", m_textures[RendererTextures_HDR].get() );
+            composeParams.setTexture( "imageDepth", m_textures[RendererTextures_Depth].get() );
             Data::RenderParameters passParams;
-            passParams.addParameter( "compose_data", composeParams );
+            passParams.setVariable( "compose_data", composeParams );
 
             for ( size_t i = 0; i < m_lightmanagers[0]->count(); ++i ) {
                 const auto l = m_lightmanagers[0]->getLight( i );
 
-                passParams.addParameter( "light_source", l->getRenderParameters() );
+                passParams.setVariable( "light_source", l->getRenderParameters() );
 
                 for ( const auto& ro : m_volumetricRenderObjects ) {
                     ro->render(
@@ -507,9 +507,9 @@ void ForwardRenderer::debugInternal( const Data::ViewingParameters& renderData )
         GL_ASSERT( glDepthMask( GL_TRUE ) );
         GL_ASSERT( glClear( GL_DEPTH_BUFFER_BIT ) );
         Data::RenderParameters xrayLightParams;
-        xrayLightParams.addParameter( "light.color", Ra::Core::Utils::Color::Grey( 5.0 ) );
-        xrayLightParams.addParameter( "light.type", Scene::Light::LightType::DIRECTIONAL );
-        xrayLightParams.addParameter( "light.directional.direction", Core::Vector3( 0, -1, 0 ) );
+        xrayLightParams.setVariable( "light.color", Ra::Core::Utils::Color::Grey( 5.0 ) );
+        xrayLightParams.setEnumVariable( "light.type", Scene::Light::LightType::DIRECTIONAL );
+        xrayLightParams.setVariable( "light.directional.direction", Core::Vector3( 0, -1, 0 ) );
         for ( const auto& ro : m_xrayRenderObjects ) {
             if ( ro->isVisible() ) { ro->render( xrayLightParams, renderData ); }
         }
@@ -668,8 +668,8 @@ class PointCloudParameterProvider : public Data::ShaderParameterProvider
     void updateGL() override {
         m_displayMaterial->updateGL();
         auto& renderParameters = getParameters();
-        renderParameters.mergeReplaceParameters( m_displayMaterial->getParameters() );
-        renderParameters.addParameter( "pointCloudSplatRadius", m_component->getSplatSize() );
+        renderParameters.mergeReplaceVariables( m_displayMaterial->getParameters() );
+        renderParameters.setVariable( "pointCloudSplatRadius", m_component->getSplatSize() );
     }
 
   private:

--- a/src/Engine/Scene/DirLight.cpp
+++ b/src/Engine/Scene/DirLight.cpp
@@ -7,7 +7,7 @@ namespace Engine {
 namespace Scene {
 DirectionalLight::DirectionalLight( Entity* entity, const std::string& name ) :
     Light( entity, Light::DIRECTIONAL, name ) {
-    getRenderParameters().addParameter( "light.directional.direction", m_direction );
+    getRenderParameters().setVariable( "light.directional.direction", m_direction );
 }
 
 std::string DirectionalLight::getShaderInclude() const {

--- a/src/Engine/Scene/DirLight.hpp
+++ b/src/Engine/Scene/DirLight.hpp
@@ -32,7 +32,7 @@ class RA_ENGINE_API DirectionalLight final : public Ra::Engine::Scene::Light
 
 inline void DirectionalLight::setDirection( const Eigen::Matrix<Scalar, 3, 1>& dir ) {
     m_direction = dir.normalized();
-    getRenderParameters().addParameter( "light.directional.direction", m_direction );
+    getRenderParameters().setVariable( "light.directional.direction", m_direction );
 }
 
 inline const Eigen::Matrix<Scalar, 3, 1>& DirectionalLight::getDirection() const {

--- a/src/Engine/Scene/Light.cpp
+++ b/src/Engine/Scene/Light.cpp
@@ -1,5 +1,6 @@
 #include <Engine/Scene/Light.hpp>
 
+#include <Core/Containers/VariableSetEnumManagement.hpp>
 #include <Engine/Data/RenderParameters.hpp>
 #include <Engine/RadiumEngine.hpp>
 
@@ -8,7 +9,7 @@ namespace Engine {
 namespace Scene {
 Light::Light( Scene::Entity* entity, const LightType& type, const std::string& name ) :
     Component( name, entity ), m_type( type ) {
-    m_params.setEnumVariable( "light.type", m_type );
+    Core::VariableSetEnumManagement::setEnumVariable( m_params, "light.type", m_type );
     m_params.setVariable( "light.color", m_color );
 }
 

--- a/src/Engine/Scene/Light.cpp
+++ b/src/Engine/Scene/Light.cpp
@@ -8,12 +8,12 @@ namespace Engine {
 namespace Scene {
 Light::Light( Scene::Entity* entity, const LightType& type, const std::string& name ) :
     Component( name, entity ), m_type( type ) {
-    m_params.addParameter( "light.type", m_type );
-    m_params.addParameter( "light.color", m_color );
+    m_params.setEnumVariable( "light.type", m_type );
+    m_params.setVariable( "light.color", m_color );
 }
 
 void Light::getRenderParameters( Data::RenderParameters& params ) const {
-    params.mergeReplaceParameters( m_params );
+    params.mergeReplaceVariables( m_params );
 }
 
 void Light::initialize() {

--- a/src/Engine/Scene/Light.hpp
+++ b/src/Engine/Scene/Light.hpp
@@ -121,7 +121,7 @@ class RA_ENGINE_API Light : public Component
 
 inline void Light::setColor( const Core::Utils::Color& color ) {
     m_color = color;
-    m_params.addParameter( "light.color", m_color );
+    m_params.setVariable( "light.color", m_color );
 }
 
 } // namespace Scene

--- a/src/Engine/Scene/PointLight.cpp
+++ b/src/Engine/Scene/PointLight.cpp
@@ -7,12 +7,11 @@ namespace Engine {
 namespace Scene {
 PointLight::PointLight( Entity* entity, const std::string& name ) :
     Light( entity, Light::POINT, name ) {
-    getRenderParameters().addParameter( "light.point.position", m_position );
-    getRenderParameters().addParameter( "light.point.attenuation.constant",
-                                        m_attenuation.constant );
-    getRenderParameters().addParameter( "light.point.attenuation.linear", m_attenuation.linear );
-    getRenderParameters().addParameter( "light.point.attenuation.quadratic",
-                                        m_attenuation.quadratic );
+    getRenderParameters().setVariable( "light.point.position", m_position );
+    getRenderParameters().setVariable( "light.point.attenuation.constant", m_attenuation.constant );
+    getRenderParameters().setVariable( "light.point.attenuation.linear", m_attenuation.linear );
+    getRenderParameters().setVariable( "light.point.attenuation.quadratic",
+                                       m_attenuation.quadratic );
 }
 
 std::string PointLight::getShaderInclude() const {

--- a/src/Engine/Scene/PointLight.hpp
+++ b/src/Engine/Scene/PointLight.hpp
@@ -37,7 +37,7 @@ class RA_ENGINE_API PointLight final : public Ra::Engine::Scene::Light
 
 inline void PointLight::setPosition( const Eigen::Matrix<Scalar, 3, 1>& pos ) {
     m_position = pos;
-    getRenderParameters().addParameter( "light.point.position", m_position );
+    getRenderParameters().setVariable( "light.point.position", m_position );
 }
 
 inline const Eigen::Matrix<Scalar, 3, 1>& PointLight::getPosition() const {
@@ -46,11 +46,10 @@ inline const Eigen::Matrix<Scalar, 3, 1>& PointLight::getPosition() const {
 
 inline void PointLight::setAttenuation( const PointLight::Attenuation& attenuation ) {
     m_attenuation = attenuation;
-    getRenderParameters().addParameter( "light.point.attenuation.constant",
-                                        m_attenuation.constant );
-    getRenderParameters().addParameter( "light.point.attenuation.linear", m_attenuation.linear );
-    getRenderParameters().addParameter( "light.point.attenuation.quadratic",
-                                        m_attenuation.quadratic );
+    getRenderParameters().setVariable( "light.point.attenuation.constant", m_attenuation.constant );
+    getRenderParameters().setVariable( "light.point.attenuation.linear", m_attenuation.linear );
+    getRenderParameters().setVariable( "light.point.attenuation.quadratic",
+                                       m_attenuation.quadratic );
 }
 
 inline void PointLight::setAttenuation( Scalar constant, Scalar linear, Scalar quadratic ) {

--- a/src/Engine/Scene/SpotLight.cpp
+++ b/src/Engine/Scene/SpotLight.cpp
@@ -6,14 +6,14 @@ namespace Engine {
 namespace Scene {
 SpotLight::SpotLight( Entity* entity, const std::string& name ) :
     Light( entity, Light::SPOT, name ) {
-    getRenderParameters().addParameter( "light.spot.position", m_position );
-    getRenderParameters().addParameter( "light.spot.direction", m_direction );
-    getRenderParameters().addParameter( "light.spot.innerAngle", m_innerAngle );
-    getRenderParameters().addParameter( "light.spot.outerAngle", m_outerAngle );
-    getRenderParameters().addParameter( "light.spot.attenuation.constant", m_attenuation.constant );
-    getRenderParameters().addParameter( "light.spot.attenuation.linear", m_attenuation.linear );
-    getRenderParameters().addParameter( "light.spot.attenuation.quadratic",
-                                        m_attenuation.quadratic );
+    getRenderParameters().setVariable( "light.spot.position", m_position );
+    getRenderParameters().setVariable( "light.spot.direction", m_direction );
+    getRenderParameters().setVariable( "light.spot.innerAngle", m_innerAngle );
+    getRenderParameters().setVariable( "light.spot.outerAngle", m_outerAngle );
+    getRenderParameters().setVariable( "light.spot.attenuation.constant", m_attenuation.constant );
+    getRenderParameters().setVariable( "light.spot.attenuation.linear", m_attenuation.linear );
+    getRenderParameters().setVariable( "light.spot.attenuation.quadratic",
+                                       m_attenuation.quadratic );
 }
 
 std::string SpotLight::getShaderInclude() const {

--- a/src/Engine/Scene/SpotLight.hpp
+++ b/src/Engine/Scene/SpotLight.hpp
@@ -54,7 +54,7 @@ class RA_ENGINE_API SpotLight final : public Ra::Engine::Scene::Light
 
 inline void SpotLight::setPosition( const Eigen::Matrix<Scalar, 3, 1>& position ) {
     m_position = position;
-    getRenderParameters().addParameter( "light.spot.position", m_position );
+    getRenderParameters().setVariable( "light.spot.position", m_position );
 }
 
 inline const Eigen::Matrix<Scalar, 3, 1>& Scene::SpotLight::getPosition() const {
@@ -63,7 +63,7 @@ inline const Eigen::Matrix<Scalar, 3, 1>& Scene::SpotLight::getPosition() const 
 
 inline void SpotLight::setDirection( const Eigen::Matrix<Scalar, 3, 1>& direction ) {
     m_direction = direction.normalized();
-    getRenderParameters().addParameter( "light.spot.direction", m_direction );
+    getRenderParameters().setVariable( "light.spot.direction", m_direction );
 }
 
 inline const Eigen::Matrix<Scalar, 3, 1>& SpotLight::getDirection() const {
@@ -72,12 +72,12 @@ inline const Eigen::Matrix<Scalar, 3, 1>& SpotLight::getDirection() const {
 
 inline void SpotLight::setInnerAngleInRadians( Scalar angle ) {
     m_innerAngle = angle;
-    getRenderParameters().addParameter( "light.spot.innerAngle", m_innerAngle );
+    getRenderParameters().setVariable( "light.spot.innerAngle", m_innerAngle );
 }
 
 inline void SpotLight::setOuterAngleInRadians( Scalar angle ) {
     m_outerAngle = angle;
-    getRenderParameters().addParameter( "light.spot.outerAngle", m_outerAngle );
+    getRenderParameters().setVariable( "light.spot.outerAngle", m_outerAngle );
 }
 
 inline void SpotLight::setInnerAngleInDegrees( Scalar angle ) {
@@ -98,10 +98,10 @@ inline Scalar SpotLight::getOuterAngle() const {
 
 inline void SpotLight::setAttenuation( const Attenuation& attenuation ) {
     m_attenuation = attenuation;
-    getRenderParameters().addParameter( "light.spot.attenuation.constant", m_attenuation.constant );
-    getRenderParameters().addParameter( "light.spot.attenuation.linear", m_attenuation.linear );
-    getRenderParameters().addParameter( "light.spot.attenuation.quadratic",
-                                        m_attenuation.quadratic );
+    getRenderParameters().setVariable( "light.spot.attenuation.constant", m_attenuation.constant );
+    getRenderParameters().setVariable( "light.spot.attenuation.linear", m_attenuation.linear );
+    getRenderParameters().setVariable( "light.spot.attenuation.quadratic",
+                                       m_attenuation.quadratic );
 }
 
 inline void SpotLight::setAttenuation( Scalar constant, Scalar linear, Scalar quadratic ) {

--- a/src/Gui/ParameterSetEditor/MaterialParameterEditor.cpp
+++ b/src/Gui/ParameterSetEditor/MaterialParameterEditor.cpp
@@ -77,7 +77,7 @@ void MaterialParameterEditor::setupFromMaterial(
     m_matParamsLayout->removeWidget( m_parametersControlPanel );
     delete m_parametersControlPanel;
     m_parametersControlPanel = new ParameterSetEditor( "Material Parameters", this );
-    m_parametersControlPanel->showUnspecified( m_showUnspecified );
+    m_parametersControlPanel->setShowUnspecified( m_showUnspecified );
     m_matParamsLayout->addWidget( m_parametersControlPanel );
 
     m_parametersControlPanel->setupFromParameters( params, metadata );
@@ -90,6 +90,6 @@ void MaterialParameterEditor::setupFromMaterial(
 
 void MaterialParameterEditor::showUnspecified( bool enable ) {
     m_showUnspecified = enable;
-    m_parametersControlPanel->showUnspecified( m_showUnspecified );
+    m_parametersControlPanel->setShowUnspecified( m_showUnspecified );
 }
 } // namespace Ra::Gui

--- a/src/Gui/ParameterSetEditor/MaterialParameterEditor.cpp
+++ b/src/Gui/ParameterSetEditor/MaterialParameterEditor.cpp
@@ -48,7 +48,7 @@ MaterialParameterEditor::MaterialParameterEditor( QWidget* parent ) : QWidget( p
 
     verticalLayout->addWidget( matParamsGroup );
     m_matParamsLayout        = new QVBoxLayout( matParamsGroup );
-    m_parametersControlPanel = new ParameterSetEditor( "Material Parameters", this );
+    m_parametersControlPanel = new VariableSetEditor( "Material Parameters", this );
     m_matParamsLayout->addWidget( m_parametersControlPanel );
 
     verticalLayout->addStretch();
@@ -76,14 +76,14 @@ void MaterialParameterEditor::setupFromMaterial(
     // clear the old control panel
     m_matParamsLayout->removeWidget( m_parametersControlPanel );
     delete m_parametersControlPanel;
-    m_parametersControlPanel = new ParameterSetEditor( "Material Parameters", this );
+    m_parametersControlPanel = new VariableSetEditor( "Material Parameters", this );
     m_parametersControlPanel->setShowUnspecified( m_showUnspecified );
     m_matParamsLayout->addWidget( m_parametersControlPanel );
 
-    m_parametersControlPanel->setupFromParameters( params, metadata );
+    m_parametersControlPanel->setupUi( params, metadata );
 
     connect( m_parametersControlPanel,
-             &ParameterSetEditor::parameterModified,
+             &VariableSetEditor::parameterModified,
              [this]( const std::string& nm ) { emit materialParametersModified( nm ); } );
     m_matInfoGroup->setVisible( true );
 }

--- a/src/Gui/ParameterSetEditor/MaterialParameterEditor.hpp
+++ b/src/Gui/ParameterSetEditor/MaterialParameterEditor.hpp
@@ -85,7 +85,7 @@ class RA_GUI_API MaterialParameterEditor : public QWidget
     /// The layout containing the control panel
     QVBoxLayout* m_matParamsLayout;
     /// The control panel re-generated whenever setupFromMaterial is called
-    ParameterSetEditor* m_parametersControlPanel;
+    VariableSetEditor* m_parametersControlPanel;
     /// wether to show the unspecified materials
     bool m_showUnspecified = false;
 

--- a/src/Gui/ParameterSetEditor/ParameterSetEditor.cpp
+++ b/src/Gui/ParameterSetEditor/ParameterSetEditor.cpp
@@ -69,7 +69,7 @@ class RenderParameterUiBuilder
                      Data::RenderParameters&& params ) {
         auto onColorParameterChanged =
             [pse = this->m_pse, &params, nm = name]( const Ra::Core::Utils::Color& val ) {
-                params.addParameter( nm, val );
+                params.setVariable( nm, val );
                 emit pse->parameterModified( nm );
             };
         if ( m_constraints.contains( name ) ) {
@@ -122,7 +122,7 @@ void ParameterSetEditor::addEnumParameterWidget( const std::string& key,
     if ( auto ec = params.getEnumConverter<T>( key ) ) {
         auto items                        = ( *ec )->getEnumerators();
         auto onEnumParameterStringChanged = [this, &params, &key]( const QString& value ) {
-            params.addParameter( key, value.toStdString() );
+            params.setVariable( key, value.toStdString() );
             emit parameterModified( key );
         };
         addComboBox( nm,
@@ -142,7 +142,7 @@ void ParameterSetEditor::addEnumParameterWidget( const std::string& key,
         }
 
         auto onEnumParameterIntChanged = [this, &params, &key]( T value ) {
-            params.addParameter( key, value );
+            params.setVariable( key, value );
             emit parameterModified( key );
         };
         addComboBox( nm, onEnumParameterIntChanged, initial, items, description );

--- a/src/Gui/ParameterSetEditor/ParameterSetEditor.cpp
+++ b/src/Gui/ParameterSetEditor/ParameterSetEditor.cpp
@@ -98,9 +98,8 @@ class RenderParameterUiBuilder
     void operator()( const std::string& name,
                      std::reference_wrapper<T>& p,
                      Core::VariableSet&& /*params*/ ) {
-
         m_pse->addLabel( name );
-        if constexpr ( std::is_assignable_v<typename std::decay<T>::type, Core::VariableSet> ) {
+        if constexpr ( std::is_assignable_v<Core::VariableSet, typename std::decay<T>::type> ) {
             if constexpr ( std::is_const_v<T> ) {
                 p.get().visit( *this,
                                const_cast<Core::VariableSet&>(

--- a/src/Gui/ParameterSetEditor/ParameterSetEditor.cpp
+++ b/src/Gui/ParameterSetEditor/ParameterSetEditor.cpp
@@ -9,6 +9,7 @@
 
 #include <limits>
 #include <memory>
+#include <type_traits>
 
 using json = nlohmann::json;
 
@@ -25,7 +26,7 @@ class RenderParameterUiBuilder
     RenderParameterUiBuilder( ParameterSetEditor* pse, const json& constraints ) :
         m_pse { pse }, m_constraints { constraints } {}
 
-    void operator()( const std::string& name, bool& p, Data::RenderParameters&& /* params */ ) {
+    void operator()( const std::string& name, bool& p, Core::VariableSet&& /* params */ ) {
         auto onBoolParameterChanged = [pse = this->m_pse, &p, nm = name]( bool val ) {
             p = val;
             emit pse->parameterModified( nm );
@@ -38,13 +39,13 @@ class RenderParameterUiBuilder
                 m_pse->addOption( nm, onBoolParameterChanged, p, description );
             }
         }
-        else if ( m_pse->m_showUnspecified ) {
+        else if ( m_pse->showUnspecified() ) {
             m_pse->addOption( name, onBoolParameterChanged, p );
         }
     }
 
     template <typename TParam, std::enable_if_t<std::is_arithmetic<TParam>::value, bool> = true>
-    void operator()( const std::string& name, TParam& p, Data::RenderParameters&& params ) {
+    void operator()( const std::string& name, TParam& p, Core::VariableSet&& params ) {
         using namespace Ra::Core::VariableSetEnumManagement;
         if ( getEnumConverter<TParam>( params, name ) ) {
             m_pse->addEnumParameterWidget( name, p, params, m_constraints );
@@ -60,13 +61,12 @@ class RenderParameterUiBuilder
               std::enable_if_t<std::is_arithmetic<TParam>::value, bool> = true>
     void operator()( const std::string& name,
                      std::vector<TParam, TAllocator>& p,
-                     Data::RenderParameters&& params ) {
+                     Core::VariableSet&& params ) {
         m_pse->addVectorParameterWidget( name, p, params, m_constraints );
     }
 
-    void operator()( const std::string& name,
-                     Ra::Core::Utils::Color& p,
-                     Data::RenderParameters&& params ) {
+    void
+    operator()( const std::string& name, Ra::Core::Utils::Color& p, Core::VariableSet&& params ) {
         auto onColorParameterChanged =
             [pse = this->m_pse, &params, nm = name]( const Ra::Core::Utils::Color& val ) {
                 params.setVariable( nm, val );
@@ -78,27 +78,36 @@ class RenderParameterUiBuilder
             std::string nm          = m.contains( "name" ) ? std::string { m["name"] } : name;
             m_pse->addColorInput( nm, onColorParameterChanged, p, m["maxItems"] == 4, description );
         }
-        else if ( m_pse->m_showUnspecified ) {
+        else if ( m_pse->showUnspecified() ) {
             m_pse->addColorInput( name, onColorParameterChanged, p );
         }
     }
 
     template <template <typename, int...> typename M, typename T, int... dim>
-    void operator()( const std::string& name, M<T, dim...>& p, Data::RenderParameters&& params ) {
+    void operator()( const std::string& name, M<T, dim...>& p, Core::VariableSet&& params ) {
         m_pse->addMatrixParameterWidget( name, p, params, m_constraints );
     }
 
     void operator()( const std::string& /*name*/,
                      Data::RenderParameters::TextureInfo& /*p*/,
-                     Data::RenderParameters&& /*params*/ ) {
+                     Core::VariableSet&& /*params*/ ) {
         // textures are not yet editable
     }
 
     template <typename T>
-    void operator()( const std::string& /*name*/,
-                     std::reference_wrapper<T>& /*p*/,
-                     Data::RenderParameters&& /*params*/ ) {
-        // wrapped reference (e.g. embedded render parameter) editing not yet available
+    void operator()( const std::string& name,
+                     std::reference_wrapper<T>& p,
+                     Core::VariableSet&& /*params*/ ) {
+
+        m_pse->addLabel( name );
+        if constexpr ( std::is_assignable_v<typename std::decay<T>::type, Core::VariableSet> ) {
+            if constexpr ( std::is_const_v<T> ) {
+                p.get().visit( *this,
+                               const_cast<Core::VariableSet&>(
+                                   static_cast<const Core::VariableSet&>( p.get() ) ) );
+            }
+            else { p.get().visit( *this, static_cast<Core::VariableSet&>( p.get() ) ); }
+        }
     }
 
   private:
@@ -113,7 +122,7 @@ ParameterSetEditor::ParameterSetEditor( const std::string& name, QWidget* parent
 template <typename T>
 void ParameterSetEditor::addEnumParameterWidget( const std::string& key,
                                                  T& initial,
-                                                 Ra::Engine::Data::RenderParameters& params,
+                                                 Core::VariableSet& params,
                                                  const json& metadata ) {
     using namespace Ra::Core::VariableSetEnumManagement;
     auto m = metadata[key];
@@ -153,7 +162,7 @@ void ParameterSetEditor::addEnumParameterWidget( const std::string& key,
 template <typename T>
 void ParameterSetEditor::addNumberParameterWidget( const std::string& key,
                                                    T& initial,
-                                                   Ra::Engine::Data::RenderParameters& /*params*/,
+                                                   Core::VariableSet& /*params*/,
                                                    const json& metadata ) {
 
     auto onNumberParameterChanged = [this, &initial, &key]( T value ) {
@@ -210,7 +219,7 @@ void ParameterSetEditor::addNumberParameterWidget( const std::string& key,
 template <typename T>
 void ParameterSetEditor::addVectorParameterWidget( const std::string& key,
                                                    std::vector<T>& initial,
-                                                   Ra::Engine::Data::RenderParameters& /*params*/,
+                                                   Core::VariableSet& /*params*/,
                                                    const json& metadata ) {
     auto onVectorParameterChanged = [this, &initial, &key]( const std::vector<T>& value ) {
         initial = value;
@@ -228,7 +237,7 @@ void ParameterSetEditor::addVectorParameterWidget( const std::string& key,
 template <typename T>
 void ParameterSetEditor::addMatrixParameterWidget( const std::string& key,
                                                    T& initial,
-                                                   Ra::Engine::Data::RenderParameters& /*params*/,
+                                                   Core::VariableSet& /*params*/,
                                                    const json& metadata ) {
     auto onMatrixParameterChanged = [this, &initial, &key]( const Ra::Core::MatrixN& value ) {
         initial = T( value );
@@ -243,7 +252,7 @@ void ParameterSetEditor::addMatrixParameterWidget( const std::string& key,
     else if ( m_showUnspecified ) { addMatrixInput( key, onMatrixParameterChanged, initial ); }
 }
 
-void ParameterSetEditor::setupFromParameters( Engine::Data::RenderParameters& params,
+void ParameterSetEditor::setupFromParameters( Core::VariableSet& params,
                                               const nlohmann::json& constraints ) {
 
     internal::RenderParameterUiBuilder uiBuilder { this, constraints };
@@ -252,8 +261,5 @@ void ParameterSetEditor::setupFromParameters( Engine::Data::RenderParameters& pa
     setVisible( true );
 }
 
-void ParameterSetEditor::showUnspecified( bool enable ) {
-    m_showUnspecified = enable;
-}
 } // namespace Gui
 } // namespace Ra

--- a/src/Gui/ParameterSetEditor/ParameterSetEditor.hpp
+++ b/src/Gui/ParameterSetEditor/ParameterSetEditor.hpp
@@ -39,24 +39,18 @@ class RA_GUI_API ParameterSetEditor : public Widgets::ControlPanel
 {
     Q_OBJECT
   public:
-    /** Constructors and destructor
-     */
-    /** \{ */
     explicit ParameterSetEditor( const std::string& name, QWidget* parent = nullptr );
     ParameterSetEditor( const ParameterSetEditor& )            = delete;
     ParameterSetEditor& operator=( const ParameterSetEditor& ) = delete;
     ParameterSetEditor( ParameterSetEditor&& )                 = delete;
     ParameterSetEditor&& operator=( ParameterSetEditor&& )     = delete;
     ~ParameterSetEditor() override                             = default;
-    /** \} */
 
     /**
      * \brief Update the different UI element with the given renderParameter, using the given
      * constraints.
      * \param params the parameter set to edit
-     * \param constraints the parameter
-     * constraints descriptor
-     * \param name (optional) the name to display in top of the editor
+     * \param constraints the parameter constraints descriptor
      */
     void setupFromParameters( Core::VariableSet& params, const nlohmann::json& constraints );
 
@@ -67,6 +61,7 @@ class RA_GUI_API ParameterSetEditor : public Widgets::ControlPanel
      */
     void setShowUnspecified( bool enable ) { m_showUnspecified = enable; }
     bool showUnspecified() { return m_showUnspecified; }
+
     /**
      * \brief Add a combobox allowing to chose the value of an enumerator.
      * \note Only un-scoped enum (i.e. implicitly convertible from and to integral type), with

--- a/src/Gui/ParameterSetEditor/ParameterSetEditor.hpp
+++ b/src/Gui/ParameterSetEditor/ParameterSetEditor.hpp
@@ -44,7 +44,7 @@ class RA_GUI_API VariableSetEditor : public Widgets::ControlPanel
     VariableSetEditor& operator=( const VariableSetEditor& ) = delete;
     VariableSetEditor( VariableSetEditor&& )                 = delete;
     VariableSetEditor&& operator=( VariableSetEditor&& )     = delete;
-    ~VariableSetEditor() override                            = default;
+    ~VariableSetEditor()                                     = default;
 
     /** \brief Update the different UI element with the given renderParameter, using the given
      * constraints.

--- a/src/Gui/ParameterSetEditor/ParameterSetEditor.hpp
+++ b/src/Gui/ParameterSetEditor/ParameterSetEditor.hpp
@@ -35,35 +35,34 @@ class RenderParameterUiBuilder;
  * The editor will expose a control panel
  * containing all of the editable parameters from a RenderParameter set.
  */
-class RA_GUI_API ParameterSetEditor : public Widgets::ControlPanel
+class RA_GUI_API VariableSetEditor : public Widgets::ControlPanel
 {
     Q_OBJECT
   public:
-    explicit ParameterSetEditor( const std::string& name, QWidget* parent = nullptr );
-    ParameterSetEditor( const ParameterSetEditor& )            = delete;
-    ParameterSetEditor& operator=( const ParameterSetEditor& ) = delete;
-    ParameterSetEditor( ParameterSetEditor&& )                 = delete;
-    ParameterSetEditor&& operator=( ParameterSetEditor&& )     = delete;
-    ~ParameterSetEditor() override                             = default;
+    explicit VariableSetEditor( const std::string& name, QWidget* parent = nullptr );
+    VariableSetEditor( const VariableSetEditor& )            = delete;
+    VariableSetEditor& operator=( const VariableSetEditor& ) = delete;
+    VariableSetEditor( VariableSetEditor&& )                 = delete;
+    VariableSetEditor&& operator=( VariableSetEditor&& )     = delete;
+    ~VariableSetEditor() override                            = default;
 
-    /**
-     * \brief Update the different UI element with the given renderParameter, using the given
+    /** \brief Update the different UI element with the given renderParameter, using the given
      * constraints.
-     * \param params the parameter set to edit
+     *
+     * \param params the VariableSet to edit
      * \param constraints the parameter constraints descriptor
      */
-    void setupFromParameters( Core::VariableSet& params, const nlohmann::json& constraints );
+    void setupUi( Core::VariableSet& params, const nlohmann::json& constraints );
 
-    /**
-     * Wether to show parameters without associated metadata
+    /** \brief Wether to show parameters without associated metadata
      *
      * \param enable
      */
     void setShowUnspecified( bool enable ) { m_showUnspecified = enable; }
     bool showUnspecified() { return m_showUnspecified; }
 
-    /**
-     * \brief Add a combobox allowing to chose the value of an enumerator.
+    /** \brief Add a combobox allowing to chose the value of an enumerator.
+     *
      * \note Only un-scoped enum (i.e. implicitly convertible from and to integral type), with
      * enumerators without initializer.
      * \tparam T
@@ -73,10 +72,10 @@ class RA_GUI_API ParameterSetEditor : public Widgets::ControlPanel
      * \param paramMetadata
      */
     template <typename T>
-    void addEnumParameterWidget( const std::string& name,
-                                 T& initial,
-                                 Core::VariableSet& params,
-                                 const nlohmann::json& paramMetadata );
+    void addEnumWidget( const std::string& name,
+                        T& initial,
+                        Core::VariableSet& params,
+                        const nlohmann::json& paramMetadata );
     /**
      * \brief
      * \tparam T
@@ -86,10 +85,10 @@ class RA_GUI_API ParameterSetEditor : public Widgets::ControlPanel
      * \param metadata
      */
     template <typename T>
-    void addNumberParameterWidget( const std::string& name,
-                                   T& initial,
-                                   Core::VariableSet& params,
-                                   const nlohmann::json& metadata );
+    void addNumberWidget( const std::string& name,
+                          T& initial,
+                          Core::VariableSet& params,
+                          const nlohmann::json& metadata );
 
     /**
      * \brief
@@ -100,10 +99,10 @@ class RA_GUI_API ParameterSetEditor : public Widgets::ControlPanel
      * \param metadata
      */
     template <typename T>
-    void addVectorParameterWidget( const std::string& key,
-                                   std::vector<T>& initial,
-                                   Core::VariableSet& params,
-                                   const nlohmann::json& metadata );
+    void addVectorWidget( const std::string& key,
+                          std::vector<T>& initial,
+                          Core::VariableSet& params,
+                          const nlohmann::json& metadata );
 
     /**
      * \brief
@@ -114,10 +113,10 @@ class RA_GUI_API ParameterSetEditor : public Widgets::ControlPanel
      * \param metadata
      */
     template <typename T>
-    void addMatrixParameterWidget( const std::string& key,
-                                   T& initial,
-                                   Core::VariableSet& params,
-                                   const nlohmann::json& metadata );
+    void addMatrixWidget( const std::string& key,
+                          T& initial,
+                          Core::VariableSet& params,
+                          const nlohmann::json& metadata );
 
   signals:
     /**

--- a/src/Gui/ParameterSetEditor/ParameterSetEditor.hpp
+++ b/src/Gui/ParameterSetEditor/ParameterSetEditor.hpp
@@ -12,6 +12,10 @@
 #include <Gui/Widgets/ControlPanel.hpp>
 
 namespace Ra {
+
+namespace Core {
+class VariableSet;
+}
 namespace Engine {
 namespace Data {
 class Material;
@@ -54,24 +58,15 @@ class RA_GUI_API ParameterSetEditor : public Widgets::ControlPanel
      * constraints descriptor
      * \param name (optional) the name to display in top of the editor
      */
-    void setupFromParameters( Engine::Data::RenderParameters& params,
-                              const nlohmann::json& constraints );
+    void setupFromParameters( Core::VariableSet& params, const nlohmann::json& constraints );
 
     /**
      * Wether to show parameters without associated metadata
      *
      * \param enable
      */
-    void showUnspecified( bool enable );
-
-  signals:
-    /**
-     * Signal emitted whenever a parameter is modified
-     */
-    void parameterModified( const std::string& name );
-
-  private:
-    friend class internal::RenderParameterUiBuilder;
+    void setShowUnspecified( bool enable ) { m_showUnspecified = enable; }
+    bool showUnspecified() { return m_showUnspecified; }
     /**
      * \brief Add a combobox allowing to chose the value of an enumerator.
      * \note Only un-scoped enum (i.e. implicitly convertible from and to integral type), with
@@ -85,7 +80,7 @@ class RA_GUI_API ParameterSetEditor : public Widgets::ControlPanel
     template <typename T>
     void addEnumParameterWidget( const std::string& name,
                                  T& initial,
-                                 Ra::Engine::Data::RenderParameters& params,
+                                 Core::VariableSet& params,
                                  const nlohmann::json& paramMetadata );
     /**
      * \brief
@@ -98,7 +93,7 @@ class RA_GUI_API ParameterSetEditor : public Widgets::ControlPanel
     template <typename T>
     void addNumberParameterWidget( const std::string& name,
                                    T& initial,
-                                   Ra::Engine::Data::RenderParameters& params,
+                                   Core::VariableSet& params,
                                    const nlohmann::json& metadata );
 
     /**
@@ -112,7 +107,7 @@ class RA_GUI_API ParameterSetEditor : public Widgets::ControlPanel
     template <typename T>
     void addVectorParameterWidget( const std::string& key,
                                    std::vector<T>& initial,
-                                   Ra::Engine::Data::RenderParameters& params,
+                                   Core::VariableSet& params,
                                    const nlohmann::json& metadata );
 
     /**
@@ -126,8 +121,16 @@ class RA_GUI_API ParameterSetEditor : public Widgets::ControlPanel
     template <typename T>
     void addMatrixParameterWidget( const std::string& key,
                                    T& initial,
-                                   Ra::Engine::Data::RenderParameters& params,
+                                   Core::VariableSet& params,
                                    const nlohmann::json& metadata );
+
+  signals:
+    /**
+     * Signal emitted whenever a parameter is modified
+     */
+    void parameterModified( const std::string& name );
+
+  private:
     /// wether to show the unspecified materials
     bool m_showUnspecified = false;
 };

--- a/src/Gui/ParameterSetEditor/ParameterSetEditor.hpp
+++ b/src/Gui/ParameterSetEditor/ParameterSetEditor.hpp
@@ -25,11 +25,6 @@ class RenderParameters;
 
 namespace Gui {
 
-/// Gui internal helpers
-namespace internal {
-/// Visitor for the RenderParameter variable set
-class RenderParameterUiBuilder;
-} // namespace internal
 /**
  * \brief Simple Widget for RenderParameter editing
  * The editor will expose a control panel

--- a/src/Gui/Viewer/Gizmo/Gizmo.cpp
+++ b/src/Gui/Viewer/Gizmo/Gizmo.cpp
@@ -110,8 +110,8 @@ Gizmo::UiSelectionControler::UiSelectionControler(
 void Gizmo::UiSelectionControler::updateGL() {
     m_associatedMaterial->updateGL();
     auto& renderParameters = getParameters();
-    renderParameters.mergeReplaceParameters( m_associatedMaterial->getParameters() );
-    if ( m_selected ) { renderParameters.addParameter( "material.color", m_selectedColor ); }
+    renderParameters.mergeReplaceVariables( m_associatedMaterial->getParameters() );
+    if ( m_selected ) { renderParameters.setVariable( "material.color", m_selectedColor ); }
 }
 
 void Gizmo::UiSelectionControler::toggleState() {

--- a/src/Gui/Widgets/ControlPanel.cpp
+++ b/src/Gui/Widgets/ControlPanel.cpp
@@ -20,17 +20,19 @@ namespace Ra::Gui::Widgets {
 ControlPanel::ControlPanel( const std::string& name, bool hline, QWidget* parent ) :
     QFrame( parent ) {
     setObjectName( name.c_str() );
-    m_mainLayout    = new QVBoxLayout( this );
-    m_contentLayout = new QGridLayout( this );
+    m_mainLayout = new QVBoxLayout();
+    m_mainLayout->setObjectName( "main layout" );
+    m_contentLayout = new QGridLayout();
+    m_contentLayout->setObjectName( "first content layout" );
 
     if ( !name.empty() ) {
-        auto panelName = new QLabel( this );
+        auto panelName = new QLabel();
         panelName->setText( name.c_str() );
         m_mainLayout->addWidget( panelName );
     }
     if ( hline ) {
         QFrame* line;
-        line = new QFrame( this );
+        line = new QFrame();
         line->setFrameShape( QFrame::HLine );
         line->setFrameShadow( QFrame::Sunken );
         m_mainLayout->addWidget( line );
@@ -46,13 +48,15 @@ void ControlPanel::addOption( const std::string& name,
                               std::function<void( bool )> callback,
                               bool set,
                               const std::string& tooltip ) {
-    auto label  = new QLabel( name.c_str(), this );
-    auto button = new QCheckBox( this );
+    auto label  = new QLabel( name.c_str() );
+    auto button = new QCheckBox();
     button->setAutoExclusive( false );
     button->setChecked( set );
     if ( !tooltip.empty() ) {
-        button->setToolTip(
-            QString( "<qt>%1</qt>" ).arg( QString( tooltip.c_str() ).toHtmlEscaped() ) );
+        auto tooltipString =
+            QString( "<qt>%1</qt>" ).arg( QString( tooltip.c_str() ).toHtmlEscaped() );
+        label->setToolTip( tooltipString );
+        button->setToolTip( tooltipString );
     }
     connect( button, &QCheckBox::stateChanged, std::move( callback ) );
 
@@ -62,7 +66,7 @@ void ControlPanel::addOption( const std::string& name,
 }
 
 void ControlPanel::addLabel( const std::string& text ) {
-    auto label = new QLabel( text.c_str(), this );
+    auto label = new QLabel( text.c_str() );
     auto index = m_contentLayout->rowCount();
     m_contentLayout->addWidget( label, index, 0, 1, -1 );
 }
@@ -88,14 +92,16 @@ void ControlPanel::addSliderInput( const std::string& name,
                                    int min,
                                    int max,
                                    const std::string& tooltip ) {
-    auto inputLabel   = new QLabel( tr( name.c_str() ), this );
+    auto inputLabel   = new QLabel( tr( name.c_str() ) );
     auto sliderLayout = new QHBoxLayout();
-    auto inputField   = new QSlider( Qt::Horizontal, this );
+    auto inputField   = new QSlider( Qt::Horizontal );
     if ( !tooltip.empty() ) {
-        inputLabel->setToolTip(
-            QString( "<qt>%1</qt>" ).arg( QString( tooltip.c_str() ).toHtmlEscaped() ) );
+        auto tooltipString =
+            QString( "<qt>%1</qt>" ).arg( QString( tooltip.c_str() ).toHtmlEscaped() );
+        inputLabel->setToolTip( tooltipString );
+        inputField->setToolTip( tooltipString );
     }
-    auto spinbox = new QSpinBox( this );
+    auto spinbox = new QSpinBox();
     inputField->setRange( min, max );
     inputField->setValue( initial );
     inputField->setTickPosition( QSlider::TicksAbove );
@@ -120,11 +126,13 @@ void ControlPanel::addPowerSliderInput( const std::string& name,
                                         double min,
                                         double max,
                                         const std::string& tooltip ) {
-    auto inputLabel = new QLabel( tr( name.c_str() ), this );
+    auto inputLabel = new QLabel( tr( name.c_str() ) );
     auto inputField = new PowerSlider();
     if ( !tooltip.empty() ) {
-        inputLabel->setToolTip(
-            QString( "<qt>%1</qt>" ).arg( QString( tooltip.c_str() ).toHtmlEscaped() ) );
+        auto tooltipString =
+            QString( "<qt>%1</qt>" ).arg( QString( tooltip.c_str() ).toHtmlEscaped() );
+        inputLabel->setToolTip( tooltipString );
+        inputField->setToolTip( tooltipString );
     }
     inputField->setObjectName( name.c_str() );
     inputField->setRange( min, max );
@@ -143,12 +151,14 @@ void ControlPanel::addMatrixInput( const std::string& name,
                                    int dec,
                                    const std::string& tooltip ) {
 
-    auto inputLabel = new QLabel( tr( name.c_str() ), this );
-    auto inputField = new MatrixEditor( initial, dec, this );
+    auto inputLabel = new QLabel( tr( name.c_str() ) );
+    auto inputField = new MatrixEditor( initial, dec );
 
     if ( !tooltip.empty() ) {
-        inputLabel->setToolTip(
-            QString( "<qt>%1</qt>" ).arg( QString( tooltip.c_str() ).toHtmlEscaped() ) );
+        auto tooltipString =
+            QString( "<qt>%1</qt>" ).arg( QString( tooltip.c_str() ).toHtmlEscaped() );
+        inputLabel->setToolTip( tooltipString );
+        inputField->setToolTip( tooltipString );
     }
     connect( inputField, &MatrixEditor::valueChanged, std::move( callback ) );
 
@@ -164,7 +174,7 @@ void ControlPanel::addColorInput(
     bool withAlpha,
     const std::string& tooltip ) {
 
-    auto button    = new QPushButton( name.c_str(), this );
+    auto button    = new QPushButton( name.c_str() );
     auto srgbColor = Ra::Core::Utils::Color::linearRGBTosRGB( color );
     auto clrBttn   = QColor::fromRgbF( srgbColor[0], srgbColor[1], srgbColor[2], srgbColor[3] );
     auto clrDlg    = [callback, clrBttn, withAlpha, button, name]() mutable {
@@ -266,8 +276,8 @@ void ControlPanel::addComboBox( const std::string& name,
                                 int initial,
                                 const std::vector<std::string>& items,
                                 const std::string& tooltip ) {
-    auto inputLabel = new QLabel( tr( name.c_str() ), this );
-    auto inputField = new QComboBox( this );
+    auto inputLabel = new QLabel( tr( name.c_str() ) );
+    auto inputField = new QComboBox();
     for ( auto v : items ) {
         inputField->addItem( QString::fromStdString( v ) );
     }
@@ -289,8 +299,8 @@ void ControlPanel::addComboBox( const std::string& name,
                                 const std::string& initial,
                                 const std::vector<std::string>& items,
                                 const std::string& tooltip ) {
-    auto inputLabel = new QLabel( tr( name.c_str() ), this );
-    auto inputField = new QComboBox( this );
+    auto inputLabel = new QLabel( tr( name.c_str() ) );
+    auto inputField = new QComboBox();
     for ( auto v : items ) {
         inputField->addItem( QString::fromStdString( v ) );
     }
@@ -310,13 +320,15 @@ void ControlPanel::addComboBox( const std::string& name,
 
 void ControlPanel::addStretch( int stretch ) {
     m_mainLayout->addStretch( stretch );
-    m_contentLayout = new QGridLayout( this );
+    m_contentLayout = new QGridLayout();
+    m_contentLayout->setObjectName( "stretch layout" );
     m_mainLayout->addLayout( m_contentLayout );
 }
 
 void ControlPanel::addWidget( QWidget* newWidget ) {
     m_mainLayout->addWidget( newWidget );
-    m_contentLayout = new QGridLayout( this );
+    m_contentLayout = new QGridLayout();
+    m_contentLayout->setObjectName( "Widget content layout" );
     m_mainLayout->addLayout( m_contentLayout );
 }
 

--- a/src/Gui/Widgets/ControlPanel.hpp
+++ b/src/Gui/Widgets/ControlPanel.hpp
@@ -5,6 +5,7 @@
 #include <Gui/Widgets/ConstrainedNumericSpinBox.hpp>
 #include <Gui/Widgets/VectorEditor.hpp>
 
+#include <QBoxLayout>
 #include <QFrame>
 #include <QVBoxLayout>
 
@@ -235,7 +236,8 @@ class RA_GUI_API ControlPanel : public QFrame
     void addStretch( int stretch );
 
     void newLayout() {
-        m_contentLayout = new QGridLayout( this );
+        m_contentLayout = new QGridLayout();
+        m_contentLayout->setObjectName( "new layout" );
         m_mainLayout->addLayout( m_contentLayout );
     }
 
@@ -252,9 +254,9 @@ void ControlPanel::addConstrainedNumberInput( const std::string& name,
                                               std::function<bool( T )> predicate,
                                               const std::string& tooltip,
                                               int dec ) {
-    auto inputLabel = new QLabel( tr( name.c_str() ), this );
+    auto inputLabel = new QLabel( tr( name.c_str() ) );
 
-    auto inputField = new ConstrainedNumericSpinBox<T>( this );
+    auto inputField = new ConstrainedNumericSpinBox<T>();
     inputField->setValue( initial );
     inputField->setMinimum( std::numeric_limits<T>::lowest() );
     inputField->setMaximum( std::numeric_limits<T>::max() );
@@ -267,8 +269,10 @@ void ControlPanel::addConstrainedNumberInput( const std::string& name,
     if constexpr ( std::is_floating_point_v<T> ) { inputField->setDecimals( dec ); }
 
     if ( !tooltip.empty() ) {
-        inputLabel->setToolTip(
-            QString( "<qt>%1</qt>" ).arg( QString( tooltip.c_str() ).toHtmlEscaped() ) );
+        auto tooltipString =
+            QString( "<qt>%1</qt>" ).arg( QString( tooltip.c_str() ).toHtmlEscaped() );
+        inputLabel->setToolTip( tooltipString );
+        inputField->setToolTip( tooltipString );
     }
     auto index = m_contentLayout->rowCount();
     m_contentLayout->addWidget( inputLabel, index, 0 );
@@ -284,10 +288,13 @@ void ControlPanel::addNumberInput( const std::string& name,
                                    const std::string& tooltip,
                                    int dec ) {
 
-    auto inputLabel = new QLabel( tr( name.c_str() ), this );
+    auto inputLabel = new QLabel( tr( name.c_str() ) );
 
     using WidgetType = typename QtSpinBox::getType<T>::Type;
-    auto inputField  = new WidgetType( this );
+    auto inputField  = new WidgetType();
+    auto inputLayout = new QHBoxLayout();
+    inputLayout->addStretch();
+    inputLayout->addWidget( inputField );
     // to prevent overflow
     inputField->setRange(
         min,
@@ -300,12 +307,14 @@ void ControlPanel::addNumberInput( const std::string& name,
     if constexpr ( std::is_floating_point_v<T> ) { inputField->setDecimals( dec ); }
 
     if ( !tooltip.empty() ) {
-        inputLabel->setToolTip(
-            QString( "<qt>%1</qt>" ).arg( QString( tooltip.c_str() ).toHtmlEscaped() ) );
+        auto tooltipString =
+            QString( "<qt>%1</qt>" ).arg( QString( tooltip.c_str() ).toHtmlEscaped() );
+        inputLabel->setToolTip( tooltipString );
+        inputField->setToolTip( tooltipString );
     }
     auto index = m_contentLayout->rowCount();
     m_contentLayout->addWidget( inputLabel, index, 0 );
-    m_contentLayout->addWidget( inputField, index, 1 );
+    m_contentLayout->addLayout( inputLayout, index, 1 );
 }
 
 template <typename T>
@@ -314,12 +323,14 @@ void ControlPanel::addVectorInput( const std::string& name,
                                    const std::vector<T>& initial,
                                    const std::string& tooltip ) {
 
-    auto inputLabel = new QLabel( tr( name.c_str() ), this );
-    auto inputField = new VectorEditor<T>( initial, this );
+    auto inputLabel = new QLabel( tr( name.c_str() ) );
+    auto inputField = new VectorEditor<T>( initial );
 
     if ( !tooltip.empty() ) {
-        inputLabel->setToolTip(
-            QString( "<qt>%1</qt>" ).arg( QString( tooltip.c_str() ).toHtmlEscaped() ) );
+        auto tooltipString =
+            QString( "<qt>%1</qt>" ).arg( QString( tooltip.c_str() ).toHtmlEscaped() );
+        inputLabel->setToolTip( tooltipString );
+        inputField->setToolTip( tooltipString );
     }
     connect( inputField,
              QOverload<const std::vector<T>&>::of( &VectorEditorSignals::valueChanged ),

--- a/tests/unittest/Core/demangle.cpp
+++ b/tests/unittest/Core/demangle.cpp
@@ -16,12 +16,7 @@ TEST_CASE( "Core/Utils/TypesUtils", "[Core][Core/Utils][TypesUtils]" ) {
         REQUIRE( std::string( demangleType<int>() ) == "int" );
         REQUIRE( std::string( demangleType<float>() ) == "float" );
         REQUIRE( std::string( demangleType<uint>() ) == "unsigned int" );
-        // TODO, verify type demangling on windows
-#ifndef _WIN32
         REQUIRE( std::string( demangleType<size_t>() ) == "unsigned long" );
-#else
-        REQUIRE( std::string( demangleType<size_t>() ) == "unsigned __int64" );
-#endif
         auto demangledName = std::string( demangleType<std::vector<int>>() );
         REQUIRE( demangledName == "std::vector<int, std::allocator<int>>" );
 
@@ -40,12 +35,7 @@ TEST_CASE( "Core/Utils/TypesUtils", "[Core][Core/Utils][TypesUtils]" ) {
         REQUIRE( std::string( demangleType( i ) ) == "int" );
         REQUIRE( std::string( demangleType( f ) ) == "float" );
         REQUIRE( std::string( demangleType( u ) ) == "unsigned int" );
-        // TODO, verify type demangling on windows
-#ifndef _WIN32
         REQUIRE( std::string( demangleType( s ) ) == "unsigned long" );
-#else
-        REQUIRE( std::string( demangleType( s ) ) == "unsigned __int64" );
-#endif
         std::vector<int> v;
         auto demangledName = std::string( demangleType( v ) );
         REQUIRE( demangledName == "std::vector<int, std::allocator<int>>" );

--- a/tests/unittest/Core/variableset.cpp
+++ b/tests/unittest/Core/variableset.cpp
@@ -113,13 +113,13 @@ TEST_CASE( "Core/Container/VariableSet", "[Core][Container][VariableSet]" ) {
         REQUIRE( params.getVariable<float>( "x" ) == 5 );
 
         // variable i store a value, copy of local variable i. Changing its value ...
-        auto inserted = params.insertOrAssignVariable( "i", 2 );
+        auto inserted = params.setVariable( "i", 2 );
         REQUIRE( inserted.second == false );
         REQUIRE( params.getVariable<int>( "i" ) == 2 );
         // does not change the local variable i
         REQUIRE( i == 0 );
 
-        inserted = params.insertOrAssignVariable( "k", 3 );
+        inserted = params.setVariable( "k", 3 );
         REQUIRE( inserted.second == true );
 
         // variable "j" is a reference to local variable i, and has the same value

--- a/tests/unittest/Engine/materials.cpp
+++ b/tests/unittest/Engine/materials.cpp
@@ -48,9 +48,8 @@ TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
         /* Setting GL Parameters */
         bp.updateGL();
         auto& bpParameters = bp.getParameters();
-        auto& bpstorage    = bpParameters.getStorage();
 
-        bpstorage.visit( PrintThemAll {} );
+        bpParameters.visit( PrintThemAll {} );
 
         REQUIRE( bpParameters.containsParameter<bool>( "material.hasPerVertexKd" ) );
         REQUIRE( bpParameters.containsParameter<Scalar>( "material.alpha" ) );
@@ -62,8 +61,8 @@ TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
         REQUIRE( alp == bp.getAlpha() );
 
         /* changing parameter values */
-        bpParameters.addParameter( "material.hasPerVertexKd", !pvc );
-        bpParameters.addParameter( "material.alpha", 0.5_ra );
+        bpParameters.setVariable( "material.hasPerVertexKd", !pvc );
+        bpParameters.setVariable( "material.alpha", 0.5_ra );
         REQUIRE( pvc != bp.isColoredByVertexAttrib() );
         REQUIRE( alp != bp.getAlpha() );
 
@@ -92,7 +91,7 @@ TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
         REQUIRE( pvc == mat.isColoredByVertexAttrib() );
 
         /* changing parameter values */
-        matParameters.addParameter( "material.perVertexColor", !pvc );
+        matParameters.setVariable( "material.perVertexColor", !pvc );
         REQUIRE( pvc != mat.isColoredByVertexAttrib() );
 
         /* Updating material parameters from GL parameters */
@@ -119,7 +118,7 @@ TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
         REQUIRE( pvc == mat.isColoredByVertexAttrib() );
 
         /* changing parameter values */
-        matParameters.addParameter( "material.perVertexColor", !pvc );
+        matParameters.setVariable( "material.perVertexColor", !pvc );
         REQUIRE( pvc != mat.isColoredByVertexAttrib() );
 
         /* Updating material parameters from GL parameters */
@@ -155,7 +154,7 @@ TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
         REQUIRE( g == 0_ra );
 
         /* changing parameter values */
-        matParameters.addParameter( "material.g", 0.5_ra );
+        matParameters.setVariable( "material.g", 0.5_ra );
         REQUIRE( g != mat.m_g );
 
         /* Updating material parameters from GL parameters */

--- a/tests/unittest/Engine/materials.cpp
+++ b/tests/unittest/Engine/materials.cpp
@@ -51,8 +51,8 @@ TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
 
         bpParameters.visit( PrintThemAll {} );
 
-        REQUIRE( bpParameters.containsParameter<bool>( "material.hasPerVertexKd" ) );
-        REQUIRE( bpParameters.containsParameter<Scalar>( "material.alpha" ) );
+        REQUIRE( bpParameters.existsVariable<bool>( "material.hasPerVertexKd" ) );
+        REQUIRE( bpParameters.existsVariable<Scalar>( "material.alpha" ) );
 
         auto& pvc = bpParameters.getParameter<bool>( "material.hasPerVertexKd" );
         REQUIRE( pvc == bp.isColoredByVertexAttrib() );
@@ -86,7 +86,7 @@ TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
         mat.updateGL();
         auto& matParameters = mat.getParameters();
 
-        REQUIRE( matParameters.containsParameter<bool>( "material.perVertexColor" ) );
+        REQUIRE( matParameters.existsVariable<bool>( "material.perVertexColor" ) );
         auto& pvc = matParameters.getParameter<bool>( "material.perVertexColor" );
         REQUIRE( pvc == mat.isColoredByVertexAttrib() );
 
@@ -113,7 +113,7 @@ TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
         mat.updateGL();
         auto& matParameters = mat.getParameters();
 
-        REQUIRE( matParameters.containsParameter<bool>( "material.perVertexColor" ) );
+        REQUIRE( matParameters.existsVariable<bool>( "material.perVertexColor" ) );
         auto& pvc = matParameters.getParameter<bool>( "material.perVertexColor" );
         REQUIRE( pvc == mat.isColoredByVertexAttrib() );
 
@@ -148,7 +148,7 @@ TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
 
         mat.updateGL();
         auto& matParameters = mat.getParameters();
-        REQUIRE( matParameters.containsParameter<Scalar>( "material.g" ) );
+        REQUIRE( matParameters.existsVariable<Scalar>( "material.g" ) );
 
         auto& g = matParameters.getParameter<Scalar>( "material.g" );
         REQUIRE( g == 0_ra );

--- a/tests/unittest/Engine/materials.cpp
+++ b/tests/unittest/Engine/materials.cpp
@@ -54,10 +54,10 @@ TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
         REQUIRE( bpParameters.existsVariable<bool>( "material.hasPerVertexKd" ) );
         REQUIRE( bpParameters.existsVariable<Scalar>( "material.alpha" ) );
 
-        auto& pvc = bpParameters.getParameter<bool>( "material.hasPerVertexKd" );
+        auto& pvc = bpParameters.getVariable<bool>( "material.hasPerVertexKd" );
         REQUIRE( pvc == bp.isColoredByVertexAttrib() );
 
-        auto& alp = bpParameters.getParameter<Scalar>( "material.alpha" );
+        auto& alp = bpParameters.getVariable<Scalar>( "material.alpha" );
         REQUIRE( alp == bp.getAlpha() );
 
         /* changing parameter values */
@@ -87,7 +87,7 @@ TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
         auto& matParameters = mat.getParameters();
 
         REQUIRE( matParameters.existsVariable<bool>( "material.perVertexColor" ) );
-        auto& pvc = matParameters.getParameter<bool>( "material.perVertexColor" );
+        auto& pvc = matParameters.getVariable<bool>( "material.perVertexColor" );
         REQUIRE( pvc == mat.isColoredByVertexAttrib() );
 
         /* changing parameter values */
@@ -114,7 +114,7 @@ TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
         auto& matParameters = mat.getParameters();
 
         REQUIRE( matParameters.existsVariable<bool>( "material.perVertexColor" ) );
-        auto& pvc = matParameters.getParameter<bool>( "material.perVertexColor" );
+        auto& pvc = matParameters.getVariable<bool>( "material.perVertexColor" );
         REQUIRE( pvc == mat.isColoredByVertexAttrib() );
 
         /* changing parameter values */
@@ -150,7 +150,7 @@ TEST_CASE( "Engine/Data/Materials", "[Engine][Engine/Data][Materials]" ) {
         auto& matParameters = mat.getParameters();
         REQUIRE( matParameters.existsVariable<Scalar>( "material.g" ) );
 
-        auto& g = matParameters.getParameter<Scalar>( "material.g" );
+        auto& g = matParameters.getVariable<Scalar>( "material.g" );
         REQUIRE( g == 0_ra );
 
         /* changing parameter values */

--- a/tests/unittest/Engine/renderparameters.cpp
+++ b/tests/unittest/Engine/renderparameters.cpp
@@ -286,9 +286,12 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
 
         // Adding the enum in the parameter set using its value
         params.setEnumVariable( "enum.semantic", Values::VALUE_0 );
+
         // checking its seen with its type (enum)
-        auto& v = params.getVariable<Values>( "enum.semantic" );
+        auto& v = params.getEnumVariable<Values>( "enum.semantic" );
+
         REQUIRE( v == Values::VALUE_0 );
+
         // The string value of an enum value (with the enumeration's underlying type) can also be
         // fetched from the parameters
         REQUIRE( params.getEnumString( "enum.semantic", v ) == "VALUE_0" );
@@ -297,16 +300,27 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         params.setEnumVariable( "enum.semantic", "VALUE_2" );
         REQUIRE( v == Values::VALUE_2 );
 
+        // variable managed with enum method could also be access directly thru underlying type
+        auto& vv = params.getVariable<ValuesType>( "enum.semantic" );
+        REQUIRE( vv == v );
+        REQUIRE( vv == Values::VALUE_2 );
+        params.setVariable( "enum.semantic", ValuesType { Values::VALUE_0 } );
+        REQUIRE( vv == v );
+        REQUIRE( vv == Values::VALUE_0 );
+
         // unregistered enum could be added only using their value
         params.setEnumVariable( "enum.unknown", Unregistered::LOW );
-        auto u = params.getVariable<Unregistered>( "enum.unknown" );
+        auto u = params.getEnumVariable<Unregistered>( "enum.unknown" );
         REQUIRE( u == Unregistered::LOW );
         REQUIRE( params.getEnumString( "enum.unknown", u ) == "" );
 
         // Trying to add unregistered enums values trough string does not change the stored value
         params.setEnumVariable( "enum.unknown", "Unregistered::HIGH" );
-        u = params.getVariable<Unregistered>( "enum.unknown" );
-        REQUIRE( u == Unregistered::LOW );
+        u = params.getEnumVariable<Unregistered>( "enum.unknown" );
+
+        // same with management thru underlying type
+        auto uu = params.getVariable<UnregisteredType>( "enum.unknown" );
+        REQUIRE( uu == Unregistered::LOW );
     }
 
     SECTION( "Parameter visit" ) {

--- a/tests/unittest/Engine/renderparameters.cpp
+++ b/tests/unittest/Engine/renderparameters.cpp
@@ -79,21 +79,21 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
     using RP = RenderParameters;
     SECTION( "Parameter storage" ) {
         RP p1;
-        REQUIRE( !( p1.hasParameterSet<int>().has_value() ) );
-        REQUIRE( !( p1.hasParameterSet<bool>().has_value() ) );
-        REQUIRE( !( p1.hasParameterSet<uint>().has_value() ) );
-        REQUIRE( !( p1.hasParameterSet<Scalar>().has_value() ) );
-        REQUIRE( !( p1.hasParameterSet<std::vector<int>>().has_value() ) );
-        REQUIRE( !( p1.hasParameterSet<std::vector<uint>>().has_value() ) );
-        REQUIRE( !( p1.hasParameterSet<std::vector<Scalar>>().has_value() ) );
-        REQUIRE( !( p1.hasParameterSet<Ra::Core::Vector2>().has_value() ) );
-        REQUIRE( !( p1.hasParameterSet<Ra::Core::Vector3>().has_value() ) );
-        REQUIRE( !( p1.hasParameterSet<Ra::Core::Vector4>().has_value() ) );
-        REQUIRE( !( p1.hasParameterSet<Ra::Core::Utils::Color>().has_value() ) );
-        REQUIRE( !( p1.hasParameterSet<Ra::Core::Matrix2>().has_value() ) );
-        REQUIRE( !( p1.hasParameterSet<Ra::Core::Matrix3>().has_value() ) );
-        REQUIRE( !( p1.hasParameterSet<Ra::Core::Matrix4>().has_value() ) );
-        REQUIRE( !( p1.hasParameterSet<RP::TextureInfo>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<int>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<bool>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<uint>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<Scalar>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<std::vector<int>>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<std::vector<uint>>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<std::vector<Scalar>>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<Ra::Core::Vector2>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<Ra::Core::Vector3>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<Ra::Core::Vector4>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<Ra::Core::Utils::Color>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<Ra::Core::Matrix2>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<Ra::Core::Matrix3>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<Ra::Core::Matrix4>().has_value() ) );
+        REQUIRE( !( p1.existsVariableType<RP::TextureInfo>().has_value() ) );
         int i    = 1;
         uint ui  = 1u;
         Scalar s = 1_ra;
@@ -126,38 +126,38 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         p1.setVariable( "Mat3Parameter", mat3 );
         p1.setVariable( "Mat4Parameter", mat4 );
 
-        REQUIRE( p1.getParameterSet<int>().size() == 1 );
-        REQUIRE( p1.getParameterSet<bool>().size() == 1 );
-        REQUIRE( p1.getParameterSet<uint>().size() == 1 );
-        REQUIRE( p1.getParameterSet<Scalar>().size() == 1 );
-        REQUIRE( p1.getParameterSet<std::vector<int>>().size() == 1 );
-        REQUIRE( p1.getParameterSet<std::vector<uint>>().size() == 1 );
-        REQUIRE( p1.getParameterSet<std::vector<Scalar>>().size() == 1 );
-        REQUIRE( p1.getParameterSet<Ra::Core::Vector2>().size() == 1 );
-        REQUIRE( p1.getParameterSet<Ra::Core::Vector3>().size() == 1 );
-        REQUIRE( p1.getParameterSet<Ra::Core::Vector4>().size() == 1 );
-        REQUIRE( p1.getParameterSet<Ra::Core::Utils::Color>().size() == 1 );
-        REQUIRE( p1.getParameterSet<Ra::Core::Matrix2>().size() == 1 );
-        REQUIRE( p1.getParameterSet<Ra::Core::Matrix3>().size() == 1 );
-        REQUIRE( p1.getParameterSet<Ra::Core::Matrix4>().size() == 1 );
-        REQUIRE( p1.getParameterSet<RP::TextureInfo>().size() == 1 );
+        REQUIRE( p1.getAllVariables<int>().size() == 1 );
+        REQUIRE( p1.getAllVariables<bool>().size() == 1 );
+        REQUIRE( p1.getAllVariables<uint>().size() == 1 );
+        REQUIRE( p1.getAllVariables<Scalar>().size() == 1 );
+        REQUIRE( p1.getAllVariables<std::vector<int>>().size() == 1 );
+        REQUIRE( p1.getAllVariables<std::vector<uint>>().size() == 1 );
+        REQUIRE( p1.getAllVariables<std::vector<Scalar>>().size() == 1 );
+        REQUIRE( p1.getAllVariables<Ra::Core::Vector2>().size() == 1 );
+        REQUIRE( p1.getAllVariables<Ra::Core::Vector3>().size() == 1 );
+        REQUIRE( p1.getAllVariables<Ra::Core::Vector4>().size() == 1 );
+        REQUIRE( p1.getAllVariables<Ra::Core::Utils::Color>().size() == 1 );
+        REQUIRE( p1.getAllVariables<Ra::Core::Matrix2>().size() == 1 );
+        REQUIRE( p1.getAllVariables<Ra::Core::Matrix3>().size() == 1 );
+        REQUIRE( p1.getAllVariables<Ra::Core::Matrix4>().size() == 1 );
+        REQUIRE( p1.getAllVariables<RP::TextureInfo>().size() == 1 );
 
-        REQUIRE( p1.getParameterSet<int>().at( "IntParameter" ) == i );
-        REQUIRE( p1.getParameterSet<bool>().at( "BoolParameter" ) == b );
-        REQUIRE( p1.getParameterSet<uint>().at( "UIntParameter" ) == ui );
-        REQUIRE( p1.getParameterSet<Scalar>().at( "ScalarParameter" ) == s );
-        REQUIRE( p1.getParameterSet<std::vector<int>>().at( "IntsParameter" ) == is );
-        REQUIRE( p1.getParameterSet<std::vector<uint>>().at( "UIntsParameter" ) == uis );
-        REQUIRE( p1.getParameterSet<std::vector<Scalar>>().at( "ScalarsParameter" ) == ss );
-        REQUIRE( p1.getParameterSet<Ra::Core::Vector2>().at( "Vec2Parameter" ) == vec2 );
-        REQUIRE( p1.getParameterSet<Ra::Core::Vector3>().at( "Vec3Parameter" ) == vec3 );
-        REQUIRE( p1.getParameterSet<Ra::Core::Vector4>().at( "Vec4Parameter" ) == vec4 );
-        REQUIRE( p1.getParameterSet<Ra::Core::Utils::Color>().at( "ColorParameter" ) == color );
-        REQUIRE( p1.getParameterSet<Ra::Core::Matrix2>().at( "Mat2Parameter" ) == mat2 );
-        REQUIRE( p1.getParameterSet<Ra::Core::Matrix3>().at( "Mat3Parameter" ) == mat3 );
-        REQUIRE( p1.getParameterSet<Ra::Core::Matrix4>().at( "Mat4Parameter" ) == mat4 );
-        REQUIRE( p1.getParameterSet<RP::TextureInfo>().at( "TextureParameter" ).first == &tex1 );
-        REQUIRE( p1.getParameterSet<RP::TextureInfo>().at( "TextureParameter" ).second == 1 );
+        REQUIRE( p1.getAllVariables<int>().at( "IntParameter" ) == i );
+        REQUIRE( p1.getAllVariables<bool>().at( "BoolParameter" ) == b );
+        REQUIRE( p1.getAllVariables<uint>().at( "UIntParameter" ) == ui );
+        REQUIRE( p1.getAllVariables<Scalar>().at( "ScalarParameter" ) == s );
+        REQUIRE( p1.getAllVariables<std::vector<int>>().at( "IntsParameter" ) == is );
+        REQUIRE( p1.getAllVariables<std::vector<uint>>().at( "UIntsParameter" ) == uis );
+        REQUIRE( p1.getAllVariables<std::vector<Scalar>>().at( "ScalarsParameter" ) == ss );
+        REQUIRE( p1.getAllVariables<Ra::Core::Vector2>().at( "Vec2Parameter" ) == vec2 );
+        REQUIRE( p1.getAllVariables<Ra::Core::Vector3>().at( "Vec3Parameter" ) == vec3 );
+        REQUIRE( p1.getAllVariables<Ra::Core::Vector4>().at( "Vec4Parameter" ) == vec4 );
+        REQUIRE( p1.getAllVariables<Ra::Core::Utils::Color>().at( "ColorParameter" ) == color );
+        REQUIRE( p1.getAllVariables<Ra::Core::Matrix2>().at( "Mat2Parameter" ) == mat2 );
+        REQUIRE( p1.getAllVariables<Ra::Core::Matrix3>().at( "Mat3Parameter" ) == mat3 );
+        REQUIRE( p1.getAllVariables<Ra::Core::Matrix4>().at( "Mat4Parameter" ) == mat4 );
+        REQUIRE( p1.getAllVariables<RP::TextureInfo>().at( "TextureParameter" ).first == &tex1 );
+        REQUIRE( p1.getAllVariables<RP::TextureInfo>().at( "TextureParameter" ).second == 1 );
 
         StaticPrintVisitor vstr;
         p1.visit( vstr, "p1 parameter set" );
@@ -188,72 +188,72 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         kept.mergeKeepVariables( p2 );
 
         // existings parameters are note changes (p1's values)
-        REQUIRE( kept.getParameterSet<int>().at( "IntParameter" ) ==
-                 p1.getParameterSet<int>().at( "IntParameter" ) );
-        REQUIRE( kept.getParameterSet<bool>().at( "BoolParameter" ) ==
-                 p1.getParameterSet<bool>().at( "BoolParameter" ) );
-        REQUIRE( kept.getParameterSet<uint>().at( "UIntParameter" ) ==
-                 p1.getParameterSet<uint>().at( "UIntParameter" ) );
-        REQUIRE( kept.getParameterSet<Scalar>().at( "ScalarParameter" ) ==
-                 p1.getParameterSet<Scalar>().at( "ScalarParameter" ) );
-        REQUIRE( kept.getParameterSet<std::vector<int>>().at( "IntsParameter" ) ==
-                 p1.getParameterSet<std::vector<int>>().at( "IntsParameter" ) );
-        REQUIRE( kept.getParameterSet<std::vector<uint>>().at( "UIntsParameter" ) ==
-                 p1.getParameterSet<std::vector<uint>>().at( "UIntsParameter" ) );
-        REQUIRE( kept.getParameterSet<std::vector<Scalar>>().at( "ScalarsParameter" ) ==
-                 p1.getParameterSet<std::vector<Scalar>>().at( "ScalarsParameter" ) );
-        REQUIRE( kept.getParameterSet<Ra::Core::Vector2>().at( "Vec2Parameter" ) ==
-                 p1.getParameterSet<Ra::Core::Vector2>().at( "Vec2Parameter" ) );
-        REQUIRE( kept.getParameterSet<Ra::Core::Vector3>().at( "Vec3Parameter" ) ==
-                 p1.getParameterSet<Ra::Core::Vector3>().at( "Vec3Parameter" ) );
-        REQUIRE( kept.getParameterSet<Ra::Core::Vector4>().at( "Vec4Parameter" ) ==
-                 p1.getParameterSet<Ra::Core::Vector4>().at( "Vec4Parameter" ) );
-        REQUIRE( kept.getParameterSet<Ra::Core::Utils::Color>().at( "ColorParameter" ) ==
-                 p1.getParameterSet<Ra::Core::Utils::Color>().at( "ColorParameter" ) );
-        REQUIRE( kept.getParameterSet<RP::TextureInfo>().at( "TextureParameter" ) ==
-                 p1.getParameterSet<RP::TextureInfo>().at( "TextureParameter" ) );
+        REQUIRE( kept.getAllVariables<int>().at( "IntParameter" ) ==
+                 p1.getAllVariables<int>().at( "IntParameter" ) );
+        REQUIRE( kept.getAllVariables<bool>().at( "BoolParameter" ) ==
+                 p1.getAllVariables<bool>().at( "BoolParameter" ) );
+        REQUIRE( kept.getAllVariables<uint>().at( "UIntParameter" ) ==
+                 p1.getAllVariables<uint>().at( "UIntParameter" ) );
+        REQUIRE( kept.getAllVariables<Scalar>().at( "ScalarParameter" ) ==
+                 p1.getAllVariables<Scalar>().at( "ScalarParameter" ) );
+        REQUIRE( kept.getAllVariables<std::vector<int>>().at( "IntsParameter" ) ==
+                 p1.getAllVariables<std::vector<int>>().at( "IntsParameter" ) );
+        REQUIRE( kept.getAllVariables<std::vector<uint>>().at( "UIntsParameter" ) ==
+                 p1.getAllVariables<std::vector<uint>>().at( "UIntsParameter" ) );
+        REQUIRE( kept.getAllVariables<std::vector<Scalar>>().at( "ScalarsParameter" ) ==
+                 p1.getAllVariables<std::vector<Scalar>>().at( "ScalarsParameter" ) );
+        REQUIRE( kept.getAllVariables<Ra::Core::Vector2>().at( "Vec2Parameter" ) ==
+                 p1.getAllVariables<Ra::Core::Vector2>().at( "Vec2Parameter" ) );
+        REQUIRE( kept.getAllVariables<Ra::Core::Vector3>().at( "Vec3Parameter" ) ==
+                 p1.getAllVariables<Ra::Core::Vector3>().at( "Vec3Parameter" ) );
+        REQUIRE( kept.getAllVariables<Ra::Core::Vector4>().at( "Vec4Parameter" ) ==
+                 p1.getAllVariables<Ra::Core::Vector4>().at( "Vec4Parameter" ) );
+        REQUIRE( kept.getAllVariables<Ra::Core::Utils::Color>().at( "ColorParameter" ) ==
+                 p1.getAllVariables<Ra::Core::Utils::Color>().at( "ColorParameter" ) );
+        REQUIRE( kept.getAllVariables<RP::TextureInfo>().at( "TextureParameter" ) ==
+                 p1.getAllVariables<RP::TextureInfo>().at( "TextureParameter" ) );
         // Foo is p2's value
-        REQUIRE( kept.getParameterSet<int>().at( "Foo" ) == p2.getParameterSet<int>().at( "Foo" ) );
+        REQUIRE( kept.getAllVariables<int>().at( "Foo" ) == p2.getAllVariables<int>().at( "Foo" ) );
 
         // Bar is on p1 side only, still here
-        REQUIRE( kept.getParameterSet<int>().at( "Bar" ) == p1.getParameterSet<int>().at( "Bar" ) );
+        REQUIRE( kept.getAllVariables<int>().at( "Bar" ) == p1.getAllVariables<int>().at( "Bar" ) );
 
         RP replaced = p1;
         replaced.mergeReplaceVariables( p2 );
         // Existings in p1 and p2, as well as new parameters are set to p2's values
-        REQUIRE( replaced.getParameterSet<int>().at( "IntParameter" ) ==
-                 p2.getParameterSet<int>().at( "IntParameter" ) );
-        REQUIRE( replaced.getParameterSet<bool>().at( "BoolParameter" ) ==
-                 p2.getParameterSet<bool>().at( "BoolParameter" ) );
-        REQUIRE( replaced.getParameterSet<uint>().at( "UIntParameter" ) ==
-                 p2.getParameterSet<uint>().at( "UIntParameter" ) );
-        REQUIRE( replaced.getParameterSet<Scalar>().at( "ScalarParameter" ) ==
-                 p2.getParameterSet<Scalar>().at( "ScalarParameter" ) );
-        REQUIRE( replaced.getParameterSet<std::vector<int>>().at( "IntsParameter" ) ==
-                 p2.getParameterSet<std::vector<int>>().at( "IntsParameter" ) );
-        REQUIRE( replaced.getParameterSet<std::vector<uint>>().at( "UIntsParameter" ) ==
-                 p2.getParameterSet<std::vector<uint>>().at( "UIntsParameter" ) );
-        REQUIRE( replaced.getParameterSet<std::vector<Scalar>>().at( "ScalarsParameter" ) ==
-                 p2.getParameterSet<std::vector<Scalar>>().at( "ScalarsParameter" ) );
-        REQUIRE( replaced.getParameterSet<Ra::Core::Vector2>().at( "Vec2Parameter" ) ==
-                 p2.getParameterSet<Ra::Core::Vector2>().at( "Vec2Parameter" ) );
-        REQUIRE( replaced.getParameterSet<Ra::Core::Vector3>().at( "Vec3Parameter" ) ==
-                 p2.getParameterSet<Ra::Core::Vector3>().at( "Vec3Parameter" ) );
-        REQUIRE( replaced.getParameterSet<Ra::Core::Vector4>().at( "Vec4Parameter" ) ==
-                 p2.getParameterSet<Ra::Core::Vector4>().at( "Vec4Parameter" ) );
-        REQUIRE( replaced.getParameterSet<Ra::Core::Utils::Color>().at( "ColorParameter" ) ==
-                 p2.getParameterSet<Ra::Core::Utils::Color>().at( "ColorParameter" ) );
-        REQUIRE( replaced.getParameterSet<int>().at( "Foo" ) ==
-                 p2.getParameterSet<int>().at( "Foo" ) );
-        REQUIRE( replaced.getParameterSet<RP::TextureInfo>().at( "TextureParameter" ) ==
-                 p2.getParameterSet<RP::TextureInfo>().at( "TextureParameter" ) );
+        REQUIRE( replaced.getAllVariables<int>().at( "IntParameter" ) ==
+                 p2.getAllVariables<int>().at( "IntParameter" ) );
+        REQUIRE( replaced.getAllVariables<bool>().at( "BoolParameter" ) ==
+                 p2.getAllVariables<bool>().at( "BoolParameter" ) );
+        REQUIRE( replaced.getAllVariables<uint>().at( "UIntParameter" ) ==
+                 p2.getAllVariables<uint>().at( "UIntParameter" ) );
+        REQUIRE( replaced.getAllVariables<Scalar>().at( "ScalarParameter" ) ==
+                 p2.getAllVariables<Scalar>().at( "ScalarParameter" ) );
+        REQUIRE( replaced.getAllVariables<std::vector<int>>().at( "IntsParameter" ) ==
+                 p2.getAllVariables<std::vector<int>>().at( "IntsParameter" ) );
+        REQUIRE( replaced.getAllVariables<std::vector<uint>>().at( "UIntsParameter" ) ==
+                 p2.getAllVariables<std::vector<uint>>().at( "UIntsParameter" ) );
+        REQUIRE( replaced.getAllVariables<std::vector<Scalar>>().at( "ScalarsParameter" ) ==
+                 p2.getAllVariables<std::vector<Scalar>>().at( "ScalarsParameter" ) );
+        REQUIRE( replaced.getAllVariables<Ra::Core::Vector2>().at( "Vec2Parameter" ) ==
+                 p2.getAllVariables<Ra::Core::Vector2>().at( "Vec2Parameter" ) );
+        REQUIRE( replaced.getAllVariables<Ra::Core::Vector3>().at( "Vec3Parameter" ) ==
+                 p2.getAllVariables<Ra::Core::Vector3>().at( "Vec3Parameter" ) );
+        REQUIRE( replaced.getAllVariables<Ra::Core::Vector4>().at( "Vec4Parameter" ) ==
+                 p2.getAllVariables<Ra::Core::Vector4>().at( "Vec4Parameter" ) );
+        REQUIRE( replaced.getAllVariables<Ra::Core::Utils::Color>().at( "ColorParameter" ) ==
+                 p2.getAllVariables<Ra::Core::Utils::Color>().at( "ColorParameter" ) );
+        REQUIRE( replaced.getAllVariables<int>().at( "Foo" ) ==
+                 p2.getAllVariables<int>().at( "Foo" ) );
+        REQUIRE( replaced.getAllVariables<RP::TextureInfo>().at( "TextureParameter" ) ==
+                 p2.getAllVariables<RP::TextureInfo>().at( "TextureParameter" ) );
         // Bar is on p1 side only and not changed
-        REQUIRE( replaced.getParameterSet<int>().at( "Bar" ) ==
-                 p1.getParameterSet<int>().at( "Bar" ) );
+        REQUIRE( replaced.getAllVariables<int>().at( "Bar" ) ==
+                 p1.getAllVariables<int>().at( "Bar" ) );
 
         auto removed = replaced.deleteVariable<int>( "Bar" );
         REQUIRE( removed == true );
-        auto found = replaced.containsParameter<int>( "Bar" );
+        auto found = replaced.existsVariable<int>( "Bar" );
         REQUIRE( found.has_value() == false );
     }
 

--- a/tests/unittest/Engine/renderparameters.cpp
+++ b/tests/unittest/Engine/renderparameters.cpp
@@ -287,7 +287,7 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         // Adding the enum in the parameter set using its value
         params.setEnumVariable( "enum.semantic", Values::VALUE_0 );
         // checking its seen with its type (enum)
-        auto& v = params.getParameter<Values>( "enum.semantic" );
+        auto& v = params.getVariable<Values>( "enum.semantic" );
         REQUIRE( v == Values::VALUE_0 );
         // The string value of an enum value (with the enumeration's underlying type) can also be
         // fetched from the parameters
@@ -299,13 +299,13 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
 
         // unregistered enum could be added only using their value
         params.setEnumVariable( "enum.unknown", Unregistered::LOW );
-        auto u = params.getParameter<Unregistered>( "enum.unknown" );
+        auto u = params.getVariable<Unregistered>( "enum.unknown" );
         REQUIRE( u == Unregistered::LOW );
         REQUIRE( params.getEnumString( "enum.unknown", u ) == "" );
 
         // Trying to add unregistered enums values trough string does not change the stored value
         params.setEnumVariable( "enum.unknown", "Unregistered::HIGH" );
-        u = params.getParameter<Unregistered>( "enum.unknown" );
+        u = params.getVariable<Unregistered>( "enum.unknown" );
         REQUIRE( u == Unregistered::LOW );
     }
 

--- a/tests/unittest/Engine/renderparameters.cpp
+++ b/tests/unittest/Engine/renderparameters.cpp
@@ -369,8 +369,7 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         subParams.setVariable( "sub.string", std::string { "SubString" } );
         addEnumConverter( subParams, "enum.semantic", valuesEnumConverter );
         setEnumVariable( subParams, "enum.semantic", "VALUE_1" );
-        paramsToVisit.setVariable( "SubParameter",
-                                   std::reference_wrapper<RenderParameters> { subParams } );
+        paramsToVisit.setVariable( "SubParameter", subParams );
         paramsToVisit.visit( vstr, "Visiting with subparameters" );
         REQUIRE( vstr.output.str() ==
                  "	Visiting with subparameters: ( int ) int.simple --> 1\n"

--- a/tests/unittest/Engine/renderparameters.cpp
+++ b/tests/unittest/Engine/renderparameters.cpp
@@ -110,21 +110,21 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         Color color  = Color::White();
         Texture tex1 { { "texture1" } };
 
-        p1.addParameter( "TextureParameter", &tex1, 1 );
-        p1.addParameter( "IntParameter", i );
-        p1.addParameter( "BoolParameter", b );
-        p1.addParameter( "UIntParameter", ui );
-        p1.addParameter( "ScalarParameter", s );
-        p1.addParameter( "IntsParameter", is );
-        p1.addParameter( "UIntsParameter", uis );
-        p1.addParameter( "ScalarsParameter", ss );
-        p1.addParameter( "Vec2Parameter", vec2 );
-        p1.addParameter( "Vec3Parameter", vec3 );
-        p1.addParameter( "Vec4Parameter", vec4 );
-        p1.addParameter( "ColorParameter", color );
-        p1.addParameter( "Mat2Parameter", mat2 );
-        p1.addParameter( "Mat3Parameter", mat3 );
-        p1.addParameter( "Mat4Parameter", mat4 );
+        p1.setTexture( "TextureParameter", &tex1, 1 );
+        p1.setVariable( "IntParameter", i );
+        p1.setVariable( "BoolParameter", b );
+        p1.setVariable( "UIntParameter", ui );
+        p1.setVariable( "ScalarParameter", s );
+        p1.setVariable( "IntsParameter", is );
+        p1.setVariable( "UIntsParameter", uis );
+        p1.setVariable( "ScalarsParameter", ss );
+        p1.setVariable( "Vec2Parameter", vec2 );
+        p1.setVariable( "Vec3Parameter", vec3 );
+        p1.setVariable( "Vec4Parameter", vec4 );
+        p1.setVariable( "ColorParameter", color );
+        p1.setVariable( "Mat2Parameter", mat2 );
+        p1.setVariable( "Mat3Parameter", mat3 );
+        p1.setVariable( "Mat4Parameter", mat4 );
 
         REQUIRE( p1.getParameterSet<int>().size() == 1 );
         REQUIRE( p1.getParameterSet<bool>().size() == 1 );
@@ -163,29 +163,29 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         p1.visit( vstr, "p1 parameter set" );
 
         RP p2;
-        p2.addParameter( "IntParameter", i + 1 );
-        p2.addParameter( "BoolParameter", !b );
-        p2.addParameter( "UIntParameter", ui + 1 );
-        p2.addParameter( "ScalarParameter", s + 1_ra );
+        p2.setVariable( "IntParameter", i + 1 );
+        p2.setVariable( "BoolParameter", !b );
+        p2.setVariable( "UIntParameter", ui + 1 );
+        p2.setVariable( "ScalarParameter", s + 1_ra );
         is.push_back( 0 );
-        p2.addParameter( "IntsParameter", is );
+        p2.setVariable( "IntsParameter", is );
         uis.push_back( 0u );
-        p2.addParameter( "UIntsParameter", uis );
+        p2.setVariable( "UIntsParameter", uis );
         ss.push_back( 0_ra );
-        p2.addParameter( "ScalarsParameter", ss );
-        p2.addParameter( "Vec2Parameter", Vector2 { vec2 + Vector2 { 1_ra, 1_ra } } );
-        p2.addParameter( "Vec3Parameter", Vector3 { vec3 + Vector3 { 1_ra, 1_ra, 1_ra } } );
-        p2.addParameter( "Vec4Parameter", Vector4 { vec4 + Vector4 { 1_ra, 1_ra, 1_ra, 1_ra } } );
-        p2.addParameter( "ColorParameter", Color::Red() );
+        p2.setVariable( "ScalarsParameter", ss );
+        p2.setVariable( "Vec2Parameter", Vector2 { vec2 + Vector2 { 1_ra, 1_ra } } );
+        p2.setVariable( "Vec3Parameter", Vector3 { vec3 + Vector3 { 1_ra, 1_ra, 1_ra } } );
+        p2.setVariable( "Vec4Parameter", Vector4 { vec4 + Vector4 { 1_ra, 1_ra, 1_ra, 1_ra } } );
+        p2.setVariable( "ColorParameter", Color::Red() );
         Texture tex2 { { "texture2" } };
-        p2.addParameter( "TextureParameter", &tex2, 2 );
-        p2.addParameter( "Foo", 42 );
+        p2.setTexture( "TextureParameter", &tex2, 2 );
+        p2.setVariable( "Foo", 42 );
 
         // add a int parameter to p1
-        p1.addParameter( "Bar", 43 );
+        p1.setVariable( "Bar", 43 );
 
         RP kept = p1;
-        kept.mergeKeepParameters( p2 );
+        kept.mergeKeepVariables( p2 );
 
         // existings parameters are note changes (p1's values)
         REQUIRE( kept.getParameterSet<int>().at( "IntParameter" ) ==
@@ -219,7 +219,7 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         REQUIRE( kept.getParameterSet<int>().at( "Bar" ) == p1.getParameterSet<int>().at( "Bar" ) );
 
         RP replaced = p1;
-        replaced.mergeReplaceParameters( p2 );
+        replaced.mergeReplaceVariables( p2 );
         // Existings in p1 and p2, as well as new parameters are set to p2's values
         REQUIRE( replaced.getParameterSet<int>().at( "IntParameter" ) ==
                  p2.getParameterSet<int>().at( "IntParameter" ) );
@@ -251,7 +251,7 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         REQUIRE( replaced.getParameterSet<int>().at( "Bar" ) ==
                  p1.getParameterSet<int>().at( "Bar" ) );
 
-        auto removed = replaced.removeParameter<int>( "Bar" );
+        auto removed = replaced.deleteVariable<int>( "Bar" );
         REQUIRE( removed == true );
         auto found = replaced.containsParameter<int>( "Bar" );
         REQUIRE( found.has_value() == false );
@@ -285,7 +285,7 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         REQUIRE( params.getEnumString( "enum.unknown", Unregistered::LOW ) == "" );
 
         // Adding the enum in the parameter set using its value
-        params.addParameter( "enum.semantic", Values::VALUE_0 );
+        params.setEnumVariable( "enum.semantic", Values::VALUE_0 );
         // checking its seen with its type (enum)
         auto& v = params.getParameter<Values>( "enum.semantic" );
         REQUIRE( v == Values::VALUE_0 );
@@ -293,18 +293,18 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         // fetched from the parameters
         REQUIRE( params.getEnumString( "enum.semantic", v ) == "VALUE_0" );
 
-        // changing the value trough addParameter and string representation
-        params.addParameter( "enum.semantic", "VALUE_2" );
+        // changing the value trough setParameter and string representation
+        params.setEnumVariable( "enum.semantic", "VALUE_2" );
         REQUIRE( v == Values::VALUE_2 );
 
         // unregistered enum could be added only using their value
-        params.addParameter( "enum.unknown", Unregistered::LOW );
+        params.setEnumVariable( "enum.unknown", Unregistered::LOW );
         auto u = params.getParameter<Unregistered>( "enum.unknown" );
         REQUIRE( u == Unregistered::LOW );
         REQUIRE( params.getEnumString( "enum.unknown", u ) == "" );
 
         // Trying to add unregistered enums values trough string does not change the stored value
-        params.addParameter( "enum.unknown", "Unregistered::HIGH" );
+        params.setEnumVariable( "enum.unknown", "Unregistered::HIGH" );
         u = params.getParameter<Unregistered>( "enum.unknown" );
         REQUIRE( u == Unregistered::LOW );
     }
@@ -321,8 +321,8 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         auto valuesEnumConverter =
             std::shared_ptr<Ra::Core::Utils::EnumConverter<ValuesType>>( vnc );
         paramsToVisit.addEnumConverter( "enum.semantic", valuesEnumConverter );
-        paramsToVisit.addParameter( "enum.semantic", "VALUE_0" );
-        paramsToVisit.addParameter( "int.simple", int( 1 ) );
+        paramsToVisit.setEnumVariable( "enum.semantic", "VALUE_0" );
+        paramsToVisit.setVariable( "int.simple", int( 1 ) );
 
         PrintThemAllVisitor ptm;
         ptm.allowVisit<ValuesType>();
@@ -336,10 +336,10 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
 
         std::cout << "Visiting with custom static visitor and hierarchical parameters:\n";
         RP subParams;
-        subParams.addParameter( "sub.int", 3 );
-        subParams.addParameter( "sub.string", "SubString" );
-        subParams.addParameter( "enum.semantic", "VALUE_1" );
-        paramsToVisit.addParameter( "SubParameter", subParams );
+        subParams.setVariable( "sub.int", 3 );
+        subParams.setEnumVariable( "sub.string", "SubString" );
+        subParams.setEnumVariable( "enum.semantic", "VALUE_1" );
+        paramsToVisit.setVariable( "SubParameter", subParams );
         paramsToVisit.visit( vstr, "Visiting with subparameters" );
     }
 }

--- a/tests/unittest/Engine/renderparameters.cpp
+++ b/tests/unittest/Engine/renderparameters.cpp
@@ -371,16 +371,27 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         setEnumVariable( subParams, "enum.semantic", "VALUE_1" );
         paramsToVisit.setVariable( "SubParameter", subParams );
         paramsToVisit.visit( vstr, "Visiting with subparameters" );
-        REQUIRE( vstr.output.str() ==
-                 "	Visiting with subparameters: ( int ) int.simple --> 1\n"
-                 "	Visiting with subparameters: ( unsigned int ) enum.semantic --> 10\n"
-                 "	Visiting with subparameters( Ra::Engine::Data::RenderParameters ) SubParameter "
-                 "--> visiting recursively\n"
-                 "		Visiting with subparameters: ( int ) sub.int --> 3\n"
-                 "		Visiting with subparameters: ( unsigned int ) enum.semantic --> 20\n"
-                 "		Visiting with subparameters: ( std::__cxx11::basic_string<char, "
-                 "std::char_traits<char>, std::allocator<char>> ) sub.string --> SubString\n"
-                 "	Visiting with subparameters( Ra::Engine::Data::RenderParameters ) SubParameter "
-                 "--> end recursive visit\n" );
+
+        // visiting order is system dependent
+        std::multiset<std::string> outputSet;
+        for ( std::string line; std::getline( vstr.output, line, '\n' ); )
+            outputSet.insert( line );
+        std::multiset<std::string> expected;
+
+        expected.insert( "\tVisiting with subparameters: ( int ) int.simple --> 1" );
+        expected.insert( "\tVisiting with subparameters: ( unsigned int ) enum.semantic --> 10" );
+        expected.insert(
+            "\tVisiting with subparameters( Ra::Engine::Data::RenderParameters ) SubParameter "
+            "--> visiting recursively" );
+        expected.insert( "\t\tVisiting with subparameters: ( int ) sub.int --> 3" );
+        expected.insert( "\t\tVisiting with subparameters: ( unsigned int ) enum.semantic --> 20" );
+        expected.insert(
+            "\t\tVisiting with subparameters: ( std::__cxx11::basic_string<char, "
+            "std::char_traits<char>, std::allocator<char>> ) sub.string --> SubString" );
+        expected.insert(
+            "\tVisiting with subparameters( Ra::Engine::Data::RenderParameters ) SubParameter "
+            "--> end recursive visit" );
+
+        REQUIRE( outputSet == expected );
     }
 }

--- a/tests/unittest/Engine/renderparameters.cpp
+++ b/tests/unittest/Engine/renderparameters.cpp
@@ -352,11 +352,16 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         ptm.allowVisit<int>();
         std::cout << "Visiting with custom dynamic visitor:\n";
         paramsToVisit.visit( ptm );
-
-        REQUIRE( ptm.output.str() ==
-                 "	PrintThemAllVisitor: ( int ) int.simple --> 1\n"
-                 "	PrintThemAllVisitor: ( unsigned int ) enum.semantic --> 10\n" );
-
+        // visiting order is system dependent, compares output ignoring output order.
+        {
+            std::multiset<std::string> outputSet;
+            for ( std::string line; std::getline( ptm.output, line, '\n' ); )
+                outputSet.insert( line );
+            std::multiset<std::string> expected;
+            expected.insert( "\tPrintThemAllVisitor: ( int ) int.simple --> 1" );
+            expected.insert( "\tPrintThemAllVisitor: ( unsigned int ) enum.semantic --> 10" );
+            REQUIRE( outputSet == expected );
+        }
         StaticPrintVisitor vstr;
         std::cout << "Visiting with custom static visitor:\n";
         paramsToVisit.visit( vstr );
@@ -372,26 +377,29 @@ TEST_CASE( "Engine/Data/RenderParameters", "[Engine][Engine/Data][RenderParamete
         paramsToVisit.setVariable( "SubParameter", subParams );
         paramsToVisit.visit( vstr, "Visiting with subparameters" );
 
-        // visiting order is system dependent
-        std::multiset<std::string> outputSet;
-        for ( std::string line; std::getline( vstr.output, line, '\n' ); )
-            outputSet.insert( line );
-        std::multiset<std::string> expected;
+        {
+            std::multiset<std::string> outputSet;
+            for ( std::string line; std::getline( vstr.output, line, '\n' ); )
+                outputSet.insert( line );
+            std::multiset<std::string> expected;
 
-        expected.insert( "\tVisiting with subparameters: ( int ) int.simple --> 1" );
-        expected.insert( "\tVisiting with subparameters: ( unsigned int ) enum.semantic --> 10" );
-        expected.insert(
-            "\tVisiting with subparameters( Ra::Engine::Data::RenderParameters ) SubParameter "
-            "--> visiting recursively" );
-        expected.insert( "\t\tVisiting with subparameters: ( int ) sub.int --> 3" );
-        expected.insert( "\t\tVisiting with subparameters: ( unsigned int ) enum.semantic --> 20" );
-        expected.insert(
-            "\t\tVisiting with subparameters: ( std::__cxx11::basic_string<char, "
-            "std::char_traits<char>, std::allocator<char>> ) sub.string --> SubString" );
-        expected.insert(
-            "\tVisiting with subparameters( Ra::Engine::Data::RenderParameters ) SubParameter "
-            "--> end recursive visit" );
+            expected.insert( "\tVisiting with subparameters: ( int ) int.simple --> 1" );
+            expected.insert(
+                "\tVisiting with subparameters: ( unsigned int ) enum.semantic --> 10" );
+            expected.insert(
+                "\tVisiting with subparameters( Ra::Engine::Data::RenderParameters ) SubParameter "
+                "--> visiting recursively" );
+            expected.insert( "\t\tVisiting with subparameters: ( int ) sub.int --> 3" );
+            expected.insert(
+                "\t\tVisiting with subparameters: ( unsigned int ) enum.semantic --> 20" );
+            expected.insert(
+                "\t\tVisiting with subparameters: ( std::__cxx11::basic_string<char, "
+                "std::char_traits<char>, std::allocator<char>> ) sub.string --> SubString" );
+            expected.insert(
+                "\tVisiting with subparameters( Ra::Engine::Data::RenderParameters ) SubParameter "
+                "--> end recursive visit" );
 
-        REQUIRE( outputSet == expected );
+            REQUIRE( outputSet == expected );
+        }
     }
 }


### PR DESCRIPTION
# Pull Request Desription

RenderParameters had VariableSet as data member and defined aliases method.
This PR make RenderParameters inherit from VariableSet and remove duplicated code. 
Enum management is also moved to VariableSet. 

The objective is to allow the creation of Gui using VariableSet directly.
Gui automatic creation handle predefined types only (i.e. gui has to know which type are possibly present and how to display them). 
That's why enum can either be treated as integral (enum underlying types, automatically handled by gui if it take care of integral types), with enum <> string conversion for display, or either as "plain" enum, but it's up to the user to specify how to manage them for gui or other usage.

- **What kind of change does this PR introduce?**
  - [x] feature


- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

RenderParameters public interface is changed (and now is mostly VariableSet.
