### PR TITLE
Ci update doxygen

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Install packages
         run : |
           sudo apt-get install graphviz
-      - name: Fetch recent doxygen (1.9.7)
+      - name: Fetch recent doxygen (1.9.8)
         run: |
           sudo apt-get install clang-9 libclang-9-dev
-          wget https://sourceforge.net/projects/doxygen/files/rel-1.9.7/doxygen-1.9.7.linux.bin.tar.gz
+          wget https://sourceforge.net/projects/doxygen/files/rel-1.9.8/doxygen-1.9.8.linux.bin.tar.gz
           tar -xvzf doxygen-1.9.7.linux.bin.tar.gz
       - name: Extract ref for badges prefix
         if: always()
@@ -54,7 +54,7 @@ jobs:
       - name: Configure Doc
         run: |
           cd build/Radium-Engine
-          cmake ../../src/Radium-Engine/doc -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=STDOUT -DDOXYGEN_EXECUTABLE=../../doxygen-1.9.7/bin/doxygen
+          cmake ../../src/Radium-Engine/doc -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=STDOUT -DDOXYGEN_EXECUTABLE=../../doxygen-1.9.8/bin/doxygen
       - name: Build Doc
         run: |
           export GITHUB_REF="${{ steps.extract-branch.outputs.branch }}"

--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -42,8 +42,9 @@ jobs:
       - name: Fetch recent doxygen (1.9.8)
         run: |
           sudo apt-get install clang-9 libclang-9-dev
-          wget https://sourceforge.net/projects/doxygen/files/rel-1.9.8/doxygen-1.9.8.linux.bin.tar.gz
-          tar -xvzf doxygen-1.9.7.linux.bin.tar.gz
+          wget https://sourceforge.net/projects/doxygen/files/rel-1.9.8/doxygen-1.9.8.linux.bin.tar.gz -O doxygen.tar.gz
+          tar -zxvf doxygen.tar.gz -C doxygen --wildcards "*/bin"
+          mv doxygen/*/bin doxygen/
       - name: Extract ref for badges prefix
         if: always()
         shell: bash
@@ -54,7 +55,7 @@ jobs:
       - name: Configure Doc
         run: |
           cd build/Radium-Engine
-          cmake ../../src/Radium-Engine/doc -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=STDOUT -DDOXYGEN_EXECUTABLE=../../doxygen-1.9.8/bin/doxygen
+          cmake ../../src/Radium-Engine/doc -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=STDOUT -DDOXYGEN_EXECUTABLE=../../doxygen/bin/doxygen
       - name: Build Doc
         run: |
           export GITHUB_REF="${{ steps.extract-branch.outputs.branch }}"

--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           mkdir -p src/Radium-Engine
           mkdir -p build/Radium-Engine
+          mkdir doxygen
       - name: Checkout remote head
         uses: actions/checkout@master
         with:
@@ -38,10 +39,9 @@ jobs:
         run: git -C src/Radium-Engine pull origin ${{ github.event.ref }}
       - name: Install packages
         run : |
-          sudo apt-get install graphviz
+          sudo apt-get install graphviz plantuml clang-9 libclang-9-dev
       - name: Fetch recent doxygen (1.9.8)
         run: |
-          sudo apt-get install clang-9 libclang-9-dev
           wget https://sourceforge.net/projects/doxygen/files/rel-1.9.8/doxygen-1.9.8.linux.bin.tar.gz -O doxygen.tar.gz
           tar -zxvf doxygen.tar.gz -C doxygen --wildcards "*/bin"
           mv doxygen/*/bin doxygen/

--- a/.github/workflows/manual-doc-artifact-build.yml
+++ b/.github/workflows/manual-doc-artifact-build.yml
@@ -1,9 +1,12 @@
-name: TEST DOC ARTIFACT
+name: Build doc artifact (trigger manually)
 
 on:
-  pull_request:
-    branches:
-      - release-candidate
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch to build'
+        required: true
+
 jobs:
   deploy-doc:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tmp-check-doc.yml
+++ b/.github/workflows/tmp-check-doc.yml
@@ -1,0 +1,49 @@
+name: TEST DOC ARTIFACT
+
+on:
+  pull_request:
+    branches:
+      - release-candidate
+jobs:
+  deploy-doc:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Prepare directories
+        run: |
+          mkdir -p src/Radium-Engine
+          mkdir -p build/Radium-Engine
+          mkdir doxygen
+      - name: Checkout remote head
+        uses: actions/checkout@master
+        with:
+          path: src/Radium-Engine
+          submodules: recursive
+      - name: Install packages
+        run : |
+          sudo apt-get install graphviz plantuml clang-9 libclang-9-dev
+      - name: Fetch recent doxygen (1.9.8)
+        run: |
+          wget https://sourceforge.net/projects/doxygen/files/rel-1.9.8/doxygen-1.9.8.linux.bin.tar.gz -O doxygen.tar.gz
+          tar -zxvf doxygen.tar.gz -C doxygen --wildcards "*/bin"
+          mv doxygen/*/bin doxygen/
+      - name: Extract ref for badges prefix
+        if: always()
+        shell: bash
+        run: |
+          GITHUB_REF=${{ github.ref }}
+          echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+        id: extract-branch
+      - name: Configure Doc
+        run: |
+          cd build/Radium-Engine
+          cmake ../../src/Radium-Engine/doc -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=STDOUT -DDOXYGEN_EXECUTABLE=../../doxygen/bin/doxygen
+      - name: Build Doc
+        run: |
+          cd build/Radium-Engine
+          cmake --build . --target RadiumDoc
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v3
+        with:
+          name: doc
+          path: build/Radium-Engine/html
+          retention-days: 5


### PR DESCRIPTION
This PR update doxygen version, it also adds a new github action to test doc creation.

It fixes doxygen missing TOC in markdown doc.

This workflow might be run manually on branches and create an artifact with the produced doc.

I'm not sure it will be ok to be run on PR branch, but is should be, and also can be modified when needed with 
```{.yml}
on:
  pull_request:
    branches:
      - release-candidate
```

see https://build5nines.com/configuring-manual-triggers-in-github-actions-with-workflow_dispatch/
https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow