### PR TITLE
1081 remove qt5 support

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -70,7 +70,7 @@ jobs:
           [[ "true" == "${{ inputs.windows }}" && "true" == "${{inputs.linux}}" ]] && echo ','
           [[ "true" == "${{ inputs.linux }}" ]] && echo '{ "name": "Ubuntu gcc", "os": "ubuntu-latest", "cc": "gcc-10", "cxx": "g++-10", "icon": "Linux", "extra-flags": "-DCMAKE_CXX_FLAGS=-Wno-deprecated-declarations -DRADIUM_ENABLE_GL_TESTING=ON" }'
           [[ "true" == "${{ inputs.windows }}" || "true" == "${{inputs.linux}}" ]] && [[ "true" == "${{inputs.macos}}" ]] && echo ','
-          [[ "true" == "${{ inputs.macos }}" ]] && echo '{ "name": "MacOS clang", "os": "macos-latest", "cc": "clang", "cxx": "clang++", "icon": "Apple", "extra-flags": "-DCMAKE_CXX_FLAGS=-Wno-deprecated-declarations" }'
+          [[ "true" == "${{ inputs.macos }}" ]] && echo '{ "name": "MacOS clang", "os": "macos-13", "cc": "clang", "cxx": "clang++", "icon": "Apple", "extra-flags": "-DCMAKE_CXX_FLAGS=-Wno-deprecated-declarations" }'
           echo '],'
           echo '"build-type" : ['
           [[ "true" == "${{ inputs.build-debug }}" ]] && echo '"Debug"'

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -50,14 +50,6 @@ on:
         required: false
         type: string
         default: "false"
-      qt5:
-        required: false
-        type: string
-        default: "true"
-      qt6:
-        required: false
-        type: string
-        default: "true"
 
 env:
   ext-dir: $GITHUB_WORKSPACE/external/install/
@@ -89,11 +81,7 @@ jobs:
           echo '{ "name": "float", "value": "OFF"}'
           [[ "true" == "${{ inputs.use-double }}" ]] && echo ', { "name": "double", "value": "ON" }'
           echo '],'
-          echo '"qtversion" : ['
-          [[ "true" == "${{ inputs.qt5 }}" ]] && echo '{ "name" : "qt5", "value" : "5.15.1"}'
-          [[ "true" == "${{ inputs.qt5 }}" && "true" == "${{ inputs.qt6 }}" ]] && echo ','
-          [[ "true" == "${{ inputs.qt6 }}" ]] && echo '{ "name" : "qt6", "value" : "6.2.0"}'
-          echo '],'
+          echo '"qtversion" : [ { "name" : "qt6", "value" : "6.2.0"}],'
           echo '"coverage" : ['
           [[ "true" == "${{ inputs.coverage }}" ]] && echo '{ "value" : "ON", "extra-flags" : "-DRADIUM_ENABLE_GL_TESTING=ON" }' || echo '{ "value" : "OFF", "extra-flags" : "" }'
           echo "]"

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -29,4 +29,3 @@ jobs:
       macos: "false"
       build-release: "false"
       coverage: "true"
-      qt6: "false"

--- a/.github/workflows/push-master-ci.yml
+++ b/.github/workflows/push-master-ci.yml
@@ -37,7 +37,6 @@ jobs:
       macos: "false"
       build-release: "false"
       coverage: "true"
-      qt6: "false"
   call-notify:
     needs: [increase-version-number]
     uses: ./.github/workflows/notify-radium-releases.yml

--- a/.github/workflows/push-rc-ci.yml
+++ b/.github/workflows/push-rc-ci.yml
@@ -37,4 +37,3 @@ jobs:
       macos: "false"
       build-release: "false"
       coverage: "true"
-      qt6: "false"

--- a/cmake/QtFunctions.cmake
+++ b/cmake/QtFunctions.cmake
@@ -1,14 +1,13 @@
 cmake_minimum_required(VERSION 3.18)
 
-# Find Qt5 or Qt6 packages Parameters: COMPONENTS <component_list>: optional parameter listing the
-# Qt packages (e.g. Core, Widgets REQUIRED: optional parameter propagated to find_package
+# Find Qt6 packages Parameters: COMPONENTS <component_list>: optional parameter listing the Qt
+# packages (e.g. Core, Widgets REQUIRED: optional parameter propagated to find_package
 #
 # Usage: find_qt_package(COMPONENTS Core Widgets OpenGL Xml REQUIRED) which is equivalent to:
-# find_package(Qt6 COMPONENTS Core Widgets OpenGL Xml REQUIRED) if Qt6 is available, or:
-# find_package(Qt5 COMPONENTS Core Widgets OpenGL Xml REQUIRED) otherwise.
+# find_package(Qt6 COMPONENTS Core Widgets OpenGL Xml REQUIRED)
 #
-# Qt5 and Qt6 can be retrieved using versionless targets introduced in Qt5.15:
 # https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html#versionless-targets
+
 macro(find_qt_package)
     set(options REQUIRED)
     set(oneValueArgs "")
@@ -26,16 +25,8 @@ macro(find_qt_package)
         set(QT_SEARCH_MODE QUIET)
     endif()
 
-    if(QT_DEFAULT_MAJOR_VERSION STREQUAL "6")
-        find_package(Qt6 COMPONENTS ${MY_OPTIONS_COMPONENTS} ${QT_SEARCH_MODE})
-    elseif(QT_DEFAULT_MAJOR_VERSION STREQUAL "5")
-        find_package(Qt5 5.15 COMPONENTS ${MY_OPTIONS_COMPONENTS} ${QT_SEARCH_MODE})
-    else() # QT_DEFAULT_MMAJOR_VERSION not set, first search 6, then 5.
-        find_package(Qt6 COMPONENTS ${MY_OPTIONS_COMPONENTS} QUIET)
-        if(NOT Qt6_FOUND)
-            find_package(Qt5 5.15 COMPONENTS ${MY_OPTIONS_COMPONENTS} ${QT_SEARCH_MODE})
-        endif()
-    endif()
+    find_package(Qt6 COMPONENTS ${MY_OPTIONS_COMPONENTS} ${QT_SEARCH_MODE})
+
 endmacro()
 
 # see find_qt_package

--- a/cmake/Windeployqt.cmake
+++ b/cmake/Windeployqt.cmake
@@ -40,9 +40,6 @@ endif()
 function(windeployqt target directory)
 
     set(QT_OPTIONS "")
-    if(Qt5_FOUND)
-        set(QT_OPTIONS ${QT_OPTIONS} --no-angle)
-    endif()
 
     set(QT_BUILD_TYPE_OPTION --release)
     if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/doc/basics/commandline.md
+++ b/doc/basics/commandline.md
@@ -31,15 +31,15 @@ Follow the usual sequence, assuming you have build dependencies as explained [he
 
 ~~~{.bash}
 cmake -S Radium-Engine -B builds/radium-build-r -DCMAKE_BUILD_TYPE=Release -C installs/radium-external-r/radium-options.cmake
-cmake --build builds/radium-build-r --config Release --parallel -DQt5_DIR=path/to/qt5
+cmake --build builds/radium-build-r --config Release --parallel -DQt6_DIR=path/to/qt6
 cmake --install builds/radium-build-r
 ~~~
 
-If Qt is installed system wide (likely on linux), `-DQt5_DIR` is not needed.
+### Qt configuration {#commandline_qt_configuration}
 
-\note Qt6 is also supported. To enable it, replace `-DQt5_DIR=path/to/qt5` by `-DQt6_DIR=path/to/qt6`. To ease maintenance accross Qt versions, you should also configure the path to Qt cmake package using `-DCMAKE_PREFIX_PATH=path/to/qtX` where `X` is the Qt version you want to use.
+If Qt is installed system wide (likely on linux), `-DQt6_DIR` is not needed.
 
-If both Qt5 and Qt6 are installed system wide, Qt6 is the default, `-DQT_DEFAULT_MAJOR_VERSION=5` allow select Qt5. During client application cmake setup `find_package(Radium COMPONENTS ... Gui ...)` will check Qt version consistency.
+To ease maintenance accross Qt versions, you should also configure the path to Qt cmake package using `-DCMAKE_PREFIX_PATH=path/to/qt6`.
 
 \note Running `cmake --install` is recommended as it will copy all the radium related library in the same place,
 generate the cmake packages and bundle applications with their dependencies (on macos and windows).

--- a/doc/basics/details.md
+++ b/doc/basics/details.md
@@ -4,8 +4,8 @@
 # Dependencies management systems
 
 We developed a series of tools to fetch and compile these dependencies easily, except for
-Qt, which needs to be installed and passed to cmake through the variables `CMAKE_PREFIX_PATH` or `Qt5_DIR` `Qt6_DIR`
-(see documentation at <https://doc.qt.io/qt-5.15/cmake-manual.html#getting-started>).
+Qt, which needs to be installed and passed to cmake through the variables `CMAKE_PREFIX_PATH` or `Qt6_DIR`
+(see documentation at <https://doc.qt.io/qt-6.5/cmake-manual.html#getting-started>).
 
 We offer two different systems to handle external dependencies (see details and how-to in the following sections):
 

--- a/doc/basics/troubleshooting.md
+++ b/doc/basics/troubleshooting.md
@@ -1,27 +1,6 @@
 \page basicsTroubleshooting Troubleshooting
 [TOC]
 
-# Qt cmake errors
-
-In case you run into an error like
-
-~~~{.bash}
-By not providing "FindQt5Widgets.cmake" in CMAKE_MODULE_PATH this project
-has asked CMake to find a package configuration file provided by
-"Qt5Widgets", but CMake did not find one.
-~~~
-
-you need to set `CMAKE_PREFIX_PATH`, pointing to the Qt root dir of your commpiler.
-For example on linux with gcc :
-
-~~~{.bash}
-cmake -DCMAKE_PREFIX_PATH=/opt/Qt/5.x/gcc_64
-~~~
-
-On windows, using cmake-gui you can use the "add entry" button, adding `CMAKE_PREFIX_PATH`
-as a string to point to the Qt directory (for example in the default installation :
-`C:/Qt/5.15/msvc2019_64` )
-
 # Crash when starting main application on windows
 
 This is usually caused by missing dlls.

--- a/doc/developer/cmakeutilities.md
+++ b/doc/developer/cmakeutilities.md
@@ -802,15 +802,15 @@ endif()
 
 # component <secondLib>
 if (<secondLib>_FOUND)
-    # manage component dependencies (e.g. <firstLib> must be requested and <secondLib> depends also on Qt5)
+    # manage component dependencies (e.g. <firstLib> must be requested and <secondLib> depends also on Qt)
     if (NOT <firstLib>_FOUND)
         set(<secondLib>_FOUND False)
         set(<packageName>_FOUND False)
         set(<packageName>_NOT_FOUND_MESSAGE "Component <secondLib> requires the component <firstLib>")
         # Note that you can also explicitely configure first lib instead of raising an error
     else()
-        if (NOT Qt5_FOUND)
-            find_dependency(Qt5 COMPONENTS Core Widgets REQUIRED)
+        if (NOT Qt6_FOUND)
+            find_qt_dependency(COMPONENTS Core Widgets REQUIRED)
         endif()
         include("${CMAKE_CURRENT_LIST_DIR}/<secondLib>Targets.cmake" )
     endif()

--- a/doc/developer/plugin.md
+++ b/doc/developer/plugin.md
@@ -32,9 +32,7 @@ Example CMakeLists.txt setup to compile a Radium plugin:
  # Use installed Radium environment
  find_package(Radium REQUIRED Core Engine PluginBase)
 
- # Find and configure Qt environment using versionless targets (Radium requires Qt >= 5.15)
- # https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html
- # find_qt_package is provided by Radium
+# Find and configure Qt environment using find_qt_package is provided by Radium
  find_qt_package(COMPONENTS Core REQUIRED)
  set(Qt_LIBRARIES Qt::Core)
  set(CMAKE_AUTOMOC ON)

--- a/examples/PluginsWithLib/Downstream/README.md
+++ b/examples/PluginsWithLib/Downstream/README.md
@@ -6,7 +6,7 @@ This example illustrates how to use a library shipped from another plugin (shoul
 
 `cmake -DRadium_DIR=/pathToInstalledRadium/lib/cmake/Radium/ -DExampleLibraryUpstream_DIR=/pathToInstalledUpstreamLibrary ..`
 
-If Qt package is not found, add the option `-DQt5_DIR=/pathToInstalledQt5/lib/cmake/Qt5` to the cmake command.
+If Qt6 package is not found, add the option `-DQt6_DIR=/pathToInstalledQt6/lib/cmake/Qt6` to the cmake command.
 
 ## Compile
 

--- a/examples/PluginsWithLib/Upstream/README.md
+++ b/examples/PluginsWithLib/Upstream/README.md
@@ -10,7 +10,7 @@ cd build
 cmake -DRadium_DIR=/pathToInstalledRadium/lib/cmake/Radium/ ..`
 ```
 
-If Qt5 package is not found, add the option `-DQt5_DIR=/pathToInstalledQt5/lib/cmake/Qt5` to the cmake command.
+If Qt6 package is not found, add the option `-DQt6_DIR=/pathToInstalledQt6/lib/cmake/Qt6` to the cmake command.
 
 ## Compile
 

--- a/external/Gui/CMakeLists.txt
+++ b/external/Gui/CMakeLists.txt
@@ -28,20 +28,14 @@ add_custom_target(GuiExternals ALL)
 
 # ------------------------------------------------------------------------------
 
-# propagate the Qt version used to compile externals if none of Qt6_DIR or Qt5_DIR is defined,
-# assume the CMAKE_PREFIX_PATH allow to find the desired Qt package
+# Force the use of Qt6, assume dependencies uses either Qt6_DIR or QT_DEFAULT_MAJOR_VERSION
 set(Qt_CONFIGURATION "")
 if(DEFINED Qt6_DIR)
     set(Qt_CONFIGURATION "-DQt6_DIR=${Qt6_DIR}")
-elseif(DEFINED Qt5_DIR)
-    set(Qt_CONFIGURATION "-DQt5_DIR=${Qt5_DIR}")
 endif()
 
-if(DEFINED QT_DEFAULT_MAJOR_VERSION)
-    set(Qt_CONFIGURATION
-        "${Qt_CONFIGURATION};-DQT_DEFAULT_MAJOR_VERSION=${QT_DEFAULT_MAJOR_VERSION}"
-    )
-endif()
+set(QT_DEFAULT_MAJOUR_VERSION 6)
+set(Qt_CONFIGURATION "${Qt_CONFIGURATION};-DQT_DEFAULT_MAJOR_VERSION=${QT_DEFAULT_MAJOR_VERSION}")
 
 # configure RPATH as expected to be used under Radium
 list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)

--- a/src/Core/Asset/Camera.cpp
+++ b/src/Core/Asset/Camera.cpp
@@ -40,7 +40,7 @@ void Camera::setDirection( const Core::Vector3& direction ) {
 
     // Special case if two directions are exactly opposites we constrain.
     // to rotate around the up vector.
-    if ( c.isApprox( Core::Vector3::Zero() ) && d < 0.0 ) {
+    if ( Math::areApproxEqual( c.squaredNorm(), 0_ra ) && d < 0_ra ) {
         T.rotate( Core::AngleAxis( Core::Math::Pi, getUpVector() ) );
     }
     else { T.rotate( Core::Quaternion::FromTwoVectors( d0, d1 ) ); }

--- a/src/Gui/Timeline/TimelineScrollArea.cpp
+++ b/src/Gui/Timeline/TimelineScrollArea.cpp
@@ -147,11 +147,9 @@ void TimelineScrollArea::wheelEvent( QWheelEvent* event ) {
         }
 
         double hScroll = horizontalScrollBar()->value();
-#if QT_VERSION < QT_VERSION_CHECK( 5, 15, 0 )
-        double x = event->x();
-#else
+
         double x = event->position().x();
-#endif
+
         double time = ( hScroll + x - double( m_zero ) ) / double( m_pixPerSec );
 
         onDrawRuler( newRulerWidth );

--- a/src/Gui/Utils/KeyMappingManager.cpp
+++ b/src/Gui/Utils/KeyMappingManager.cpp
@@ -4,7 +4,6 @@
 #include <Core/Utils/Log.hpp>
 
 #include <QMessageBox>
-#include <QtGlobal> //QT_VERSION, QT_VERSION_CHECK
 
 namespace Ra::Gui {
 

--- a/src/Gui/Viewer/WindowQt.cpp
+++ b/src/Gui/Viewer/WindowQt.cpp
@@ -182,11 +182,8 @@ glbinding::ProcAddress WindowQt::getProcAddress( const char* name ) {
 
     const auto symbol = std::string( name );
 
-#if ( QT_VERSION >= QT_VERSION_CHECK( 5, 4, 0 ) )
     const auto qtSymbol = QByteArray::fromStdString( symbol );
-#else
-    const auto qtSymbol = QByteArray::fromRawData( symbol.c_str(), symbol.size() );
-#endif
+
     return s_getProcAddressHelper->m_context->getProcAddress( qtSymbol );
 }
 

--- a/src/Gui/Widgets/ControlPanel.cpp
+++ b/src/Gui/Widgets/ControlPanel.cpp
@@ -98,9 +98,7 @@ void ControlPanel::addSliderInput( const std::string& name,
     spinbox->setRange( min, max );
     spinbox->setValue( initial );
     connect( inputField, &QSlider::valueChanged, spinbox, &QSpinBox::setValue );
-    // Qt6 do not need QOverload<int> but Qt5 do. Keep Qt5 syntax
-    connect(
-        spinbox, QOverload<int>::of( &QSpinBox::valueChanged ), inputField, &QSlider::setValue );
+    connect( spinbox, &QSpinBox::valueChanged, inputField, &QSlider::setValue );
     connect( inputField, &QSlider::valueChanged, std::move( callback ) );
     sliderLayout->addWidget( inputField );
     sliderLayout->addWidget( spinbox );


### PR DESCRIPTION
# Pull Request Description

## Check if you branch history is PR compatible


- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Be aware that the PR request cannot be accepted if it doesn't pass the Continuous Integration tests.

- **What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] other: drop support of QT5, closes #1081 

- **What is the current behavior?** (You can also link to an open issue here)

Both qt5 and qt6 are supported, but the CI lacks support of qt5 (see #1081)

- **What is the new behavior (if this is a feature change)?**

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

If there is Qt5 specific configuration (in cmake) or code (in c++), user codes have to be updated.


