### PR TITLE
[ci] Manual doc build uses deploy-doc, remove doc build from pr ci.

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -73,8 +73,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: doc
-          path: |
-            build/Radium-Engine/html/
+          path: build/Radium-Engine/html/
+          retention-days: 5
       - name: Fix badges github ref
         if: ${{ inputs.deploy-on-gh-pages == 'true' }}
         run: |

--- a/.github/workflows/manual-doc-artifact-build.yml
+++ b/.github/workflows/manual-doc-artifact-build.yml
@@ -8,45 +8,7 @@ on:
         required: true
 
 jobs:
-  deploy-doc:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Prepare directories
-        run: |
-          mkdir -p src/Radium-Engine
-          mkdir -p build/Radium-Engine
-          mkdir doxygen
-      - name: Checkout remote head
-        uses: actions/checkout@master
-        with:
-          path: src/Radium-Engine
-          submodules: recursive
-      - name: Install packages
-        run : |
-          sudo apt-get install graphviz plantuml clang-9 libclang-9-dev
-      - name: Fetch recent doxygen (1.9.8)
-        run: |
-          wget https://sourceforge.net/projects/doxygen/files/rel-1.9.8/doxygen-1.9.8.linux.bin.tar.gz -O doxygen.tar.gz
-          tar -zxvf doxygen.tar.gz -C doxygen --wildcards "*/bin"
-          mv doxygen/*/bin doxygen/
-      - name: Extract ref for badges prefix
-        if: always()
-        shell: bash
-        run: |
-          GITHUB_REF=${{ github.ref }}
-          echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
-        id: extract-branch
-      - name: Configure Doc
-        run: |
-          cd build/Radium-Engine
-          cmake ../../src/Radium-Engine/doc -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=STDOUT -DDOXYGEN_EXECUTABLE=../../doxygen/bin/doxygen
-      - name: Build Doc
-        run: |
-          cd build/Radium-Engine
-          cmake --build . --target RadiumDoc
-      - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v3
-        with:
-          name: doc
-          path: build/Radium-Engine/html
-          retention-days: 5
+  call-build-doc:
+    uses: ./.github/workflows/deploy-doc.yml
+    with:
+      deploy-on-gh-pages: "false"

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -29,7 +29,3 @@ jobs:
       macos: "false"
       build-release: "false"
       coverage: "true"
-  call-deploy-doc:
-    uses: ./.github/workflows/deploy-doc.yml
-    with:
-      deploy-on-gh-pages: "false"


### PR DESCRIPTION
Remove duplicated code in CI (I had forgotten we have a manual doc build action).
