### PR TITLE
Build script

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -161,27 +161,28 @@ jobs:
       - name: Build windows dep, config path
         if: runner.os == 'Windows'
         run: |
-          mkdir -p ${{ github.workspace }}/glfw_install/
-          cmake -S glfw -B glfw/build-shared -G "Visual Studio 17 2022" -DBUILD_SHARED_LIBS=OFF -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_TESTS=OFF -DGLFW_BUILD_DOCS=OFF -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/glfw_install/
+          posix_path=$(cygpath -u "${{ github.workspace }}")
+          mkdir -p "$posix_path/glfw_install/"
+          cmake -S glfw -B glfw/build-shared -G "Visual Studio 17 2022" -DBUILD_SHARED_LIBS=OFF \
+          -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_TESTS=OFF -DGLFW_BUILD_DOCS=OFF \
+          -DCMAKE_INSTALL_PREFIX="$posix_path/glfw_install/"
           cmake --build glfw/build-shared --parallel --config Release
           cmake --build glfw/build-shared --target install --config Release
-          posix_path=$(cygpath -u "${{ github.workspace }}")
           echo "glfw_path=-Dglfw3_DIR=$posix_path/glfw_install/lib/cmake/glfw3/" >> $GITHUB_ENV
-
           # Setting paths to dll needed by catch2 and run in build dir
-          echo "${{ github.workspace }}/glfw_install/lib/" >> $GITHUB_PATH
-          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Core" >> $GITHUB_PATH
-          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Engine" >> $GITHUB_PATH
-          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/Core" >> $GITHUB_PATH
-          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/QtGui" >> $GITHUB_PATH
-          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Gui" >> $GITHUB_PATH
-          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Headless" >> $GITHUB_PATH
-          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/IO" >> $GITHUB_PATH
-          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/PluginBase" >> $GITHUB_PATH
-          echo "${{ github.workspace }}/${{ steps.paths.outputs.external_install_dir }}/bin" >> $GITHUB_PATH
-          echo "${{ github.workspace }}/${{ steps.paths.outputs.external_install_dir }}/glbinding" >> $GITHUB_PATH
-          echo "${{ github.workspace }}/${{ steps.paths.outputs.external_install_dir }}/install_prefix/globjects" >> $GITHUB_PATH
-          echo "${{ github.workspace }}/${{ steps.paths.outputs.external_install_dir }}/install_prefix/cpplocate" >> $GITHUB_PATH
+          echo "$posix_path/glfw_install/lib" >> $GITHUB_PATH
+          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/Core" >> $GITHUB_PATH
+          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/Engine" >> $GITHUB_PATH
+          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/Core" >> $GITHUB_PATH
+          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/QtGui" >> $GITHUB_PATH
+          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/Gui" >> $GITHUB_PATH
+          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/Headless" >> $GITHUB_PATH
+          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/IO" >> $GITHUB_PATH
+          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/PluginBase" >> $GITHUB_PATH
+          echo "$posix_path/${{ steps.paths.outputs.external_install_dir }}/bin" >> $GITHUB_PATH
+          echo "$posix_path/${{ steps.paths.outputs.external_install_dir }}/glbinding" >> $GITHUB_PATH
+          echo "$posix_path/${{ steps.paths.outputs.external_install_dir }}/globjects" >> $GITHUB_PATH
+          echo "$posix_path/${{ steps.paths.outputs.external_install_dir }}/cpplocate" >> $GITHUB_PATH
 
       - name: Prepare directories
         run: |

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -171,7 +171,7 @@ jobs:
           echo "glfw_path=-Dglfw3_DIR=$posix_path/glfw_install/lib/cmake/glfw3/" >> $GITHUB_ENV
 
           # Setting paths to dll needed by catch2 and run in build dir
-          echo "${{ github.workspace }}/glfw_install/lib/cmake/glfw3/" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/glfw_install/lib/" >> $GITHUB_PATH
           echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Core" >> $GITHUB_PATH
           echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Engine" >> $GITHUB_PATH
           echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/Core" >> $GITHUB_PATH

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -128,8 +128,6 @@ jobs:
           echo "external_build_dir=$external_build_dir" >> $GITHUB_OUTPUT
           echo "external_install_dir=$external_install_dir" >> $GITHUB_OUTPUT
 
-      - name: Install Ninja
-        run: ${{ runner.os == 'macOS' && 'brew install ninja' || runner.os == 'Windows' && 'choco install ninja' || 'sudo apt-get install ninja-build' }}
       - name: Add msbuild to PATH
         uses: seanmiddleditch/gha-setup-vsdevenv@master
         if: runner.os == 'Windows'

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -173,19 +173,19 @@ jobs:
           # save cmake glfw opt
           echo "glfw_path=-Dglfw3_DIR=$posix_path/glfw_install/lib/cmake/glfw3/" >> $GITHUB_ENV
           # Setting paths to dll needed by catch2 and run in build dir
-          echo "$posix_path/glfw_install/lib" >> $GITHUB_PATH
-          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/Core" >> $GITHUB_PATH
-          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/Engine" >> $GITHUB_PATH
-          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/Core" >> $GITHUB_PATH
-          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/QtGui" >> $GITHUB_PATH
-          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/Gui" >> $GITHUB_PATH
-          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/Headless" >> $GITHUB_PATH
-          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/IO" >> $GITHUB_PATH
-          echo "$posix_path/${{ steps.paths.outputs.radium_build_dir }}/src/PluginBase" >> $GITHUB_PATH
-          echo "$posix_path/${{ steps.paths.outputs.external_install_dir }}/bin" >> $GITHUB_PATH
-          echo "$posix_path/${{ steps.paths.outputs.external_install_dir }}/glbinding" >> $GITHUB_PATH
-          echo "$posix_path/${{ steps.paths.outputs.external_install_dir }}/globjects" >> $GITHUB_PATH
-          echo "$posix_path/${{ steps.paths.outputs.external_install_dir }}/cpplocate" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/glfw_install/lib/" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Core" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Engine" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/Core" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/QtGui" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Gui" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Headless" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/IO" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/PluginBase" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.external_install_dir }}/bin" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.external_install_dir }}/glbinding" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.external_install_dir }}/globjects" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.external_install_dir }}/cpplocate" >> $GITHUB_PATH
 
       - name: Prepare directories
         run: |

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -213,12 +213,18 @@ jobs:
       - name: Configure and build external
         if: steps.cache-external.outputs.cache-hit != 'true'
         run: |
-          "${{ env.src_prefix }}/Radium-Engine/scripts/build.sh" -B "${{ env.build_prefix }}" -e true -r false -G Ninja --cc ${{ matrix.config.cc }} --cxx ${{ matrix.config.cxx }} -c ${{ matrix.build-type }} --install-external "${{ steps.paths.outputs.external_install_dir }}"
+          "${{ env.src_prefix }}/Radium-Engine/scripts/build.sh" -e true -r false \
+          -B "${{ env.build_prefix }}" -c ${{ matrix.build-type }} \
+          -G Ninja --cc ${{ matrix.config.cc }} --cxx ${{ matrix.config.cxx }} \
+          --install-external "${{ steps.paths.outputs.external_install_dir }}"
 
       - name: Configure and build Radium
         run: |
-          "${{ env.src_prefix }}/Radium-Engine/scripts/build.sh" -B "${{ env.build_prefix }}" -e false -r true -G Ninja --cc ${{ matrix.config.cc }} --cxx ${{ matrix.config.cxx }} \
-          -c ${{ matrix.build-type }} --install-external ${{ steps.paths.outputs.external_install_dir }} --install-radium  "${{ steps.paths.outputs.radium_install_dir }}" \
+          "${{ env.src_prefix }}/Radium-Engine/scripts/build.sh" -e false -r true \
+          -B "${{ env.build_prefix }}" -c ${{ matrix.build-type }} \
+          -G Ninja --cc ${{ matrix.config.cc }} --cxx ${{ matrix.config.cxx }} \
+          --install-external ${{ steps.paths.outputs.external_install_dir }} \
+          --install-radium  "${{ steps.paths.outputs.radium_install_dir }}" \
           -o "${{ env.glfw_path }} ${{ matrix.config.extra-flags }} ${{ matrix.coverage.extra-flags }}" \
           --use-double ${{ matrix.precision.value }} --enable-coverage ${{ matrix.coverage.value }}
 

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -203,7 +203,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.external_install_dir }}
-          key: ${{ matrix.config.name }}-${{ matrix.build-type }}-${{ matrix.qtversion.name }}-external-v1-${{ hashFiles( 'src/Radium-Engine/external/**/CMakeLists.txt') }} # no env in hashFiles
+          key: ${{ matrix.config.name }}-${{ matrix.build-type }}-${{ matrix.qtversion.name }}-external-v1-${{ hashFiles('src/Radium-Engine/external/**/CMakeLists.txt') }} # no env in hashFiles
       - name: Configure and build external
         if: steps.cache-external.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -54,7 +54,9 @@ on:
         default: "false"
 
 env:
-  ext-dir: $GITHUB_WORKSPACE/external/install/
+  install_prefix: install
+  build_prefix: build
+  src_prefix:  src
 
 jobs:
   # inpiration from https://www.cynkra.com/blog/2020-12-23-dynamic-gha/
@@ -113,9 +115,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.create-matrix.outputs.matrix) }}
+    env:
+      radium_build_dir: $build_prefix/${{ matrix.build-type }}/Radium-Engine
+      radium_install_dir: $install_prefix/${{ matrix.build-type }}/Radium-Engine
+      external_build_dir: $build_prefix/${{ matrix.build-type }}/external
+      external_install_dir: $install_prefix/${{ matrix.build-type }}/external
     steps:
+      - name: echo
+        run: |
+          echo ${{ github.workspace }}
+          echo ${{ env.radium_build_dir }}
+          echo ${{ env.radium_install_dir }}
+          echo ${{ env.external_build_dir }}
+          echo ${{ env.external_install_dir }}
+          echo ${{ env.install_prefix }}
+          echo ${{ env.build_prefix }}
+          echo ${{ env.src_prefix }}
       - name: Install Ninja
-        shell: bash
         run: ${{ runner.os == 'macOS' && 'brew install ninja' || runner.os == 'Windows' && 'choco install ninja' || 'sudo apt-get install ninja-build' }}
       - name: Add msbuild to PATH
         uses: seanmiddleditch/gha-setup-vsdevenv@master
@@ -145,83 +161,67 @@ jobs:
       - name: Build windows dep, config path
         if: runner.os == 'Windows'
         run: |
-          mkdir $GITHUB_WORKSPACE/glfw_install/
-          cmake -S glfw -B glfw/build-shared -G "Visual Studio 17 2022" -DBUILD_SHARED_LIBS=OFF -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_TESTS=OFF -DGLFW_BUILD_DOCS=OFF -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/glfw_install/
+          mkdir -p ${{ github.workspace }}/glfw_install/
+          cmake -S glfw -B glfw/build-shared -G "Visual Studio 17 2022" -DBUILD_SHARED_LIBS=OFF -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_TESTS=OFF -DGLFW_BUILD_DOCS=OFF -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/glfw_install/
           cmake --build glfw/build-shared --parallel --config Release
           cmake --build glfw/build-shared --target install --config Release
-          echo "glfw-path=-Dglfw3_DIR=\$GITHUB_WORKSPACE/glfw_install/lib/cmake/glfw3/" >> $GITHUB_ENV
+          echo "glfw-path=-Dglfw3_DIR=${{ github.workspace }}/glfw_install/lib/cmake/glfw3/" >> $GITHUB_ENV
           # Setting paths to dll needed by catch2 and run in build dir
-          echo "$GITHUB_WORKSPACE/build/Radium-Engine/src/Core" >> $GITHUB_PATH
-          echo "$GITHUB_WORKSPACE/build/Radium-Engine/src/Engine" >> $GITHUB_PATH
-          echo "$GITHUB_WORKSPACE/build/Radium-Engine/src/Dataflow/Core" >> $GITHUB_PATH
-          echo "$GITHUB_WORKSPACE/build/Radium-Engine/src/Dataflow/QtGui" >> $GITHUB_PATH
-          echo "$GITHUB_WORKSPACE/build/Radium-Engine/src/Gui" >> $GITHUB_PATH
-          echo "$GITHUB_WORKSPACE/build/Radium-Engine/src/Headless" >> $GITHUB_PATH
-          echo "$GITHUB_WORKSPACE/build/Radium-Engine/src/IO" >> $GITHUB_PATH
-          echo "$GITHUB_WORKSPACE/build/Radium-Engine/src/PluginBase" >> $GITHUB_PATH
-          echo "$GITHUB_WORKSPACE/glfw_install/lib/cmake/glfw3/" >> $GITHUB_PATH
-          echo "${{ env.ext-dir }}/bin" >> $GITHUB_PATH
-          echo "${{ env.ext-dir }}/glbinding" >> $GITHUB_PATH
-          echo "${{ env.ext-dir }}/globjects" >> $GITHUB_PATH
-          echo "${{ env.ext-dir }}/cpplocate" >> $GITHUB_PATH
+          echo " ${{ github.workspace }}/glfw_install/lib/cmake/glfw3/" >> $GITHUB_PATH
+          echo "${{ env.radium_build_dir }}/src/Core" >> $GITHUB_PATH
+          echo "${{ env.radium_build_dir }}/src/Engine" >> $GITHUB_PATH
+          echo "${{ env.radium_build_dir }}/src/Dataflow/Core" >> $GITHUB_PATH
+          echo "${{ env.radium_build_dir }}/src/Dataflow/QtGui" >> $GITHUB_PATH
+          echo "${{ env.radium_build_dir }}/src/Gui" >> $GITHUB_PATH
+          echo "${{ env.radium_build_dir }}/src/Headless" >> $GITHUB_PATH
+          echo "${{ env.radium_build_dir }}/src/IO" >> $GITHUB_PATH
+          echo "${{ env.radium_build_dir }}/src/PluginBase" >> $GITHUB_PATH
+          echo "${{ env.external_install_dir }}/bin" >> $GITHUB_PATH
+          echo "${{ env.external_install_dir }}/glbinding" >> $GITHUB_PATH
+          echo "${{ env.external_install_dir }}/install_prefix/globjects" >> $GITHUB_PATH
+          echo "${{ env.external_install_dir }}/install_prefix/cpplocate" >> $GITHUB_PATH
       - name: Prepare directories
         run: |
-          mkdir -p install/
-          mkdir -p src/Radium-Engine
-          mkdir -p build/Radium-Engine
-          mkdir -p external/install/
-          mkdir -p external/build/
+          mkdir -p "${{ env.src_prefix }}"
+          mkdir -p "${{ env.radium_build_dir }}"
+          mkdir -p "${{ env.external_build_dir }}"
+          mkdir -p "${{ env.radium_install_dir }}"
+          mkdir -p "${{ env.external_install_dir }}"
+
       - name: Checkout remote head
         uses: actions/checkout@master
         with:
-          path: src/Radium-Engine
+          path: ${{ env.src_prefix }}/Radium-Engine
           submodules: 'recursive'
       - name: pull updated repo (e.g. with new VERSION)
         if: ${{ github.event_name == 'push' }}
         run: |
-          git -C src/Radium-Engine pull origin ${{ github.event.ref }}
-          git -C src/Radium-Engine submodule update --init --recursive
+          git -C "${{ env.src_prefix }}/Radium-Engine" pull origin ${{ github.event.ref }}
+          git -C "${{ env.src_prefix }}/Radium-Engine" submodule update --init --recursive
       - name: Cache externals
         id: cache-external
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
-          path: external
-          key: ${{ matrix.config.name }}-${{ matrix.build-type }}-${{ matrix.qtversion.name }}-external-v1-${{ hashFiles('src/Radium-Engine/external/**/CMakeLists.txt') }}
+          path: ${{ env.external_install_dir }}
+          key: ${{ matrix.config.name }}-${{ matrix.build-type }}-${{ matrix.qtversion.name }}-external-v1-${{ hashFiles('$src_prefix/Radium-Engine/external/**/CMakeLists.txt') }}
       - name: Configure and build external
         if: steps.cache-external.outputs.cache-hit != 'true'
         run: |
-          cd external/build/
-          cmake ../../src/Radium-Engine/external  -GNinja -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} \
-          -DCMAKE_C_COMPILER=${{ matrix.config.cc }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
-          -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=STDOUT -DCMAKE_INSTALL_MESSAGE=LAZY \
-          -DRADIUM_UPDATE_VERSION=OFF \
-          -DCMAKE_INSTALL_PREFIX=../install/
-          cmake --build . --parallel --config ${{ matrix.build-type }}
-      - name: Configure Radium
+          "${{ env.src_prefix }}/Radium-Engine/scripts/build.sh" -B "${{ env.build_prefix }}" -e true -r false -G Ninja --cc ${{ matrix.config.cc }} --cxx ${{ matrix.config.cxx }} -c ${{ matrix.build-type }} --install-external "${{ env.external_install_dir }}"
+      - name: Configure and build Radium
         run: |
-          cd build/Radium-Engine
-          cmake ../../src/Radium-Engine -GNinja -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} \
-          -DCMAKE_C_COMPILER=${{ matrix.config.cc }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
-          ${{ matrix.config.extra-flags }} \
-          ${{ matrix.coverage.extra-flags }} \
-          -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=STDOUT \
-          -DRADIUM_USE_DOUBLE=${{ matrix.precision.value }} -DRADIUM_UPDATE_VERSION=OFF -DRADIUM_ENABLE_PCH=ON \
-          -DRADIUM_INSTALL_DOC=OFF -DRADIUM_ENABLE_TESTING=ON -DRADIUM_ENABLE_EXAMPLES=ON -DRADIUM_ENABLE_COVERAGE=${{ matrix.coverage.value }} \
-          -C ${{ env.ext-dir }}/radium-options.cmake \
-          -DCMAKE_INSTALL_PREFIX=../../install/ \
-          ${{ env.glfw-path }}
-      - name: Build Radium
-        run: |
-          cmake --build build/Radium-Engine --parallel --config ${{ matrix.build-type }} --target install
+          "${{ env.src_prefix }}/Radium-Engine/scripts/build.sh" -B "${{ env.build_prefix }}" -e false -r true -G Ninja --cc ${{ matrix.config.cc }} --cxx ${{ matrix.config.cxx }} \
+          -c ${{ matrix.build-type }} --install-external ${{ env.external_install_dir }} --install-radium  "${{ env.radium_install_dir }}" \
+          -o "${{ env.glfw-path }} ${{ matrix.config.extra-flags }} ${{ matrix.coverage.extra-flags }}" \
+          --use-double ${{ matrix.precision.value }} --enable-coverage ${{ matrix.coverage.value }}
       - name: Run unit tests
         if: ${{ inputs.coverage == 'false' }}
         run: |
-          cmake --build build/Radium-Engine --parallel --config ${{ matrix.build-type }} --target check
-          cmake --build build/Radium-Engine --parallel --config ${{ matrix.build-type }} --target Install_CoreExample
-          ./install/bin/CoreExample
+          cmake --build "${{ env.radium_build_dir }}" --parallel --config ${{ matrix.build-type }} --target check
+          cmake --build "${{ env.radium_build_dir }}" --parallel --config ${{ matrix.build-type }} --target Install_CoreExample
+          "${{ env.radium_install_dir }}/bin/CoreExample"
       - name: Extract ref for badges prefix
         if: always()
-        shell: bash
         run: |
           GITHUB_REF=${{ github.ref }}
           echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
@@ -253,15 +253,14 @@ jobs:
       - name: Create coverage report
         if: ${{ inputs.coverage == 'true' }}
         run: |
-          cd build/Radium-Engine
-          cmake --build . --config Debug --target fastcov_integration
-          cmake --build . --config Debug --target fastcov_unittests
+          cmake --build "${{ env.radium_build_dir }}" --config Debug --target fastcov_integration
+          cmake --build "${{ env.radium_build_dir }}" --config Debug --target fastcov_unittests
       - name: Upload unittests coverage report
         if: ${{ inputs.coverage == 'true' }}
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true # optional (default = false)
-          files: ./build/Radium-Engine/fastcov_unittests.info
+          files: ${{ env.radium_build_dir }}/fastcov_unittests.info
           flags: unittests
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true # optional (default = false)
@@ -271,7 +270,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true # optional (default = false)
-          files: ./build/Radium-Engine/fastcov_integration.info
+          files: ${{ env.radium_build_dir }}/Radium-Engine/fastcov_integration.info
           flags: integration
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true # optional (default = false)

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -163,11 +163,14 @@ jobs:
         run: |
           posix_path=$(cygpath -u "${{ github.workspace }}")
           mkdir -p "$posix_path/glfw_install/"
+          # configure glfw
           cmake -S glfw -B glfw/build-shared -G "Visual Studio 17 2022" -DBUILD_SHARED_LIBS=OFF \
           -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_TESTS=OFF -DGLFW_BUILD_DOCS=OFF \
           -DCMAKE_INSTALL_PREFIX="$posix_path/glfw_install/"
+          # build glfw
           cmake --build glfw/build-shared --parallel --config Release
           cmake --build glfw/build-shared --target install --config Release
+          # save cmake glfw opt
           echo "glfw_path=-Dglfw3_DIR=$posix_path/glfw_install/lib/cmake/glfw3/" >> $GITHUB_ENV
           # Setting paths to dll needed by catch2 and run in build dir
           echo "$posix_path/glfw_install/lib" >> $GITHUB_PATH

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -127,36 +127,31 @@ jobs:
           echo "radium_install_dir=$radium_install_dir" >> $GITHUB_OUTPUT
           echo "external_build_dir=$external_build_dir" >> $GITHUB_OUTPUT
           echo "external_install_dir=$external_install_dir" >> $GITHUB_OUTPUT
-      - name: echo
-        run: |
-          echo ${{ github.workspace }}
-          echo ${{ steps.paths.outputs.radium_build_dir }}
-          echo ${{ steps.paths.outputs.radium_install_dir }}
-          echo ${{ steps.paths.outputs.external_build_dir }}
-          echo ${{ steps.paths.outputs.external_install_dir }}
-          echo ${{ env.install_prefix }}
-          echo ${{ env.build_prefix }}
-          echo ${{ env.src_prefix }}
+
       - name: Install Ninja
         run: ${{ runner.os == 'macOS' && 'brew install ninja' || runner.os == 'Windows' && 'choco install ninja' || 'sudo apt-get install ninja-build' }}
       - name: Add msbuild to PATH
         uses: seanmiddleditch/gha-setup-vsdevenv@master
         if: runner.os == 'Windows'
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
           cache: true
           cache-key-prefix: install-qt-action-${{ matrix.config.name }}-${{ matrix.qtversion.value }}
           version: ${{ matrix.qtversion.value }}
+
       - name: Install dep Linux (normal, test, coverage)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libglfw3-dev libxml2-utils lcov
           pip3 install fastcov
+
       - name: Install dep MacOS
         if: runner.os == 'macOS'
         run: brew install glfw
+
       - name: Install dep windows checkout
         if: runner.os == 'Windows'
         uses: actions/checkout@v2
@@ -164,6 +159,7 @@ jobs:
           repository: glfw/glfw
           ref: 3.4
           path: glfw
+
       - name: Build windows dep, config path
         if: runner.os == 'Windows'
         run: |
@@ -171,9 +167,11 @@ jobs:
           cmake -S glfw -B glfw/build-shared -G "Visual Studio 17 2022" -DBUILD_SHARED_LIBS=OFF -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_TESTS=OFF -DGLFW_BUILD_DOCS=OFF -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/glfw_install/
           cmake --build glfw/build-shared --parallel --config Release
           cmake --build glfw/build-shared --target install --config Release
-          echo "glfw-path=-Dglfw3_DIR=${{ github.workspace }}/glfw_install/lib/cmake/glfw3/" >> $GITHUB_ENV
+          posix_path=$(cygpath -u "${{ github.workspace }}")
+          echo "glfw_path=-Dglfw3_DIR=$posix_path/glfw_install/lib/cmake/glfw3/" >> $GITHUB_ENV
+
           # Setting paths to dll needed by catch2 and run in build dir
-          echo " ${{ github.workspace }}/glfw_install/lib/cmake/glfw3/" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/glfw_install/lib/cmake/glfw3/" >> $GITHUB_PATH
           echo "${{ steps.paths.outputs.radium_build_dir }}/src/Core" >> $GITHUB_PATH
           echo "${{ steps.paths.outputs.radium_build_dir }}/src/Engine" >> $GITHUB_PATH
           echo "${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/Core" >> $GITHUB_PATH
@@ -186,6 +184,7 @@ jobs:
           echo "${{ steps.paths.outputs.external_install_dir }}/glbinding" >> $GITHUB_PATH
           echo "${{ steps.paths.outputs.external_install_dir }}/install_prefix/globjects" >> $GITHUB_PATH
           echo "${{ steps.paths.outputs.external_install_dir }}/install_prefix/cpplocate" >> $GITHUB_PATH
+
       - name: Prepare directories
         run: |
           mkdir -p "${{ env.src_prefix }}"
@@ -199,39 +198,46 @@ jobs:
         with:
           path: ${{ env.src_prefix }}/Radium-Engine
           submodules: 'recursive'
+
       - name: pull updated repo (e.g. with new VERSION)
         if: ${{ github.event_name == 'push' }}
         run: |
           git -C "${{ env.src_prefix }}/Radium-Engine" pull origin ${{ github.event.ref }}
           git -C "${{ env.src_prefix }}/Radium-Engine" submodule update --init --recursive
+
       - name: Cache externals
         id: cache-external
         uses: actions/cache@v4
         with:
           path: ${{ steps.paths.outputs.external_install_dir }}
           key: ${{ matrix.config.name }}-${{ matrix.build-type }}-${{ matrix.qtversion.name }}-external-v1-${{ hashFiles('src/Radium-Engine/external/**/CMakeLists.txt') }} # no env in hashFiles
+
       - name: Configure and build external
         if: steps.cache-external.outputs.cache-hit != 'true'
         run: |
           "${{ env.src_prefix }}/Radium-Engine/scripts/build.sh" -B "${{ env.build_prefix }}" -e true -r false -G Ninja --cc ${{ matrix.config.cc }} --cxx ${{ matrix.config.cxx }} -c ${{ matrix.build-type }} --install-external "${{ steps.paths.outputs.external_install_dir }}"
+
       - name: Configure and build Radium
         run: |
           "${{ env.src_prefix }}/Radium-Engine/scripts/build.sh" -B "${{ env.build_prefix }}" -e false -r true -G Ninja --cc ${{ matrix.config.cc }} --cxx ${{ matrix.config.cxx }} \
           -c ${{ matrix.build-type }} --install-external ${{ steps.paths.outputs.external_install_dir }} --install-radium  "${{ steps.paths.outputs.radium_install_dir }}" \
-          -o "${{ env.glfw-path }} ${{ matrix.config.extra-flags }} ${{ matrix.coverage.extra-flags }}" \
+          -o "${{ env.glfw_path }} ${{ matrix.config.extra-flags }} ${{ matrix.coverage.extra-flags }}" \
           --use-double ${{ matrix.precision.value }} --enable-coverage ${{ matrix.coverage.value }}
+
       - name: Run unit tests
         if: ${{ inputs.coverage == 'false' }}
         run: |
           cmake --build "${{ steps.paths.outputs.radium_build_dir }}" --parallel --config ${{ matrix.build-type }} --target check
           cmake --build "${{ steps.paths.outputs.radium_build_dir }}" --parallel --config ${{ matrix.build-type }} --target Install_CoreExample
           "${{ steps.paths.outputs.radium_install_dir }}/bin/CoreExample"
+
       - name: Extract ref for badges prefix
         if: always()
         run: |
           GITHUB_REF=${{ github.ref }}
           echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: extract-branch
+
       - name: Update badge on merge (failure)
         if: ${{ failure() && inputs.generate-badges == 'true' }}
         uses: schneegans/dynamic-badges-action@v1.0.0
@@ -244,6 +250,7 @@ jobs:
           namedLogo: ${{ matrix.config.icon }}
           logoColor: white
           color: CC1B1B
+
       - name: Update badge on merge (success)
         if: ${{ success() && inputs.generate-badges == 'true' }}
         uses: schneegans/dynamic-badges-action@v1.0.0
@@ -256,11 +263,13 @@ jobs:
           namedLogo: ${{ matrix.config.icon }}
           logoColor: white
           color: 1BCC1B
+
       - name: Create coverage report
         if: ${{ inputs.coverage == 'true' }}
         run: |
           cmake --build "${{ steps.paths.outputs.radium_build_dir }}" --config Debug --target fastcov_integration
           cmake --build "${{ steps.paths.outputs.radium_build_dir }}" --config Debug --target fastcov_unittests
+
       - name: Upload unittests coverage report
         if: ${{ inputs.coverage == 'true' }}
         uses: codecov/codecov-action@v5
@@ -271,12 +280,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true # optional (default = false)
           disable_search: true
+
       - name: Upload integration coverage report
         if: ${{ inputs.coverage == 'true' }}
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true # optional (default = false)
-          files: ${{ steps.paths.outputs.radium_build_dir }}/Radium-Engine/fastcov_integration.info
+          files: ${{ steps.paths.outputs.radium_build_dir }}/fastcov_integration.info
           flags: integration
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true # optional (default = false)

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -115,19 +115,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.create-matrix.outputs.matrix) }}
-    env:
-      radium_build_dir: $build_prefix/${{ matrix.build-type }}/Radium-Engine
-      radium_install_dir: $install_prefix/${{ matrix.build-type }}/Radium-Engine
-      external_build_dir: $build_prefix/${{ matrix.build-type }}/external
-      external_install_dir: $install_prefix/${{ matrix.build-type }}/external
     steps:
+      - name: Compute paths
+        id: paths
+        run: |
+          radium_build_dir="${{ env.build_prefix }}/${{ matrix.build-type }}/Radium-Engine"
+          radium_install_dir="${{ env.install_prefix }}/${{ matrix.build-type }}/Radium-Engine"
+          external_build_dir="${{ env.build_prefix }}/${{ matrix.build-type }}/external"
+          external_install_dir="${{ env.install_prefix }}/${{ matrix.build-type }}/external"
+          echo "radium_build_dir=$radium_build_dir" >> $GITHUB_OUTPUT
+          echo "radium_install_dir=$radium_install_dir" >> $GITHUB_OUTPUT
+          echo "external_build_dir=$external_build_dir" >> $GITHUB_OUTPUT
+          echo "external_install_dir=$external_install_dir" >> $GITHUB_OUTPUT
       - name: echo
         run: |
           echo ${{ github.workspace }}
-          echo ${{ env.radium_build_dir }}
-          echo ${{ env.radium_install_dir }}
-          echo ${{ env.external_build_dir }}
-          echo ${{ env.external_install_dir }}
+          echo ${{ steps.paths.outputs.radium_build_dir }}
+          echo ${{ steps.paths.outputs.radium_install_dir }}
+          echo ${{ steps.paths.outputs.external_build_dir }}
+          echo ${{ steps.paths.outputs.external_install_dir }}
           echo ${{ env.install_prefix }}
           echo ${{ env.build_prefix }}
           echo ${{ env.src_prefix }}
@@ -168,25 +174,25 @@ jobs:
           echo "glfw-path=-Dglfw3_DIR=${{ github.workspace }}/glfw_install/lib/cmake/glfw3/" >> $GITHUB_ENV
           # Setting paths to dll needed by catch2 and run in build dir
           echo " ${{ github.workspace }}/glfw_install/lib/cmake/glfw3/" >> $GITHUB_PATH
-          echo "${{ env.radium_build_dir }}/src/Core" >> $GITHUB_PATH
-          echo "${{ env.radium_build_dir }}/src/Engine" >> $GITHUB_PATH
-          echo "${{ env.radium_build_dir }}/src/Dataflow/Core" >> $GITHUB_PATH
-          echo "${{ env.radium_build_dir }}/src/Dataflow/QtGui" >> $GITHUB_PATH
-          echo "${{ env.radium_build_dir }}/src/Gui" >> $GITHUB_PATH
-          echo "${{ env.radium_build_dir }}/src/Headless" >> $GITHUB_PATH
-          echo "${{ env.radium_build_dir }}/src/IO" >> $GITHUB_PATH
-          echo "${{ env.radium_build_dir }}/src/PluginBase" >> $GITHUB_PATH
-          echo "${{ env.external_install_dir }}/bin" >> $GITHUB_PATH
-          echo "${{ env.external_install_dir }}/glbinding" >> $GITHUB_PATH
-          echo "${{ env.external_install_dir }}/install_prefix/globjects" >> $GITHUB_PATH
-          echo "${{ env.external_install_dir }}/install_prefix/cpplocate" >> $GITHUB_PATH
+          echo "${{ steps.paths.outputs.radium_build_dir }}/src/Core" >> $GITHUB_PATH
+          echo "${{ steps.paths.outputs.radium_build_dir }}/src/Engine" >> $GITHUB_PATH
+          echo "${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/Core" >> $GITHUB_PATH
+          echo "${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/QtGui" >> $GITHUB_PATH
+          echo "${{ steps.paths.outputs.radium_build_dir }}/src/Gui" >> $GITHUB_PATH
+          echo "${{ steps.paths.outputs.radium_build_dir }}/src/Headless" >> $GITHUB_PATH
+          echo "${{ steps.paths.outputs.radium_build_dir }}/src/IO" >> $GITHUB_PATH
+          echo "${{ steps.paths.outputs.radium_build_dir }}/src/PluginBase" >> $GITHUB_PATH
+          echo "${{ steps.paths.outputs.external_install_dir }}/bin" >> $GITHUB_PATH
+          echo "${{ steps.paths.outputs.external_install_dir }}/glbinding" >> $GITHUB_PATH
+          echo "${{ steps.paths.outputs.external_install_dir }}/install_prefix/globjects" >> $GITHUB_PATH
+          echo "${{ steps.paths.outputs.external_install_dir }}/install_prefix/cpplocate" >> $GITHUB_PATH
       - name: Prepare directories
         run: |
           mkdir -p "${{ env.src_prefix }}"
-          mkdir -p "${{ env.radium_build_dir }}"
-          mkdir -p "${{ env.external_build_dir }}"
-          mkdir -p "${{ env.radium_install_dir }}"
-          mkdir -p "${{ env.external_install_dir }}"
+          mkdir -p "${{ steps.paths.outputs.radium_build_dir }}"
+          mkdir -p "${{ steps.paths.outputs.external_build_dir }}"
+          mkdir -p "${{ steps.paths.outputs.radium_install_dir }}"
+          mkdir -p "${{ steps.paths.outputs.external_install_dir }}"
 
       - name: Checkout remote head
         uses: actions/checkout@master
@@ -202,24 +208,24 @@ jobs:
         id: cache-external
         uses: actions/cache@v4
         with:
-          path: ${{ env.external_install_dir }}
+          path: ${{ steps.paths.outputs.external_install_dir }}
           key: ${{ matrix.config.name }}-${{ matrix.build-type }}-${{ matrix.qtversion.name }}-external-v1-${{ hashFiles('src/Radium-Engine/external/**/CMakeLists.txt') }} # no env in hashFiles
       - name: Configure and build external
         if: steps.cache-external.outputs.cache-hit != 'true'
         run: |
-          "${{ env.src_prefix }}/Radium-Engine/scripts/build.sh" -B "${{ env.build_prefix }}" -e true -r false -G Ninja --cc ${{ matrix.config.cc }} --cxx ${{ matrix.config.cxx }} -c ${{ matrix.build-type }} --install-external "${{ env.external_install_dir }}"
+          "${{ env.src_prefix }}/Radium-Engine/scripts/build.sh" -B "${{ env.build_prefix }}" -e true -r false -G Ninja --cc ${{ matrix.config.cc }} --cxx ${{ matrix.config.cxx }} -c ${{ matrix.build-type }} --install-external "${{ steps.paths.outputs.external_install_dir }}"
       - name: Configure and build Radium
         run: |
           "${{ env.src_prefix }}/Radium-Engine/scripts/build.sh" -B "${{ env.build_prefix }}" -e false -r true -G Ninja --cc ${{ matrix.config.cc }} --cxx ${{ matrix.config.cxx }} \
-          -c ${{ matrix.build-type }} --install-external ${{ env.external_install_dir }} --install-radium  "${{ env.radium_install_dir }}" \
+          -c ${{ matrix.build-type }} --install-external ${{ steps.paths.outputs.external_install_dir }} --install-radium  "${{ steps.paths.outputs.radium_install_dir }}" \
           -o "${{ env.glfw-path }} ${{ matrix.config.extra-flags }} ${{ matrix.coverage.extra-flags }}" \
           --use-double ${{ matrix.precision.value }} --enable-coverage ${{ matrix.coverage.value }}
       - name: Run unit tests
         if: ${{ inputs.coverage == 'false' }}
         run: |
-          cmake --build "${{ env.radium_build_dir }}" --parallel --config ${{ matrix.build-type }} --target check
-          cmake --build "${{ env.radium_build_dir }}" --parallel --config ${{ matrix.build-type }} --target Install_CoreExample
-          "${{ env.radium_install_dir }}/bin/CoreExample"
+          cmake --build "${{ steps.paths.outputs.radium_build_dir }}" --parallel --config ${{ matrix.build-type }} --target check
+          cmake --build "${{ steps.paths.outputs.radium_build_dir }}" --parallel --config ${{ matrix.build-type }} --target Install_CoreExample
+          "${{ steps.paths.outputs.radium_install_dir }}/bin/CoreExample"
       - name: Extract ref for badges prefix
         if: always()
         run: |
@@ -253,14 +259,14 @@ jobs:
       - name: Create coverage report
         if: ${{ inputs.coverage == 'true' }}
         run: |
-          cmake --build "${{ env.radium_build_dir }}" --config Debug --target fastcov_integration
-          cmake --build "${{ env.radium_build_dir }}" --config Debug --target fastcov_unittests
+          cmake --build "${{ steps.paths.outputs.radium_build_dir }}" --config Debug --target fastcov_integration
+          cmake --build "${{ steps.paths.outputs.radium_build_dir }}" --config Debug --target fastcov_unittests
       - name: Upload unittests coverage report
         if: ${{ inputs.coverage == 'true' }}
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true # optional (default = false)
-          files: ${{ env.radium_build_dir }}/fastcov_unittests.info
+          files: ${{ steps.paths.outputs.radium_build_dir }}/fastcov_unittests.info
           flags: unittests
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true # optional (default = false)
@@ -270,7 +276,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true # optional (default = false)
-          files: ${{ env.radium_build_dir }}/Radium-Engine/fastcov_integration.info
+          files: ${{ steps.paths.outputs.radium_build_dir }}/Radium-Engine/fastcov_integration.info
           flags: integration
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true # optional (default = false)

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -203,7 +203,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.external_install_dir }}
-          key: ${{ matrix.config.name }}-${{ matrix.build-type }}-${{ matrix.qtversion.name }}-external-v1-${{ hashFiles('$src_prefix/Radium-Engine/external/**/CMakeLists.txt') }}
+          key: ${{ matrix.config.name }}-${{ matrix.build-type }}-${{ matrix.qtversion.name }}-external-v1-${{ hashFiles( 'src/Radium-Engine/external/**/CMakeLists.txt') }} # no env in hashFiles
       - name: Configure and build external
         if: steps.cache-external.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -172,18 +172,18 @@ jobs:
 
           # Setting paths to dll needed by catch2 and run in build dir
           echo "${{ github.workspace }}/glfw_install/lib/cmake/glfw3/" >> $GITHUB_PATH
-          echo "${{ steps.paths.outputs.radium_build_dir }}/src/Core" >> $GITHUB_PATH
-          echo "${{ steps.paths.outputs.radium_build_dir }}/src/Engine" >> $GITHUB_PATH
-          echo "${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/Core" >> $GITHUB_PATH
-          echo "${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/QtGui" >> $GITHUB_PATH
-          echo "${{ steps.paths.outputs.radium_build_dir }}/src/Gui" >> $GITHUB_PATH
-          echo "${{ steps.paths.outputs.radium_build_dir }}/src/Headless" >> $GITHUB_PATH
-          echo "${{ steps.paths.outputs.radium_build_dir }}/src/IO" >> $GITHUB_PATH
-          echo "${{ steps.paths.outputs.radium_build_dir }}/src/PluginBase" >> $GITHUB_PATH
-          echo "${{ steps.paths.outputs.external_install_dir }}/bin" >> $GITHUB_PATH
-          echo "${{ steps.paths.outputs.external_install_dir }}/glbinding" >> $GITHUB_PATH
-          echo "${{ steps.paths.outputs.external_install_dir }}/install_prefix/globjects" >> $GITHUB_PATH
-          echo "${{ steps.paths.outputs.external_install_dir }}/install_prefix/cpplocate" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Core" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Engine" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/Core" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Dataflow/QtGui" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Gui" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/Headless" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/IO" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.radium_build_dir }}/src/PluginBase" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.external_install_dir }}/bin" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.external_install_dir }}/glbinding" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.external_install_dir }}/install_prefix/globjects" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/${{ steps.paths.outputs.external_install_dir }}/install_prefix/cpplocate" >> $GITHUB_PATH
 
       - name: Prepare directories
         run: |

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -28,22 +28,6 @@ else()
 
     project(${RADIUM_DEPENDENCIES_PROJECT_NAME} VERSION 1.0.0)
 
-    # Changing the default value for CMAKE_BUILD_PARALLEL_LEVEL
-    if(NOT DEFINED ENV{CMAKE_BUILD_PARALLEL_LEVEL})
-        include(ProcessorCount)
-        ProcessorCount(N)
-        if(NOT N EQUAL 0)
-            set(CTEST_BUILD_FLAGS -j${N})
-            set(ctest_test_args ${ctest_test_args} PARALLEL_LEVEL ${N})
-            set(ENV{CMAKE_BUILD_PARALLEL_LEVEL} ${N})
-        endif()
-    endif()
-
-    message(STATUS "")
-    message(STATUS "    == ${PROJECT_NAME} Project configuration ==")
-    message(STATUS "")
-    message(STATUS "Externals will be built with $ENV{CMAKE_BUILD_PARALLEL_LEVEL} core(s)")
-
     # -----------------------------------------------------------------------------
     # Set default install location to dist folder in build dir we do not want to install to /usr by
     # default

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -uoe pipefail
-set -x
+
 BLUE='\033[0;34m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
@@ -10,7 +10,13 @@ COMMAND_COLOR='\033[0;90m'
 NC='\033[0m'
 
 
-JOBS=$(nproc)
+
+if [ "$(uname)" == "Darwin" ]; then
+    JOBS=$(sysctl -n hw.logicalcpu)
+else
+    JOBS=$(nproc)
+fi
+
 BUILD_TYPE=Release
 BUILD_EXT=true
 BUILD_RADIUM=true
@@ -38,6 +44,8 @@ function usage {
     echo "  -r, --build-radium BOOL Build radium (default: ${BUILD_RADIUM})"
     echo "  -G, --generator GEN     Specify CMake generator (e.g., 'Ninja')"
     echo "  -o, --options OPTS      More cmake configure options."
+    echo "            double quote if multiple OPTS, single quote if spaces"
+    echo "            as in -o \"-Da -Ddir='a b'\""
     echo "  -B, --build-prefix DIR  Set BUILD_PREFIX (Radium-Engine/build),"
     echo "            then uses BUILD_PREFIX/CONFIG/{external|Radium-Engine}"
     echo "  -i, --install DIR       Install path PREFIX"
@@ -87,7 +95,8 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -o|--options)
-            CMAKE_EXTRA_ARGS="$2"
+            eval "CMAKE_EXTRA_ARGS=($2)"
+            echo "${CMAKE_EXTRA_ARGS[@]}"
             shift 2
             ;;
         -i|--install)
@@ -210,8 +219,7 @@ if [ "${BUILD_RADIUM}" = true ]; then
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
           -DCMAKE_INSTALL_PREFIX=${RADIUM_INSTALL_DIR} \
           -C ${EXTERNAL_INSTALL_DIR}/radium-options.cmake \
-          ${CMAKE_ARGS:+"${CMAKE_ARGS}"}  \
-          ${CMAKE_EXTRA_ARGS:+"${CMAKE_EXTRA_ARGS}"} \
+          ${CMAKE_EXTRA_ARGS:+"${CMAKE_EXTRA_ARGS[@]}"} \
           -DRADIUM_USE_DOUBLE=${USE_DOUBLE} \
           -DRADIUM_UPDATE_VERSION=${UPDATE_VERSION} \
           -DRADIUM_ENABLE_PCH=${ENABLE_PCH} \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,6 +28,14 @@ ENABLE_EXAMPLE=ON
 ENABLE_COVERAGE=OFF
 ENABLE_TESTING=ON
 
+VERBOSE=true
+function eval_verbose {
+    if [ "$VERBOSE" = true ]; then
+        echo -e "${COMMAND_COLOR}$*${NC}"
+    fi
+    "$@"
+}
+
 # Help function
 function usage {
     echo "Usage: $0 [OPTIONS]"
@@ -96,7 +104,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         -o|--options)
             eval "CMAKE_EXTRA_ARGS=($2)"
-            echo "${CMAKE_EXTRA_ARGS[@]}"
             shift 2
             ;;
         -i|--install)
@@ -200,33 +207,49 @@ if [ ! -z ${CCX+x} ]; then
 fi
 
 if [ "${BUILD_EXT}" = true ]; then
-    cmake -S ${THIS_DIR}/external -B ${EXTERNAL_BUILD_DIR} \
-          ${GENERATOR_ARG:+"${GENERATOR_ARG}"} \
-          ${COMPILER_ARG:+"${COMPILER_ARG}"} \
-          -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-          -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=NONE \
-          -DCMAKE_INSTALL_MESSAGE=LAZY \
-          -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_DIR}
+    echo -e "\n${GREEN}Configure externals...${NC}"
 
-    cmake --build ${EXTERNAL_BUILD_DIR} --parallel ${JOBS} --config ${BUILD_TYPE}
+    eval_verbose cmake -S ${THIS_DIR}/external -B ${EXTERNAL_BUILD_DIR} \
+                 ${GENERATOR_ARG:+"${GENERATOR_ARG}"} \
+                 ${COMPILER_ARG:+"${COMPILER_ARG}"} \
+                 -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+                 -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=NONE \
+                 -DCMAKE_INSTALL_MESSAGE=LAZY \
+                 -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_DIR}
+
+    echo -e "\n${GREEN}Configure externals done.${NC}"
+    echo -e "\n${GREEN}Build externals...${NC}"
+
+    eval_verbose cmake --build ${EXTERNAL_BUILD_DIR} --parallel ${JOBS}\
+                 --config ${BUILD_TYPE}
+    echo -e "\n${GREEN}Build externals done.${NC}"
 fi
 
 if [ "${BUILD_RADIUM}" = true ]; then
-    cmake -S ${THIS_DIR}/ -B ${RADIUM_BUILD_DIR} \
-          -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=NONE \
-          ${GENERATOR_ARG:+"${GENERATOR_ARG}"} \
-          ${COMPILER_ARG:+"${COMPILER_ARG}"} \
-          -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-          -DCMAKE_INSTALL_PREFIX=${RADIUM_INSTALL_DIR} \
-          -C ${EXTERNAL_INSTALL_DIR}/radium-options.cmake \
-          ${CMAKE_EXTRA_ARGS:+"${CMAKE_EXTRA_ARGS[@]}"} \
-          -DRADIUM_USE_DOUBLE=${USE_DOUBLE} \
-          -DRADIUM_UPDATE_VERSION=${UPDATE_VERSION} \
-          -DRADIUM_ENABLE_PCH=${ENABLE_PCH} \
-          -DRADIUM_INSTALL_DOC=${INSTALL_DOC} \
-          -DRADIUM_ENABLE_EXAMPLES=${ENABLE_EXAMPLE} \
-          -DRADIUM_ENABLE_TESTING=${ENABLE_TESTING} \
-          -DRADIUM_ENABLE_COVERAGE=${ENABLE_COVERAGE}
+    echo -e "\n${GREEN}Configure Radium Engine...${NC}"
 
-    cmake --build ${RADIUM_BUILD_DIR} --parallel ${JOBS} --config ${BUILD_TYPE} --target install
+    eval_verbose cmake -S ${THIS_DIR}/ -B ${RADIUM_BUILD_DIR} \
+                 -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=NONE \
+                 ${GENERATOR_ARG:+"${GENERATOR_ARG}"} \
+                 ${COMPILER_ARG:+"${COMPILER_ARG}"} \
+                 -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+                 -DCMAKE_INSTALL_PREFIX=${RADIUM_INSTALL_DIR} \
+                 -C ${EXTERNAL_INSTALL_DIR}/radium-options.cmake \
+                 ${CMAKE_EXTRA_ARGS:+"${CMAKE_EXTRA_ARGS[@]}"} \
+                 -DRADIUM_USE_DOUBLE=${USE_DOUBLE} \
+                 -DRADIUM_UPDATE_VERSION=${UPDATE_VERSION} \
+                 -DRADIUM_ENABLE_PCH=${ENABLE_PCH} \
+                 -DRADIUM_INSTALL_DOC=${INSTALL_DOC} \
+                 -DRADIUM_ENABLE_EXAMPLES=${ENABLE_EXAMPLE} \
+                 -DRADIUM_ENABLE_TESTING=${ENABLE_TESTING} \
+                 -DRADIUM_ENABLE_COVERAGE=${ENABLE_COVERAGE}
+
+    echo -e "\n${GREEN}Configure Radium Engine done.${NC}"
+    echo -e "\n${GREEN}Build Radium Engine...${NC}"
+
+    eval_verbose cmake --build ${RADIUM_BUILD_DIR} --parallel ${JOBS}\
+                 --config ${BUILD_TYPE} --target install
+
+    echo -e "\n${GREEN}Build Radium Engine done.${NC}"
+
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+
+set -uo pipefail
+
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+COMMAND_COLOR='\033[0;90m'
+NC='\033[0m'
+
+
+JOBS=$(nproc)
+BUILD_TYPE=Release
+BUILD_EXT=true
+BUILD_RADIUM=true
+USE_DOUBLE=OFF
+UPDATE_VERSION=OFF
+ENABLE_PCH=ON
+INSTALL_DOC=OFF
+ENABLE_EXAMPLE=ON
+ENABLE_COVERAGE=OFF
+ENABLE_TESTING=ON
+
+# Help function
+function usage {
+    echo "Usage: $0 [OPTIONS]"
+    echo
+    echo "Options:"
+    echo "  -h, --help              Show this help message and exit",
+    echo "  -j, --jobs N            Use N jobs for parallel build"
+    echo "                          (default: number of CPU cores, ${JOBS})"
+    echo "  -c, --config TYPE       Build CONFIG using cmake convention"
+    echo "                          (default: ${BUILD_TYPE})"
+    echo "  --cc                    Set cc, default to system."
+    echo "  --cxx                   Set cxx, default to system."
+    echo "  -e, --build-ext BOOL    Build external (default: ${BUILD_EXT})"
+    echo "  -r, --build-radium BOOL Build radium (default: ${BUILD_RADIUM})"
+    echo "  -G, --generator GEN     Specify CMake generator (e.g., 'Ninja')"
+    echo "  -o, --options OPTS      More cmake configure options."
+    echo "  -B, --build-prefix DIR  Set BUILD_PREFIX (Radium-Engine/build),"
+    echo "            then uses BUILD_PREFIX/CONFIG/{external|Radium-Engine}"
+    echo "  -i, --install DIR       Install path PREFIX"
+    echo "            (default: ../radium-install)"
+    echo "            install in PREFIX/CONFIG/Radium-Engine|externals"
+    echo "  --install-radium DIR     Install radium path (superseed prefix)"
+    echo "  --install-external DIR   Install path prefix (superseed prefix)"
+    echo "  --use-double ON/OFF      default: ${USE_DOUBLE}"
+    echo "  --update-version ON/OFF  default: ${UPDATE_VERSION}"
+    echo "  --enable-pch ON/OFF      default: ${ENABLE_PCH}"
+    echo "  --install-doc ON/OFF     default: ${INSTALL_DOC}"
+    echo "  --enable-example ON/OFF  default: ${ENABLE_EXAMPLE}"
+    echo "  --enable-testing ON/OFF  default: ${ENABLE_TESTING}"
+    echo "  --enable-coverage ON/OFF default: ${ENABLE_COVERAGE}"
+}
+
+if [[ $? -gt 0 ]]; then
+    usage
+    exit
+fi
+
+# Parse options, todo fix missing parameters
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -j|--jobs)
+            JOBS="$2"
+            shift 2
+            ;;
+        -c|--config)
+            BUILD_TYPE="$2"
+            shift 2
+            ;;
+        -e|--build-ext)
+            BUILD_EXT=$2
+            shift 2
+            ;;
+        -r|--build-radium)
+            BUILD_RADIUM=$2
+            shift 2
+            ;;
+        -G|--generator)
+            CMAKE_GENERATOR="$2"
+            shift 2
+            ;;
+        -o|--options)
+            CMAKE_EXTRA_ARGS="$2"
+            shift 2
+            ;;
+        -i|--install)
+            INSTALL_PREFIX="$2"
+            shift 2
+            ;;
+        --install-external)
+            EXTERNAL_INSTALL_DIR="$2"
+            shift 2
+            ;;
+        --install-radium)
+            RADIUM_INSTALL_DIR="$2"
+            shift 2
+            ;;
+         -B|--build-prefix)
+            BUILD_PREFIX="$2"
+            shift 2
+            ;;
+         --cc)
+            CC="$2"
+            shift 2
+            ;;
+         --cxx)
+             CXX="$2"
+             shift 2
+             ;;
+         --use-double)
+             USE_DOUBLE="$2"
+             shift 2
+             ;;
+         --update-version)
+             UPDATE_VERSION="$2"
+             shift 2
+             ;;
+         --enable-pch)
+             ENABLE_PCH="$2"
+             shift 2
+             ;;
+         --install-doc)
+             INSTALL_DOC="$2"
+             shift 2
+             ;;
+         --enable-example)
+             ENABLE_EXAMPLE="$2"
+             shift 2
+             ;;
+         --enable-testing)
+             ENABLE_TESTING="$2"
+             shift 2
+             ;;
+         --enable-coverage)
+             ENABLE_COVERAGE="$2"
+             shift 2
+             ;;
+         --) shift; break ;;
+         *) # Invalid option
+             echo -e "${RED}Error: Invalid option [$1]${NC}\n"
+             usage
+             exit
+             ;;
+    esac
+done
+
+
+# Get SDK directory (directory where this script is located)
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}/" )/../" && pwd )"
+
+if [ -z ${BUILD_PREFIX+x} ]; then
+    BUILD_ROOT="${THIS_DIR}/build"
+else
+    BUILD_ROOT="${BUILD_PREFIX}"
+fi
+
+# Define build and install directories
+EXTERNAL_BUILD_DIR="${BUILD_ROOT}/${BUILD_TYPE}/external"
+RADIUM_BUILD_DIR="${BUILD_ROOT}/${BUILD_TYPE}/Radium-Engine"
+
+if [ -z ${INSTALL_PREFIX+x} ]; then
+    INSTALL_PREFIX="${THIS_DIR}/../install/${BUILD_TYPE}"
+fi
+
+if [ -z ${RADIUM_INSTALL_DIR+x} ]; then
+    RADIUM_INSTALL_DIR="${INSTALL_PREFIX}/Radium-Engine"
+fi
+
+if [ -z ${EXTERNAL_INSTALL_DIR+x} ]; then
+    EXTERNAL_INSTALL_DIR="${INSTALL_PREFIX}/external"
+fi
+
+GENERATOR_ARG=""
+if [ ! -z ${CMAKE_GENERATOR+x} ]; then
+    GENERATOR_ARG="-G ${CMAKE_GENERATOR}"
+fi
+
+COMPILER_ARG=""
+if [ ! -z ${CC+x} ]; then
+    COMPILER_ARG="-DCMAKE_C_COMPILER=${CC}"
+fi
+if [ ! -z ${CCX+x} ]; then
+    COMPILER_ARG="${COMPILER_ARG} -DCMAKE_C_COMPILER=${CXX}"
+fi
+
+if [ "${BUILD_EXT}" = true ]; then
+    cmake -S ${THIS_DIR}/external -B ${EXTERNAL_BUILD_DIR} \
+          ${GENERATOR_ARG:+"${GENERATOR_ARG}"} \
+          ${COMPILER_ARG:+"${COMPILER_ARG}"} \
+          -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+          -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=NONE \
+          -DCMAKE_INSTALL_MESSAGE=LAZY \
+          -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_DIR}
+
+    cmake --build ${EXTERNAL_BUILD_DIR} --parallel ${JOBS} --config ${BUILD_TYPE}
+fi
+
+if [ "${BUILD_RADIUM}" = true ]; then
+    cmake -S ${THIS_DIR}/ -B ${RADIUM_BUILD_DIR} \
+          -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=NONE \
+          ${GENERATOR_ARG:+"${GENERATOR_ARG}"} \
+          ${COMPILER_ARG:+"${COMPILER_ARG}"} \
+          -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+          -DCMAKE_INSTALL_PREFIX=${RADIUM_INSTALL_DIR} \
+          -C ${EXTERNAL_INSTALL_DIR}/radium-options.cmake \
+          ${CMAKE_ARGS:+"${CMAKE_ARGS}"}  \
+          ${CMAKE_EXTRA_ARGS:+"${CMAKE_EXTRA_ARGS}"} \
+          -DRADIUM_USE_DOUBLE=${USE_DOUBLE} \
+          -DRADIUM_UPDATE_VERSION=${UPDATE_VERSION} \
+          -DRADIUM_ENABLE_PCH=${ENABLE_PCH} \
+          -DRADIUM_INSTALL_DOC=${INSTALL_DOC} \
+          -DRADIUM_ENABLE_EXAMPLES=${ENABLE_EXAMPLE} \
+          -DRADIUM_ENABLE_TESTING=${ENABLE_TESTING} \
+          -DRADIUM_ENABLE_COVERAGE=${ENABLE_COVERAGE}
+
+    cmake --build ${RADIUM_BUILD_DIR} --parallel ${JOBS} --config ${BUILD_TYPE} --target install
+fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-set -uo pipefail
-
+set -uoe pipefail
+set -x
 BLUE='\033[0;34m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,9 +2,7 @@
 
 set -uoe pipefail
 
-BLUE='\033[0;34m'
 GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
 RED='\033[0;31m'
 COMMAND_COLOR='\033[0;90m'
 NC='\033[0m'
@@ -209,46 +207,46 @@ fi
 if [ "${BUILD_EXT}" = true ]; then
     echo -e "\n${GREEN}Configure externals...${NC}"
 
-    eval_verbose cmake -S ${THIS_DIR}/external -B ${EXTERNAL_BUILD_DIR} \
+    eval_verbose cmake -S "${THIS_DIR}/external" -B "${EXTERNAL_BUILD_DIR}" \
                  ${GENERATOR_ARG:+"${GENERATOR_ARG}"} \
                  ${COMPILER_ARG:+"${COMPILER_ARG}"} \
-                 -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+                 -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
                  -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=NONE \
                  -DCMAKE_INSTALL_MESSAGE=LAZY \
-                 -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_DIR}
+                 -DCMAKE_INSTALL_PREFIX="${EXTERNAL_INSTALL_DIR}"
 
     echo -e "\n${GREEN}Configure externals done.${NC}"
     echo -e "\n${GREEN}Build externals...${NC}"
 
-    eval_verbose cmake --build ${EXTERNAL_BUILD_DIR} --parallel ${JOBS}\
-                 --config ${BUILD_TYPE}
+    eval_verbose cmake --build "${EXTERNAL_BUILD_DIR}" --parallel "${JOBS}" \
+                 --config "${BUILD_TYPE}"
     echo -e "\n${GREEN}Build externals done.${NC}"
 fi
 
 if [ "${BUILD_RADIUM}" = true ]; then
     echo -e "\n${GREEN}Configure Radium Engine...${NC}"
 
-    eval_verbose cmake -S ${THIS_DIR}/ -B ${RADIUM_BUILD_DIR} \
+    eval_verbose cmake -S "${THIS_DIR}/" -B "${RADIUM_BUILD_DIR}" \
                  -DCMAKE_EXECUTE_PROCESS_COMMAND_ECHO=NONE \
                  ${GENERATOR_ARG:+"${GENERATOR_ARG}"} \
                  ${COMPILER_ARG:+"${COMPILER_ARG}"} \
-                 -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-                 -DCMAKE_INSTALL_PREFIX=${RADIUM_INSTALL_DIR} \
-                 -C ${EXTERNAL_INSTALL_DIR}/radium-options.cmake \
+                 -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+                 -DCMAKE_INSTALL_PREFIX="${RADIUM_INSTALL_DIR}" \
+                 -C "${EXTERNAL_INSTALL_DIR}/radium-options.cmake" \
                  ${CMAKE_EXTRA_ARGS:+"${CMAKE_EXTRA_ARGS[@]}"} \
-                 -DRADIUM_USE_DOUBLE=${USE_DOUBLE} \
-                 -DRADIUM_UPDATE_VERSION=${UPDATE_VERSION} \
-                 -DRADIUM_ENABLE_PCH=${ENABLE_PCH} \
-                 -DRADIUM_INSTALL_DOC=${INSTALL_DOC} \
-                 -DRADIUM_ENABLE_EXAMPLES=${ENABLE_EXAMPLE} \
-                 -DRADIUM_ENABLE_TESTING=${ENABLE_TESTING} \
-                 -DRADIUM_ENABLE_COVERAGE=${ENABLE_COVERAGE}
+                 -DRADIUM_USE_DOUBLE="${USE_DOUBLE}" \
+                 -DRADIUM_UPDATE_VERSION="${UPDATE_VERSION}" \
+                 -DRADIUM_ENABLE_PCH="${ENABLE_PCH}" \
+                 -DRADIUM_INSTALL_DOC="${INSTALL_DOC}" \
+                 -DRADIUM_ENABLE_EXAMPLES="${ENABLE_EXAMPLE}" \
+                 -DRADIUM_ENABLE_TESTING="${ENABLE_TESTING}" \
+                 -DRADIUM_ENABLE_COVERAGE="${ENABLE_COVERAGE}"
 
     echo -e "\n${GREEN}Configure Radium Engine done.${NC}"
     echo -e "\n${GREEN}Build Radium Engine...${NC}"
 
-    eval_verbose cmake --build ${RADIUM_BUILD_DIR} --parallel ${JOBS}\
-                 --config ${BUILD_TYPE} --target install
+    eval_verbose cmake --build "${RADIUM_BUILD_DIR}" --parallel "${JOBS}" \
+                 --config "${BUILD_TYPE}" --target install
 
     echo -e "\n${GREEN}Build Radium Engine done.${NC}"
 

--- a/src/Headless/CMakeLists.txt
+++ b/src/Headless/CMakeLists.txt
@@ -66,10 +66,11 @@ else()
         PACKAGE_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in FILES "${installed_headers}"
     )
     set(RADIUM_COMPONENTS ${RADIUM_COMPONENTS} ${ra_headless_target} PARENT_SCOPE)
-endif()
 
-if(RADIUM_ENABLE_PCH)
-    target_precompile_headers(${ra_headless_target} PRIVATE pch.hpp)
+    if(RADIUM_ENABLE_PCH)
+        target_precompile_headers(${ra_headless_target} PRIVATE pch.hpp)
+    endif()
+
 endif()
 
 message_prefix_pop()


### PR DESCRIPTION
Add a script `build.sh` to ease workflow run, to be used in Radium-Apps and Radium-Release as well.
Highly configurable, I hope for most situation.

Also fixes workflow (windows build missed glfw due to bad path configuration).