### PR TITLE
Update ci actions

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -128,10 +128,8 @@ jobs:
           echo "external_build_dir=$external_build_dir" >> $GITHUB_OUTPUT
           echo "external_install_dir=$external_install_dir" >> $GITHUB_OUTPUT
 
-#      - name: Add msbuild to PATH
-#        uses: seanmiddleditch/gha-setup-vsdevenv@master
-#        if: runner.os == 'Windows'
-#
+      - name: Add msbuild to PATH
+        uses: ilammy/msvc-dev-cmd@138b1c783b65ec697d8342918306b7b2db4e88f1
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -128,10 +128,10 @@ jobs:
           echo "external_build_dir=$external_build_dir" >> $GITHUB_OUTPUT
           echo "external_install_dir=$external_install_dir" >> $GITHUB_OUTPUT
 
-      - name: Add msbuild to PATH
-        uses: seanmiddleditch/gha-setup-vsdevenv@master
-        if: runner.os == 'Windows'
-
+#      - name: Add msbuild to PATH
+#        uses: seanmiddleditch/gha-setup-vsdevenv@master
+#        if: runner.os == 'Windows'
+#
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -278,7 +278,7 @@ jobs:
 
       - name: Upload unittests coverage report
         if: ${{ inputs.coverage == 'true' }}
-        uses: codecov/codecov-action@v5.5.2
+        uses: codecov/codecov-action@v6.0.0
         with:
           fail_ci_if_error: true # optional (default = false)
           files: ${{ steps.paths.outputs.radium_build_dir }}/fastcov_unittests.info
@@ -289,7 +289,7 @@ jobs:
 
       - name: Upload integration coverage report
         if: ${{ inputs.coverage == 'true' }}
-        uses: codecov/codecov-action@v5.5.2
+        uses: codecov/codecov-action@v6.0.0
         with:
           fail_ci_if_error: true # optional (default = false)
           files: ${{ steps.paths.outputs.radium_build_dir }}/fastcov_integration.info

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -248,7 +248,7 @@ jobs:
 
       - name: Update badge on merge (failure)
         if: ${{ failure() && inputs.generate-badges == 'true' }}
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@v1.8.0
         with:
           auth: ${{ secrets.GIST_BADGES_TOKEN }}
           gistID: ${{ secrets.GIST_BADGES_SECRET }}
@@ -261,7 +261,7 @@ jobs:
 
       - name: Update badge on merge (success)
         if: ${{ success() && inputs.generate-badges == 'true' }}
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@v1.8.0
         with:
           auth: ${{ secrets.GIST_BADGES_TOKEN }}
           gistID: ${{ secrets.GIST_BADGES_SECRET }}


### PR DESCRIPTION
Bump actions
Remove windows env (unmaintained)
gh-pages still don't have a Node update ... 